### PR TITLE
swarm/storage: DPA, dbstore retrieve bugs

### DIFF
--- a/swarm/storage/dbstore.go
+++ b/swarm/storage/dbstore.go
@@ -95,10 +95,19 @@ func NewDbStore(path string, hash SwarmHasher, capacity uint64, radius int) (s *
 
 	data, _ := s.db.Get(keyEntryCnt)
 	s.entryCnt = BytesToU64(data)
+	if len(data) > 0 {
+		s.entryCnt++
+	}
 	data, _ = s.db.Get(keyAccessCnt)
 	s.accessCnt = BytesToU64(data)
+	if len(data) > 0 {
+		s.accessCnt++
+	}
 	data, _ = s.db.Get(keyDataIdx)
 	s.dataIdx = BytesToU64(data)
+	if len(data) > 0 {
+		s.dataIdx++
+	}
 	s.gcPos, _ = s.db.Get(keyGCPos)
 	if s.gcPos == nil {
 		s.gcPos = s.gcStartPos

--- a/swarm/storage/dpa.go
+++ b/swarm/storage/dpa.go
@@ -63,9 +63,12 @@ type DPA struct {
 }
 
 // for testing locally
-func NewLocalDPA(datadir string) (*DPA, error) {
+func NewLocalDPA(datadir string, hashalgorithm string) (*DPA, error) {
 
-	hash := MakeHashFunc("SHA256")
+	if hashalgorithm == "" {
+		hashalgorithm = "SHA3"
+	}
+	hash := MakeHashFunc(hashalgorithm)
 
 	dbStore, err := NewDbStore(datadir, hash, singletonSwarmDbCapacity, 0)
 	if err != nil {
@@ -116,6 +119,7 @@ func (self *DPA) Start() {
 
 func (self *DPA) Stop() {
 	self.lock.Lock()
+	self.Close()
 	defer self.lock.Unlock()
 	if !self.running {
 		return

--- a/swarm/storage/localstore.go
+++ b/swarm/storage/localstore.go
@@ -74,4 +74,6 @@ func (self *LocalStore) Get(key Key) (chunk *Chunk, err error) {
 }
 
 // Close local store
-func (self *LocalStore) Close() {}
+func (self *LocalStore) Close() {
+	self.DbStore.Close()
+}


### PR DESCRIPTION
Fixes three bugs:

- LocalDPA and localstore did not close underlying db on shutdown
- DbStore overwrites last entry stored after restart
- LocalDPA uses different hash algorithm than chunker