### PR TITLE
p2p/adapters: Add "docker" node adapter

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -567,6 +567,17 @@ func (n *Node) Attach() (*rpc.Client, error) {
 	return rpc.DialInProc(n.inprocHandler), nil
 }
 
+// RPCHandler returns the in-process RPC request handler.
+func (n *Node) RPCHandler() (*rpc.Server, error) {
+	n.lock.RLock()
+	defer n.lock.RUnlock()
+
+	if n.inprocHandler == nil {
+		return nil, ErrNodeStopped
+	}
+	return n.inprocHandler, nil
+}
+
 // Server retrieves the currently running P2P network layer. This method is meant
 // only to inspect fields of the currently running server, life cycle management
 // should be left to this Node entity.

--- a/p2p/adapters/docker.go
+++ b/p2p/adapters/docker.go
@@ -2,52 +2,127 @@ package adapters
 
 import (
 	"fmt"
-	"net"
-	// "net/http"
-	// "time"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+
+	"github.com/docker/docker/pkg/reexec"
+	"github.com/ethereum/go-ethereum/node"
 )
 
-func NewRemoteNode(id *NodeId, n Network) *RemoteNode {
-	return &RemoteNode{
-		ID:      id,
-		Network: n,
+// DockerNode is a NodeAdapter which wraps an ExecNode but exec's the current
+// binary in a docker container rather than locally
+type DockerNode struct {
+	ExecNode
+}
+
+// NewDockerNode creates a new DockerNode, building the docker image if
+// necessary
+func NewDockerNode(id *NodeId, service string) (*DockerNode, error) {
+	if runtime.GOOS != "linux" {
+		return nil, fmt.Errorf("NewDockerNode can only be used on Linux as it uses the current binary (which must be a Linux binary)")
 	}
+
+	if _, exists := serviceFuncs[service]; !exists {
+		return nil, fmt.Errorf("unknown node service %q", service)
+	}
+
+	// build the docker image
+	var err error
+	dockerOnce.Do(func() {
+		err = buildDockerImage()
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// generate the config
+	conf := node.DefaultConfig
+	conf.DataDir = "/data"
+	conf.P2P.NoDiscovery = true
+	conf.P2P.NAT = nil
+
+	node := &DockerNode{
+		ExecNode: ExecNode{
+			ID:      id,
+			Service: service,
+			Config:  &conf,
+		},
+	}
+	node.newCmd = node.dockerCommand
+	return node, nil
 }
 
-// RemoteNode is the network adapter that
-type RemoteNode struct {
-	ID   *NodeId
-	addr net.Addr
-	Network
+// dockerCommand returns a command which exec's the binary in a docker
+// container.
+//
+// It uses a shell so that we can pass the _P2P_NODE_CONFIG environment
+// variable to the container using the --env flag.
+func (n *DockerNode) dockerCommand() *exec.Cmd {
+	return exec.Command(
+		"sh", "-c",
+		fmt.Sprintf(
+			`exec docker run --interactive --env _P2P_NODE_CONFIG="${_P2P_NODE_CONFIG}" %s p2p-node %s %s`,
+			dockerImage, n.Service, n.ID.String(),
+		),
+	)
 }
 
-func Name(id []byte) string {
-	return fmt.Sprintf("test-%08x", id)
-}
+// dockerImage is the name of the docker image
+const dockerImage = "p2p-node"
 
-// inject(s) sends an RPC command remotely via ssh to the particular dockernode
-func (self *RemoteNode) inject(string) error {
+// dockerOnce is used to build the docker image only once
+var dockerOnce sync.Once
+
+// buildDockerImage builds the docker image which is used to run devp2p nodes
+// using docker.
+//
+// It adds the current binary as "p2p-node" so that it runs execP2PNode
+// when executed.
+func buildDockerImage() error {
+	// create a directory to use as the docker build context
+	dir, err := ioutil.TempDir("", "p2p-docker")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(dir)
+
+	// copy the current binary into the build context
+	bin, err := os.Open(reexec.Self())
+	if err != nil {
+		return err
+	}
+	defer bin.Close()
+	dst, err := os.OpenFile(filepath.Join(dir, "self.bin"), os.O_WRONLY|os.O_CREATE, 0755)
+	if err != nil {
+		return err
+	}
+	defer dst.Close()
+	if _, err := io.Copy(dst, bin); err != nil {
+		return err
+	}
+
+	// create the Dockerfile
+	dockerfile := []byte(`
+FROM ubuntu:16.04
+RUN mkdir /data
+ADD self.bin /bin/p2p-node
+	`)
+	if err := ioutil.WriteFile(filepath.Join(dir, "Dockerfile"), dockerfile, 0644); err != nil {
+		return err
+	}
+
+	// run 'docker build'
+	cmd := exec.Command("docker", "build", "-t", dockerImage, dir)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error building docker image: %s", err)
+	}
+
 	return nil
-}
-
-func (self *RemoteNode) LocalAddr() []byte {
-	return []byte(self.addr.String())
-}
-
-func (self *RemoteNode) ParseAddr(p []byte, s string) ([]byte, error) {
-	return p, nil
-}
-
-func (self *RemoteNode) Disconnect(rid []byte) error {
-	// ssh+ipc -> drop
-	// assumes the remote node is running the p2p module as part of the protocol
-	cmd := fmt.Sprintf(`p2p.Drop("%v")`, string(rid))
-	return self.inject(cmd)
-}
-
-func (self *RemoteNode) Connect(rid []byte) error {
-	// ssh+ipc -> connect
-	//
-	cmd := fmt.Sprintf(`admin.addPeer("%v")`, string(rid))
-	return self.inject(cmd)
 }

--- a/p2p/adapters/inproc.go
+++ b/p2p/adapters/inproc.go
@@ -166,7 +166,7 @@ func (self *SimNode) RunProtocol(id *NodeId, rw, rrw p2p.MsgReadWriter, peer *Pe
 		return nil
 	}
 	log.Trace(fmt.Sprintf("protocol starting on peer %v (connection with %v)", self.Id, id))
-	p := p2p.NewPeer(id.NodeID, Name(id.Bytes()), []p2p.Cap{})
+	p := p2p.NewPeer(id.NodeID, id.Label(), []p2p.Cap{})
 	go func() {
 		self.network.DidConnect(self.Id, id)
 		err := self.Run(p, rw)

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -177,6 +177,14 @@ func DialContext(ctx context.Context, rawurl string) (*Client, error) {
 	}
 }
 
+// NewClientWithConn creates an RPC client which uses the provided net.Conn.
+func NewClientWithConn(conn net.Conn) *Client {
+	client, _ := newClient(context.Background(), func(context.Context) (net.Conn, error) {
+		return conn, nil
+	})
+	return client
+}
+
 func newClient(initctx context.Context, connectFunc func(context.Context) (net.Conn, error)) (*Client, error) {
 	conn, err := connectFunc(initctx)
 	if err != nil {

--- a/swarm/network/simulations/discovery/discovery_test.go
+++ b/swarm/network/simulations/discovery/discovery_test.go
@@ -41,6 +41,30 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+func TestDiscoverySimulationDockerAdapter(t *testing.T) {
+	setup := func(net *simulations.Network, trigger chan *adapters.NodeId) {
+		var ids []*adapters.NodeId
+
+		// TODO: get events from the devp2p node
+		time.AfterFunc(10*time.Second, func() {
+			for _, id := range ids {
+				trigger <- id
+			}
+		})
+
+		net.SetNaf(func(conf *simulations.NodeConfig) adapters.NodeAdapter {
+			node, err := adapters.NewDockerNode(conf.Id, serviceName)
+			if err != nil {
+				panic(err)
+			}
+			ids = append(ids, conf.Id)
+			return node
+		})
+	}
+
+	testDiscoverySimulation(t, setup)
+}
+
 func TestDiscoverySimulationExecAdapter(t *testing.T) {
 	baseDir, err := ioutil.TempDir("", "swarm-test")
 	if err != nil {
@@ -52,7 +76,7 @@ func TestDiscoverySimulationExecAdapter(t *testing.T) {
 		var ids []*adapters.NodeId
 
 		// TODO: get events from the devp2p node
-		time.AfterFunc(5*time.Second, func() {
+		time.AfterFunc(10*time.Second, func() {
 			for _, id := range ids {
 				trigger <- id
 			}
@@ -133,7 +157,7 @@ func testDiscoverySimulation(t *testing.T, setup func(net *simulations.Network, 
 		return true, nil
 	}
 
-	timeout := 10 * time.Second
+	timeout := 30 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 


### PR DESCRIPTION
This adds a "docker" node adapter which runs devp2p nodes in docker containers.

I have also updated the RPC communication to happen using stdin / stdout of the node (rather than the IPC socket) so that the calling code does not need access to either the node's filesystem or TCP stack.

Because we copy the current binary into the docker image and exec it there, any tests using the docker adapter must be run on Linux (e.g. inside [the dev environment](https://github.com/ethereum/go-ethereum/pull/14332)).