### PR TITLE
p2p/simulations: Get peer events via RPC

### DIFF
--- a/p2p/adapters/exec.go
+++ b/p2p/adapters/exec.go
@@ -2,6 +2,8 @@ package adapters
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,6 +18,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/pkg/reexec"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p"
@@ -55,11 +58,12 @@ type ExecNode struct {
 
 	client *rpc.Client
 	newCmd func() *exec.Cmd
+	key    *ecdsa.PrivateKey
 }
 
 // NewExecNode creates a new ExecNode which will run the given service using a
 // sub-directory of the given baseDir
-func NewExecNode(id *NodeId, service, baseDir string) (*ExecNode, error) {
+func NewExecNode(id *NodeId, key *ecdsa.PrivateKey, service, baseDir string) (*ExecNode, error) {
 	if _, exists := serviceFuncs[service]; !exists {
 		return nil, fmt.Errorf("unknown node service %q", service)
 	}
@@ -82,6 +86,7 @@ func NewExecNode(id *NodeId, service, baseDir string) (*ExecNode, error) {
 		Service: service,
 		Dir:     dir,
 		Config:  &conf,
+		key:     key,
 	}
 	node.newCmd = node.execCommand
 	return node, nil
@@ -99,9 +104,10 @@ func (n *ExecNode) Client() (*rpc.Client, error) {
 	return n.client, nil
 }
 
-// Start exec's the node passing the ID and service as command line arguments
-// and the node config encoded as JSON in the _P2P_NODE_CONFIG environment
-// variable
+// Start exec's the node passing the ID and service as command line arguments,
+// the node config encoded as JSON in the _P2P_NODE_CONFIG environment
+// variable and the node's private key hex-endoded in the _P2P_NODE_KEY
+// environment variable
 func (n *ExecNode) Start() (err error) {
 	if n.Cmd != nil {
 		return errors.New("already started")
@@ -119,6 +125,9 @@ func (n *ExecNode) Start() (err error) {
 		return fmt.Errorf("error generating node config: %s", err)
 	}
 
+	// encode the private key
+	key := hex.EncodeToString(crypto.FromECDSA(n.key))
+
 	// create a net.Pipe for RPC communication over stdin / stdout
 	pipe1, pipe2 := net.Pipe()
 
@@ -127,7 +136,10 @@ func (n *ExecNode) Start() (err error) {
 	cmd.Stdin = pipe1
 	cmd.Stdout = pipe1
 	cmd.Stderr = os.Stderr
-	cmd.Env = append(os.Environ(), fmt.Sprintf("_P2P_NODE_CONFIG=%s", conf))
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("_P2P_NODE_CONFIG=%s", conf),
+		fmt.Sprintf("_P2P_NODE_KEY=%s", key),
+	)
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("error starting node: %s", err)
 	}
@@ -215,6 +227,17 @@ func execP2PNode() {
 		log.Crit("error decoding _P2P_NODE_CONFIG", "err", err)
 	}
 
+	// decode the private key
+	keyEnv := os.Getenv("_P2P_NODE_KEY")
+	if keyEnv == "" {
+		log.Crit("missing _P2P_NODE_KEY")
+	}
+	key, err := hex.DecodeString(keyEnv)
+	if err != nil {
+		log.Crit("error decoding _P2P_NODE_KEY", "err", err)
+	}
+	conf.P2P.PrivateKey = crypto.ToECDSA(key)
+
 	// initialize the service
 	serviceFunc, exists := serviceFuncs[serviceName]
 	if !exists {
@@ -268,16 +291,87 @@ func startP2PNode(conf *node.Config, service node.Service) (*node.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	constructor := func(ctx *node.ServiceContext) (node.Service, error) {
-		return service, nil
+
+	constructor := func(s node.Service) node.ServiceConstructor {
+		return func(ctx *node.ServiceContext) (node.Service, error) {
+			return s, nil
+		}
 	}
-	if err := stack.Register(constructor); err != nil {
+
+	// register the peer events API
+	//
+	// TODO: move this to node.PrivateAdminAPI once the following is merged:
+	//       https://github.com/ethereum/go-ethereum/pull/13885
+	if err := stack.Register(constructor(&PeerAPI{stack.Server})); err != nil {
+		return nil, err
+	}
+
+	if err := stack.Register(constructor(service)); err != nil {
 		return nil, err
 	}
 	if err := stack.Start(); err != nil {
 		return nil, err
 	}
 	return stack, nil
+}
+
+// PeerAPI is used to expose peer events under the "eth" RPC namespace.
+//
+// TODO: move this to node.PrivateAdminAPI and expose under the "admin"
+//       namespace once the following is merged:
+//       https://github.com/ethereum/go-ethereum/pull/13885
+type PeerAPI struct {
+	server func() p2p.Server
+}
+
+func (p *PeerAPI) Protocols() []p2p.Protocol {
+	return nil
+}
+
+func (p *PeerAPI) APIs() []rpc.API {
+	return []rpc.API{{
+		Namespace: "eth",
+		Version:   "1.0",
+		Service:   p,
+	}}
+}
+
+func (p *PeerAPI) Start(p2p.Server) error {
+	return nil
+}
+
+func (p *PeerAPI) Stop() error {
+	return nil
+}
+
+// PeerEvents creates an RPC sunscription which receives peer events from the
+// underlying p2p.Server
+func (p *PeerAPI) PeerEvents(ctx context.Context) (*rpc.Subscription, error) {
+	notifier, supported := rpc.NotifierFromContext(ctx)
+	if !supported {
+		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
+	}
+
+	rpcSub := notifier.CreateSubscription()
+
+	go func() {
+		events := make(chan *p2p.PeerEvent)
+		sub := p.server().SubscribePeers(events)
+		defer sub.Unsubscribe()
+
+		for {
+			select {
+			case event := <-events:
+				notifier.Notify(rpcSub.ID, event)
+			case <-rpcSub.Err():
+				return
+			case <-notifier.Closed():
+				return
+			}
+		}
+	}()
+
+	return rpcSub, nil
 }
 
 // stdioConn wraps os.Stdin / os.Stdout with a nop Close method so we can

--- a/p2p/adapters/types.go
+++ b/p2p/adapters/types.go
@@ -17,7 +17,6 @@
 package adapters
 
 import (
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -78,23 +77,4 @@ type ProtocolRunner interface {
 type Reporter interface {
 	DidConnect(*NodeId, *NodeId) error
 	DidDisconnect(*NodeId, *NodeId) error
-}
-
-func RandomNodeId() *NodeId {
-	key, err := crypto.GenerateKey()
-	if err != nil {
-		panic("unable to generate key")
-	}
-	var id discover.NodeID
-	pubkey := crypto.FromECDSAPub(&key.PublicKey)
-	copy(id[:], pubkey[1:])
-	return &NodeId{id}
-}
-
-func RandomNodeIds(n int) []*NodeId {
-	var ids []*NodeId
-	for i := 0; i < n; i++ {
-		ids = append(ids, RandomNodeId())
-	}
-	return ids
 }

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -60,6 +60,26 @@ type protoHandshake struct {
 	Rest []rlp.RawValue `rlp:"tail"`
 }
 
+// PeerEventType is the type of peer events emitted by a p2p.Server
+type PeerEventType string
+
+const (
+	// PeerEventTypeAdd is the type of event emitted when a peer is added
+	// to a p2p.Server
+	PeerEventTypeAdd PeerEventType = "add"
+
+	// PeerEventTypeDrop is the type of event emitted when a peer is
+	// dropped from a p2p.Server
+	PeerEventTypeDrop PeerEventType = "drop"
+)
+
+// PeerEvent is an event emitted when peers are either added or dropped from
+// a p2p.Server
+type PeerEvent struct {
+	Type PeerEventType
+	Peer discover.NodeID
+}
+
 // Peer represents a connected remote node.
 type Peer struct {
 	rw      *conn

--- a/p2p/protocols/protocol_test.go
+++ b/p2p/protocols/protocol_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/adapters"
+	"github.com/ethereum/go-ethereum/p2p/simulations"
 	p2ptest "github.com/ethereum/go-ethereum/p2p/testing"
 )
 
@@ -117,8 +118,8 @@ func newProtocol(pp *p2ptest.TestPeerPool) adapters.ProtoCall {
 }
 
 func protocolTester(t *testing.T, pp *p2ptest.TestPeerPool) *p2ptest.ProtocolTester {
-	id := adapters.RandomNodeId()
-	return p2ptest.NewProtocolTester(t, id, 2, newProtocol(pp))
+	conf := simulations.RandomNodeConfig()
+	return p2ptest.NewProtocolTester(t, conf.Id, 2, newProtocol(pp))
 }
 
 func protoHandshakeExchange(id *adapters.NodeId, proto *protoHandshake) []p2ptest.Exchange {

--- a/p2p/simulations/mocker.go
+++ b/p2p/simulations/mocker.go
@@ -163,7 +163,8 @@ func MockEvents(eventer *event.TypeMux, ids []*adapters.NodeId, conf *MockerConf
 		var mustconnect []int
 		for i := 0; len(offNodes) > 0 && i < nodesUp; i++ {
 			c := rand.Intn(len(offNodes))
-			sn := &Node{Id: offNodes[c]}
+			sn := &Node{}
+			sn.Id = offNodes[c]
 			err := eventer.Post(sn.EmitEvent(ControlEvent))
 			if err != nil {
 				panic(err.Error())

--- a/swarm/network/hive_test.go
+++ b/swarm/network/hive_test.go
@@ -82,7 +82,6 @@ func TestRegisterAndConnect(t *testing.T) {
 		},
 		ticker: make(chan time.Time),
 	}
-	//pp.Start(tc.connect, tc.ping)
 	pp.Start(s.TestNodeAdapter, tc.ping)
 	defer pp.Stop()
 	tc.ticker <- time.Now()

--- a/swarm/network/simulations/overlay.go
+++ b/swarm/network/simulations/overlay.go
@@ -118,11 +118,16 @@ func nethook(conf *simulations.NetworkConfig) (simulations.NetworkControl, *simu
 	conf.Backend = true
 	net := NewNetwork(simulations.NewNetwork(conf))
 
-	//ids := p2ptest.RandomNodeIds(10)
-	ids := adapters.RandomNodeIds(10)
+	ids := make([]*adapters.NodeId, 10)
+	for i := 0; i < 10; i++ {
+		conf, err := net.NewNode()
+		if err != nil {
+			panic(err.Error())
+		}
+		ids[i] = conf.Id
+	}
 
 	for i, id := range ids {
-		net.NewNode(&simulations.NodeConfig{Id: id})
 		var peerId *adapters.NodeId
 		if i == 0 {
 			peerId = ids[len(ids)-1]
@@ -138,7 +143,6 @@ func nethook(conf *simulations.NetworkConfig) (simulations.NetworkControl, *simu
 		for _, id := range ids {
 			n := rand.Intn(1000)
 			time.Sleep(time.Duration(n) * time.Millisecond)
-			net.NewNode(&simulations.NodeConfig{Id: id})
 			net.Start(id)
 			log.Debug(fmt.Sprintf("node %v starting up", id))
 			// time.Sleep(1000 * time.Millisecond)


### PR DESCRIPTION
Summary:

* Added the node's private key to `NodeConfig` so the real nodes use the correct ID (otherwise they get an ephemeral key)
* Add an RPC `PeerEvents` subscription which receives events whenever peers are added or dropped from a `p2p.Server`
* Subscribe to peer events when starting nodes in `simulations.Network`, relay to the journal via `DidConnect` / `DidDisconnect`

I wanted to add `PeerEvents` to the private admin API but that won't work until https://github.com/ethereum/go-ethereum/pull/13885 is merged, so for now I am adding a custom API under the "eth" namespace.