### PR TITLE
p2p/simulations: Send current nodes & conns in event stream

### DIFF
--- a/p2p/simulations/cmd/p2psim/main.go
+++ b/p2p/simulations/cmd/p2psim/main.go
@@ -65,6 +65,12 @@ func main() {
 			Name:   "events",
 			Usage:  "stream network events",
 			Action: streamNetwork,
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "current",
+					Usage: "get existing nodes and conns first",
+				},
+			},
 		},
 		{
 			Name:   "snapshot",
@@ -176,7 +182,7 @@ func streamNetwork(ctx *cli.Context) error {
 		return cli.ShowCommandHelp(ctx, ctx.Command.Name)
 	}
 	events := make(chan *simulations.Event)
-	sub, err := client.SubscribeNetwork(events)
+	sub, err := client.SubscribeNetwork(events, ctx.Bool("current"))
 	if err != nil {
 		return err
 	}

--- a/p2p/simulations/http_test.go
+++ b/p2p/simulations/http_test.go
@@ -145,7 +145,7 @@ func TestHTTPNetwork(t *testing.T) {
 	// subscribe to events so we can check them later
 	client := NewClient(s.URL)
 	events := make(chan *Event, 100)
-	sub, err := client.SubscribeNetwork(events)
+	sub, err := client.SubscribeNetwork(events, false)
 	if err != nil {
 		t.Fatalf("error subscribing to network events: %s", err)
 	}
@@ -211,6 +211,20 @@ func TestHTTPNetwork(t *testing.T) {
 		x.nodeEvent(nodeIDs[0], true),
 		x.nodeEvent(nodeIDs[1], true),
 		x.connEvent(nodeIDs[0], nodeIDs[1], false),
+		x.connEvent(nodeIDs[0], nodeIDs[1], true),
+	)
+
+	// reconnect the stream and check we get the current nodes and conns
+	events = make(chan *Event, 100)
+	sub, err = client.SubscribeNetwork(events, true)
+	if err != nil {
+		t.Fatalf("error subscribing to network events: %s", err)
+	}
+	defer sub.Unsubscribe()
+	x = &expectEvents{t, events, sub}
+	x.expect(
+		x.nodeEvent(nodeIDs[0], true),
+		x.nodeEvent(nodeIDs[1], true),
 		x.connEvent(nodeIDs[0], nodeIDs[1], true),
 	)
 }
@@ -411,7 +425,7 @@ func TestHTTPSnapshot(t *testing.T) {
 
 	// subscribe to events so we can check them later
 	events := make(chan *Event, 100)
-	sub, err := client.SubscribeNetwork(events)
+	sub, err := client.SubscribeNetwork(events, false)
 	if err != nil {
 		t.Fatalf("error subscribing to network events: %s", err)
 	}


### PR DESCRIPTION
This simplifies connecting to existing networks by passing `current=true` when subscribing to events and receiving the current nodes and conns before receiving new ones.

/cc @holisticode 