### PR TITLE
Noderunner2

### DIFF
--- a/p2p/simulations/adapters/state.go
+++ b/p2p/simulations/adapters/state.go
@@ -1,0 +1,35 @@
+// Copyright 2017 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+package adapters
+
+type SimStateStore struct {
+	m map[string][]byte
+}
+
+func (self *SimStateStore) Load(s string) ([]byte, error) {
+	return self.m[s], nil
+}
+
+func (self *SimStateStore) Save(s string, data []byte) error {
+	self.m[s] = data
+	return nil
+}
+
+func NewSimStateStore() *SimStateStore {
+	return &SimStateStore{
+		make(map[string][]byte),
+	}
+}

--- a/p2p/simulations/http.go
+++ b/p2p/simulations/http.go
@@ -278,6 +278,7 @@ func NewServer(network *Network) *Server {
 	s.GET("/", s.GetNetwork)
 	s.POST("/start", s.StartNetwork)
 	s.POST("/stop", s.StopNetwork)
+	s.POST("/reset", s.ResetNetwork)
 	s.GET("/events", s.StreamNetworkEvents)
 	s.GET("/snapshot", s.CreateSnapshot)
 	s.POST("/snapshot", s.LoadSnapshot)
@@ -314,6 +315,13 @@ func (s *Server) StopNetwork(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// StopNetwork stops all nodes in the network
+func (s *Server) ResetNetwork(w http.ResponseWriter, req *http.Request) {
+	s.network.Reset()
 
 	w.WriteHeader(http.StatusOK)
 }

--- a/p2p/simulations/network.go
+++ b/p2p/simulations/network.go
@@ -502,6 +502,19 @@ func (self *Network) Shutdown() {
 	close(self.quitc)
 }
 
+//Reset resets all network properties:
+//emtpies the nodes and the connection list
+func (self *Network) Reset() {
+	for k := range self.nodeMap {
+		delete(self.nodeMap, k)
+	}
+	for c := range self.connMap {
+		delete(self.connMap, c)
+	}
+	self.Nodes = nil
+	self.Conns = nil
+}
+
 // Node is a wrapper around adapters.Node which is used to track the status
 // of a node in the network
 type Node struct {

--- a/p2p/simulations/noderunner.go
+++ b/p2p/simulations/noderunner.go
@@ -1,0 +1,250 @@
+// Copyright 2017 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package simulations simulates p2p networks.
+// A NodeRunner simulates starting and stopping real nodes in a network.
+package simulations
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/p2p/discover"
+	"github.com/julienschmidt/httprouter"
+)
+
+//A NodeRunner only has a Run function
+type NodeRunner interface {
+	Run()
+}
+
+//used to stop the NodeRunner loop
+var quit chan struct{}
+
+//nodeRunner holds properties needed
+//the idea is that we create specific noderunner instances
+//with their own run loop, with each one implementing Run()
+type nodeRunner struct {
+	router    *httprouter.Router
+	nodes     []discover.NodeID
+	network   *Network
+	nodeCount int
+}
+
+//startStopRunner: just starts and stops nodes periodically
+type startStopRunner struct {
+	nodeRunner
+}
+
+//probabilisticRunner: starts and stops nodes in a more probabilistic pattern
+type probabilisticRunner struct {
+	nodeRunner
+}
+
+//bootRunner: only boots up all nodes
+type bootRunner struct {
+	nodeRunner
+}
+
+//create a new runner
+func NewNodeRunner(network *Network, runnerId string, nodeCount int) {
+	var runner NodeRunner
+	//init properties
+	nr := nodeRunner{
+		nodeCount: nodeCount,
+		network:   network,
+	}
+	//create stop channel
+	quit = make(chan struct{}, 1)
+	//instantiate specific runner
+	switch runnerId {
+	case "startStop":
+		runner = &startStopRunner{nr}
+	case "probabilistic":
+		runner = &probabilisticRunner{nr}
+	case "boot":
+		runner = &bootRunner{nr}
+	default:
+		runner = nil
+	}
+	if runner == nil {
+		panic("No runner assigned")
+	}
+	//setup HHTP Routes
+	nr.setupRoutes(runner)
+	//start HTTP endpoint
+	http.ListenAndServe(":8889", nil)
+}
+
+//setup HTTP endpoints for a runner
+//available routes are:
+//* `runSim`: run a node simulation
+//* `stopSim`: stop the node simulation
+func (r *nodeRunner) setupRoutes(runner NodeRunner) {
+	//runSim
+	http.HandleFunc("/runSim", func(w http.ResponseWriter, req *http.Request) {
+		log.Info("Starting node simulation...")
+		go runner.Run()
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+		w.WriteHeader(http.StatusOK)
+	})
+	//stopSim
+	http.HandleFunc("/stopSim", func(w http.ResponseWriter, req *http.Request) {
+		log.Info("Stopping node simulation...")
+		r.stopSim()
+		r.network.StopAll()
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+//stopping the node simulation is just sending an empty signal to the channel
+func (r nodeRunner) stopSim() {
+	quit <- struct{}{}
+}
+
+//the bootRunner only starts up all nodes and doesn't do anything else
+func (r *bootRunner) Run() {
+	r.nodeRunner.connectNodesInRing()
+}
+
+//the startStopRunner first boots all nodes in a ring,
+//then starts and stops a (randomly selected) node in a periodic interval
+func (r *startStopRunner) Run() {
+	nodes := r.nodeRunner.connectNodesInRing()
+	net := r.nodeRunner.network
+	for range time.Tick(10 * time.Second) {
+		select {
+		case <-quit:
+			log.Info("Terminating simulation loop")
+			return
+		default:
+		}
+		id := nodes[rand.Intn(len(nodes))]
+		go func() {
+			log.Info("stopping node", "id", id)
+			if err := net.Stop(id); err != nil {
+				log.Error("error stopping node", "id", id, "err", err)
+				return
+			}
+
+			time.Sleep(3 * time.Second)
+
+			log.Debug("starting node", "id", id)
+			if err := net.Start(id); err != nil {
+				log.Error("error starting node", "id", id, "err", err)
+				return
+			}
+		}()
+	}
+}
+
+//the probabilisticRunner has a more probabilistic pattern (can be improved of course):
+//nodes are connected in a ring, then selects a varying number of random nodes
+//stops and starts them in random intervals, and continues the loop
+func (r *probabilisticRunner) Run() {
+	nodes := r.nodeRunner.connectNodesInRing()
+	net := r.nodeRunner.network
+	for {
+		select {
+		case <-quit:
+			log.Info("Terminating simulation loop")
+			return
+		default:
+		}
+		var lowid, highid int
+		var wg sync.WaitGroup
+		randWait := rand.Intn(5000) + 1000
+		rand1 := rand.Intn(9)
+		rand2 := rand.Intn(9)
+		if rand1 < rand2 {
+			lowid = rand1
+			highid = rand2
+		} else if rand1 > rand2 {
+			highid = rand1
+			lowid = rand2
+		} else {
+			if rand1 == 0 {
+				rand2 = 9
+			} else if rand1 == 9 {
+				rand1 = 0
+			}
+			lowid = rand1
+			highid = rand2
+		}
+		var steps = highid - lowid
+		wg.Add(steps)
+		for i := lowid; i < highid; i++ {
+			select {
+			case <-quit:
+				log.Info("Terminating simulation loop")
+				return
+			default:
+			}
+			log.Debug(fmt.Sprintf("node %v shutting down", nodes[i]))
+			net.Stop(nodes[i])
+			go func(id discover.NodeID) {
+				time.Sleep(time.Duration(randWait) * time.Millisecond)
+				net.Start(id)
+				wg.Done()
+			}(nodes[i])
+			time.Sleep(time.Duration(randWait) * time.Millisecond)
+		}
+		wg.Wait()
+	}
+
+}
+
+//connect nodeCount number of  nodes in a ring
+func (r *nodeRunner) connectNodesInRing() []discover.NodeID {
+	ids := make([]discover.NodeID, r.nodeCount)
+	net := r.network
+	for i := 0; i < r.nodeCount; i++ {
+		node, err := net.NewNode()
+		if err != nil {
+			panic(err.Error())
+		}
+		ids[i] = node.ID()
+	}
+
+	for _, id := range ids {
+		if err := net.Start(id); err != nil {
+			panic(err.Error())
+		}
+		log.Debug(fmt.Sprintf("node %v starting up", id))
+	}
+	for i, id := range ids {
+		var peerID discover.NodeID
+		//first node connects with last one
+		if i == 0 {
+			peerID = ids[len(ids)-1]
+		} else {
+			//every other one connects with previous
+			peerID = ids[i-1]
+		}
+		if err := net.Connect(id, peerID); err != nil {
+			panic(err.Error())
+		}
+	}
+
+	return ids
+}

--- a/swarm/network/simulations/overlay.go
+++ b/swarm/network/simulations/overlay.go
@@ -7,8 +7,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
-	"math/rand"
 	"net/http"
 	"os"
 	"runtime"
@@ -61,7 +59,7 @@ func (s *Simulation) NewService(ctx *adapters.ServiceContext) (node.Service, err
 	kad.Prune(ticker.C)
 	hp := network.NewHiveParams()
 	hp.Discovery = !*noDiscovery
-	hp.KeepAliveInterval = 300 * time.Millisecond
+	hp.KeepAliveInterval = 3 * time.Second
 
 	config := &network.BzzConfig{
 		OverlayAddr:  addr.Over(),
@@ -72,162 +70,27 @@ func (s *Simulation) NewService(ctx *adapters.ServiceContext) (node.Service, err
 	return network.NewBzz(config, kad, store), nil
 }
 
-func createMockers() map[string]*simulations.MockerConfig {
-	configs := make(map[string]*simulations.MockerConfig)
-
-	defaultCfg := simulations.DefaultMockerConfig()
-	defaultCfg.ID = "start-stop"
-	defaultCfg.Description = "Starts and Stops nodes in go routines"
-	defaultCfg.Mocker = startStopMocker
-
-	bootNetworkCfg := simulations.DefaultMockerConfig()
-	bootNetworkCfg.ID = "bootNet"
-	bootNetworkCfg.Description = "Only boots up all nodes in the config"
-	bootNetworkCfg.Mocker = bootMocker
-
-	randomNodesCfg := simulations.DefaultMockerConfig()
-	randomNodesCfg.ID = "randomNodes"
-	randomNodesCfg.Description = "Boots nodes and then starts and stops some picking randomly"
-	randomNodesCfg.Mocker = randomMocker
-
-	configs[defaultCfg.ID] = defaultCfg
-	configs[bootNetworkCfg.ID] = bootNetworkCfg
-	configs[randomNodesCfg.ID] = randomNodesCfg
-
-	return configs
-}
-
-func setupMocker(net *simulations.Network) []discover.NodeID {
-	nodeCount := 30
-	ids := make([]discover.NodeID, nodeCount)
-	for i := 0; i < nodeCount; i++ {
-		node, err := net.NewNode()
-		if err != nil {
-			panic(err.Error())
-		}
-		ids[i] = node.ID()
-	}
-
-	for _, id := range ids {
-		if err := net.Start(id); err != nil {
-			panic(err.Error())
-		}
-	}
-	for i, id := range ids {
-		log.Trace(fmt.Sprintf("setup mocker: register a peer on node %x", id[:4]))
-		var peerID discover.NodeID
-		if i == 0 {
-			peerID = ids[len(ids)-1]
-		} else {
-			peerID = ids[i-1]
-		}
-		ch := make(chan network.OverlayAddr)
-		go func() {
-			defer close(ch)
-			ch <- network.NewAddrFromNodeID(peerID)
-		}()
-		log.Trace(fmt.Sprintf("%x registers peer %x", id[:4], peerID[:4]))
-		if err := net.GetNode(id).Node.(*adapters.SimNode).Services()[0].(*network.Bzz).Hive.Register(ch); err != nil {
-			panic(err.Error())
-		}
-	}
-
-	return ids
-}
-
-func bootMocker(net *simulations.Network) {
-	setupMocker(net)
-}
-
-func randomMocker(net *simulations.Network) {
-	ids := setupMocker(net)
-
-	for {
-		var lowid, highid int
-		var wg sync.WaitGroup
-		randWait := rand.Intn(5000) + 1000
-		rand1 := rand.Intn(9)
-		rand2 := rand.Intn(9)
-		if rand1 < rand2 {
-			lowid = rand1
-			highid = rand2
-		} else if rand1 > rand2 {
-			highid = rand1
-			lowid = rand2
-		} else {
-			if rand1 == 0 {
-				rand2 = 9
-			} else if rand1 == 9 {
-				rand1 = 0
-			}
-			lowid = rand1
-			highid = rand2
-		}
-		var steps = highid - lowid
-		wg.Add(steps)
-		for i := lowid; i < highid; i++ {
-			log.Info(fmt.Sprintf("node %v shutting down", ids[i]))
-			net.Stop(ids[i])
-			go func(id discover.NodeID) {
-				time.Sleep(time.Duration(randWait) * time.Millisecond)
-				net.Start(id)
-				wg.Done()
-			}(ids[i])
-			time.Sleep(time.Duration(randWait) * time.Millisecond)
-		}
-		wg.Wait()
-	}
-}
-
-func startStopMocker(net *simulations.Network) {
-	ids := setupMocker(net)
-
-	for range time.Tick(10 * time.Second) {
-		id := ids[rand.Intn(len(ids))]
-		go func() {
-			log.Error("stopping node", "id", id)
-			if err := net.Stop(id); err != nil {
-				log.Error("error stopping node", "id", id, "err", err)
-				return
-			}
-
-			time.Sleep(3 * time.Second)
-
-			log.Error("starting node", "id", id)
-			if err := net.Start(id); err != nil {
-				log.Error("error starting node", "id", id, "err", err)
-				return
-			}
-		}()
-	}
-}
-
 // var server
 func main() {
 	flag.Parse()
 
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
-	log.Root().SetHandler(log.LvlFilterHandler(log.LvlTrace, log.StreamHandler(os.Stderr, log.TerminalFormat(false))))
+	log.Root().SetHandler(log.LvlFilterHandler(log.LvlInfo, log.StreamHandler(os.Stderr, log.TerminalFormat(true))))
 
 	s := NewSimulation()
 	services := adapters.Services{
 		"overlay": s.NewService,
 	}
 	adapter := adapters.NewSimAdapter(services)
-
 	network := simulations.NewNetwork(adapter, &simulations.NetworkConfig{
 		DefaultService: "overlay",
 	})
 
-	mockers := createMockers()
-
-	config := simulations.ServerConfig{
-		DefaultMockerID: "randomNodes",
-		// DefaultMockerID: "bootNet",
-		Mockers: mockers,
-	}
+	nodeCount := 30
+	log.Info("starting simulation node runner on 0.0.0.0:8889...")
+	go simulations.NewNodeRunner(network, "probabilistic", nodeCount)
 
 	log.Info("starting simulation server on 0.0.0.0:8888...")
-	http.ListenAndServe(":8888", simulations.NewServer(network, config))
+	http.ListenAndServe(":8888", simulations.NewServer(network))
 }


### PR DESCRIPTION
This PR 
1. Re-introduces the state.go into `network-testing-framework-kademlia`. This file missing caused the overlay simulation to break
2. Replaces the mocker with a `NodeRunner` (see `p2p/simulations/noderunner.go`, which allows simulations to run a node simulator which can be started and stopped (e.g. from frontend).