### PR TITLE
swarm/pss: Introduce pss topic

### DIFF
--- a/swarm/pss/api.go
+++ b/swarm/pss/api.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/rpc"
-	whisper "github.com/ethereum/go-ethereum/whisper/whisperv5"
 )
 
 // Wrapper for receiving pss messages when using the pss API
@@ -33,7 +32,7 @@ func NewAPI(ps *Pss) *API {
 //
 // All incoming messages to the node matching this topic will be encapsulated in the APIMsg
 // struct and sent to the subscriber
-func (pssapi *API) Receive(ctx context.Context, topic whisper.TopicType) (*rpc.Subscription, error) {
+func (pssapi *API) Receive(ctx context.Context, topic Topic) (*rpc.Subscription, error) {
 	notifier, supported := rpc.NotifierFromContext(ctx)
 	if !supported {
 		return nil, fmt.Errorf("Subscribe not supported")
@@ -74,7 +73,7 @@ func (pssapi *API) GetPublicKey() (keybytes []byte) {
 }
 
 // Set Public key to associate with a particular Pss peer
-func (pssapi *API) SetPeerPublicKey(pubkey []byte, topic whisper.TopicType, addr PssAddress) error {
+func (pssapi *API) SetPeerPublicKey(pubkey []byte, topic Topic, addr PssAddress) error {
 	err := pssapi.Pss.SetPeerPublicKey(crypto.ToECDSAPub(pubkey), topic, &addr)
 	if err != nil {
 		return fmt.Errorf("Invalid key: %x", pubkey)
@@ -82,14 +81,14 @@ func (pssapi *API) SetPeerPublicKey(pubkey []byte, topic whisper.TopicType, addr
 	return nil
 }
 
-func (pssapi *API) GetSymmetricAddressHint(topic whisper.TopicType, asymmetric bool, key string) (PssAddress, error) {
+func (pssapi *API) GetSymmetricAddressHint(topic Topic, asymmetric bool, key string) (PssAddress, error) {
 	return *pssapi.Pss.symKeyPool[key][topic].address, nil
 }
 
-func (pssapi *API) GetAsymmetricAddressHint(topic whisper.TopicType, asymmetric bool, key string) (PssAddress, error) {
+func (pssapi *API) GetAsymmetricAddressHint(topic Topic, asymmetric bool, key string) (PssAddress, error) {
 	return *pssapi.Pss.pubKeyPool[key][topic].address, nil
 }
 
-func (pssapi *API) StringToTopic(topicstring string) (whisper.TopicType, error) {
+func (pssapi *API) StringToTopic(topicstring string) (Topic, error) {
 	return BytesToTopic([]byte(topicstring)), nil
 }

--- a/swarm/pss/client/client_test.go
+++ b/swarm/pss/client/client_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
@@ -79,7 +78,6 @@ func init() {
 func TestHandshake(t *testing.T) {
 	sendLimit = 3
 	topic := pss.ProtocolTopic(pss.PingProtocol)
-	hextopic := common.ToHex(topic[:])
 
 	clients, err := setupNetwork(2)
 	if err != nil {
@@ -138,21 +136,21 @@ func TestHandshake(t *testing.T) {
 		t.Fatalf("rpc get node 2 pubkey fail: %v", err)
 	}
 
-	err = clients[0].Call(nil, "pss_setPeerPublicKey", rpubkey, hextopic, roaddr)
+	err = clients[0].Call(nil, "pss_setPeerPublicKey", rpubkey, topic, roaddr)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = clients[1].Call(nil, "pss_setPeerPublicKey", lpubkey, hextopic, loaddr)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = clients[0].Call(nil, "pss_addHandshake", hextopic)
+	err = clients[1].Call(nil, "pss_setPeerPublicKey", lpubkey, topic, loaddr)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = clients[1].Call(nil, "pss_addHandshake", hextopic)
+	err = clients[0].Call(nil, "pss_addHandshake", topic)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = clients[1].Call(nil, "pss_addHandshake", topic)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swarm/pss/handshake_test.go
+++ b/swarm/pss/handshake_test.go
@@ -31,7 +31,6 @@ func testHandshake(t *testing.T) {
 	// set up two nodes directly connected
 	// (we are not testing pss routing here)
 	topic := BytesToTopic([]byte("foo:42"))
-	hextopic := common.ToHex(topic[:])
 
 	clients, err := setupNetwork(2)
 	if err != nil {
@@ -68,11 +67,11 @@ func testHandshake(t *testing.T) {
 	time.Sleep(time.Millisecond * 1000) // replace with hive healthy code
 
 	// give each node its peer's public key
-	err = clients[0].Call(nil, "pss_setPeerPublicKey", rpubkey, hextopic, roaddr)
+	err = clients[0].Call(nil, "pss_setPeerPublicKey", rpubkey, topic, roaddr)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = clients[1].Call(nil, "pss_setPeerPublicKey", lpubkey, hextopic, loaddr)
+	err = clients[1].Call(nil, "pss_setPeerPublicKey", lpubkey, topic, loaddr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,17 +82,17 @@ func testHandshake(t *testing.T) {
 	// L <- send 4 keys, request 4 keys <- R
 	// L -> send 4 keys -> R
 	// the call will fill the array with symkeys L needs for sending to R
-	err = clients[0].Call(nil, "pss_addHandshake", hextopic)
+	err = clients[0].Call(nil, "pss_addHandshake", topic)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = clients[1].Call(nil, "pss_addHandshake", hextopic)
+	err = clients[1].Call(nil, "pss_addHandshake", topic)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	var lhsendsymkeyids []string
-	err = clients[0].Call(&lhsendsymkeyids, "pss_handshake", common.ToHex(rpubkey), hextopic, true, true)
+	err = clients[0].Call(&lhsendsymkeyids, "pss_handshake", common.ToHex(rpubkey), topic, true, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +102,7 @@ func testHandshake(t *testing.T) {
 
 	// check if we have 6 outgoing keys stored, and they match what was received from R
 	var lsendsymkeyids []string
-	err = clients[0].Call(&lsendsymkeyids, "pss_getHandshakeKeys", common.ToHex(rpubkey), hextopic, false, true)
+	err = clients[0].Call(&lsendsymkeyids, "pss_getHandshakeKeys", common.ToHex(rpubkey), topic, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,17 +120,17 @@ func testHandshake(t *testing.T) {
 
 	// check if in- and outgoing keys on l-node and r-node match up and are in opposite categories (l recv = r send, l send = r recv)
 	var rsendsymkeyids []string
-	err = clients[1].Call(&rsendsymkeyids, "pss_getHandshakeKeys", common.ToHex(lpubkey), hextopic, false, true)
+	err = clients[1].Call(&rsendsymkeyids, "pss_getHandshakeKeys", common.ToHex(lpubkey), topic, false, true)
 	if err != nil {
 		t.Fatal(err)
 	}
 	var lrecvsymkeyids []string
-	err = clients[0].Call(&lrecvsymkeyids, "pss_getHandshakeKeys", common.ToHex(rpubkey), hextopic, true, false)
+	err = clients[0].Call(&lrecvsymkeyids, "pss_getHandshakeKeys", common.ToHex(rpubkey), topic, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	var rrecvsymkeyids []string
-	err = clients[1].Call(&rrecvsymkeyids, "pss_getHandshakeKeys", common.ToHex(lpubkey), hextopic, true, false)
+	err = clients[1].Call(&rrecvsymkeyids, "pss_getHandshakeKeys", common.ToHex(lpubkey), topic, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -195,13 +194,13 @@ func testHandshake(t *testing.T) {
 	}
 
 	// send new handshake request, should send no keys
-	err = clients[0].Call(nil, "pss_handshake", common.ToHex(rpubkey), hextopic, false)
+	err = clients[0].Call(nil, "pss_handshake", common.ToHex(rpubkey), topic, false)
 	if err == nil {
 		t.Fatal("expected full symkey buffer error")
 	}
 
 	// expire one key, send new handshake request
-	err = clients[0].Call(nil, "pss_releaseHandshakeKey", common.ToHex(rpubkey), hextopic, lsendsymkeyids[0], true)
+	err = clients[0].Call(nil, "pss_releaseHandshakeKey", common.ToHex(rpubkey), topic, lsendsymkeyids[0], true)
 	if err != nil {
 		t.Fatalf("release left send key %s fail: %v", lsendsymkeyids[0], err)
 	}
@@ -210,7 +209,7 @@ func testHandshake(t *testing.T) {
 
 	// send new handshake request, should now receive one key
 	// check that it is not in previous right recv key array
-	err = clients[0].Call(&newlhsendkeyids, "pss_handshake", common.ToHex(rpubkey), hextopic, true, false)
+	err = clients[0].Call(&newlhsendkeyids, "pss_handshake", common.ToHex(rpubkey), topic, true, false)
 	if err != nil {
 		t.Fatalf("handshake send fail: %v", err)
 	} else if len(newlhsendkeyids) != defaultSymKeyCapacity {

--- a/swarm/pss/protocol_test.go
+++ b/swarm/pss/protocol_test.go
@@ -36,7 +36,6 @@ func testProtocol(t *testing.T) {
 	addrsize, _ = strconv.ParseInt(paramstring[1], 10, 0)
 	log.Info("protocol test", "addrsize", addrsize)
 
-	hextopic := common.ToHex(PingTopic[:])
 	clients, err := setupNetwork(2)
 	if err != nil {
 		t.Fatal(err)
@@ -75,21 +74,21 @@ func testProtocol(t *testing.T) {
 
 	lmsgC := make(chan APIMsg)
 	lctx, _ := context.WithTimeout(context.Background(), time.Second*10)
-	lsub, err := clients[0].Subscribe(lctx, "pss", lmsgC, "receive", hextopic)
+	lsub, err := clients[0].Subscribe(lctx, "pss", lmsgC, "receive", PingTopic)
 	log.Trace("lsub", "id", lsub)
 	defer lsub.Unsubscribe()
 	rmsgC := make(chan APIMsg)
 	rctx, _ := context.WithTimeout(context.Background(), time.Second*10)
-	rsub, err := clients[1].Subscribe(rctx, "pss", rmsgC, "receive", hextopic)
+	rsub, err := clients[1].Subscribe(rctx, "pss", rmsgC, "receive", PingTopic)
 	log.Trace("rsub", "id", rsub)
 	defer rsub.Unsubscribe()
 
 	// set reciprocal public keys
-	err = clients[0].Call(nil, "pss_setPeerPublicKey", rpubkey, hextopic, roaddr)
+	err = clients[0].Call(nil, "pss_setPeerPublicKey", rpubkey, PingTopic, roaddr)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = clients[1].Call(nil, "pss_setPeerPublicKey", lpubkey, hextopic, loaddr)
+	err = clients[1].Call(nil, "pss_setPeerPublicKey", lpubkey, PingTopic, loaddr)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Uses pss topics instead of whisper topics, and replaces the whisper topic unmarshaler that required hex input. Thus whisper is fully concealed by pss.

Also removed error return if no handlers for a topic is found, causing relaying nodes to disconnect from the devp2p peer, and not pass on the message themselves. Topic error is not relevant to the devp2p, and should not happen. (thanks to @howleysv for raising the issue)