### PR TITLE
Resolve bzz:// through http protocol handler

### DIFF
--- a/bzz/httpaccess.go
+++ b/bzz/httpaccess.go
@@ -7,8 +7,9 @@ import (
 	"bytes"
 	"io"
 	"net/http"
-	//	"net/url"
+	"net/url"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -18,7 +19,8 @@ import (
 )
 
 const (
-	rawType = "application/octet-stream"
+	rawType   = "application/octet-stream"
+	bzzPrefix = "bzz%3A%2F%2F"
 )
 
 var (
@@ -64,6 +66,14 @@ func handler(w http.ResponseWriter, r *http.Request, api *Api) {
 		raw = true
 		return ""
 	})
+
+	// HTTP-based URL protocol handler
+	if strings.HasPrefix(uri, bzzPrefix) {
+		decodedUri, err := url.QueryUnescape(uri[len(bzzPrefix):len(uri)])
+		if err == nil {
+			uri = decodedUri
+		}
+	}
 
 	glog.V(logger.Debug).Infof("[BZZ] Swarm: %s request '%s' received.", r.Method, uri)
 

--- a/bzz/httpaccess.go
+++ b/bzz/httpaccess.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
-	"net/url"
+	//"net/url"
 	"regexp"
 	"strings"
 	"sync"
@@ -20,7 +20,7 @@ import (
 
 const (
 	rawType   = "application/octet-stream"
-	bzzPrefix = "bzz%3A%2F%2F"
+	bzzPrefix = "/bzz:/"
 )
 
 var (
@@ -62,18 +62,17 @@ func handler(w http.ResponseWriter, r *http.Request, api *Api) {
 	glog.V(logger.Debug).Infof("[BZZ] Swarm: HTTP request URL: '%s', Host: '%s', Path: '%s', Referer: '%s', Accept: '%s'", r.RequestURI, requestURL.Host, requestURL.Path, r.Referer(), r.Header.Get("Accept"))
 	uri := requestURL.Path
 	var raw bool
+
+	// HTTP-based URL protocol handler
+	if strings.HasPrefix(uri, bzzPrefix) {
+		uri = uri[len(bzzPrefix)-1 : len(uri)]
+		glog.V(logger.Debug).Infof("[BZZ] Swarm: BZZ request URI: '%s'", uri)
+	}
+
 	path := rawUrl.ReplaceAllStringFunc(uri, func(string) string {
 		raw = true
 		return ""
 	})
-
-	// HTTP-based URL protocol handler
-	if strings.HasPrefix(uri, bzzPrefix) {
-		decodedUri, err := url.QueryUnescape(uri[len(bzzPrefix):len(uri)])
-		if err == nil {
-			uri = decodedUri
-		}
-	}
 
 	glog.V(logger.Debug).Infof("[BZZ] Swarm: %s request '%s' received.", r.Method, uri)
 


### PR DESCRIPTION
This is a very simple addition, would make bzz:// URL's just work  after setting up http://localhost:8500 as a http protocol handler for the bzz protocol in any browser.
