### PR TITLE
p2p: Correct use of MsgReadWriter in protocol implementations

### DIFF
--- a/p2p/adapters/rlpx.go
+++ b/p2p/adapters/rlpx.go
@@ -60,11 +60,11 @@ func NewReportingRLPx(addr []byte, srv *p2p.Server, m Messenger, r Reporter) *RL
 	return rlpx
 }
 
-func (*RLPxMessenger) SendMsg(w p2p.MsgWriter, code uint64, msg interface{}) error {
+func (RLPxMessenger) SendMsg(w p2p.MsgWriter, code uint64, msg interface{}) error {
 	return p2p.Send(w, code, msg)
 }
 
-func (*RLPxMessenger) ReadMsg(r p2p.MsgReader) (p2p.Msg, error) {
+func (RLPxMessenger) ReadMsg(r p2p.MsgReader) (p2p.Msg, error) {
 	return r.ReadMsg()
 }
 

--- a/p2p/protocols/protocol.go
+++ b/p2p/protocols/protocol.go
@@ -33,6 +33,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/ethereum/go-ethereum/p2p/adapters"
 	"github.com/ethereum/go-ethereum/logger"
 	"github.com/ethereum/go-ethereum/logger/glog"
 	"github.com/ethereum/go-ethereum/p2p"
@@ -156,23 +157,18 @@ func (self *CodeMap) Register(msgs ...interface{}) {
 // a remote peer
 type Peer struct {
 	ct         *CodeMap                                   // CodeMap for the protocol
-	m          Messenger                                  // defines senf and receive
+	m          adapters.Messenger                                  // defines senf and receive
 	*p2p.Peer                                             // the p2p.Peer object representing the remote
 	rw         p2p.MsgReadWriter                          // p2p.MsgReadWriter to send messages to and read messages from
 	handlers   map[reflect.Type][]func(interface{}) error //  message type -> message handler callback(s) map
 	disconnect func()                                     // Disconnect function set differently for testing
 }
 
-type Messenger interface {
-	SendMsg(p2p.MsgWriter, uint64, interface{}) error
-	ReadMsg(p2p.MsgReader) (p2p.Msg, error)
-}
-
 // NewPeer returns a new peer
 // this constructor is called by the p2p.Protocol#Run function
 // the first two arguments are comming the arguments passed to p2p.Protocol.Run function
 // the third argument is the CodeMap describing the protocol messages and options
-func NewPeer(p *p2p.Peer, rw p2p.MsgReadWriter, ct *CodeMap, m Messenger, disconn func()) *Peer {
+func NewPeer(p *p2p.Peer, rw p2p.MsgReadWriter, ct *CodeMap, m adapters.Messenger, disconn func()) *Peer {
 	return &Peer{
 		ct:         ct,
 		m:          m,


### PR DESCRIPTION
**p2p/rlpx.go:**

* `p2p/rlpxFrameRW.conn` implements `io.ReadWriter`
* `p2p/rlpx.rw` is `rlpxFrameRW`
* `p2p/rlpx.fd` is `net.Conn`, implements `io.ReadWriter`
* `(*p2p/rlpx).doEncHandshake()` defines: `(*p2p/rlpx).rw = newRLPXFrameRW((*rlpx).fd, sec)`
* `(*p2p/rlpx)` is the only implementation of `p2p.transport` interface (itself wrapping `p2p/MsgReadWriter`), defined in *p2p/server.go*

---

**p2p/server.go:**

* `p2p.transport` (hopefully not to be confused with `p2p/discv5.transport` and `p2p/discover.transport`) is anonymous member of `p2p.conn`
* `p2p.transport` is set by `newTransport()`
* `newTransport()` is pointed to `newRLPX()` in `p2p/Server.Start()`

* `p2p/Server.listenLoop()` starts `p2p/Server.setupConn(fd...)` where fd is go-native-pkg `net.Conn` which runs `newTransport()`
* `p2p/Server.conn.fd` is `net.Conn` (implements `io.ReadWriter`)

*(NB! p2p/Server.newTransport() is listed under "hooks for testing," even though it seems to be the only working implentation of transport layer for p2p. Maybe this comment should be removed?)*

---

**p2p/peer.go:**

* `p2p/Peer.rw` is `p2p/Server.conn`
* `p2p/Peer` has array of `p2p/protoRW` pointer, each implementing `p2p/MsgReadWriter`
* `p2p/ProtoRW` implements `(p2p/MsgReadWriter).ReadMsg()` through it's own in-channel, `(p2p/MsgReadWriter).WriteMsg()` through a different `p2p/MsgReadWriter`, passed on from `p2p/Peer.rw`

**`p2p/Peer.rw` is actually a `p2p/Server.conn` which is passed as the fd all the way down to `rlpx.fd` and `rlpx.rw,` seemingly the lowest layer. This suggests that the implementation of `p2p/ProtoRW` *write* is sane, because it uses the same io.ReadWriter through the whole stack, though maybe the *read* could need review**

====

**p2p/protocols/protocol.go**

* `p2p/ProtoRW.Protocol` accepts `p2p/MsgReadWriter` as parameter, which in the end does the actual reading and writing in the protocol message handler code, as demonstrated in *p2p/protocols/protocol_test.go*

Tested dumping the contents of `p2p/protocols/Peer.(*p2p).Peer.running` (which is a `map[string]*protoRW`) in the *p2p/protocols/protocol_test.go* tests, here is the output:

```
$ go test -v .
=== RUN   TestProtoHandshakeVersionMismatch
map[]map[]--- PASS: TestProtoHandshakeVersionMismatch (0.00s)
=== RUN   TestProtoHandshakeNetworkIdMismatch
map[]map[]--- PASS: TestProtoHandshakeNetworkIdMismatch (0.00s)
=== RUN   TestProtoHandshakeSuccess
map[]map[]--- PASS: TestProtoHandshakeSuccess (0.00s)
=== RUN   TestModuleHandshakeError
map[]map[]--- PASS: TestModuleHandshakeError (0.00s)
=== RUN   TestModuleHandshakeSuccess
map[]map[]--- PASS: TestModuleHandshakeSuccess (0.00s)
=== RUN   TestMultiplePeersDropSelf
map[]map[]--- PASS: TestMultiplePeersDropSelf (0.00s)
=== RUN   TestMultiplePeersDropOther
map[]map[]--- PASS: TestMultiplePeersDropOther (0.00s)
PASS
ok  	github.com/ethereum/go-ethereum/p2p/protocols	0.055s
```

gdb also confirms that the fields are empty:

```
Thread 1 "protocols.test" hit Breakpoint 1, github.com/ethereum/go-ethereum/p2p/protocols.newProtocol.func1.1 (p=0xc82019c080, rw=..., 
    ~r2=...) at /home/lash/programming/projects/go/src/github.com/ethereum/go-ethereum/p2p/protocols/protocol_test.go:70
70				peer.Register(&kill{}, func(msg interface{}) error {
(gdb) p *p.running
$5 = {count = 0, flags = 0 '\000', B = 0 '\000', hash0 = 1473690077, buckets = 0x0, oldbuckets = 0x0, nevacuate = 0, overflow = 0x0}
```

====

Since `p2p/Peer.protoRW` is not in use at all, this could suggest that the intended interface for implementation of protocol i/o in the *p2p* layer is not extended in the *p2p/protocols* layer (and other layers that have to do with network simulation).
