### PR TITLE
DPA cache for pss

### DIFF
--- a/swarm/api/config.go
+++ b/swarm/api/config.go
@@ -77,7 +77,7 @@ func NewConfig(path string, contract common.Address, prvKey *ecdsa.PrivateKey, n
 		HiveParams:    network.NewHiveParams(),
 		ChunkerParams: storage.NewChunkerParams(),
 		StoreParams:   storage.NewStoreParams(dirpath),
-		PssParams:	   network.NewPssParams(),
+		PssParams:	   network.NewPssParams(nil),
 		Port:          port,
 		Path:          dirpath,
 		Swap:          swap.DefaultSwapParams(contract, prvKey),

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -187,14 +187,14 @@ func (self *Swarm) Start(net p2p.Server) error {
 	log.Info(fmt.Sprintf("Swarm network started on bzz address: %v", self.hive.GetAddr()))
 
 	if self.pssEnabled {
-		pssparams := network.NewPssParams()
+		pssparams := network.NewPssParams(self.dpa)
 		self.pss = network.NewPss(self.hive.Overlay, pssparams)
 
 		// for testing purposes, shold be removed in production environment!!
 		pingtopic, _ := network.MakeTopic("pss", 1)
 		self.pss.Register(pingtopic, self.pss.GetPingHandler())
 
-		log.Debug("Pss started: %v", self.pss)
+		log.Info(fmt.Sprintf("Pss started on overlay address %x", self.pss.GetBaseAddr()))
 	}
 
 	self.dpa.Start()


### PR DESCRIPTION
Messages are cached using DPA, at the same time constituting a mailbox store for pss messages on swarm