### PR TITLE
p2p/simulations: removed requirement for a mocker from network

### DIFF
--- a/p2p/simulations/http.go
+++ b/p2p/simulations/http.go
@@ -320,7 +320,8 @@ func (s *Server) StartMocker(w http.ResponseWriter, req *http.Request) {
 	mockerid := req.Context().Value("mock").(string)
 
 	if len(s.Mockers) == 0 {
-		http.Error(w, "mocker not configured", http.StatusInternalServerError)
+		//don't require a mocker to be present
+		s.JSON(w, http.StatusNotModified, "No mocker configured")
 		return
 	}
 


### PR DESCRIPTION
With this PR, mockers are optional, and the frontend has no dependency to the existence of mockers.