### PR TITLE
p2p: Messenger interface cleanup

### DIFF
--- a/p2p/adapters/rlpx.go
+++ b/p2p/adapters/rlpx.go
@@ -60,11 +60,11 @@ func NewReportingRLPx(addr []byte, srv *p2p.Server, m Messenger, r Reporter) *RL
 	return rlpx
 }
 
-func (*RLPxMessenger) SendMsg(w p2p.MsgWriter, code uint64, msg interface{}) error {
+func (RLPxMessenger) SendMsg(w p2p.MsgWriter, code uint64, msg interface{}) error {
 	return p2p.Send(w, code, msg)
 }
 
-func (*RLPxMessenger) ReadMsg(r p2p.MsgReader) (p2p.Msg, error) {
+func (RLPxMessenger) ReadMsg(r p2p.MsgReader) (p2p.Msg, error) {
 	return r.ReadMsg()
 }
 

--- a/p2p/protocols/protocol.go
+++ b/p2p/protocols/protocol.go
@@ -33,6 +33,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/ethereum/go-ethereum/p2p/adapters"
 	"github.com/ethereum/go-ethereum/logger"
 	"github.com/ethereum/go-ethereum/logger/glog"
 	"github.com/ethereum/go-ethereum/p2p"
@@ -156,23 +157,18 @@ func (self *CodeMap) Register(msgs ...interface{}) {
 // a remote peer
 type Peer struct {
 	ct         *CodeMap                                   // CodeMap for the protocol
-	m          Messenger                                  // defines senf and receive
+	m          adapters.Messenger                                  // defines senf and receive
 	*p2p.Peer                                             // the p2p.Peer object representing the remote
 	rw         p2p.MsgReadWriter                          // p2p.MsgReadWriter to send messages to and read messages from
 	handlers   map[reflect.Type][]func(interface{}) error //  message type -> message handler callback(s) map
 	disconnect func()                                     // Disconnect function set differently for testing
 }
 
-type Messenger interface {
-	SendMsg(p2p.MsgWriter, uint64, interface{}) error
-	ReadMsg(p2p.MsgReader) (p2p.Msg, error)
-}
-
 // NewPeer returns a new peer
 // this constructor is called by the p2p.Protocol#Run function
 // the first two arguments are comming the arguments passed to p2p.Protocol.Run function
 // the third argument is the CodeMap describing the protocol messages and options
-func NewPeer(p *p2p.Peer, rw p2p.MsgReadWriter, ct *CodeMap, m Messenger, disconn func()) *Peer {
+func NewPeer(p *p2p.Peer, rw p2p.MsgReadWriter, ct *CodeMap, m adapters.Messenger, disconn func()) *Peer {
 	return &Peer{
 		ct:         ct,
 		m:          m,


### PR DESCRIPTION
This PR seeks to clean up the implementations of the Messenger interface. Currently the issues isolated are:

- p2p/adapters/RLPxMessenger is implemented with pointer receiver, incompatible with p2p/protocols Peer instantiation.
- The Messenger interface is declared in duplicate (p2p/adapters/types.go and p2p/protocols/protocol.go)
