### PR TITLE
p2p/simulations: eventstream backend double-backslash on init 

### DIFF
--- a/p2p/simulations/http.go
+++ b/p2p/simulations/http.go
@@ -466,6 +466,7 @@ func (s *Server) StreamNetworkEvents(w http.ResponseWriter, req *http.Request) {
 
 	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
+	fmt.Fprintf(w, "\n\n")
 	if fw, ok := w.(http.Flusher); ok {
 		fw.Flush()
 	}


### PR DESCRIPTION
This change allows FF to properly react to the `onopen` event and correctly init and run the frontend