### PR TITLE
Scenarios

### DIFF
--- a/p2p/simulations/mocker.go
+++ b/p2p/simulations/mocker.go
@@ -15,6 +15,8 @@ type MockerConfig struct {
 	Id              string
 	NodeCount       int
 	UpdateInterval  int
+	Mocker          func(*Network)
+	Description     string
 	SwitchonRate    int // fraction of off nodes switching on
 	DropoutRate     int // fraction of on nodes dropping out
 	NewConnCount    int // new connection per node per tick

--- a/swarm/network/simulations/overlay.go
+++ b/swarm/network/simulations/overlay.go
@@ -90,7 +90,32 @@ func NewSimNode(id *adapters.NodeId, snapshot []byte) node.Service {
 	}
 }
 
-func mocker(net *simulations.Network) {
+func createMockers() map[string]*simulations.MockerConfig {
+	configs := make(map[string]*simulations.MockerConfig)
+
+	defaultCfg := simulations.DefaultMockerConfig()
+	defaultCfg.Id = "start-stop"
+	defaultCfg.Description = "Starts and Stops nodes in go routines"
+	defaultCfg.Mocker = startStopMocker
+
+	bootNetworkCfg := simulations.DefaultMockerConfig()
+	bootNetworkCfg.Id = "bootNet"
+	bootNetworkCfg.Description = "Only boots up all nodes in the config"
+	bootNetworkCfg.Mocker = bootMocker
+
+	randomNodesCfg := simulations.DefaultMockerConfig()
+	randomNodesCfg.Id = "randomNodes"
+	randomNodesCfg.Description = "Boots nodes and then starts and stops some picking randomly"
+	randomNodesCfg.Mocker = randomMocker
+
+	configs[defaultCfg.Id] = defaultCfg
+	configs[bootNetworkCfg.Id] = bootNetworkCfg
+	configs[randomNodesCfg.Id] = randomNodesCfg
+
+	return configs
+}
+
+func setupMocker(net *simulations.Network) []*adapters.NodeId {
 	conf := net.Config()
 	conf.DefaultService = "overlay"
 
@@ -123,6 +148,49 @@ func mocker(net *simulations.Network) {
 		}
 	}
 
+	return ids
+}
+
+func bootMocker(net *simulations.Network) {
+	setupMocker(net)
+}
+
+func randomMocker(net *simulations.Network) {
+	ids := setupMocker(net)
+
+	for {
+		var lowid, highid int
+		randWait := rand.Intn(5000) + 1000
+		rand1 := rand.Intn(9)
+		rand2 := rand.Intn(9)
+		if rand1 < rand2 {
+			lowid = rand1
+			highid = rand2
+		} else if rand1 > rand2 {
+			highid = rand1
+			lowid = rand2
+		} else {
+			if rand1 == 0 {
+				rand2 = 9
+			} else if rand1 == 9 {
+				rand1 = 0
+			}
+		}
+		for i := lowid; i < highid; i++ {
+			log.Debug(fmt.Sprintf("node %v shutting down", ids[i]))
+			net.Stop(ids[i])
+			go func(id *adapters.NodeId) {
+				time.Sleep(time.Duration(randWait) * time.Millisecond)
+				net.Start(id)
+			}(ids[i])
+			time.Sleep(time.Duration(randWait) * time.Millisecond)
+		}
+	}
+}
+
+func startStopMocker(net *simulations.Network) {
+	ids := setupMocker(net)
+
 	for i, id := range ids {
 		n := 3000 + i*1000
 		go func(id *adapters.NodeId) {
@@ -154,9 +222,12 @@ func main() {
 	}
 	adapters.RegisterServices(services)
 
+	mockers := createMockers()
+
 	config := &simulations.ServerConfig{
-		NewAdapter: func() adapters.NodeAdapter { return adapters.NewSimAdapter(services) },
-		Mocker:     mocker,
+		NewAdapter:      func() adapters.NodeAdapter { return adapters.NewSimAdapter(services) },
+		DefaultMockerId: "start-stop",
+		Mockers:         mockers,
 	}
 
 	log.Info("starting simulation server on 0.0.0.0:8888...")


### PR DESCRIPTION
This PR adds simulation scenarios to the backend. A ServerConfig can now include a map of different mockers which can be run. A frontend can choose which scenario it wants to run. 

Also, OPTIONS support has been added to the http REST API handler. Browsers seem to issue an "OPTIONS" request before a "DELETE" when using ajax. 