### PR TITLE
swarm/storage: Resource updates initial framework

### DIFF
--- a/contracts/ens/ens.go
+++ b/contracts/ens/ens.go
@@ -101,6 +101,10 @@ func ensNode(name string) common.Hash {
 	return crypto.Keccak256Hash(parentNode[:], parentLabel[:])
 }
 
+func EnsNode(name string) common.Hash {
+	return ensNode(name)
+}
+
 func (self *ENS) getResolver(node [32]byte) (*contract.PublicResolverSession, error) {
 	resolverAddr, err := self.Resolver(node)
 	if err != nil {

--- a/contracts/ens/ens.go
+++ b/contracts/ens/ens.go
@@ -101,6 +101,7 @@ func ensNode(name string) common.Hash {
 	return crypto.Keccak256Hash(parentNode[:], parentLabel[:])
 }
 
+// Suggest exporting ensNode so external code can use it for generating ens namehashes
 func EnsNode(name string) common.Hash {
 	return ensNode(name)
 }

--- a/swarm/storage/dbstore.go
+++ b/swarm/storage/dbstore.go
@@ -476,12 +476,14 @@ func (s *DbStore) Get(key Key) (chunk *Chunk, err error) {
 			return
 		}
 
-		hasher := s.hashfunc()
-		hasher.Write(data)
-		hash := hasher.Sum(nil)
-		if !bytes.Equal(hash, key) {
-			s.delete(index.Idx, getIndexKey(key))
-			log.Warn("Invalid Chunk in Database. Please repair with command: 'swarm cleandb'")
+		if s.hashfunc != nil {
+			hasher := s.hashfunc()
+			hasher.Write(data)
+			hash := hasher.Sum(nil)
+			if !bytes.Equal(hash, key) {
+				s.delete(index.Idx, getIndexKey(key))
+				log.Warn("Invalid Chunk in Database. Please repair with command: 'swarm cleandb'")
+			}
 		}
 
 		chunk = &Chunk{

--- a/swarm/storage/dpa.go
+++ b/swarm/storage/dpa.go
@@ -65,7 +65,7 @@ type DPA struct {
 // for testing locally
 func NewLocalDPA(datadir string) (*DPA, error) {
 
-	hash := MakeHashFunc("SHA256")
+	hash := MakeHashFunc("SHA3")
 
 	dbStore, err := NewDbStore(datadir, hash, singletonSwarmDbCapacity, 0)
 	if err != nil {

--- a/swarm/storage/localstore.go
+++ b/swarm/storage/localstore.go
@@ -74,4 +74,6 @@ func (self *LocalStore) Get(key Key) (chunk *Chunk, err error) {
 }
 
 // Close local store
-func (self *LocalStore) Close() {}
+func (self *LocalStore) Close() {
+	self.DbStore.Close()
+}

--- a/swarm/storage/resource.go
+++ b/swarm/storage/resource.go
@@ -239,16 +239,6 @@ func (self *ResourceHandler) SetResource(rsrc *resource, allowOverwrite bool) er
 		return fmt.Errorf("Startblock cannot be higher than current block (%d > %d)", rsrc.startBlock, currentblock)
 	}
 
-	if rsrc.frequency == 0 {
-		return fmt.Errorf("Frequency cannot be 0")
-	}
-
-	if len(rsrc.ensName) > 0 {
-		ensName := ens.EnsNode(rsrc.name)
-		if ensName != rsrc.ensName {
-			return fmt.Errorf("Namehash %x is not a valid namehash of IDNA name '%s'", rsrc.ensName, rsrc.name)
-		}
-	}
 	self.resources[utfname] = rsrc
 	return nil
 }

--- a/swarm/storage/resource.go
+++ b/swarm/storage/resource.go
@@ -1,0 +1,469 @@
+package storage
+
+import (
+	"encoding/binary"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+
+	"golang.org/x/net/idna"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/contracts/ens"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+/***
+*
+* Resource updates is a data update scheme built on swarm chunks
+* with chunk keys following a predictable, versionable pattern.
+*
+* The intended use case is to update data locations of certain
+* hashes
+*
+* Updates are defined to be periodic in nature, where periods are
+* expressed in terms of number of blocks.
+*
+* The root entry of a resource update is tied to a unique identifier,
+* typically - but not necessarily - an ens name. It also contains the
+* block number when the resource update was first registered, and
+* the block frequency with which the resource will be updated.
+* Thus, a resource update for identifier "foo.bar" starting at block 4200
+* with frequency 42 will have updates on block 4242, 4284, 4326 and so on.
+*
+* the identifier is supplied as a string, but will be IDNA converted and
+* passed through the ENS namehash function. Pure ascii identifiers without
+* periods will thus merely be hashed.
+*
+* The data format of the root entry is the ENS namehash as key and
+* blocknumber and frequency in little-endian uint64 representation as values,
+* concatenated in that order, for a total of 16 bytes.
+*
+* Note that the root entry is not required for the resource update scheme to
+* work. A normal chunk of the blocknumber/frequency data can also be created,
+* and pointed to by an actual ENS entry instead.
+*
+* Actual data updates are also made in the form of swarm chunks. The keys
+* of the updates are the hash of a concatenation of properties as follows:
+*
+* sha256(namehash|blocknumber|version)
+*
+* The blocknumber here is the next block period after the current block
+* calculated from the start block and frequency of the resource update.
+* Using our previous example, this means that an update made at block 4285,
+* and even 4284, will have 4326 as the block number.
+*
+* If more than one update is made to the same block number, incremental
+* version numbers are used successively.
+*
+* A lookup agent need only know the identifier name
+*
+* NOTE: the following is yet to be implemented
+* The resource update chunks will be stored in the swarm, but receive special
+* treatment as their keys do not validate as hashes of their data. They are also
+* stored using a separate store, and forwarding/syncing protocols carry per-chunk
+* flags to tell whether the chunk can be validated or not; if not it is to be
+* treated as a resource update chunk.
+*
+* TODO: signature and signature validation
+ */
+
+// Encapsulates an actual resource update. When synced it contains the most recent
+// version of the resource update data.
+type resource struct {
+	name       string
+	ensname    common.Hash
+	startblock uint64
+	lastblock  uint64
+	frequency  uint64
+	version    uint64
+	data       []byte
+	updated    time.Time
+}
+
+// Main interface to resource updates. Creates/opens the resource database,
+// and sets up rpc client to the blockchain api
+type ResourceHandler struct {
+	ChunkStore
+	ethapi       *rpc.Client
+	resources    map[string]*resource
+	hashLock     *sync.Mutex
+	resourceLock *sync.Mutex
+	hasher       SwarmHash
+}
+
+// Create or open resource update chunk store
+func NewResourceHandler(datadir string, cloudStore CloudStore, ethapi *rpc.Client) (*ResourceHandler, error) {
+	path := filepath.Join(datadir, "resource")
+	dbStore, err := NewDbStore(datadir, nil, singletonSwarmDbCapacity, 0)
+	if err != nil {
+		return nil, err
+	}
+	localStore := &LocalStore{
+		memStore: NewMemStore(dbStore, singletonSwarmDbCapacity),
+		DbStore:  dbStore,
+	}
+	hasher := MakeHashFunc("SHA256")
+	return &ResourceHandler{
+		ChunkStore:   newResourceChunkStore(path, hasher, localStore, cloudStore),
+		ethapi:       ethapi,
+		resources:    make(map[string]*resource),
+		resourceLock: &sync.Mutex{},
+		hashLock:     &sync.Mutex{},
+		hasher:       hasher(),
+	}, nil
+}
+
+// Creates a standalone resource object
+//
+// Can be passed to SetResource if external root data lookups are used
+func NewResource(name string, startblock uint64, frequency uint64) (*resource, error) {
+	validname, err := idna.ToASCII(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resource{
+		name:       validname,
+		ensname:    ens.EnsNode(validname),
+		startblock: startblock,
+		frequency:  frequency,
+	}, nil
+}
+
+// Creates a new root entry for a resource update identified by `name` with the specified `frequency`.
+//
+// The start block of the resource update will be the actual current block height of the connected network.
+func (self *ResourceHandler) NewResource(name string, frequency uint64) (*resource, error) {
+
+	// make sure our ens identifier is idna safe
+	validname, err := idna.ToASCII(name)
+	if err != nil {
+		return nil, err
+	}
+	ensname := ens.EnsNode(validname)
+
+	// get our blockheight at this time
+	currentblock, err := self.getBlock()
+	if err != nil {
+		return nil, err
+	}
+
+	// chunk with key equal to namehash points to data of first blockheight + update frequency
+	// from this we know from what blockheight we should look for updates, and how often
+	chunk := NewChunk(Key(ensname[:]), nil)
+	chunk.SData = make([]byte, 24)
+
+	// resource update root chunks follow same convention as "normal" chunks
+	// with 8 bytes prefix specifying size
+	val := make([]byte, 8)
+	chunk.SData[0] = 16 // size, little-endian
+	binary.LittleEndian.PutUint64(val, currentblock)
+	copy(chunk.SData[8:16], val)
+	binary.LittleEndian.PutUint64(val, frequency)
+	copy(chunk.SData[16:], val)
+	self.Put(chunk)
+	log.Debug("new resource", "name", validname, "key", ensname, "startblock", currentblock, "frequency", frequency)
+
+	self.resourceLock.Lock()
+	defer self.resourceLock.Unlock()
+	self.resources[name] = &resource{
+		name:       validname,
+		ensname:    ensname,
+		startblock: currentblock,
+		frequency:  frequency,
+		updated:    time.Now(),
+	}
+	return self.resources[name], nil
+}
+
+// Set an externally defined resource object
+//
+// If the resource update root chunk is located externally (for example as a normal
+// chunk looked up by ENS) the data would be manually added with this method).
+//
+// Method will fail if resource is already registered in this session, unless
+// `allowOverwrite` is set
+func (self *ResourceHandler) SetResource(rsrc *resource, allowOverwrite bool) error {
+
+	if rsrc.name == "" {
+		return fmt.Errorf("Resource name cannot be empty")
+	}
+
+	utfname, err := idna.ToUnicode(rsrc.name)
+	if err != nil {
+		return fmt.Errorf("Invalid IDNA rsrc name '%s'", rsrc.name)
+	}
+	if !allowOverwrite {
+		if _, ok := self.resources[utfname]; ok {
+			return fmt.Errorf("Resource exists")
+		}
+	}
+
+	// get our blockheight at this time
+	currentblock, err := self.getBlock()
+	if err != nil {
+		return err
+	}
+
+	if rsrc.startblock > currentblock {
+		return fmt.Errorf("Startblock cannot be higher than current block (%d > %d)", rsrc.startblock, currentblock)
+	}
+
+	if rsrc.frequency == 0 {
+		return fmt.Errorf("Frequency cannot be 0")
+	}
+
+	if len(rsrc.ensname) > 0 {
+		ensname := ens.EnsNode(rsrc.name)
+		if ensname != rsrc.ensname {
+			return fmt.Errorf("Namehash %x is not a valid namehash of IDNA name '%s'", rsrc.ensname, rsrc.name)
+		}
+	}
+	self.resources[utfname] = rsrc
+	return nil
+}
+
+// Searches and retrieves the last version of the resource update identified by `name`
+//
+// It starts at the next period after the current block height, and upon failure
+// tries the corresponding keys of each previous period until one is found
+// (or startblock is reached, in which case there are no updates).
+// If an update is found, version numbers are iterated until failure, and the last
+// successfully retrieved version is copied to the corresponding resources map entry
+// and returned.
+//
+// If refresh is set to true, the resource data will be reloaded from the resource update
+// root chunk.
+// It is the callers responsibility to make sure that this chunk exists (if the resource
+// update root data was retrieved externally, it typically doesn't)
+func (self *ResourceHandler) OpenResource(name string, refresh bool) (*resource, error) {
+
+	rsrc := &resource{}
+
+	// if the resource is not known to this session we must load it
+	// if refresh is set, we force load
+	if _, ok := self.resources[name]; !ok || refresh {
+
+		// make sure our ens identifier is idna safe
+		validname, err := idna.ToASCII(name)
+		if err != nil {
+			return nil, err
+		}
+		rsrc.name = validname
+		rsrc.ensname = ens.EnsNode(validname)
+
+		// get the root info chunk and update the cached value
+		chunk, err := self.Get(Key(rsrc.ensname[:]))
+		if err != nil {
+			return nil, err
+		}
+
+		// sanity check for chunk data
+		// data is prefixed by 8 bytes of size
+		if len(chunk.SData) < 24 {
+			return nil, fmt.Errorf("Invalid chunk length %d", len(chunk.SData))
+		} else {
+			chunklength := binary.LittleEndian.Uint64(chunk.SData[:8])
+			if chunklength != uint64(16) {
+				return nil, fmt.Errorf("Invalid chunk length header %d", chunklength)
+			}
+		}
+		rsrc.startblock = binary.LittleEndian.Uint64(chunk.SData[8:16])
+		rsrc.frequency = binary.LittleEndian.Uint64(chunk.SData[16:])
+	} else {
+		rsrc.name = self.resources[name].name
+		rsrc.ensname = self.resources[name].ensname
+		rsrc.startblock = self.resources[name].startblock
+		rsrc.frequency = self.resources[name].frequency
+	}
+
+	// get our blockheight at this time and the next block of the update period
+	currentblock, err := self.getBlock()
+	if err != nil {
+		return nil, err
+	}
+	nextblock := getNextBlock(rsrc.startblock, currentblock, rsrc.frequency)
+
+	// start from the last possible block period, and iterate previous ones until we find a match
+	// if we hit startblock we're out of options
+	version := uint64(1)
+	for nextblock > rsrc.startblock {
+		key := self.resourceHash(rsrc.ensname, nextblock, version)
+		chunk, err := self.Get(key)
+		if err == nil {
+			// check if we have versions > 1. If a version fails, the previous version is used and returned.
+			log.Trace("rsrc update version 1 found, checking for version updates", "nextblock", nextblock, "key", key)
+			for {
+				newversion := version + 1
+				key := self.resourceHash(rsrc.ensname, nextblock, newversion)
+				newchunk, err := self.Get(key)
+				if err != nil {
+					// rsrc update data chunks are total hacks
+					// and have no size prefix :D
+					if len(chunk.SData) == 0 {
+						return nil, fmt.Errorf("Update contains no data")
+					}
+					// update our rsrcs entry map
+					rsrc.lastblock = nextblock
+					rsrc.version = version
+					rsrc.data = make([]byte, len(chunk.SData))
+					rsrc.updated = time.Now()
+					copy(rsrc.data, chunk.SData)
+					log.Debug("Resource synced", "name", rsrc.name, "key", chunk.Key, "block", nextblock, "version", version)
+					self.resourceLock.Lock()
+					self.resources[name] = rsrc
+					self.resourceLock.Unlock()
+					return rsrc, nil
+				}
+				log.Trace("version update found, checking next", "version", version, "block", nextblock, "key", key)
+				chunk = newchunk
+				version = newversion
+			}
+		}
+		log.Trace("rsrc update not found, checking previous period", "block", nextblock, "key", key)
+		nextblock -= rsrc.frequency
+	}
+	return nil, fmt.Errorf("no updates found")
+}
+
+// Adds an actual data update
+//
+// Uses the data currently loaded in the resources map entry.
+// It is the caller's responsibility to make sure that this data is not stale.
+//
+// A resource update cannot span chunks, and thus has max length 4096
+func (self *ResourceHandler) Update(name string, data []byte) (Key, error) {
+
+	// can be only one chunk long
+	if len(data) > 4096 {
+		return nil, fmt.Errorf("Data overflow: %d / 4096 bytes", len(data))
+	}
+
+	// get the cached information
+	self.resourceLock.Lock()
+	defer self.resourceLock.Unlock()
+	resource, ok := self.resources[name]
+	if !ok {
+		return nil, fmt.Errorf("No such resource")
+	} else if resource.updated.IsZero() {
+		return nil, fmt.Errorf("Invalid resource")
+	}
+
+	// get our blockheight at this time and the next block of the update period
+	currentblock, err := self.getBlock()
+	if err != nil {
+		return nil, err
+	}
+	nextblock := getNextBlock(resource.startblock, currentblock, resource.frequency)
+
+	// if we already have an update for this block then increment version
+	var version uint64
+	if nextblock == resource.lastblock {
+		version = resource.version
+	}
+	version++
+
+	// create the update chunk and send it
+	key := self.resourceHash(resource.ensname, nextblock, version)
+	chunk := NewChunk(key, nil)
+	chunk.SData = data
+	chunk.Size = int64(len(data))
+	self.Put(chunk)
+	log.Trace("resource update", "name", resource.name, "key", key, "currentblock", currentblock, "lastblock", nextblock, "version", version)
+
+	// update our resources map entry and return the new key
+	resource.lastblock = nextblock
+	resource.version = version
+	resource.data = make([]byte, len(data))
+	copy(resource.data, data)
+	return key, nil
+}
+
+// Closes the datastore.
+// Always call this at shutdown to avoid data corruption.
+func (self *ResourceHandler) Close() {
+	self.ChunkStore.Close()
+}
+
+func (self *ResourceHandler) getBlock() (uint64, error) {
+	// get the block height and convert to uint64
+	var currentblock string
+	err := self.ethapi.Call(&currentblock, "eth_blockNumber")
+	if err != nil {
+		return 0, err
+	}
+	if currentblock == "0x0" {
+		return 0, nil
+	}
+	return strconv.ParseUint(currentblock, 10, 64)
+}
+
+func (self *ResourceHandler) resourceHash(namehash common.Hash, blockheight uint64, version uint64) Key {
+	// format is: hash(namehash|blockheight|version)
+	self.hashLock.Lock()
+	defer self.hashLock.Unlock()
+	self.hasher.Reset()
+	self.hasher.Write(namehash[:])
+	b := make([]byte, 8)
+	c := binary.PutUvarint(b, blockheight)
+	self.hasher.Write(b)
+	// PutUvarint only overwrites first c bytes
+	for i := 0; i < c; i++ {
+		b[i] = 0
+	}
+	c = binary.PutUvarint(b, version)
+	self.hasher.Write(b)
+	return self.hasher.Sum(nil)
+}
+
+type resourceChunkStore struct {
+	localStore ChunkStore
+	netStore   ChunkStore
+}
+
+func newResourceChunkStore(path string, hasher SwarmHasher, localStore *LocalStore, cloudStore CloudStore) *resourceChunkStore {
+	return &resourceChunkStore{
+		localStore: localStore,
+		netStore:   NewNetStore(hasher, localStore, cloudStore, NewStoreParams(path)),
+	}
+}
+
+func (r *resourceChunkStore) Get(key Key) (*Chunk, error) {
+	chunk, err := r.netStore.Get(key)
+	if err != nil {
+		return nil, err
+	}
+	// if the chunk has to be remotely retrieved, we define a timeout of how long to wait for it before failing.
+	// sadly due to the nature of swarm, the error will never be conclusive as to whether it was a network issue
+	// that caused the failure or that the chunk doesn't exist.
+	if chunk.Req == nil {
+		return chunk, nil
+	}
+	t := time.NewTimer(time.Second * 1)
+	select {
+	case <-t.C:
+		return nil, fmt.Errorf("timeout")
+	case <-chunk.C:
+		log.Trace("Received resource update chunk", "peer", chunk.Req.Source)
+	}
+	return chunk, nil
+}
+
+func (r *resourceChunkStore) Put(chunk *Chunk) {
+	r.netStore.Put(chunk)
+}
+
+func (r *resourceChunkStore) Close() {
+	r.netStore.Close()
+	r.localStore.Close()
+}
+
+func getNextBlock(start uint64, current uint64, frequency uint64) uint64 {
+	blockdiff := current - start
+	periods := (blockdiff / frequency) + 1
+	return start + (frequency * periods)
+}

--- a/swarm/storage/resource_test.go
+++ b/swarm/storage/resource_test.go
@@ -1,0 +1,180 @@
+package storage
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"golang.org/x/net/idna"
+
+	"github.com/ethereum/go-ethereum/contracts/ens"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+var (
+	blockCount = uint64(4200)
+)
+
+func init() {
+	log.Root().SetHandler(log.CallerFileHandler(log.LvlFilterHandler(log.LvlTrace, log.StreamHandler(os.Stderr, log.TerminalFormat(true)))))
+}
+
+type FakeRPC struct {
+	blockcount *uint64
+}
+
+func (r *FakeRPC) BlockNumber() (string, error) {
+	return strconv.FormatUint(*r.blockcount, 10), nil
+}
+
+func TestResourceHandler(t *testing.T) {
+	datadir, err := ioutil.TempDir("", "rh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(datadir)
+	log.Trace("starttest", "dir", datadir)
+
+	// starting the whole stack just to get blocknumbers is too cumbersome
+	// so we fake the rpc server to get blocknumbers for testing
+	ipcpath := filepath.Join(datadir, "test.ipc")
+	ipcl, err := rpc.CreateIPCListener(ipcpath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rpcserver := rpc.NewServer()
+	rpcserver.RegisterName("eth", &FakeRPC{
+		blockcount: &blockCount,
+	})
+	go func() {
+		rpcserver.ServeListener(ipcl)
+	}()
+	defer rpcserver.Stop()
+
+	// connect to fake rpc
+	rpcclient, err := rpc.Dial(ipcpath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rh, err := NewResourceHandler(datadir, &testCloudStore{}, rpcclient)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create a new resource
+	resourcename := "føø.bar"
+	resourcevalidname, err := idna.ToASCII(resourcename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resourcefrequency := uint64(42)
+	_, err = rh.NewResource(resourcename, resourcefrequency)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check that the new resource is stored correctly
+	namehash := ens.EnsNode(resourcevalidname)
+	chunk, err := rh.ChunkStore.(*resourceChunkStore).localStore.(*LocalStore).memStore.Get(Key(namehash[:]))
+	if err != nil {
+		t.Fatal(err)
+	}
+	startblocknumber := binary.LittleEndian.Uint64(chunk.SData[8:16])
+	chunkfrequency := binary.LittleEndian.Uint64(chunk.SData[16:])
+	if startblocknumber != blockCount {
+		t.Fatalf("stored block number %d does not match provided block number %d", startblocknumber, blockCount)
+	}
+	if chunkfrequency != resourcefrequency {
+		t.Fatalf("stored frequency %d does not match provided frequency %d", chunkfrequency, resourcefrequency)
+	}
+
+	// update halfway to first period
+	key := make(map[string]Key)
+	blockCount = startblocknumber + (resourcefrequency / 2)
+	key["blinky"], err = rh.Update(resourcename, []byte("blinky"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// update on first period
+	blockCount = startblocknumber + resourcefrequency
+	key["pinky"], err = rh.Update(resourcename, []byte("pinky"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// update on second period
+	blockCount = startblocknumber + (resourcefrequency * 2)
+	key["inky"], err = rh.Update(resourcename, []byte("inky"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// update just after second period
+	blockCount = startblocknumber + (resourcefrequency * 2) + 1
+	key["clyde"], err = rh.Update(resourcename, []byte("clyde"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(time.Second)
+	rh.Close()
+
+	// check we can retrieve the updates after close
+	// it will match on second iteration startblocknumber + (resourcefrequency * 3)
+	blockCount = startblocknumber + (resourcefrequency * 4)
+
+	rh2, err := NewResourceHandler(datadir, &testCloudStore{}, rpcclient)
+	_, err = rh2.OpenResource(resourcename, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// last update should be "clyde", version two, blockheight startblocknumber + (resourcefrequency * 3)
+	if !bytes.Equal(rh2.resources[resourcename].data, []byte("clyde")) {
+		t.Fatalf("resource data was %v, expected %v", rh2.resources[resourcename].data, []byte("clyde"))
+	}
+	if rh2.resources[resourcename].version != 2 {
+		t.Fatalf("resource version was %d, expected 2", rh2.resources[resourcename].version)
+	}
+	if rh2.resources[resourcename].lastblock != startblocknumber+(resourcefrequency*3) {
+		t.Fatalf("resource blockheight was %d, expected %d", rh2.resources[resourcename].lastblock, startblocknumber+(resourcefrequency*3))
+	}
+
+	rsrc, err := NewResource(resourcename, startblocknumber, resourcefrequency)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = rh2.SetResource(rsrc, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource, err := rh2.OpenResource(resourcename, false) // if key is specified, refresh is implicit
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check data
+	if !bytes.Equal(resource.data, []byte("clyde")) {
+		t.Fatalf("resource data was %v, expected %v", rh2.resources[resourcename].data, []byte("clyde"))
+	}
+
+}
+
+type testCloudStore struct {
+}
+
+func (c *testCloudStore) Store(*Chunk) {
+}
+
+func (c *testCloudStore) Deliver(*Chunk) {
+}
+
+func (c *testCloudStore) Retrieve(*Chunk) {
+}

--- a/swarm/storage/resource_test.go
+++ b/swarm/storage/resource_test.go
@@ -40,15 +40,15 @@ func (r *FakeRPC) BlockNumber() (string, error) {
 
 func TestResourceValidContent(t *testing.T) {
 
-	rh, privkey, _, err := setupTest()
+	rh, privkey, _, err, teardownTest := setupTest()
 	if err != nil {
-		teardownTest(t, err.Error())
+		teardownTest(t, err)
 	}
 
 	// create a new resource
 	validname, err := idna.ToASCII("føø.bar")
 	if err != nil {
-		teardownTest(t, err.Error())
+		teardownTest(t, err)
 	}
 
 	// generate a hash for block 4200 version 1
@@ -59,96 +59,98 @@ func TestResourceValidContent(t *testing.T) {
 	data := make([]byte, 8)
 	_, err = rand.Read(data)
 	if err != nil {
-		teardownTest(t, err.Error())
+		teardownTest(t, err)
 	}
 	rh.hasher.Reset()
 	rh.hasher.Write(data)
 	datahash := rh.hasher.Sum(nil)
 	sig, err := crypto.Sign(datahash, privkey)
 	if err != nil {
-		teardownTest(t, err.Error())
+		teardownTest(t, err)
 	}
 
 	// put sig and data in the chunk
-	chunk.SData = make([]byte, 8+SIGNATURE_LENGTH)
-	copy(chunk.SData[:SIGNATURE_LENGTH], sig)
-	copy(chunk.SData[SIGNATURE_LENGTH:], data)
+	chunk.SData = make([]byte, 8+signatureLength)
+	copy(chunk.SData[:signatureLength], sig)
+	copy(chunk.SData[signatureLength:], data)
 
 	// check that we can recover the owner account from the update chunk's signature
 	// TODO: change this to verifyContent on ENS integration
 	recoveredaddress, err := rh.getContentAccount(chunk.SData)
 	if err != nil {
-		teardownTest(t, err.Error())
+		teardownTest(t, err)
 	}
 	originaladdress := crypto.PubkeyToAddress(privkey.PublicKey)
 
 	if recoveredaddress != originaladdress {
-		teardownTest(t, fmt.Sprintf("addresses dont match: %x != %x", originaladdress, recoveredaddress))
+		teardownTest(t, fmt.Errorf("addresses dont match: %x != %x", originaladdress, recoveredaddress))
 	}
-	teardownTest(t, "")
+	teardownTest(t, nil)
 }
 
 func TestResourceHandler(t *testing.T) {
 
-	rh, privkey, datadir, err := setupTest()
+	rh, privkey, datadir, err, teardownTest := setupTest()
 	if err != nil {
-		teardownTest(t, err.Error())
+		teardownTest(t, err)
 	}
 
 	// create a new resource
 	resourcename := "føø.bar"
 	resourcevalidname, err := idna.ToASCII(resourcename)
 	if err != nil {
-		teardownTest(t, err.Error())
+		teardownTest(t, err)
 	}
 	resourcefrequency := uint64(42)
 	_, err = rh.NewResource(resourcename, resourcefrequency)
 	if err != nil {
-		teardownTest(t, err.Error())
+		teardownTest(t, err)
 	}
 
 	// check that the new resource is stored correctly
 	namehash := ens.EnsNode(resourcevalidname)
 	chunk, err := rh.ChunkStore.(*resourceChunkStore).localStore.(*LocalStore).memStore.Get(Key(namehash[:]))
 	if err != nil {
-		teardownTest(t, err.Error())
+		teardownTest(t, err)
+	} else if len(chunk.SData) < 16 {
+		teardownTest(t, fmt.Errorf("chunk data must be minimum 16 bytes, is %d", len(chunk.SData)))
 	}
 	startblocknumber := binary.LittleEndian.Uint64(chunk.SData[8:16])
 	chunkfrequency := binary.LittleEndian.Uint64(chunk.SData[16:])
 	if startblocknumber != blockCount {
-		teardownTest(t, fmt.Sprintf("stored block number %d does not match provided block number %d", startblocknumber, blockCount))
+		teardownTest(t, fmt.Errorf("stored block number %d does not match provided block number %d", startblocknumber, blockCount))
 	}
 	if chunkfrequency != resourcefrequency {
-		teardownTest(t, fmt.Sprintf("stored frequency %d does not match provided frequency %d", chunkfrequency, resourcefrequency))
+		teardownTest(t, fmt.Errorf("stored frequency %d does not match provided frequency %d", chunkfrequency, resourcefrequency))
 	}
 
 	// update halfway to first period
-	key := make(map[string]Key)
+	resourcekey := make(map[string]Key)
 	blockCount = startblocknumber + (resourcefrequency / 2)
-	key["blinky"], err = rh.Update(resourcename, []byte("blinky"))
+	resourcekey["blinky"], err = rh.Update(resourcename, []byte("blinky"))
 	if err != nil {
-		teardownTest(t, err.Error())
+		teardownTest(t, err)
 	}
 
 	// update on first period
 	blockCount = startblocknumber + resourcefrequency
-	key["pinky"], err = rh.Update(resourcename, []byte("pinky"))
+	resourcekey["pinky"], err = rh.Update(resourcename, []byte("pinky"))
 	if err != nil {
-		teardownTest(t, err.Error())
+		teardownTest(t, err)
 	}
 
 	// update on second period
 	blockCount = startblocknumber + (resourcefrequency * 2)
-	key["inky"], err = rh.Update(resourcename, []byte("inky"))
+	resourcekey["inky"], err = rh.Update(resourcename, []byte("inky"))
 	if err != nil {
-		teardownTest(t, err.Error())
+		teardownTest(t, err)
 	}
 
 	// update just after second period
 	blockCount = startblocknumber + (resourcefrequency * 2) + 1
-	key["clyde"], err = rh.Update(resourcename, []byte("clyde"))
+	resourcekey["clyde"], err = rh.Update(resourcename, []byte("clyde"))
 	if err != nil {
-		teardownTest(t, err.Error())
+		teardownTest(t, err)
 	}
 	time.Sleep(time.Second)
 	rh.Close()
@@ -160,42 +162,42 @@ func TestResourceHandler(t *testing.T) {
 	rh2, err := NewResourceHandler(privkey, datadir, &testCloudStore{}, rh.ethapi)
 	_, err = rh2.OpenResource(resourcename, true)
 	if err != nil {
-		teardownTest(t, err.Error())
+		teardownTest(t, err)
 	}
 
 	// last update should be "clyde", version two, blockheight startblocknumber + (resourcefrequency * 3)
 	if !bytes.Equal(rh2.resources[resourcename].data, []byte("clyde")) {
-		teardownTest(t, fmt.Sprintf("resource data was %v, expected %v", rh2.resources[resourcename].data, []byte("clyde")))
+		teardownTest(t, fmt.Errorf("resource data was %v, expected %v", rh2.resources[resourcename].data, []byte("clyde")))
 	}
 	if rh2.resources[resourcename].version != 2 {
-		teardownTest(t, fmt.Sprintf("resource version was %d, expected 2", rh2.resources[resourcename].version))
+		teardownTest(t, fmt.Errorf("resource version was %d, expected 2", rh2.resources[resourcename].version))
 	}
 	if rh2.resources[resourcename].lastBlock != startblocknumber+(resourcefrequency*3) {
-		teardownTest(t, fmt.Sprintf("resource blockheight was %d, expected %d", rh2.resources[resourcename].lastBlock, startblocknumber+(resourcefrequency*3)))
+		teardownTest(t, fmt.Errorf("resource blockheight was %d, expected %d", rh2.resources[resourcename].lastBlock, startblocknumber+(resourcefrequency*3)))
 	}
 
 	rsrc, err := NewResource(resourcename, startblocknumber, resourcefrequency)
 	if err != nil {
-		teardownTest(t, err.Error())
+		teardownTest(t, err)
 	}
 	err = rh2.SetResource(rsrc, true)
 	if err != nil {
-		teardownTest(t, err.Error())
+		teardownTest(t, err)
 	}
 	resource, err := rh2.OpenResource(resourcename, false) // if key is specified, refresh is implicit
 	if err != nil {
-		teardownTest(t, err.Error())
+		teardownTest(t, err)
 	}
 
 	// check data
 	if !bytes.Equal(resource.data, []byte("clyde")) {
-		teardownTest(t, fmt.Sprintf("resource data was %v, expected %v", rh2.resources[resourcename].data, []byte("clyde")))
+		teardownTest(t, fmt.Errorf("resource data was %v, expected %v", rh2.resources[resourcename].data, []byte("clyde")))
 	}
-	teardownTest(t, "")
+	teardownTest(t, nil)
 
 }
 
-func setupTest() (rh *ResourceHandler, privkey *ecdsa.PrivateKey, datadir string, err error) {
+func setupTest() (rh *ResourceHandler, privkey *ecdsa.PrivateKey, datadir string, err error, teardown func(*testing.T, error)) {
 
 	var fsClean func()
 	var rpcClean func()
@@ -248,16 +250,22 @@ func setupTest() (rh *ResourceHandler, privkey *ecdsa.PrivateKey, datadir string
 	}
 
 	rh, err = NewResourceHandler(privkey, datadir, &testCloudStore{}, rpcclient)
-	return
-
-}
-
-func teardownTest(t *testing.T, errstr string) {
-	cleanF()
-	if errstr != "" {
-		t.Fatal(errstr)
+	teardown = func(t *testing.T, err error) {
+		cleanF()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
+
+	return
 }
+
+//func teardownTest(t *testing.T, errstr string) {
+//	cleanF()
+//	if errstr != "" {
+//		t.Fatal(errstr)
+//	}
+//}
 
 type testCloudStore struct {
 }

--- a/swarm/storage/resource_test.go
+++ b/swarm/storage/resource_test.go
@@ -2,8 +2,10 @@ package storage
 
 import (
 	"bytes"
+	"crypto/ecdsa"
 	"crypto/rand"
 	"encoding/binary"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -21,6 +23,7 @@ import (
 
 var (
 	blockCount = uint64(4200)
+	cleanF     func()
 )
 
 func init() {
@@ -36,128 +39,87 @@ func (r *FakeRPC) BlockNumber() (string, error) {
 }
 
 func TestResourceValidContent(t *testing.T) {
-	// privkey for signing updates
-	privkey, err := crypto.GenerateKey()
+
+	rh, privkey, _, err := setupTest()
 	if err != nil {
-		t.Fatal(err)
+		teardownTest(t, err.Error())
 	}
 
-	// temp datadir
-	datadir, err := ioutil.TempDir("", "rh")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(datadir)
-
-	rh, err := NewResourceHandler(privkey, datadir, &testCloudStore{}, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	// create a new resource
 	validname, err := idna.ToASCII("føø.bar")
 	if err != nil {
-		t.Fatal(err)
+		teardownTest(t, err.Error())
 	}
 
+	// generate a hash for block 4200 version 1
 	key := rh.resourceHash(ens.EnsNode(validname), 4200, 1)
 	chunk := NewChunk(key, nil)
 
+	// generate some bogus data for the chunk and sign it
 	data := make([]byte, 8)
 	_, err = rand.Read(data)
 	if err != nil {
-		t.Fatal(err)
+		teardownTest(t, err.Error())
 	}
 	rh.hasher.Reset()
 	rh.hasher.Write(data)
 	datahash := rh.hasher.Sum(nil)
 	sig, err := crypto.Sign(datahash, privkey)
 	if err != nil {
-		t.Fatal(err)
+		teardownTest(t, err.Error())
 	}
 
+	// put sig and data in the chunk
 	chunk.SData = make([]byte, 8+SIGNATURE_LENGTH)
 	copy(chunk.SData[:SIGNATURE_LENGTH], sig)
 	copy(chunk.SData[SIGNATURE_LENGTH:], data)
 
+	// check that we can recover the owner account from the update chunk's signature
 	// TODO: change this to verifyContent on ENS integration
 	recoveredaddress, err := rh.getContentAccount(chunk.SData)
 	if err != nil {
-		t.Fatal(err)
+		teardownTest(t, err.Error())
 	}
 	originaladdress := crypto.PubkeyToAddress(privkey.PublicKey)
 
 	if recoveredaddress != originaladdress {
-		t.Fatalf("addresses dont match: %x != %x", originaladdress, recoveredaddress)
+		teardownTest(t, fmt.Sprintf("addresses dont match: %x != %x", originaladdress, recoveredaddress))
 	}
+	teardownTest(t, "")
 }
 
 func TestResourceHandler(t *testing.T) {
 
-	// privkey for signing updates
-	privkey, err := crypto.GenerateKey()
+	rh, privkey, datadir, err := setupTest()
 	if err != nil {
-		t.Fatal(err)
-	}
-
-	// temp datadir
-	datadir, err := ioutil.TempDir("", "rh")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(datadir)
-
-	// starting the whole stack just to get blocknumbers is too cumbersome
-	// so we fake the rpc server to get blocknumbers for testing
-	ipcpath := filepath.Join(datadir, "test.ipc")
-	ipcl, err := rpc.CreateIPCListener(ipcpath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	rpcserver := rpc.NewServer()
-	rpcserver.RegisterName("eth", &FakeRPC{
-		blockcount: &blockCount,
-	})
-	go func() {
-		rpcserver.ServeListener(ipcl)
-	}()
-	defer rpcserver.Stop()
-
-	// connect to fake rpc
-	rpcclient, err := rpc.Dial(ipcpath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	rh, err := NewResourceHandler(privkey, datadir, &testCloudStore{}, rpcclient)
-	if err != nil {
-		t.Fatal(err)
+		teardownTest(t, err.Error())
 	}
 
 	// create a new resource
 	resourcename := "føø.bar"
 	resourcevalidname, err := idna.ToASCII(resourcename)
 	if err != nil {
-		t.Fatal(err)
+		teardownTest(t, err.Error())
 	}
 	resourcefrequency := uint64(42)
 	_, err = rh.NewResource(resourcename, resourcefrequency)
 	if err != nil {
-		t.Fatal(err)
+		teardownTest(t, err.Error())
 	}
 
 	// check that the new resource is stored correctly
 	namehash := ens.EnsNode(resourcevalidname)
 	chunk, err := rh.ChunkStore.(*resourceChunkStore).localStore.(*LocalStore).memStore.Get(Key(namehash[:]))
 	if err != nil {
-		t.Fatal(err)
+		teardownTest(t, err.Error())
 	}
 	startblocknumber := binary.LittleEndian.Uint64(chunk.SData[8:16])
 	chunkfrequency := binary.LittleEndian.Uint64(chunk.SData[16:])
 	if startblocknumber != blockCount {
-		t.Fatalf("stored block number %d does not match provided block number %d", startblocknumber, blockCount)
+		teardownTest(t, fmt.Sprintf("stored block number %d does not match provided block number %d", startblocknumber, blockCount))
 	}
 	if chunkfrequency != resourcefrequency {
-		t.Fatalf("stored frequency %d does not match provided frequency %d", chunkfrequency, resourcefrequency)
+		teardownTest(t, fmt.Sprintf("stored frequency %d does not match provided frequency %d", chunkfrequency, resourcefrequency))
 	}
 
 	// update halfway to first period
@@ -165,28 +127,28 @@ func TestResourceHandler(t *testing.T) {
 	blockCount = startblocknumber + (resourcefrequency / 2)
 	key["blinky"], err = rh.Update(resourcename, []byte("blinky"))
 	if err != nil {
-		t.Fatal(err)
+		teardownTest(t, err.Error())
 	}
 
 	// update on first period
 	blockCount = startblocknumber + resourcefrequency
 	key["pinky"], err = rh.Update(resourcename, []byte("pinky"))
 	if err != nil {
-		t.Fatal(err)
+		teardownTest(t, err.Error())
 	}
 
 	// update on second period
 	blockCount = startblocknumber + (resourcefrequency * 2)
 	key["inky"], err = rh.Update(resourcename, []byte("inky"))
 	if err != nil {
-		t.Fatal(err)
+		teardownTest(t, err.Error())
 	}
 
 	// update just after second period
 	blockCount = startblocknumber + (resourcefrequency * 2) + 1
 	key["clyde"], err = rh.Update(resourcename, []byte("clyde"))
 	if err != nil {
-		t.Fatal(err)
+		teardownTest(t, err.Error())
 	}
 	time.Sleep(time.Second)
 	rh.Close()
@@ -195,41 +157,106 @@ func TestResourceHandler(t *testing.T) {
 	// it will match on second iteration startblocknumber + (resourcefrequency * 3)
 	blockCount = startblocknumber + (resourcefrequency * 4)
 
-	rh2, err := NewResourceHandler(privkey, datadir, &testCloudStore{}, rpcclient)
+	rh2, err := NewResourceHandler(privkey, datadir, &testCloudStore{}, rh.ethapi)
 	_, err = rh2.OpenResource(resourcename, true)
 	if err != nil {
-		t.Fatal(err)
+		teardownTest(t, err.Error())
 	}
 
 	// last update should be "clyde", version two, blockheight startblocknumber + (resourcefrequency * 3)
 	if !bytes.Equal(rh2.resources[resourcename].data, []byte("clyde")) {
-		t.Fatalf("resource data was %v, expected %v", rh2.resources[resourcename].data, []byte("clyde"))
+		teardownTest(t, fmt.Sprintf("resource data was %v, expected %v", rh2.resources[resourcename].data, []byte("clyde")))
 	}
 	if rh2.resources[resourcename].version != 2 {
-		t.Fatalf("resource version was %d, expected 2", rh2.resources[resourcename].version)
+		teardownTest(t, fmt.Sprintf("resource version was %d, expected 2", rh2.resources[resourcename].version))
 	}
 	if rh2.resources[resourcename].lastBlock != startblocknumber+(resourcefrequency*3) {
-		t.Fatalf("resource blockheight was %d, expected %d", rh2.resources[resourcename].lastBlock, startblocknumber+(resourcefrequency*3))
+		teardownTest(t, fmt.Sprintf("resource blockheight was %d, expected %d", rh2.resources[resourcename].lastBlock, startblocknumber+(resourcefrequency*3)))
 	}
 
 	rsrc, err := NewResource(resourcename, startblocknumber, resourcefrequency)
 	if err != nil {
-		t.Fatal(err)
+		teardownTest(t, err.Error())
 	}
 	err = rh2.SetResource(rsrc, true)
 	if err != nil {
-		t.Fatal(err)
+		teardownTest(t, err.Error())
 	}
 	resource, err := rh2.OpenResource(resourcename, false) // if key is specified, refresh is implicit
 	if err != nil {
-		t.Fatal(err)
+		teardownTest(t, err.Error())
 	}
 
 	// check data
 	if !bytes.Equal(resource.data, []byte("clyde")) {
-		t.Fatalf("resource data was %v, expected %v", rh2.resources[resourcename].data, []byte("clyde"))
+		teardownTest(t, fmt.Sprintf("resource data was %v, expected %v", rh2.resources[resourcename].data, []byte("clyde")))
+	}
+	teardownTest(t, "")
+
+}
+
+func setupTest() (rh *ResourceHandler, privkey *ecdsa.PrivateKey, datadir string, err error) {
+
+	var fsClean func()
+	var rpcClean func()
+	cleanF = func() {
+		if fsClean != nil {
+			fsClean()
+		}
+		if rpcClean != nil {
+			rpcClean()
+		}
 	}
 
+	// privkey for signing updates
+	privkey, err = crypto.GenerateKey()
+	if err != nil {
+		return
+	}
+
+	// temp datadir
+	datadir, err = ioutil.TempDir("", "rh")
+	if err != nil {
+		return
+	}
+	fsClean = func() {
+		os.RemoveAll(datadir)
+	}
+
+	// starting the whole stack just to get blocknumbers is too cumbersome
+	// so we fake the rpc server to get blocknumbers for testing
+	ipcpath := filepath.Join(datadir, "test.ipc")
+	ipcl, err := rpc.CreateIPCListener(ipcpath)
+	if err != nil {
+		return
+	}
+	rpcserver := rpc.NewServer()
+	rpcserver.RegisterName("eth", &FakeRPC{
+		blockcount: &blockCount,
+	})
+	go func() {
+		rpcserver.ServeListener(ipcl)
+	}()
+	rpcClean = func() {
+		rpcserver.Stop()
+	}
+
+	// connect to fake rpc
+	rpcclient, err := rpc.Dial(ipcpath)
+	if err != nil {
+		return
+	}
+
+	rh, err = NewResourceHandler(privkey, datadir, &testCloudStore{}, rpcclient)
+	return
+
+}
+
+func teardownTest(t *testing.T, errstr string) {
+	cleanF()
+	if errstr != "" {
+		t.Fatal(errstr)
+	}
 }
 
 type testCloudStore struct {

--- a/swarm/storage/resource_test.go
+++ b/swarm/storage/resource_test.go
@@ -208,8 +208,8 @@ func TestResourceHandler(t *testing.T) {
 	if rh2.resources[resourcename].version != 2 {
 		t.Fatalf("resource version was %d, expected 2", rh2.resources[resourcename].version)
 	}
-	if rh2.resources[resourcename].lastblock != startblocknumber+(resourcefrequency*3) {
-		t.Fatalf("resource blockheight was %d, expected %d", rh2.resources[resourcename].lastblock, startblocknumber+(resourcefrequency*3))
+	if rh2.resources[resourcename].lastBlock != startblocknumber+(resourcefrequency*3) {
+		t.Fatalf("resource blockheight was %d, expected %d", rh2.resources[resourcename].lastBlock, startblocknumber+(resourcefrequency*3))
 	}
 
 	rsrc, err := NewResource(resourcename, startblocknumber, resourcefrequency)

--- a/swarm/storage/resource_test.go
+++ b/swarm/storage/resource_test.go
@@ -160,7 +160,7 @@ func TestResourceHandler(t *testing.T) {
 	blockCount = startblocknumber + (resourcefrequency * 4)
 
 	rh2, err := NewResourceHandler(privkey, datadir, &testCloudStore{}, rh.ethapi)
-	_, err = rh2.OpenResource(resourcename, true)
+	_, err = rh2.LookupLatest(resourcename, true)
 	if err != nil {
 		teardownTest(t, err)
 	}
@@ -184,14 +184,38 @@ func TestResourceHandler(t *testing.T) {
 	if err != nil {
 		teardownTest(t, err)
 	}
-	resource, err := rh2.OpenResource(resourcename, false) // if key is specified, refresh is implicit
+
+	// latest block, latest version
+	resource, err := rh2.LookupLatest(resourcename, false) // if key is specified, refresh is implicit
 	if err != nil {
 		teardownTest(t, err)
 	}
 
 	// check data
 	if !bytes.Equal(resource.data, []byte("clyde")) {
-		teardownTest(t, fmt.Errorf("resource data was %v, expected %v", rh2.resources[resourcename].data, []byte("clyde")))
+		teardownTest(t, fmt.Errorf("resource data (latest) was %v, expected %v", rh2.resources[resourcename].data, []byte("clyde")))
+	}
+
+	// specific block, latest version
+	resource, err = rh2.LookupHistorical(resourcename, startblocknumber+(resourcefrequency*3), true)
+	if err != nil {
+		teardownTest(t, err)
+	}
+
+	// check data
+	if !bytes.Equal(resource.data, []byte("clyde")) {
+		teardownTest(t, fmt.Errorf("resource data (historical) was %v, expected %v", rh2.resources[resourcename].data, []byte("clyde")))
+	}
+
+	// specific block, specific version
+	resource, err = rh2.LookupVersion(resourcename, startblocknumber+(resourcefrequency*3), 1, true)
+	if err != nil {
+		teardownTest(t, err)
+	}
+
+	// check data
+	if !bytes.Equal(resource.data, []byte("inky")) {
+		teardownTest(t, fmt.Errorf("resource data (historical) was %v, expected %v", rh2.resources[resourcename].data, []byte("inky")))
 	}
 	teardownTest(t, nil)
 


### PR DESCRIPTION
This commit introduces the resource update framework. At the moment it is fully standalone, and because of the non-standard use of chunks it cannot be connected to any middleware that performs integrity checking of chunks. This will be done after the basic framework is established.

Explanation of the implementation can be found in the comment field on top of `swarm/storage/resource.go`. It is based on the concepts outlined by @zelig in https://gist.github.com/zelig/895563df3357ef862f30be5c4344e63f 

Note that signature verification (lookup of ENS owner) is not yet implemented - that will be the next round.

`swarm-resourceupdate` is branched off `ethersphere/master` as a proxy for merging updates, and will be rebase on same until the functionality can be fully included. 