### PR TITLE
Msgfilter and overlay address

### DIFF
--- a/p2p/message.go
+++ b/p2p/message.go
@@ -41,7 +41,6 @@ import (
 // separate Msg with a bytes.Reader as Payload for each send.
 type Msg struct {
 	Code       uint64
-  Protocol   string
 	Size       uint32 // size of the paylod
 	Payload    io.Reader
 	ReceivedAt time.Time
@@ -54,13 +53,13 @@ type Msg struct {
 func (msg Msg) Decode(val interface{}) error {
 	s := rlp.NewStream(msg.Payload, uint64(msg.Size))
 	if err := s.Decode(val); err != nil {
-		return newPeerError(errInvalidMsg, "%v: (code %x) (size %d) %v", msg.Protocol, msg.Code, msg.Size, err)
+		return newPeerError(errInvalidMsg, "(code %x) (size %d) %v", msg.Code, msg.Size, err)
 	}
 	return nil
 }
 
 func (msg Msg) String() string {
-	return fmt.Sprintf("msg %v: #%v (%v bytes)", msg.Protocol, msg.Code, msg.Size)
+	return fmt.Sprintf("msg #%v (%v bytes)", msg.Code, msg.Size)
 }
 
 // Discard reads any remaining payload data into a black hole.
@@ -280,17 +279,17 @@ func ExpectMsg(r MsgReader, code uint64, content interface{}) error {
 type MsgEventer struct {
 	MsgReadWriter
 
-	feed   *event.Feed
-	peerID discover.NodeID
-  Protocol string
+	feed     *event.Feed
+	peerID   discover.NodeID
+	Protocol string
 }
 
 func NewMsgEventer(rw MsgReadWriter, feed *event.Feed, peerID discover.NodeID, proto string) *MsgEventer {
 	return &MsgEventer{
-		MsgReadWriter:  rw,
-		feed:           feed,
-		peerID:         peerID,
-    Protocol:       proto,
+		MsgReadWriter: rw,
+		feed:          feed,
+		peerID:        peerID,
+		Protocol:      proto,
 	}
 }
 
@@ -302,7 +301,7 @@ func (self *MsgEventer) ReadMsg() (Msg, error) {
 	self.feed.Send(&PeerEvent{
 		Type:     PeerEventTypeMsgRecv,
 		Peer:     self.peerID,
-    Protocol: self.Protocol,
+		Protocol: self.Protocol,
 		MsgCode:  &msg.Code,
 		MsgSize:  &msg.Size,
 	})
@@ -317,7 +316,7 @@ func (self *MsgEventer) WriteMsg(msg Msg) error {
 	self.feed.Send(&PeerEvent{
 		Type:     PeerEventTypeMsgSend,
 		Peer:     self.peerID,
-    Protocol: self.Protocol,
+		Protocol: self.Protocol,
 		MsgCode:  &msg.Code,
 		MsgSize:  &msg.Size,
 	})

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -85,12 +85,12 @@ const (
 // PeerEvent is an event emitted when peers are either added or dropped from
 // a p2p.Server or when a message is sent or received on a peer connection
 type PeerEvent struct {
-	Type      PeerEventType   `json:"type"`
-	Peer      discover.NodeID `json:"peer"`
-	Error     string          `json:"error,omitempty"`
-  Protocol  string          `json:"protocol"`
-	MsgCode   *uint64         `json:"msg_code,omitempty"`
-	MsgSize   *uint32         `json:"msg_size,omitempty"`
+	Type     PeerEventType   `json:"type"`
+	Peer     discover.NodeID `json:"peer"`
+	Error    string          `json:"error,omitempty"`
+	Protocol string          `json:"protocol,omitempty"`
+	MsgCode  *uint64         `json:"msg_code,omitempty"`
+	MsgSize  *uint32         `json:"msg_size,omitempty"`
 }
 
 // Peer represents a connected remote node.
@@ -334,7 +334,7 @@ func (p *Peer) startProtocols(writeStart <-chan struct{}, writeErr chan<- error)
 		proto.werr = writeErr
 		var rw MsgReadWriter = proto
 		if p.events != nil {
-			rw =  NewMsgEventer(rw, p.events, p.ID(), proto.Name)
+			rw = NewMsgEventer(rw, p.events, p.ID(), proto.Name)
 		}
 		p.log.Trace(fmt.Sprintf("Starting protocol %s/%d", proto.Name, proto.Version))
 		go func() {

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -85,11 +85,12 @@ const (
 // PeerEvent is an event emitted when peers are either added or dropped from
 // a p2p.Server or when a message is sent or received on a peer connection
 type PeerEvent struct {
-	Type    PeerEventType   `json:"type"`
-	Peer    discover.NodeID `json:"peer"`
-	Error   string          `json:"error,omitempty"`
-	MsgCode *uint64         `json:"msg_code,omitempty"`
-	MsgSize *uint32         `json:"msg_size,omitempty"`
+	Type      PeerEventType   `json:"type"`
+	Peer      discover.NodeID `json:"peer"`
+	Error     string          `json:"error,omitempty"`
+  Protocol  string          `json:"protocol"`
+	MsgCode   *uint64         `json:"msg_code,omitempty"`
+	MsgSize   *uint32         `json:"msg_size,omitempty"`
 }
 
 // Peer represents a connected remote node.
@@ -333,7 +334,7 @@ func (p *Peer) startProtocols(writeStart <-chan struct{}, writeErr chan<- error)
 		proto.werr = writeErr
 		var rw MsgReadWriter = proto
 		if p.events != nil {
-			rw = NewMsgEventer(rw, p.events, p.ID())
+			rw =  NewMsgEventer(rw, p.events, p.ID(), proto.Name)
 		}
 		p.log.Trace(fmt.Sprintf("Starting protocol %s/%d", proto.Name, proto.Version))
 		go func() {

--- a/p2p/simulations/adapters/inproc.go
+++ b/p2p/simulations/adapters/inproc.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"sync"
 
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p"
@@ -80,7 +81,7 @@ func (s *SimAdapter) NewNode(config *NodeConfig) (Node, error) {
 			MaxPeers:        math.MaxInt32,
 			NoDiscovery:     true,
 			Dialer:          s,
-			EnableMsgEvents: false,
+			EnableMsgEvents: true,
 		},
 		NoUSB: true,
 	})
@@ -152,7 +153,10 @@ type SimNode struct {
 
 // Addr returns the node's discovery address
 func (self *SimNode) Addr() []byte {
-	return []byte(self.Node().String())
+  log.Warn("Node.String(): %v", self.Node().String())
+  log.Warn("self.ID.String.(): %v", self.ID.String())
+  return []byte(self.ID.String())
+	//return []byte(self.Node().String())
 }
 
 // Node returns a discover.Node representing the SimNode

--- a/p2p/simulations/adapters/inproc.go
+++ b/p2p/simulations/adapters/inproc.go
@@ -23,7 +23,6 @@ import (
 	"net"
 	"sync"
 
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p"
@@ -153,10 +152,7 @@ type SimNode struct {
 
 // Addr returns the node's discovery address
 func (self *SimNode) Addr() []byte {
-  log.Warn("Node.String(): %v", self.Node().String())
-  log.Warn("self.ID.String.(): %v", self.ID.String())
-  return []byte(self.ID.String())
-	//return []byte(self.Node().String())
+	return []byte(self.Node().String())
 }
 
 // Node returns a discover.Node representing the SimNode

--- a/p2p/simulations/http_test.go
+++ b/p2p/simulations/http_test.go
@@ -34,12 +34,26 @@ func newTestService(ctx *adapters.ServiceContext) (node.Service, error) {
 }
 
 func (t *testService) Protocols() []p2p.Protocol {
-	return []p2p.Protocol{{
-		Name:    "test",
-		Version: 1,
-		Length:  1,
-		Run:     t.Run,
-	}}
+	return []p2p.Protocol{
+		{
+			Name:    "test",
+			Version: 1,
+			Length:  3,
+			Run:     t.RunTest,
+		},
+		{
+			Name:    "dum",
+			Version: 1,
+			Length:  1,
+			Run:     t.RunDum,
+		},
+		{
+			Name:    "prb",
+			Version: 1,
+			Length:  1,
+			Run:     t.RunPrb,
+		},
+	}
 }
 
 func (t *testService) APIs() []rpc.API {
@@ -61,20 +75,63 @@ func (t *testService) Stop() error {
 	return nil
 }
 
-func (t *testService) Run(_ *p2p.Peer, rw p2p.MsgReadWriter) error {
-	// perform a handshake using an empty struct
+func (t *testService) handshake(rw p2p.MsgReadWriter, code uint64) error {
 	errc := make(chan error, 2)
-	go func() { errc <- p2p.Send(rw, 0, struct{}{}) }()
-	go func() { errc <- p2p.ExpectMsg(rw, 0, struct{}{}) }()
+	go func() { errc <- p2p.Send(rw, code, struct{}{}) }()
+	go func() { errc <- p2p.ExpectMsg(rw, code, struct{}{}) }()
 	for i := 0; i < 2; i++ {
 		if err := <-errc; err != nil {
 			return err
 		}
 	}
+	return nil
+}
+
+func (t *testService) RunTest(_ *p2p.Peer, rw p2p.MsgReadWriter) error {
+	// perform three handshakes with three different message codes,
+	//used to test message sending and filtering
+	if err := t.handshake(rw, 2); err != nil {
+		return err
+	}
+	if err := t.handshake(rw, 1); err != nil {
+		return err
+	}
+	if err := t.handshake(rw, 0); err != nil {
+		return err
+	}
 
 	// track the peer
 	atomic.AddInt64(&t.peerCount, 1)
 	defer atomic.AddInt64(&t.peerCount, -1)
+
+	// block until the peer is dropped
+	for {
+		_, err := rw.ReadMsg()
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func (t *testService) RunDum(_ *p2p.Peer, rw p2p.MsgReadWriter) error {
+	// perform a handshake using an empty struct
+	if err := t.handshake(rw, 0); err != nil {
+		return err
+	}
+
+	// block until the peer is dropped
+	for {
+		_, err := rw.ReadMsg()
+		if err != nil {
+			return err
+		}
+	}
+}
+func (t *testService) RunPrb(_ *p2p.Peer, rw p2p.MsgReadWriter) error {
+	// perform a handshake using an empty struct
+	if err := t.handshake(rw, 0); err != nil {
+		return err
+	}
 
 	// block until the peer is dropped
 	for {
@@ -174,12 +231,47 @@ func TestHTTPNetwork(t *testing.T) {
 	// subscribe to events so we can check them later
 	client := NewClient(s.URL)
 	events := make(chan *Event, 100)
-	sub, err := client.SubscribeNetwork(events, false)
+	opts := SubscribeOpts{
+		Current: false,
+		Filter:  "",
+	}
+	sub, err := client.SubscribeNetwork(events, opts)
 	if err != nil {
 		t.Fatalf("error subscribing to network events: %s", err)
 	}
 	defer sub.Unsubscribe()
 
+	nodeCount := 2
+	nodeIDs := startNetwork(network, client, t, nodeCount)
+
+	// check we got all the events
+	x := &expectEvents{t, events, sub}
+	x.expect(
+		x.nodeEvent(nodeIDs[0], false),
+		x.nodeEvent(nodeIDs[1], false),
+		x.nodeEvent(nodeIDs[0], true),
+		x.nodeEvent(nodeIDs[1], true),
+		x.connEvent(nodeIDs[0], nodeIDs[1], false),
+		x.connEvent(nodeIDs[0], nodeIDs[1], true),
+	)
+
+	// reconnect the stream and check we get the current nodes and conns
+	events = make(chan *Event, 100)
+	opts.Current = true
+	sub, err = client.SubscribeNetwork(events, opts)
+	if err != nil {
+		t.Fatalf("error subscribing to network events: %s", err)
+	}
+	defer sub.Unsubscribe()
+	x = &expectEvents{t, events, sub}
+	x.expect(
+		x.nodeEvent(nodeIDs[0], true),
+		x.nodeEvent(nodeIDs[1], true),
+		x.connEvent(nodeIDs[0], nodeIDs[1], true),
+	)
+}
+
+func startNetwork(network *Network, client *Client, t *testing.T, nodeCount int) []string {
 	// check we can retrieve details about the network
 	gotNetwork, err := client.GetNetwork()
 	if err != nil {
@@ -189,9 +281,9 @@ func TestHTTPNetwork(t *testing.T) {
 		t.Fatalf("expected network to have ID %q, got %q", network.ID, gotNetwork.ID)
 	}
 
-	// create 2 nodes
-	nodeIDs := make([]string, 2)
-	for i := 0; i < 2; i++ {
+	// create nodeCount nodes
+	nodeIDs := make([]string, nodeCount)
+	for i := 0; i < nodeCount; i++ {
 		node, err := client.CreateNode(nil)
 		if err != nil {
 			t.Fatalf("error creating node: %s", err)
@@ -204,8 +296,8 @@ func TestHTTPNetwork(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error getting nodes: %s", err)
 	}
-	if len(nodes) != 2 {
-		t.Fatalf("expected 2 nodes, got %d", len(nodes))
+	if len(nodes) != nodeCount {
+		t.Fatalf("expected %d nodes, got %d", nodeCount, len(nodes))
 	}
 	for i, nodeID := range nodeIDs {
 		if nodes[i].ID != nodeID {
@@ -228,34 +320,17 @@ func TestHTTPNetwork(t *testing.T) {
 	}
 
 	// connect the nodes
-	if err := client.ConnectNode(nodeIDs[0], nodeIDs[1]); err != nil {
-		t.Fatalf("error connecting nodes: %s", err)
+	for i := 0; i < nodeCount-1; i++ {
+		peerId := i + 1
+		if i == nodeCount-1 {
+			peerId = 0
+		}
+		if err := client.ConnectNode(nodeIDs[i], nodeIDs[peerId]); err != nil {
+			t.Fatalf("error connecting nodes: %s", err)
+		}
 	}
 
-	// check we got all the events
-	x := &expectEvents{t, events, sub}
-	x.expect(
-		x.nodeEvent(nodeIDs[0], false),
-		x.nodeEvent(nodeIDs[1], false),
-		x.nodeEvent(nodeIDs[0], true),
-		x.nodeEvent(nodeIDs[1], true),
-		x.connEvent(nodeIDs[0], nodeIDs[1], false),
-		x.connEvent(nodeIDs[0], nodeIDs[1], true),
-	)
-
-	// reconnect the stream and check we get the current nodes and conns
-	events = make(chan *Event, 100)
-	sub, err = client.SubscribeNetwork(events, true)
-	if err != nil {
-		t.Fatalf("error subscribing to network events: %s", err)
-	}
-	defer sub.Unsubscribe()
-	x = &expectEvents{t, events, sub}
-	x.expect(
-		x.nodeEvent(nodeIDs[0], true),
-		x.nodeEvent(nodeIDs[1], true),
-		x.connEvent(nodeIDs[0], nodeIDs[1], true),
-	)
+	return nodeIDs
 }
 
 type expectEvents struct {
@@ -285,6 +360,34 @@ func (t *expectEvents) connEvent(one, other string, up bool) *Event {
 			Other: discover.MustHexID(other),
 			Up:    up,
 		},
+	}
+}
+
+func (t *expectEvents) expectMsg(filters map[MsgFilter]struct{}, msgCount int) {
+	timeout := time.After(10 * time.Second)
+	for i := 0; i < msgCount; i++ {
+		select {
+		case event := <-t.events:
+
+			if event.Type != EventTypeMsg {
+				break
+			}
+
+			t.Logf("received %s event: %s", event.Type, event.Msg)
+
+			if event.Msg == nil {
+				t.Fatal("expected event.Msg to be set")
+			}
+			if _, ok := filters[MsgFilter{event.Msg.Protocol, event.Msg.Code}]; !ok {
+				t.Fatalf("expected event.Msg to match filter, got protocol '%s' with code '%d' while filter is '%v'", event.Msg.Protocol, event.Msg.Code, filters)
+			}
+
+		case err := <-t.sub.Err():
+			t.Fatalf("network stream closed unexpectedly: %s", err)
+
+		case <-timeout:
+			t.Fatal("timed out waiting for expected events")
+		}
 	}
 }
 
@@ -454,7 +557,11 @@ func TestHTTPSnapshot(t *testing.T) {
 
 	// subscribe to events so we can check them later
 	events := make(chan *Event, 100)
-	sub, err := client.SubscribeNetwork(events, false)
+	opts := SubscribeOpts{
+		Current: false,
+		Filter:  "",
+	}
+	sub, err := client.SubscribeNetwork(events, opts)
 	if err != nil {
 		t.Fatalf("error subscribing to network events: %s", err)
 	}
@@ -516,4 +623,130 @@ func TestHTTPSnapshot(t *testing.T) {
 		x.connEvent(nodes[0].ID, nodes[1].ID, false),
 		x.connEvent(nodes[0].ID, nodes[1].ID, true),
 	)
+}
+
+//Following test tests message filtering
+//It sets up a filter with multiple protocols
+//It expects the messages to pass
+func TestMsgFilterPassMultiple(t *testing.T) {
+	// start the server
+	network, s := testHTTPServer(t)
+	defer s.Close()
+
+	client := NewClient(s.URL)
+	events := make(chan *Event, 100)
+	//TODO: add more exhaustive unit tests for the filterstr
+	filterstr := "prb:0;test:0"
+	opts := SubscribeOpts{
+		Current: false,
+		Filter:  filterstr,
+	}
+	sub, err := client.SubscribeNetwork(events, opts)
+	if err != nil {
+		t.Fatalf("error subscribing to network events: %s", err)
+	}
+	defer sub.Unsubscribe()
+	// check we got all the events
+
+	nodeCount := 30
+	startNetwork(network, client, t, nodeCount)
+	x := &expectEvents{t, events, sub}
+
+	filters := make(map[MsgFilter]struct{})
+	filters[MsgFilter{Proto: "prb", Code: 0}] = struct{}{}
+	filters[MsgFilter{Proto: "dum", Code: 1}] = struct{}{}
+	filters[MsgFilter{Proto: "test", Code: 0}] = struct{}{}
+	x.expectMsg(filters, 100)
+}
+
+func TestMsgFilterPassWildcard(t *testing.T) {
+	// start the server
+	network, s := testHTTPServer(t)
+	defer s.Close()
+
+	client := NewClient(s.URL)
+	events := make(chan *Event, 100)
+	filterstr := "prb:0,2-test:*"
+	opts := SubscribeOpts{
+		Current: false,
+		Filter:  filterstr,
+	}
+	sub, err := client.SubscribeNetwork(events, opts)
+	if err != nil {
+		t.Fatalf("error subscribing to network events: %s", err)
+	}
+	defer sub.Unsubscribe()
+	// check we got all the events
+
+	nodeCount := 30
+	startNetwork(network, client, t, nodeCount)
+	x := &expectEvents{t, events, sub}
+
+	filters := make(map[MsgFilter]struct{})
+	filters[MsgFilter{Proto: "prb", Code: 0}] = struct{}{}
+	filters[MsgFilter{Proto: "prb", Code: 2}] = struct{}{}
+	filters[MsgFilter{Proto: "test", Code: 0}] = struct{}{}
+	filters[MsgFilter{Proto: "test", Code: 1}] = struct{}{}
+	filters[MsgFilter{Proto: "test", Code: 2}] = struct{}{}
+	x.expectMsg(filters, 100)
+}
+
+func TestMsgFilterPassSingle(t *testing.T) {
+	// start the server
+	network, s := testHTTPServer(t)
+	defer s.Close()
+
+	client := NewClient(s.URL)
+	events := make(chan *Event, 10)
+	filterstr := "dum:0"
+	opts := SubscribeOpts{
+		Current: false,
+		Filter:  filterstr,
+	}
+	sub, err := client.SubscribeNetwork(events, opts)
+	if err != nil {
+		t.Fatalf("error subscribing to network events: %s", err)
+	}
+	defer sub.Unsubscribe()
+	// check we got all the events
+
+	nodeCount := 10
+	startNetwork(network, client, t, nodeCount)
+	x := &expectEvents{t, events, sub}
+
+	filters := make(map[MsgFilter]struct{})
+	filters[MsgFilter{Proto: "dum", Code: 0}] = struct{}{}
+	x.expectMsg(filters, 10)
+}
+
+func TestMsgFilterFailBadParams(t *testing.T) {
+	// start the server
+	_, s := testHTTPServer(t)
+
+	client := NewClient(s.URL)
+	events := make(chan *Event, 10)
+	filterstr := "foo:"
+	opts := SubscribeOpts{
+		Current: false,
+		Filter:  filterstr,
+	}
+	_, err := client.SubscribeNetwork(events, opts)
+	if err == nil {
+		t.Fatalf("expected event subscription to fail but succeeded!")
+	}
+
+	filterstr = "bzz:aa"
+	opts.Filter = filterstr
+	_, err = client.SubscribeNetwork(events, opts)
+	if err == nil {
+		t.Fatalf("expected event subscription to fail but succeeded!")
+	}
+
+	filterstr = "invalid"
+	opts.Filter = filterstr
+	_, err = client.SubscribeNetwork(events, opts)
+	if err == nil {
+		t.Fatalf("expected event subscription to fail but succeeded!")
+	}
+	s.Close()
 }

--- a/p2p/simulations/network.go
+++ b/p2p/simulations/network.go
@@ -408,7 +408,7 @@ func (self *Network) Stop(id discover.NodeID) error {
 	node.Up = false
 	log.Info(fmt.Sprintf("stop node %v: %v", id, node.Up))
 
-	self.events.Send(NewEvent(node))
+	self.events.Send(ControlEvent(node))
 	return nil
 }
 

--- a/swarm/network/protocol.go
+++ b/swarm/network/protocol.go
@@ -122,16 +122,21 @@ func (b *Bzz) UpdateLocalAddr(byteaddr []byte) *bzzAddr {
 	return b.localAddr
 }
 
+func (b *Bzz) NodeInfo() interface{} {
+	return b.localAddr.Address()
+}
+
 // Bzz implements the node.Service interface, offers Protocols
 // * handshake/hive
 // * discovery
 func (b *Bzz) Protocols() []p2p.Protocol {
 	return []p2p.Protocol{
 		{
-			Name:    BzzHandshakeSpec.Name,
-			Version: BzzHandshakeSpec.Version,
-			Length:  BzzHandshakeSpec.Length(),
-			Run:     b.runHandshake,
+			Name:     BzzHandshakeSpec.Name,
+			Version:  BzzHandshakeSpec.Version,
+			Length:   BzzHandshakeSpec.Length(),
+			Run:      b.runHandshake,
+			NodeInfo: b.NodeInfo,
 		},
 		{
 			Name:     DiscoverySpec.Name,

--- a/swarm/network/simulations/overlay.go
+++ b/swarm/network/simulations/overlay.go
@@ -143,6 +143,7 @@ func randomMocker(net *simulations.Network) {
 
 	for {
 		var lowid, highid int
+    var wg sync.WaitGroup
 		randWait := rand.Intn(5000) + 1000
 		rand1 := rand.Intn(9)
 		rand2 := rand.Intn(9)
@@ -158,16 +159,22 @@ func randomMocker(net *simulations.Network) {
 			} else if rand1 == 9 {
 				rand1 = 0
 			}
+      lowid = rand1
+      highid = rand2
 		}
+    var steps = highid - lowid
+    wg.Add(steps)
 		for i := lowid; i < highid; i++ {
-			log.Debug(fmt.Sprintf("node %v shutting down", ids[i]))
+			log.Info(fmt.Sprintf("node %v shutting down", ids[i]))
 			net.Stop(ids[i])
 			go func(id discover.NodeID) {
 				time.Sleep(time.Duration(randWait) * time.Millisecond)
 				net.Start(id)
+        wg.Done()
 			}(ids[i])
 			time.Sleep(time.Duration(randWait) * time.Millisecond)
 		}
+    wg.Wait()
 	}
 }
 
@@ -200,7 +207,7 @@ func main() {
 
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
-	log.Root().SetHandler(log.LvlFilterHandler(log.LvlDebug, log.StreamHandler(os.Stderr, log.TerminalFormat(false))))
+	log.Root().SetHandler(log.LvlFilterHandler(log.LvlInfo, log.StreamHandler(os.Stderr, log.TerminalFormat(true))))
 
 	s := NewSimulation()
 	services := adapters.Services{

--- a/swarm/network/simulations/overlay.go
+++ b/swarm/network/simulations/overlay.go
@@ -143,7 +143,7 @@ func randomMocker(net *simulations.Network) {
 
 	for {
 		var lowid, highid int
-    var wg sync.WaitGroup
+		var wg sync.WaitGroup
 		randWait := rand.Intn(5000) + 1000
 		rand1 := rand.Intn(9)
 		rand2 := rand.Intn(9)
@@ -159,22 +159,22 @@ func randomMocker(net *simulations.Network) {
 			} else if rand1 == 9 {
 				rand1 = 0
 			}
-      lowid = rand1
-      highid = rand2
+			lowid = rand1
+			highid = rand2
 		}
-    var steps = highid - lowid
-    wg.Add(steps)
+		var steps = highid - lowid
+		wg.Add(steps)
 		for i := lowid; i < highid; i++ {
 			log.Info(fmt.Sprintf("node %v shutting down", ids[i]))
 			net.Stop(ids[i])
 			go func(id discover.NodeID) {
 				time.Sleep(time.Duration(randWait) * time.Millisecond)
 				net.Start(id)
-        wg.Done()
+				wg.Done()
 			}(ids[i])
 			time.Sleep(time.Duration(randWait) * time.Millisecond)
 		}
-    wg.Wait()
+		wg.Wait()
 	}
 }
 


### PR DESCRIPTION
Allows messages to be filtered. If no filters are provided, no messages are being transmitted via event stream.

This PR also introduces transmitting the overlay address of swarm to frontend via the `p2p.Protocols[].NodeInfo` property.