### PR TITLE
swarm/storage: Externalize signatures of Resource updates

### DIFF
--- a/swarm/storage/resource.go
+++ b/swarm/storage/resource.go
@@ -29,15 +29,6 @@ var emptySignature Signature
 
 type SignFunc func(common.Hash) (Signature, error)
 
-func bytesToSignature(b []byte) (Signature, error) {
-	var s Signature
-	if len(b) != signatureLength {
-		return [signatureLength]byte{}, fmt.Errorf("Must be %d bytes", signatureLength)
-	}
-	copy(s[:], b)
-	return s, nil
-}
-
 // Encapsulates an actual resource update. When synced it contains the most recent
 // version of the resource update data.
 type resource struct {

--- a/swarm/storage/resource_ens.go
+++ b/swarm/storage/resource_ens.go
@@ -1,27 +1,47 @@
 package storage
 
 import (
+	"fmt"
+
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/contracts/ens"
 )
 
-// ENS validation of mutable resource owners
-type ENSValidator struct {
-	api *ens.ENS
+type baseValidator struct {
+	signFunc SignFunc
 }
 
-func NewENSValidator(contractaddress common.Address, backend bind.ContractBackend, transactOpts *bind.TransactOpts) (*ENSValidator, error) {
+func (b *baseValidator) sign(datahash common.Hash) (Signature, error) {
+	if b.signFunc == nil {
+		return emptySignature, fmt.Errorf("No signature function")
+	}
+	return b.signFunc(datahash)
+}
+
+// ENS validation of mutable resource owners
+type ENSValidator struct {
+	*baseValidator
+	api        *ens.ENS
+	hashlength int
+}
+
+func NewENSValidator(contractaddress common.Address, backend bind.ContractBackend, transactOpts *bind.TransactOpts, signFunc SignFunc) (*ENSValidator, error) {
 	var err error
-	validator := &ENSValidator{}
+	validator := &ENSValidator{
+		baseValidator: &baseValidator{
+			signFunc: signFunc,
+		},
+	}
 	validator.api, err = ens.NewENS(transactOpts, contractaddress, backend)
 	if err != nil {
 		return nil, err
 	}
+	validator.hashlength = len(ens.EnsNode(dbDirName).Bytes())
 	return validator, nil
 }
 
-func (self *ENSValidator) isOwner(name string, address common.Address) (bool, error) {
+func (self *ENSValidator) checkAccess(name string, address common.Address) (bool, error) {
 	owneraddr, err := self.api.Owner(self.nameHash(name))
 	if err != nil {
 		return false, err
@@ -35,15 +55,23 @@ func (self *ENSValidator) nameHash(name string) common.Hash {
 
 // Default fallthrough validation of mutable resource ownership
 type GenericValidator struct {
-	hashFunc func(string) common.Hash
+	*baseValidator
+	hashFunc   func(string) common.Hash
+	hashlength int
 }
 
-func NewGenericValidator(hashFunc func(string) common.Hash) *GenericValidator {
+func NewGenericValidator(hashFunc func(string) common.Hash, signFunc SignFunc) *GenericValidator {
 	return &GenericValidator{
-		hashFunc: hashFunc,
+		baseValidator: &baseValidator{
+			signFunc: signFunc,
+		},
+		hashFunc:   hashFunc,
+		hashlength: len(hashFunc(dbDirName).Bytes()),
 	}
+
 }
-func (self *GenericValidator) isOwner(name string, address common.Address) (bool, error) {
+
+func (self *GenericValidator) checkAccess(name string, address common.Address) (bool, error) {
 	return true, nil
 }
 

--- a/swarm/storage/resource_ens.go
+++ b/swarm/storage/resource_ens.go
@@ -8,27 +8,25 @@ import (
 
 // ENS validation of mutable resource owners
 type ENSValidator struct {
-	owner common.Address
-	api   *ens.ENS
+	api *ens.ENS
 }
 
-func NewENSValidator(owneraddress common.Address, contractaddress common.Address, backend bind.ContractBackend, transactOpts *bind.TransactOpts) (*ENSValidator, error) {
+func NewENSValidator(contractaddress common.Address, backend bind.ContractBackend, transactOpts *bind.TransactOpts) (*ENSValidator, error) {
 	var err error
 	validator := &ENSValidator{}
 	validator.api, err = ens.NewENS(transactOpts, contractaddress, backend)
 	if err != nil {
 		return nil, err
 	}
-	validator.owner = owneraddress
 	return validator, nil
 }
 
-func (self *ENSValidator) isOwner(name string) (bool, error) {
+func (self *ENSValidator) isOwner(name string, address common.Address) (bool, error) {
 	owneraddr, err := self.api.Owner(self.nameHash(name))
 	if err != nil {
 		return false, err
 	}
-	return owneraddr == self.owner, nil
+	return owneraddr == address, nil
 }
 
 func (self *ENSValidator) nameHash(name string) common.Hash {
@@ -45,7 +43,7 @@ func NewGenericValidator(hashFunc func(string) common.Hash) *GenericValidator {
 		hashFunc: hashFunc,
 	}
 }
-func (self *GenericValidator) isOwner(name string) (bool, error) {
+func (self *GenericValidator) isOwner(name string, address common.Address) (bool, error) {
 	return true, nil
 }
 

--- a/swarm/storage/resource_test.go
+++ b/swarm/storage/resource_test.go
@@ -535,18 +535,17 @@ func setupENS(addr common.Address, transactOpts *bind.TransactOpts, sub string, 
 	return contractAddress, contractBackend, nil
 }
 
-func signContent(privKey *ecdsa.PrivateKey, data []byte) ([signatureLength]byte, error) {
+func signContent(privKey *ecdsa.PrivateKey, data []byte) (Signature, error) {
 	hasher.Reset()
 	hasher.Write(data)
 	datahash := hasher.Sum(nil)
 
-	signature, err := crypto.Sign(datahash, privKey)
+	signaturebytes, err := crypto.Sign(datahash, privKey)
 	if err != nil {
 		return [signatureLength]byte{}, err
 	}
-	var signaturetype [signatureLength]byte
-	copy(signaturetype[:], signature)
-	return signaturetype, nil
+	signature, err := NewSignature(signaturebytes)
+	return signature, err
 }
 
 type testCloudStore struct {

--- a/swarm/storage/resource_test.go
+++ b/swarm/storage/resource_test.go
@@ -150,9 +150,6 @@ func TestResourceHandler(t *testing.T) {
 	}
 
 	// create a new resource
-	if err != nil {
-		teardownTest(t, err)
-	}
 	_, err = rh.NewResource(safeName, resourceFrequency)
 	if err != nil {
 		teardownTest(t, err)


### PR DESCRIPTION
This PR eliminates the storage of private key in the `ResourceHandler` object, and implements the following changes:

* External sign function
* Make resource hash data order equal to order in chunk sdata
* Make sure uniform hash function in all components
* Remove function for setting "external" resources on handler (can be reimplemented if there is an actual usecase)
* Remove redundant length from root chunk data
* Force use of valid idna names, also for resource index
* Omit signature data from chunk data if no validation
* Move `GenericValidator` to test as `testValidator` and allow validator to be nil
