### PR TITLE
swarm/api: url scheme bzz-hash to get hashes of swarm content (#15238)

### DIFF
--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -130,15 +130,6 @@ func (self *Api) Put(content, contentType string) (storage.Key, error) {
 // to resolve basePath to content using dpa retrieve
 // it returns a section reader, mimeType, status and an error
 func (self *Api) Get(key storage.Key, path string) (reader storage.LazySectionReader, mimeType string, status int, err error) {
-	reader, _, mimeType, status, err = self.GetHash(key, path)
-	return
-}
-
-// GetHash extends the Get method to return the hash of the content,
-// it uses iterative manifest retrieval and prefix matching
-// to resolve basePath to content using dpa retrieve
-// it returns a section reader, hash, mimeType, status and an error
-func (self *Api) GetHash(key storage.Key, path string) (reader storage.LazySectionReader, hash storage.Key, mimeType string, status int, err error) {
 	trie, err := loadManifest(self.dpa, key, nil)
 	if err != nil {
 		status = http.StatusNotFound
@@ -151,14 +142,14 @@ func (self *Api) GetHash(key storage.Key, path string) (reader storage.LazySecti
 	entry, _ := trie.getEntry(path)
 
 	if entry != nil {
-		hash = common.Hex2Bytes(entry.Hash)
+		key = common.Hex2Bytes(entry.Hash)
 		status = entry.Status
 		if status == http.StatusMultipleChoices {
 			return
 		} else {
 			mimeType = entry.ContentType
-			log.Trace(fmt.Sprintf("content lookup key: '%v' (%v)", hash, mimeType))
-			reader = self.dpa.Retrieve(hash)
+			log.Trace(fmt.Sprintf("content lookup key: '%v' (%v)", key, mimeType))
+			reader = self.dpa.Retrieve(key)
 		}
 	} else {
 		status = http.StatusNotFound

--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -130,6 +130,15 @@ func (self *Api) Put(content, contentType string) (storage.Key, error) {
 // to resolve basePath to content using dpa retrieve
 // it returns a section reader, mimeType, status and an error
 func (self *Api) Get(key storage.Key, path string) (reader storage.LazySectionReader, mimeType string, status int, err error) {
+	reader, _, mimeType, status, err = self.GetHash(key, path)
+	return
+}
+
+// GetHash extends the Get method to return the hash of the content,
+// it uses iterative manifest retrieval and prefix matching
+// to resolve basePath to content using dpa retrieve
+// it returns a section reader, hash, mimeType, status and an error
+func (self *Api) GetHash(key storage.Key, path string) (reader storage.LazySectionReader, hash storage.Key, mimeType string, status int, err error) {
 	trie, err := loadManifest(self.dpa, key, nil)
 	if err != nil {
 		status = http.StatusNotFound
@@ -142,14 +151,14 @@ func (self *Api) Get(key storage.Key, path string) (reader storage.LazySectionRe
 	entry, _ := trie.getEntry(path)
 
 	if entry != nil {
-		key = common.Hex2Bytes(entry.Hash)
+		hash = common.Hex2Bytes(entry.Hash)
 		status = entry.Status
 		if status == http.StatusMultipleChoices {
 			return
 		} else {
 			mimeType = entry.ContentType
-			log.Trace(fmt.Sprintf("content lookup key: '%v' (%v)", key, mimeType))
-			reader = self.dpa.Retrieve(key)
+			log.Trace(fmt.Sprintf("content lookup key: '%v' (%v)", hash, mimeType))
+			reader = self.dpa.Retrieve(hash)
 		}
 	} else {
 		status = http.StatusNotFound

--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -290,9 +290,12 @@ func (s *Server) HandleDelete(w http.ResponseWriter, r *Request) {
 	fmt.Fprint(w, newKey)
 }
 
-// HandleGetRaw handles a GET request to bzzr://<key> and responds with
-// the raw content stored at the given storage key
-func (s *Server) HandleGetRaw(w http.ResponseWriter, r *Request) {
+// HandleGet handles a GET request to
+// - bzzr://<key> and responds with the raw content stored at the
+//   given storage key
+// - bzz-hash://<key> and responds with the hash of the content stored
+//   at the given storage key as a text/plain response
+func (s *Server) HandleGet(w http.ResponseWriter, r *Request) {
 	key, err := s.api.Resolve(r.uri)
 	if err != nil {
 		s.Error(w, r, fmt.Errorf("error resolving %s: %s", r.uri.Addr, err))
@@ -345,15 +348,22 @@ func (s *Server) HandleGetRaw(w http.ResponseWriter, r *Request) {
 		return
 	}
 
-	// allow the request to overwrite the content type using a query
-	// parameter
-	contentType := "application/octet-stream"
-	if typ := r.URL.Query().Get("content_type"); typ != "" {
-		contentType = typ
-	}
-	w.Header().Set("Content-Type", contentType)
+	switch {
+	case r.uri.Raw():
+		// allow the request to overwrite the content type using a query
+		// parameter
+		contentType := "application/octet-stream"
+		if typ := r.URL.Query().Get("content_type"); typ != "" {
+			contentType = typ
+		}
+		w.Header().Set("Content-Type", contentType)
 
-	http.ServeContent(w, &r.Request, "", time.Now(), reader)
+		http.ServeContent(w, &r.Request, "", time.Now(), reader)
+	case r.uri.Hash():
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, key)
+	}
 }
 
 // HandleGetFiles handles a GET request to bzz:/<manifest> with an Accept
@@ -616,8 +626,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		s.HandleDelete(w, req)
 
 	case "GET":
-		if uri.Raw() {
-			s.HandleGetRaw(w, req)
+		if uri.Raw() || uri.Hash() {
+			s.HandleGet(w, req)
 			return
 		}
 

--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -290,9 +290,12 @@ func (s *Server) HandleDelete(w http.ResponseWriter, r *Request) {
 	fmt.Fprint(w, newKey)
 }
 
-// HandleGetRaw handles a GET request to bzzr://<key> and responds with
-// the raw content stored at the given storage key
-func (s *Server) HandleGetRaw(w http.ResponseWriter, r *Request) {
+// HandleGet handles a GET request to
+// - bzzr://<key> and responds with the raw content stored at the
+//   given storage key
+// - bzz-hash://<key> and responds with the hash of the content stored
+//   at the given storage key as a text/plain response
+func (s *Server) HandleGet(w http.ResponseWriter, r *Request) {
 	key, err := s.api.Resolve(r.uri)
 	if err != nil {
 		s.Error(w, r, fmt.Errorf("error resolving %s: %s", r.uri.Addr, err))
@@ -345,15 +348,22 @@ func (s *Server) HandleGetRaw(w http.ResponseWriter, r *Request) {
 		return
 	}
 
-	// allow the request to overwrite the content type using a query
-	// parameter
-	contentType := "application/octet-stream"
-	if typ := r.URL.Query().Get("content_type"); typ != "" {
-		contentType = typ
-	}
-	w.Header().Set("Content-Type", contentType)
+	switch {
+	case r.uri.Raw():
+		// allow the request to overwrite the content type using a query
+		// parameter
+		contentType := "application/octet-stream"
+		if typ := r.URL.Query().Get("content_type"); typ != "" {
+			contentType = typ
+		}
+		w.Header().Set("Content-Type", contentType)
 
-	http.ServeContent(w, &r.Request, "", time.Now(), reader)
+		http.ServeContent(w, &r.Request, "", time.Now(), reader)
+	case r.uri.Hash():
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, key)
+	}
 }
 
 // HandleGetFiles handles a GET request to bzz:/<manifest> with an Accept
@@ -522,11 +532,8 @@ func (s *Server) getManifestList(key storage.Key, prefix string) (list api.Manif
 	return list, nil
 }
 
-// HandleGetFile handles a GET request to
-// - bzz://<manifest>/<path> and responds with the content of the file at
-//   <path> from the given <manifest>
-// - bzz-hash://<key>/<path> and responds with the hash of the content stored
-//   at the given storage key as a text/plain response
+// HandleGetFile handles a GET request to bzz://<manifest>/<path> and responds
+// with the content of the file at <path> from the given <manifest>
 func (s *Server) HandleGetFile(w http.ResponseWriter, r *Request) {
 	// ensure the root path has a trailing slash so that relative URLs work
 	if r.uri.Path == "" && !strings.HasSuffix(r.URL.Path, "/") {
@@ -540,7 +547,7 @@ func (s *Server) HandleGetFile(w http.ResponseWriter, r *Request) {
 		return
 	}
 
-	reader, hash, contentType, status, err := s.api.GetHash(key, r.uri.Path)
+	reader, contentType, status, err := s.api.Get(key, r.uri.Path)
 	if err != nil {
 		switch status {
 		case http.StatusNotFound:
@@ -570,13 +577,6 @@ func (s *Server) HandleGetFile(w http.ResponseWriter, r *Request) {
 	// check the root chunk exists by retrieving the file's size
 	if _, err := reader.Size(nil); err != nil {
 		s.NotFound(w, r, fmt.Errorf("File not found %s: %s", r.uri, err))
-		return
-	}
-
-	if r.uri.Hash() {
-		w.Header().Set("Content-Type", "text/plain")
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, hash)
 		return
 	}
 
@@ -626,8 +626,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		s.HandleDelete(w, req)
 
 	case "GET":
-		if uri.Raw() {
-			s.HandleGetRaw(w, req)
+		if uri.Raw() || uri.Hash() {
+			s.HandleGet(w, req)
 			return
 		}
 

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/swarm/testutil"
 )
 
-func TestBzzrGetPath(t *testing.T) {
+func TestBzzGetPath(t *testing.T) {
 
 	var err error
 
@@ -104,15 +104,46 @@ func TestBzzrGetPath(t *testing.T) {
 		}
 	}
 
+	for k, v := range testrequests {
+		var resp *http.Response
+		var respbody []byte
+
+		url := srv.URL + "/bzz-hash:/"
+		if k[:] != "" {
+			url += common.ToHex(key[0])[2:] + "/" + k[1:]
+		}
+		resp, err = http.Get(url)
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+		defer resp.Body.Close()
+		respbody, err = ioutil.ReadAll(resp.Body)
+
+		if string(respbody) != key[v].String() {
+			isexpectedfailrequest := false
+
+			for _, r := range expectedfailrequests {
+				if k[:] == r {
+					isexpectedfailrequest = true
+				}
+			}
+			if !isexpectedfailrequest {
+				t.Fatalf("Response body does not match, expected: %v, got %v", key[v], string(respbody))
+			}
+		}
+	}
+
 	nonhashtests := []string{
 		srv.URL + "/bzz:/name",
 		srv.URL + "/bzzi:/nonhash",
 		srv.URL + "/bzzr:/nonhash",
+		srv.URL + "/bzz-hash:/nonhash",
 	}
 
 	nonhashresponses := []string{
 		"error resolving name: no DNS to resolve name: &#34;name&#34;",
 		"error resolving nonhash: immutable address not a content hash: &#34;nonhash&#34;",
+		"error resolving nonhash: no DNS to resolve name: &#34;nonhash&#34;",
 		"error resolving nonhash: no DNS to resolve name: &#34;nonhash&#34;",
 	}
 

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -118,6 +118,9 @@ func TestBzzGetPath(t *testing.T) {
 		}
 		defer resp.Body.Close()
 		respbody, err = ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("Read request body: %v", err)
+		}
 
 		if string(respbody) != key[v].String() {
 			isexpectedfailrequest := false

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/swarm/testutil"
 )
 
-func TestBzzrGetPath(t *testing.T) {
+func TestBzzGetPath(t *testing.T) {
 
 	var err error
 
@@ -100,6 +100,35 @@ func TestBzzrGetPath(t *testing.T) {
 			}
 			if !isexpectedfailrequest {
 				t.Fatalf("Response body does not match, expected: %v, got %v", testmanifest[v], string(respbody))
+			}
+		}
+	}
+
+	for k, v := range testrequests {
+		var resp *http.Response
+		var respbody []byte
+
+		url := srv.URL + "/bzz-hash:/"
+		if k[:] != "" {
+			url += common.ToHex(key[0])[2:] + "/" + k[1:]
+		}
+		resp, err = http.Get(url)
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+		defer resp.Body.Close()
+		respbody, err = ioutil.ReadAll(resp.Body)
+
+		if string(respbody) != key[v].String() {
+			isexpectedfailrequest := false
+
+			for _, r := range expectedfailrequests {
+				if k[:] == r {
+					isexpectedfailrequest = true
+				}
+			}
+			if !isexpectedfailrequest {
+				t.Fatalf("Response body does not match, expected: %v, got %v", key[v], string(respbody))
 			}
 		}
 	}
@@ -194,65 +223,5 @@ func TestBzzRootRedirect(t *testing.T) {
 	}
 	if !bytes.Equal(gotData, data) {
 		t.Fatalf("expected response to equal %q, got %q", data, gotData)
-	}
-}
-
-// TestBzzHash tests if requests with bzz-hash:// scheme
-// return the hash of the swarm content.
-func TestBzzHash(t *testing.T) {
-	srv := testutil.NewTestSwarmServer(t)
-	defer srv.Close()
-
-	client := swarm.NewClient(srv.URL)
-
-	for _, c := range []struct {
-		data string
-		path string
-	}{
-		{
-			data: "test root",
-			path: "",
-		},
-		{
-			data: "test /a",
-			path: "a",
-		},
-		{
-			data: "test /a/b",
-			path: "a/b",
-		},
-	} {
-		t.Run("path "+c.path, func(t *testing.T) {
-			hash, err := client.Upload(&swarm.File{
-				ReadCloser: ioutil.NopCloser(strings.NewReader(c.data)),
-				ManifestEntry: api.ManifestEntry{
-					Path:        "",
-					ContentType: "text/plain",
-					Size:        int64(len(c.data)),
-				},
-			}, "")
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			manifest, err := client.DownloadManifest(hash)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			res, err := http.Get(srv.URL + "/bzz-hash:/" + hash + "/")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer res.Body.Close()
-
-			body, err := ioutil.ReadAll(res.Body)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if string(body) != manifest.Entries[0].Hash {
-				t.Fatalf("expected response to equal %q, got %q", manifest.Entries[0].Hash, string(body))
-			}
-		})
 	}
 }

--- a/swarm/api/uri.go
+++ b/swarm/api/uri.go
@@ -30,6 +30,8 @@ type URI struct {
 	// * bzzr - raw swarm content
 	// * bzzi - immutable URI of an entry in a swarm manifest
 	//          (address is not resolved)
+	// * bzz-hash - hash of swarm content
+	//
 	Scheme string
 
 	// Addr is either a hexadecimal storage key or it an address which
@@ -50,7 +52,7 @@ type URI struct {
 // * <scheme>://<addr>
 // * <scheme>://<addr>/<path>
 //
-// with scheme one of bzz, bzzr or bzzi
+// with scheme one of bzz, bzzr, bzzi or bzz-hash
 func Parse(rawuri string) (*URI, error) {
 	u, err := url.Parse(rawuri)
 	if err != nil {
@@ -60,7 +62,7 @@ func Parse(rawuri string) (*URI, error) {
 
 	// check the scheme is valid
 	switch uri.Scheme {
-	case "bzz", "bzzi", "bzzr":
+	case "bzz", "bzzi", "bzzr", "bzz-hash":
 	default:
 		return nil, fmt.Errorf("unknown scheme %q", u.Scheme)
 	}
@@ -89,6 +91,10 @@ func (u *URI) Raw() bool {
 
 func (u *URI) Immutable() bool {
 	return u.Scheme == "bzzi"
+}
+
+func (u *URI) Hash() bool {
+	return u.Scheme == "bzz-hash"
 }
 
 func (u *URI) String() string {

--- a/swarm/api/uri.go
+++ b/swarm/api/uri.go
@@ -58,7 +58,6 @@ type URI struct {
 // * <scheme>://<addr>
 // * <scheme>://<addr>/<path>
 //
-
 // with scheme one of bzz, bzz-raw, bzz-immutable, bzz-list or bzz-hash
 // or deprecated ones bzzr and bzzi
 func Parse(rawuri string) (*URI, error) {

--- a/swarm/api/uri_test.go
+++ b/swarm/api/uri_test.go
@@ -28,6 +28,7 @@ func TestParseURI(t *testing.T) {
 		expectErr       bool
 		expectRaw       bool
 		expectImmutable bool
+		expectHash      bool
 	}
 	tests := []test{
 		{
@@ -95,6 +96,16 @@ func TestParseURI(t *testing.T) {
 			uri:       "bzz://abc123/path/to/entry",
 			expectURI: &URI{Scheme: "bzz", Addr: "abc123", Path: "path/to/entry"},
 		},
+		{
+			uri:        "bzz-hash:",
+			expectURI:  &URI{Scheme: "bzz-hash"},
+			expectHash: true,
+		},
+		{
+			uri:        "bzz-hash:/",
+			expectURI:  &URI{Scheme: "bzz-hash"},
+			expectHash: true,
+		},
 	}
 	for _, x := range tests {
 		actual, err := Parse(x.uri)
@@ -115,6 +126,9 @@ func TestParseURI(t *testing.T) {
 		}
 		if actual.Immutable() != x.expectImmutable {
 			t.Fatalf("expected %s immutable to be %t, got %t", x.uri, x.expectImmutable, actual.Immutable())
+		}
+		if actual.Hash() != x.expectHash {
+			t.Fatalf("expected %s hash to be %t, got %t", x.uri, x.expectHash, actual.Hash())
 		}
 	}
 }


### PR DESCRIPTION
Update URI to support bzz-hash scheme and handle such HTTP requests by
responding with hash of the content as a text/plain response.

More discussion on this subject is on a related PR ethersphere#141 and gist https://gist.github.com/gbalint/ce09ada0bebc38f3a8a3dd2ce6c6299f.