### PR TITLE
swarm/pss: client fix

### DIFF
--- a/swarm/pss/api.go
+++ b/swarm/pss/api.go
@@ -3,6 +3,7 @@ package pss
 import (
 	"context"
 	"fmt"
+
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p"
@@ -63,6 +64,25 @@ func (pssapi *API) Receive(ctx context.Context, topic Topic) (*rpc.Subscription,
 	}()
 
 	return psssub, nil
+}
+
+func (pssapi *API) GetAddress(topic Topic, asymmetric bool, key string) (PssAddress, error) {
+	var addr *PssAddress
+	if asymmetric {
+		peer, ok := pssapi.Pss.pubKeyPool[key][topic]
+		if !ok {
+			return nil, fmt.Errorf("pubkey/topic pair %x/%x doesn't exist", key, topic)
+		}
+		addr = peer.address
+	} else {
+		peer, ok := pssapi.Pss.symKeyPool[key][topic]
+		if !ok {
+			return nil, fmt.Errorf("symkey/topic pair %x/%x doesn't exist", key, topic)
+		}
+		addr = peer.address
+
+	}
+	return *addr, nil
 }
 
 // Retrieves the node's public key in byte form

--- a/swarm/pss/client/client.go
+++ b/swarm/pss/client/client.go
@@ -289,7 +289,6 @@ func (self *Client) Close() error {
 // The key must exist in the key store of the pss node
 // before the peer is added. The method will return an error
 // if it is not.
-//func (self *Client) AddPssPeer(key *ecdsa.PublicKey, addr []byte, spec *protocols.Spec) error {
 func (self *Client) AddPssPeer(pubkeyid string, addr []byte, spec *protocols.Spec) error {
 	topic := pss.ProtocolTopic(spec)
 	if self.peerPool[topic] == nil {
@@ -300,7 +299,7 @@ func (self *Client) AddPssPeer(pubkeyid string, addr []byte, spec *protocols.Spe
 		if err != nil {
 			return err
 		}
-		symkeyid, err := rw.handshake(handshakeRetryCount, true, true)
+		_, err := rw.handshake(handshakeRetryCount, true, true)
 		if err != nil {
 			return err
 		}
@@ -308,7 +307,6 @@ func (self *Client) AddPssPeer(pubkeyid string, addr []byte, spec *protocols.Spe
 		nid, _ := discover.HexID("0x00")
 		p := p2p.NewPeer(nid, fmt.Sprintf("%v", addr), []p2p.Cap{})
 		go self.protos[topic].Run(p, self.peerPool[topic][pubkeyid])
-		_ = symkeyid
 	}
 	return nil
 }

--- a/swarm/pss/client/client_test.go
+++ b/swarm/pss/client/client_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p"
@@ -95,15 +95,15 @@ func TestHandshake(t *testing.T) {
 	lpssping := &pss.Ping{
 		OutC: make(chan bool),
 		InC:  make(chan bool),
-		Pong: true,
+		Pong: false,
 	}
 	rpssping := &pss.Ping{
 		OutC: make(chan bool),
 		InC:  make(chan bool),
-		Pong: true,
+		Pong: false,
 	}
-	lproto := pss.NewPingProtocol(lpssping.OutC, lpssping.PingHandler)
-	rproto := pss.NewPingProtocol(rpssping.OutC, rpssping.PingHandler)
+	lproto := pss.NewPingProtocol(lpssping)
+	rproto := pss.NewPingProtocol(rpssping)
 
 	ctx, _ := context.WithTimeout(context.Background(), time.Second*10)
 	err = lpsc.RunProtocol(ctx, lproto)
@@ -145,19 +145,9 @@ func TestHandshake(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = clients[0].Call(nil, "pss_addHandshake", topic)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = clients[1].Call(nil, "pss_addHandshake", topic)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	time.Sleep(time.Second)
 
-	err = lpsc.AddPssPeer(crypto.ToECDSAPub(rpubkey), roaddr, pss.PingProtocol)
+	err = lpsc.AddPssPeer(common.ToHex(rpubkey), roaddr, pss.PingProtocol)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swarm/pss/handshake.go
+++ b/swarm/pss/handshake.go
@@ -1,4 +1,4 @@
-// +build !nohandshake
+// +build !nopsshandshake
 
 package pss
 
@@ -6,14 +6,19 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
+	"time"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
-	"sync"
-	"time"
+)
+
+const (
+	IsActiveHandshake = true
 )
 
 var (

--- a/swarm/pss/handshake_none.go
+++ b/swarm/pss/handshake_none.go
@@ -1,0 +1,11 @@
+// +build nopsshandshake
+
+package pss
+
+const (
+	IsActiveHandshake = false
+)
+
+func NewHandshakeParams() interface{} {
+	return nil
+}

--- a/swarm/pss/ping.go
+++ b/swarm/pss/ping.go
@@ -52,7 +52,6 @@ var PingProtocol = &protocols.Spec{
 
 var PingTopic = ProtocolTopic(PingProtocol)
 
-//func NewPingProtocol(pingC chan bool, handler func(interface{}) error) *p2p.Protocol {
 func NewPingProtocol(ping *Ping) *p2p.Protocol {
 	return &p2p.Protocol{
 		Name:    PingProtocol.Name,

--- a/swarm/pss/ping.go
+++ b/swarm/pss/ping.go
@@ -1,4 +1,4 @@
-// +build !noprotocol
+// +build !nopssprotocol,!nopssping
 
 package pss
 
@@ -25,7 +25,7 @@ type Ping struct {
 	InC  chan bool // optional, report back to calling code
 }
 
-func (self *Ping) PingHandler(msg interface{}) error {
+func (self *Ping) pingHandler(msg interface{}) error {
 	var pingmsg *PingMsg
 	var ok bool
 	if pingmsg, ok = msg.(*PingMsg); !ok {
@@ -52,7 +52,8 @@ var PingProtocol = &protocols.Spec{
 
 var PingTopic = ProtocolTopic(PingProtocol)
 
-func NewPingProtocol(pingC chan bool, handler func(interface{}) error) *p2p.Protocol {
+//func NewPingProtocol(pingC chan bool, handler func(interface{}) error) *p2p.Protocol {
+func NewPingProtocol(ping *Ping) *p2p.Protocol {
 	return &p2p.Protocol{
 		Name:    PingProtocol.Name,
 		Version: PingProtocol.Version,
@@ -60,11 +61,11 @@ func NewPingProtocol(pingC chan bool, handler func(interface{}) error) *p2p.Prot
 		Run: func(p *p2p.Peer, rw p2p.MsgReadWriter) error {
 			quitC := make(chan struct{})
 			pp := protocols.NewPeer(p, rw, PingProtocol)
-			log.Trace(fmt.Sprintf("running pss vprotocol on peer %v", p, "outc", pingC))
+			log.Trace(fmt.Sprintf("running pss vprotocol on peer %v", p, "outc", ping.OutC))
 			go func() {
 				for {
 					select {
-					case ispong := <-pingC:
+					case ispong := <-ping.OutC:
 						pp.Send(&PingMsg{
 							Created: time.Now(),
 							Pong:    ispong,
@@ -73,7 +74,7 @@ func NewPingProtocol(pingC chan bool, handler func(interface{}) error) *p2p.Prot
 					}
 				}
 			}()
-			err := pp.Run(handler)
+			err := pp.Run(ping.pingHandler)
 			quitC <- struct{}{}
 			return err
 		},

--- a/swarm/pss/protocol.go
+++ b/swarm/pss/protocol.go
@@ -1,4 +1,4 @@
-// +build !noprotocol
+// +build !nopssprotocol
 
 package pss
 
@@ -10,6 +10,10 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/protocols"
 	"github.com/ethereum/go-ethereum/rlp"
 	"time"
+)
+
+const (
+	IsActiveProtocol = true
 )
 
 // Convenience wrapper for devp2p protocol messages for transport over pss

--- a/swarm/pss/protocol_none.go
+++ b/swarm/pss/protocol_none.go
@@ -1,0 +1,7 @@
+// +build nopssprotocol
+
+package pss
+
+const (
+	IsActiveProtocol = false
+)

--- a/swarm/pss/pss_test.go
+++ b/swarm/pss/pss_test.go
@@ -866,9 +866,8 @@ func benchmarkSymkeyBruteforceChangeaddr(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		err := ps.process(pssmsgs[len(pssmsgs)-(i%len(pssmsgs))-1])
-		if err != nil {
-			b.Fatalf("pss processing failed: %v", err)
+		if !ps.process(pssmsgs[len(pssmsgs)-(i%len(pssmsgs))-1]) {
+			b.Fatalf("pss processing failed")
 		}
 	}
 }
@@ -948,8 +947,7 @@ func benchmarkSymkeyBruteforceSameaddr(b *testing.B) {
 		Payload: env,
 	}
 	for i := 0; i < b.N; i++ {
-		err := ps.process(pssmsg)
-		if err != nil {
+		if !ps.process(pssmsg) {
 			b.Fatalf("pss processing failed: %v", err)
 		}
 	}
@@ -1039,7 +1037,7 @@ func newServices() adapters.Services {
 				OutC: make(chan bool),
 				Pong: true,
 			}
-			p2pp := NewPingProtocol(ping.OutC, ping.PingHandler)
+			p2pp := NewPingProtocol(ping)
 			pp, err := RegisterProtocol(ps, &PingTopic, PingProtocol, p2pp, &ProtocolParams{Asymmetric: true})
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Client implementation was broken after handshake changes:

- Add missing api call GetAddress()
- Use keyid instead of ecdsa.PublicKey in client
- Move client handshake activation to inside client RunProtocol code
- Simplify client handshake

Also implements some lesser cosmetics:

- Added build tag for exluding ping code
- Added "pss" in build tags
- Add conditional compile bool values
- Simplify Ping Protocol code