### PR TITLE
p2p/simulations: Use a single network for the HTTP API

### DIFF
--- a/p2p/simulations/examples/p2psim.sh
+++ b/p2p/simulations/examples/p2psim.sh
@@ -9,13 +9,9 @@ main() {
     fail "missing p2psim binary (you need to build p2p/simulations/cmd/p2psim)"
   fi
 
-  info "creating the example network"
-  export P2PSIM_NETWORK="example"
-  p2psim network create --id "${P2PSIM_NETWORK}"
-
   info "creating 10 nodes"
   for i in $(seq 1 10); do
-    p2psim node create --name "$(node_name $i)" --services "ping-pong"
+    p2psim node create --name "$(node_name $i)"
     p2psim node start "$(node_name $i)"
   done
 

--- a/swarm/network/simulations/overlay.go
+++ b/swarm/network/simulations/overlay.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -21,6 +22,8 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
 	"github.com/ethereum/go-ethereum/swarm/network"
 )
+
+var noDiscovery = flag.Bool("no-discovery", false, "disable discovery (useful if you want to load a snapshot)")
 
 type Simulation struct {
 	mtx    sync.Mutex
@@ -57,6 +60,7 @@ func (s *Simulation) NewService(ctx *adapters.ServiceContext) (node.Service, err
 	ticker := time.NewTicker(time.Duration(kad.PruneInterval) * time.Millisecond)
 	kad.Prune(ticker.C)
 	hp := network.NewHiveParams()
+	hp.Discovery = !*noDiscovery
 	hp.KeepAliveInterval = 3 * time.Second
 
 	config := &network.BzzConfig{
@@ -192,6 +196,8 @@ func startStopMocker(net *simulations.Network) {
 
 // var server
 func main() {
+	flag.Parse()
+
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	log.Root().SetHandler(log.LvlFilterHandler(log.LvlDebug, log.StreamHandler(os.Stderr, log.TerminalFormat(false))))


### PR DESCRIPTION
This simplifies the simulation API by only exposing a single network, so the backend can fully specify what that network is (either a new or existing network), and the frontend can focus on visualising that single network.

I've also fixed restarting sim nodes, and added a `--no-discovery` flag to the overlay simulation.

/cc @zelig @holisticode 