### PR TITLE
HTTP API for mutable resources

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -560,7 +560,7 @@ func registerBzzService(bzzconfig *bzzapi.Config, ctx *cli.Context, stack *node.
 		}
 
 		// In production, mockStore must be always nil.
-		return swarm.NewSwarm(ctx, swapClient, ensClient, bzzconfig, bzzconfig.SwapEnabled, bzzconfig.SyncEnabled, bzzconfig.Cors, bzzconfig.PssEnabled, bzzconfig.ResourceEnabled, nil)
+		return swarm.NewSwarm(ctx, swapClient, ensClient, bzzconfig, nil)
 	}
 	//register within the ethereum node
 	if err := stack.Register(boot); err != nil {

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -560,7 +560,7 @@ func registerBzzService(bzzconfig *bzzapi.Config, ctx *cli.Context, stack *node.
 		}
 
 		// In production, mockStore must be always nil.
-		return swarm.NewSwarm(ctx, swapClient, ensClient, bzzconfig, bzzconfig.SwapEnabled, bzzconfig.SyncEnabled, bzzconfig.Cors, bzzconfig.PssEnabled, nil)
+		return swarm.NewSwarm(ctx, swapClient, ensClient, bzzconfig, bzzconfig.SwapEnabled, bzzconfig.SyncEnabled, bzzconfig.Cors, bzzconfig.PssEnabled, bzzconfig.ResourceEnabled, nil)
 	}
 	//register within the ethereum node
 	if err := stack.Register(boot); err != nil {

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"strconv"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -77,13 +76,19 @@ type rpcBlock struct {
 	UncleHashes  []common.Hash    `json:"uncles"`
 }
 
-func (ec *Client) BlockNumber(ctx context.Context) (uint64, error) {
-	var number string
-	err := ec.c.CallContext(ctx, &number, "eth_blockNumber")
+func (ec *Client) BlockNumber(ctx context.Context) (big.Int, error) {
+	var numberstr string
+	number := &big.Int{}
+	err := ec.c.CallContext(ctx, &numberstr, "eth_blockNumber")
 	if err != nil {
-		return 0, err
+		return *number, err
 	}
-	return strconv.ParseUint(number, 10, 64)
+	var ok bool
+	number, ok = number.SetString(numberstr, 10)
+	if !ok {
+		err = errors.New("Failed to parse bigint")
+	}
+	return *number, err
 }
 
 func (ec *Client) getBlock(ctx context.Context, method string, args ...interface{}) (*types.Block, error) {

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -76,12 +76,6 @@ type rpcBlock struct {
 	UncleHashes  []common.Hash    `json:"uncles"`
 }
 
-func (ec *Client) BlockNumber(ctx context.Context) (big.Int, error) {
-	number := &big.Int{}
-	err := ec.c.CallContext(ctx, &number, "eth_blockNumber")
-	return *number, err
-}
-
 func (ec *Client) getBlock(ctx context.Context, method string, args ...interface{}) (*types.Block, error) {
 	var raw json.RawMessage
 	err := ec.c.CallContext(ctx, &raw, method, args...)

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -77,17 +77,8 @@ type rpcBlock struct {
 }
 
 func (ec *Client) BlockNumber(ctx context.Context) (big.Int, error) {
-	var numberstr string
 	number := &big.Int{}
-	err := ec.c.CallContext(ctx, &numberstr, "eth_blockNumber")
-	if err != nil {
-		return *number, err
-	}
-	var ok bool
-	number, ok = number.SetString(numberstr, 10)
-	if !ok {
-		err = errors.New("Failed to parse bigint")
-	}
+	err := ec.c.CallContext(ctx, &number, "eth_blockNumber")
 	return *number, err
 }
 

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strconv"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -74,6 +75,15 @@ type rpcBlock struct {
 	Hash         common.Hash      `json:"hash"`
 	Transactions []rpcTransaction `json:"transactions"`
 	UncleHashes  []common.Hash    `json:"uncles"`
+}
+
+func (ec *Client) BlockNumber(ctx context.Context) (uint64, error) {
+	var number string
+	err := ec.c.CallContext(ctx, &number, "eth_blockNumber")
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseUint(number, 10, 64)
 }
 
 func (ec *Client) getBlock(ctx context.Context, method string, args ...interface{}) (*types.Block, error) {

--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -365,13 +365,13 @@ func (self *Api) BuildDirectoryTree(mhash string, nameresolver bool) (key storag
 }
 
 // Look up mutable resource updates at specific periods and versions
-func (self *Api) DbLookup(key storage.Key, name string, period uint32, version uint32) (storage.Key, io.ReadSeeker, int, error) {
+func (self *Api) DbLookup(key storage.Key, name string, period uint32, version uint32) (storage.Key, []byte, error) {
 	var err error
 	if version != 0 {
 		if period == 0 {
 			currentblocknumber, err := self.resource.GetBlock()
 			if err != nil {
-				return nil, nil, 0, fmt.Errorf("Could not determine latest block: %v", err)
+				return nil, nil, fmt.Errorf("Could not determine latest block: %v", err)
 			}
 			period = self.resource.BlockToPeriod(name, currentblocknumber)
 		}
@@ -382,13 +382,13 @@ func (self *Api) DbLookup(key storage.Key, name string, period uint32, version u
 		_, err = self.resource.LookupLatestByName(name, true)
 	}
 	if err != nil {
-		return nil, nil, 0, err
+		return nil, nil, err
 	}
 	key, data, err := self.resource.GetContent(name)
 	if err != nil {
-		return nil, nil, 0, err
+		return nil, nil, err
 	}
-	return key, bytes.NewReader(data), len(data), nil
+	return key, data, nil
 }
 
 func (self *Api) DbCreate(name string, frequency uint64) (err error) {

--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -384,11 +384,7 @@ func (self *Api) ResourceLookup(name string, period uint32, version uint32) (sto
 	if err != nil {
 		return nil, nil, err
 	}
-	key, data, err := self.resource.GetContent(name)
-	if err != nil {
-		return nil, nil, err
-	}
-	return key, data, nil
+	return self.resource.GetContent(name)
 }
 
 func (self *Api) ResourceCreate(name string, frequency uint64) (err error) {

--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -365,7 +365,7 @@ func (self *Api) BuildDirectoryTree(mhash string, nameresolver bool) (key storag
 }
 
 // Look up mutable resource updates at specific periods and versions
-func (self *Api) DbLookup(key storage.Key, name string, period uint32, version uint32) (storage.Key, []byte, error) {
+func (self *Api) DbLookup(name string, period uint32, version uint32) (storage.Key, []byte, error) {
 	var err error
 	if version != 0 {
 		if period == 0 {

--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -365,13 +365,13 @@ func (self *Api) BuildDirectoryTree(mhash string, nameresolver bool) (key storag
 }
 
 // Look up mutable resource updates at specific periods and versions
-func (self *Api) DbLookup(key storage.Key, name string, period uint32, version uint32) (io.ReadSeeker, error) {
+func (self *Api) DbLookup(key storage.Key, name string, period uint32, version uint32) (storage.Key, io.ReadSeeker, int, error) {
 	var err error
 	if version != 0 {
 		if period == 0 {
 			currentblocknumber, err := self.resource.GetBlock()
 			if err != nil {
-				return nil, fmt.Errorf("Could not determine latest block: %v", err)
+				return nil, nil, 0, fmt.Errorf("Could not determine latest block: %v", err)
 			}
 			period = self.resource.BlockToPeriod(name, currentblocknumber)
 		}
@@ -382,13 +382,13 @@ func (self *Api) DbLookup(key storage.Key, name string, period uint32, version u
 		_, err = self.resource.LookupLatestByName(name, true)
 	}
 	if err != nil {
-		return nil, err
+		return nil, nil, 0, err
 	}
-	data, err := self.resource.GetData(name)
+	key, data, err := self.resource.GetContent(name)
 	if err != nil {
-		return nil, err
+		return nil, nil, 0, err
 	}
-	return bytes.NewReader(data), nil
+	return key, bytes.NewReader(data), len(data), nil
 }
 
 func (self *Api) DbCreate(name string, frequency uint64) (err error) {
@@ -405,4 +405,8 @@ func (self *Api) DbUpdate(name string, data []byte) (storage.Key, uint32, uint32
 
 func (self *Api) DbHashSize() int {
 	return self.resource.HashSize()
+}
+
+func (self *Api) DbIsValidated() bool {
+	return self.resource.IsValidated()
 }

--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -387,9 +387,10 @@ func (self *Api) ResourceLookup(name string, period uint32, version uint32) (sto
 	return self.resource.GetContent(name)
 }
 
-func (self *Api) ResourceCreate(name string, frequency uint64) (err error) {
-	_, err = self.resource.NewResource(name, frequency)
-	return err
+func (self *Api) ResourceCreate(name string, frequency uint64) (storage.Key, error) {
+	rsrc, err := self.resource.NewResource(name, frequency)
+	h := rsrc.NameHash()
+	return storage.Key(h[:]), err
 }
 
 func (self *Api) ResourceUpdate(name string, data []byte) (storage.Key, uint32, uint32, error) {

--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -389,8 +389,11 @@ func (self *Api) ResourceLookup(name string, period uint32, version uint32) (sto
 
 func (self *Api) ResourceCreate(name string, frequency uint64) (storage.Key, error) {
 	rsrc, err := self.resource.NewResource(name, frequency)
+	if err != nil {
+		return nil, err
+	}
 	h := rsrc.NameHash()
-	return storage.Key(h[:]), err
+	return storage.Key(h[:]), nil
 }
 
 func (self *Api) ResourceUpdate(name string, data []byte) (storage.Key, uint32, uint32, error) {

--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -365,7 +365,7 @@ func (self *Api) BuildDirectoryTree(mhash string, nameresolver bool) (key storag
 }
 
 // Look up mutable resource updates at specific periods and versions
-func (self *Api) DbLookup(name string, period uint32, version uint32) (storage.Key, []byte, error) {
+func (self *Api) ResourceLookup(name string, period uint32, version uint32) (storage.Key, []byte, error) {
 	var err error
 	if version != 0 {
 		if period == 0 {
@@ -391,22 +391,22 @@ func (self *Api) DbLookup(name string, period uint32, version uint32) (storage.K
 	return key, data, nil
 }
 
-func (self *Api) DbCreate(name string, frequency uint64) (err error) {
+func (self *Api) ResourceCreate(name string, frequency uint64) (err error) {
 	_, err = self.resource.NewResource(name, frequency)
 	return err
 }
 
-func (self *Api) DbUpdate(name string, data []byte) (storage.Key, uint32, uint32, error) {
+func (self *Api) ResourceUpdate(name string, data []byte) (storage.Key, uint32, uint32, error) {
 	key, err := self.resource.Update(name, data)
 	period, _ := self.resource.GetLastPeriod(name)
 	version, _ := self.resource.GetVersion(name)
 	return key, period, version, err
 }
 
-func (self *Api) DbHashSize() int {
+func (self *Api) ResourceHashSize() int {
 	return self.resource.HashSize()
 }
 
-func (self *Api) DbIsValidated() bool {
+func (self *Api) ResourceIsValidated() bool {
 	return self.resource.IsValidated()
 }

--- a/swarm/api/api_test.go
+++ b/swarm/api/api_test.go
@@ -40,7 +40,7 @@ func testApi(t *testing.T, f func(*Api)) {
 	if err != nil {
 		return
 	}
-	api := NewApi(dpa, nil)
+	api := NewApi(dpa, nil, nil)
 	dpa.Start()
 	f(api)
 	dpa.Stop()

--- a/swarm/api/config.go
+++ b/swarm/api/config.go
@@ -63,6 +63,7 @@ type Config struct {
 	Cors            string
 	BzzAccount      string
 	BootNodes       string
+	privateKey      *ecdsa.PrivateKey
 }
 
 //create a default config with all parameters to set to defaults
@@ -113,5 +114,14 @@ func (self *Config) Init(prvKey *ecdsa.PrivateKey) {
 	if self.SwapEnabled {
 		self.Swap.Init(self.Contract, prvKey)
 	}
+	self.privateKey = prvKey
 	self.StoreParams.Init(self.Path)
+}
+
+func (self *Config) ShiftPrivateKey() (privKey *ecdsa.PrivateKey) {
+	if self.privateKey != nil {
+		privKey = self.privateKey
+		self.privateKey = nil
+	}
+	return privKey
 }

--- a/swarm/api/config.go
+++ b/swarm/api/config.go
@@ -46,22 +46,23 @@ type Config struct {
 	*network.HiveParams
 	Swap *swap.SwapParams
 	//*network.SyncParams
-	Contract    common.Address
-	EnsRoot     common.Address
-	EnsApi      string
-	Path        string
-	ListenAddr  string
-	Port        string
-	PublicKey   string
-	BzzKey      string
-	NetworkId   uint64
-	SwapEnabled bool
-	SyncEnabled bool
-	PssEnabled  bool
-	SwapApi     string
-	Cors        string
-	BzzAccount  string
-	BootNodes   string
+	Contract        common.Address
+	EnsRoot         common.Address
+	EnsApi          string
+	Path            string
+	ListenAddr      string
+	Port            string
+	PublicKey       string
+	BzzKey          string
+	NetworkId       uint64
+	SwapEnabled     bool
+	SyncEnabled     bool
+	PssEnabled      bool
+	ResourceEnabled bool
+	SwapApi         string
+	Cors            string
+	BzzAccount      string
+	BootNodes       string
 }
 
 //create a default config with all parameters to set to defaults
@@ -72,18 +73,19 @@ func NewConfig() (self *Config) {
 		ChunkerParams: storage.NewChunkerParams(),
 		HiveParams:    network.NewHiveParams(),
 		//SyncParams:    network.NewDefaultSyncParams(),
-		Swap:        swap.NewDefaultSwapParams(),
-		ListenAddr:  DefaultHTTPListenAddr,
-		Port:        DefaultHTTPPort,
-		Path:        node.DefaultDataDir(),
-		EnsApi:      node.DefaultIPCEndpoint("geth"),
-		EnsRoot:     ens.TestNetAddress,
-		NetworkId:   network.NetworkID,
-		SwapEnabled: false,
-		SyncEnabled: true,
-		PssEnabled:  true,
-		SwapApi:     "",
-		BootNodes:   "",
+		Swap:            swap.NewDefaultSwapParams(),
+		ListenAddr:      DefaultHTTPListenAddr,
+		Port:            DefaultHTTPPort,
+		Path:            node.DefaultDataDir(),
+		EnsApi:          node.DefaultIPCEndpoint("geth"),
+		EnsRoot:         ens.TestNetAddress,
+		NetworkId:       network.NetworkID,
+		SwapEnabled:     false,
+		SyncEnabled:     true,
+		PssEnabled:      true,
+		ResourceEnabled: true,
+		SwapApi:         "",
+		BootNodes:       "",
 	}
 
 	return

--- a/swarm/api/config.go
+++ b/swarm/api/config.go
@@ -110,8 +110,8 @@ func (self *Config) Init(prvKey *ecdsa.PrivateKey) {
 	self.PublicKey = pubkeyhex
 	self.BzzKey = keyhex
 
-	self.Swap.Init(self.Contract, prvKey)
-	//self.SyncParams.Init(self.Path)
-	//self.HiveParams.Init(self.Path)
+	if self.SwapEnabled {
+		self.Swap.Init(self.Contract, prvKey)
+	}
 	self.StoreParams.Init(self.Path)
 }

--- a/swarm/api/config_test.go
+++ b/swarm/api/config_test.go
@@ -49,12 +49,9 @@ func TestConfig(t *testing.T) {
 	if one.PublicKey == "" {
 		t.Fatal("Expected PublicKey to be set")
 	}
-
-	//the Init function should append subdirs to the given path
-	if one.Swap.PayProfile.Beneficiary == (common.Address{}) {
+	if one.Swap.PayProfile.Beneficiary == (common.Address{}) && one.SwapEnabled {
 		t.Fatal("Failed to correctly initialize SwapParams")
 	}
-
 	if one.StoreParams.ChunkDbPath == one.Path {
 		t.Fatal("Failed to correctly initialize StoreParams")
 	}

--- a/swarm/api/config_test.go
+++ b/swarm/api/config_test.go
@@ -55,10 +55,6 @@ func TestConfig(t *testing.T) {
 		t.Fatal("Failed to correctly initialize SwapParams")
 	}
 
-	if one.HiveParams.MaxPeersPerRequest != 5 {
-		t.Fatal("Failed to correctly initialize HiveParams")
-	}
-
 	if one.StoreParams.ChunkDbPath == one.Path {
 		t.Fatal("Failed to correctly initialize StoreParams")
 	}

--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -299,7 +299,7 @@ func (s *Server) HandlePostResource(w http.ResponseWriter, r *Request) {
 			s.BadRequest(w, r, fmt.Sprintf("Cannot parse frequency parameter: %v", err))
 			return
 		}
-		key, err := s.api.ResourceCreate(r.uri.Addr, frequency)
+		key, err := s.api.ResourceCreate(r.Context(), r.uri.Addr, frequency)
 		if err != nil {
 			s.Error(w, r, fmt.Errorf("Resource creation failed: %v", err))
 			return
@@ -312,7 +312,7 @@ func (s *Server) HandlePostResource(w http.ResponseWriter, r *Request) {
 		s.Error(w, r, err)
 		return
 	}
-	_, _, _, err = s.api.ResourceUpdate(r.uri.Addr, data)
+	_, _, _, err = s.api.ResourceUpdate(r.Context(), r.uri.Addr, data)
 	if err != nil {
 		s.Error(w, r, fmt.Errorf("Update resource failed: %v", err))
 		return
@@ -350,7 +350,7 @@ func (s *Server) handleGetResource(w http.ResponseWriter, r *Request, name strin
 	log.Debug("handlegetdb", "name", name)
 	switch len(params) {
 	case 0:
-		updateKey, data, err = s.api.ResourceLookup(name, 0, 0)
+		updateKey, data, err = s.api.ResourceLookup(r.Context(), name, 0, 0)
 	case 2:
 		version, err = strconv.ParseUint(params[1], 10, 32)
 		if err != nil {
@@ -360,13 +360,13 @@ func (s *Server) handleGetResource(w http.ResponseWriter, r *Request, name strin
 		if err != nil {
 			break
 		}
-		updateKey, data, err = s.api.ResourceLookup(name, uint32(period), uint32(version))
+		updateKey, data, err = s.api.ResourceLookup(r.Context(), name, uint32(period), uint32(version))
 	case 1:
 		period, err = strconv.ParseUint(params[0], 10, 32)
 		if err != nil {
 			break
 		}
-		updateKey, data, err = s.api.ResourceLookup(name, uint32(period), uint32(version))
+		updateKey, data, err = s.api.ResourceLookup(r.Context(), name, uint32(period), uint32(version))
 	default:
 		s.BadRequest(w, r, "Invalid mutable resource request")
 		return

--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -447,7 +447,7 @@ func (s *Server) HandleGet(w http.ResponseWriter, r *Request) {
 			return api.SkipManifest
 		})
 		if entry == nil {
-			s.NotFound(w, r, fmt.Errorf("Manifest entry could not be loaded"))
+			s.NotFound(w, r, errors.New("Manifest entry could not be loaded"))
 			return
 		}
 		key = storage.Key(common.Hex2Bytes(entry.Hash))

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -64,13 +64,15 @@ func TestBzzResource(t *testing.T) {
 	resp, err := http.Post(url, "application/octet-stream", bytes.NewReader(databytes))
 	if err != nil {
 		t.Fatal(err)
-	} else if resp.StatusCode != http.StatusOK {
+	}
+	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("err %s", resp.Status)
 	}
 	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
-	} else if !bytes.Equal(b, []byte(keybyteshash)) {
+	}
+	if !bytes.Equal(b, []byte(keybyteshash)) {
 		t.Fatalf("resource update hash mismatch, expected '%s' got '%s'", keybyteshash, b)
 	}
 	resp.Body.Close()
@@ -80,13 +82,15 @@ func TestBzzResource(t *testing.T) {
 	resp, err = http.Get(url)
 	if err != nil {
 		t.Fatal(err)
-	} else if resp.StatusCode != http.StatusOK {
+	}
+	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("err %s", resp.Status)
 	}
 	b, err = ioutil.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
-	} else if !bytes.Equal(databytes, b) {
+	}
+	if !bytes.Equal(databytes, b) {
 		t.Fatalf("Expected body '%x', got '%x'", databytes, b)
 	}
 	resp.Body.Close()
@@ -97,7 +101,8 @@ func TestBzzResource(t *testing.T) {
 	resp, err = http.Post(url, "application/octet-stream", bytes.NewReader(data))
 	if err != nil {
 		t.Fatal(err)
-	} else if resp.StatusCode != http.StatusOK {
+	}
+	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("Update returned %d", resp.Status)
 	}
 
@@ -106,13 +111,15 @@ func TestBzzResource(t *testing.T) {
 	resp, err = http.Get(url)
 	if err != nil {
 		t.Fatal(err)
-	} else if resp.StatusCode != http.StatusOK {
+	}
+	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("err %s", resp.Status)
 	}
 	b, err = ioutil.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
-	} else if !bytes.Equal(data, b) {
+	}
+	if !bytes.Equal(data, b) {
 		t.Fatalf("Expected body '%x', got '%x'", data, b)
 	}
 	resp.Body.Close()

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -47,46 +47,53 @@ func TestBzzGetDb(t *testing.T) {
 	keybytes := make([]byte, common.HashLength) // nearest we get to source of info
 	_, err := rand.Read(keybytes)
 	if err != nil {
-		fmt.Printf("err: %v\n", err)
-		return
+		t.Fatal(err)
 	}
 
 	url := fmt.Sprintf("%s/bzz-db:/%s/42", srv.URL, fmt.Sprintf("%x", keybytes))
 	resp, err := http.Post(url, "application/octet-stream", nil)
 	if err != nil {
-		fmt.Printf("err: %v\n", err)
-		return
+		t.Fatal(err)
 	}
 	b, err := ioutil.ReadAll(resp.Body)
-	fmt.Printf("Create: %s : %s\n", resp.Status, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Debug("Create", "status", resp.Status, "body", b)
 
-	url = fmt.Sprintf("%s/bzz-db:/%s", srv.URL, fmt.Sprintf("%x", keybytes))
+	url = fmt.Sprintf("%s/bzz-db:/%x", srv.URL, keybytes)
 	data := []byte("foo")
 	resp, err = http.Post(url, "application/octet-stream", bytes.NewReader(data))
 	if err != nil {
-		fmt.Printf("err: %v\n", err)
-		return
+		t.Fatal(err)
 	}
 	b, err = ioutil.ReadAll(resp.Body)
-	fmt.Printf("Update: %s : %s\n", resp.Status, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Debug("Update", "status", resp.Status, "body", b)
 
 	url = fmt.Sprintf("%s/bzz-db-raw:/%s", srv.URL, fmt.Sprintf("%x", keybytes))
 	resp, err = http.Get(url)
 	if err != nil {
-		fmt.Printf("err: %v\n", err)
-		return
+		t.Fatal(err)
 	}
 	b, err = ioutil.ReadAll(resp.Body)
-	fmt.Printf("Get: %s : %s\n", resp.Status, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Debug("Get raw", "status", resp.Status, "body", b)
 
 	url = fmt.Sprintf("%s/bzz-db:/%s", srv.URL, fmt.Sprintf("%x", keybytes))
 	resp, err = http.Get(url)
 	if err != nil {
-		fmt.Printf("err: %v\n", err)
-		return
+		t.Fatal(err)
 	}
 	b, err = ioutil.ReadAll(resp.Body)
-	fmt.Printf("Get: %s : %s\n", resp.Status, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Debug("Get manifest", "status", resp.Status, "body", b)
 
 }
 

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -40,7 +40,7 @@ func init() {
 	log.Root().SetHandler(log.CallerFileHandler(log.LvlFilterHandler(log.LvlTrace, log.StreamHandler(os.Stderr, log.TerminalFormat(true)))))
 }
 
-func TestBzzGetDb(t *testing.T) {
+func TestBzzResource(t *testing.T) {
 	srv := testutil.NewTestSwarmServer(t)
 	defer srv.Close()
 

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -78,6 +78,16 @@ func TestBzzGetDb(t *testing.T) {
 	}
 	b, err = ioutil.ReadAll(resp.Body)
 	fmt.Printf("Get: %s : %s\n", resp.Status, b)
+
+	url = fmt.Sprintf("%s/bzz-db:/%s", srv.URL, fmt.Sprintf("%x", keybytes))
+	resp, err = http.Get(url)
+	if err != nil {
+		fmt.Printf("err: %v\n", err)
+		return
+	}
+	b, err = ioutil.ReadAll(resp.Body)
+	fmt.Printf("Get: %s : %s\n", resp.Status, b)
+
 }
 
 func TestBzzGetPath(t *testing.T) {

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -53,7 +53,7 @@ func TestBzzGetDb(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	url := fmt.Sprintf("%s/bzz-db:/%x/42", srv.URL, keybytes)
+	url := fmt.Sprintf("%s/bzz-resource:/%x/42", srv.URL, keybytes)
 	resp, err := http.Post(url, "application/octet-stream", bytes.NewReader(databytes))
 	if err != nil {
 		t.Fatal(err)
@@ -67,7 +67,7 @@ func TestBzzGetDb(t *testing.T) {
 	}
 	log.Debug("Create", "status", resp.Status, "body", manifesthash)
 
-	url = fmt.Sprintf("%s/bzz-db:/%x", srv.URL, keybytes)
+	url = fmt.Sprintf("%s/bzz-resource:/%x", srv.URL, keybytes)
 	data := []byte("foo")
 	resp, err = http.Post(url, "application/octet-stream", bytes.NewReader(data))
 	if err != nil {
@@ -88,9 +88,9 @@ func TestBzzGetDb(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	log.Debug("Manifest", "status", resp.Status, "body", fmt.Sprintf("%s", b))
+	log.Debug("Get raw", "status", resp.Status, "body", fmt.Sprintf("%s", b))
 
-	url = fmt.Sprintf("%s/bzz-db-raw:/%x", srv.URL, keybytes)
+	url = fmt.Sprintf("%s/bzz-resource:/%x", srv.URL, keybytes)
 	resp, err = http.Get(url)
 	if err != nil {
 		t.Fatal(err)
@@ -99,18 +99,7 @@ func TestBzzGetDb(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	log.Debug("Get raw", "status", resp.Status)
-
-	url = fmt.Sprintf("%s/bzz-db:/%x", srv.URL, keybytes)
-	resp, err = http.Get(url)
-	if err != nil {
-		t.Fatal(err)
-	}
-	b, err = ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	log.Debug("Get manifest", "status", resp.Status)
+	log.Debug("Get resource", "status", resp.Status, "data", b)
 
 }
 

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -55,14 +55,14 @@ func TestBzzResource(t *testing.T) {
 	resp, err := http.Post(url, "application/octet-stream", bytes.NewReader(databytes))
 	if err != nil {
 		t.Fatal(err)
+	} else if resp.StatusCode != http.StatusOK {
+		t.Fatalf("err %s", resp.Status)
 	}
 	manifesthash, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("err %s", resp.Status)
-	}
+	resp.Body.Close()
 
 	// update 2
 	url = fmt.Sprintf("%s/bzz-resource:/%x", srv.URL, keybytes)
@@ -79,6 +79,8 @@ func TestBzzResource(t *testing.T) {
 	resp, err = http.Get(url)
 	if err != nil {
 		t.Fatal(err)
+	} else if resp.StatusCode != http.StatusOK {
+		t.Fatalf("err %s", resp.Status)
 	}
 	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -86,12 +88,15 @@ func TestBzzResource(t *testing.T) {
 	} else if !bytes.Equal(data, b) {
 		t.Fatalf("Expected body '%x', got '%x'", data, b)
 	}
+	resp.Body.Close()
 
 	// get latest update (1.2) through resource directly
 	url = fmt.Sprintf("%s/bzz-resource:/%x", srv.URL, keybytes)
 	resp, err = http.Get(url)
 	if err != nil {
 		t.Fatal(err)
+	} else if resp.StatusCode != http.StatusOK {
+		t.Fatalf("err %s", resp.Status)
 	}
 	b, err = ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -99,7 +104,7 @@ func TestBzzResource(t *testing.T) {
 	} else if !bytes.Equal(data, b) {
 		t.Fatalf("Expected body '%x', got '%x'", data, b)
 	}
-
+	resp.Body.Close()
 }
 
 func TestBzzGetPath(t *testing.T) {

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -69,6 +69,7 @@ func TestBzzResource(t *testing.T) {
 	if !bytes.Equal(b, []byte(keybyteshash)) {
 		t.Fatalf("resource update hash mismatch, expected '%s' got '%s'", keybyteshash, b)
 	}
+	t.Logf("creatreturn %v / %v", keybyteshash, b)
 
 	// get latest update (1.1) through resource directly
 	url = fmt.Sprintf("%s/bzz-resource:/%x", srv.URL, keybytes)
@@ -97,7 +98,7 @@ func TestBzzResource(t *testing.T) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("Update returned %d", resp.Status)
+		t.Fatalf("Update returned %s", resp.Status)
 	}
 
 	// get latest update (1.2) through resource directly

--- a/swarm/api/manifest.go
+++ b/swarm/api/manifest.go
@@ -33,7 +33,8 @@ import (
 )
 
 const (
-	ManifestType = "application/bzz-manifest+json"
+	ManifestType   = "application/bzz-manifest+json"
+	DbManifestType = "application/bzz-db-manifest+json"
 )
 
 // Manifest represents a swarm manifest

--- a/swarm/api/manifest.go
+++ b/swarm/api/manifest.go
@@ -33,8 +33,8 @@ import (
 )
 
 const (
-	ManifestType   = "application/bzz-manifest+json"
-	DbManifestType = "application/bzz-db-manifest+json"
+	ManifestType        = "application/bzz-manifest+json"
+	ResourceContentType = "application/bzz-resource"
 )
 
 // Manifest represents a swarm manifest

--- a/swarm/api/uri.go
+++ b/swarm/api/uri.go
@@ -69,7 +69,7 @@ func Parse(rawuri string) (*URI, error) {
 
 	// check the scheme is valid
 	switch uri.Scheme {
-	case "bzz", "bzz-raw", "bzz-immutable", "bzz-list", "bzz-hash", "bzzr", "bzzi", "bzz-db":
+	case "bzz", "bzz-raw", "bzz-immutable", "bzz-list", "bzz-hash", "bzzr", "bzzi", "bzz-db", "bzz-db-raw":
 	default:
 		return nil, fmt.Errorf("unknown scheme %q", u.Scheme)
 	}
@@ -94,6 +94,10 @@ func Parse(rawuri string) (*URI, error) {
 
 func (u *URI) Db() bool {
 	return u.Scheme == "bzz-db"
+}
+
+func (u *URI) DbRaw() bool {
+	return u.Scheme == "bzz-db-raw"
 }
 
 func (u *URI) Raw() bool {

--- a/swarm/api/uri.go
+++ b/swarm/api/uri.go
@@ -69,7 +69,7 @@ func Parse(rawuri string) (*URI, error) {
 
 	// check the scheme is valid
 	switch uri.Scheme {
-	case "bzz", "bzz-raw", "bzz-immutable", "bzz-list", "bzz-hash", "bzzr", "bzzi", "bzz-db", "bzz-db-raw":
+	case "bzz", "bzz-raw", "bzz-immutable", "bzz-list", "bzz-hash", "bzzr", "bzzi", "bzz-resource":
 	default:
 		return nil, fmt.Errorf("unknown scheme %q", u.Scheme)
 	}
@@ -92,12 +92,8 @@ func Parse(rawuri string) (*URI, error) {
 	return uri, nil
 }
 
-func (u *URI) Db() bool {
-	return u.Scheme == "bzz-db"
-}
-
-func (u *URI) DbRaw() bool {
-	return u.Scheme == "bzz-db-raw"
+func (u *URI) Resource() bool {
+	return u.Scheme == "bzz-resource"
 }
 
 func (u *URI) Raw() bool {

--- a/swarm/api/uri.go
+++ b/swarm/api/uri.go
@@ -69,7 +69,7 @@ func Parse(rawuri string) (*URI, error) {
 
 	// check the scheme is valid
 	switch uri.Scheme {
-	case "bzz", "bzz-raw", "bzz-immutable", "bzz-list", "bzz-hash", "bzzr", "bzzi":
+	case "bzz", "bzz-raw", "bzz-immutable", "bzz-list", "bzz-hash", "bzzr", "bzzi", "bzz-db":
 	default:
 		return nil, fmt.Errorf("unknown scheme %q", u.Scheme)
 	}
@@ -90,6 +90,10 @@ func Parse(rawuri string) (*URI, error) {
 		uri.Path = parts[1]
 	}
 	return uri, nil
+}
+
+func (u *URI) Db() bool {
+	return u.Scheme == "bzz-db"
 }
 
 func (u *URI) Raw() bool {

--- a/swarm/fuse/swarmfs_test.go
+++ b/swarm/fuse/swarmfs_test.go
@@ -812,7 +812,7 @@ func TestFUSE(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ta := &testAPI{api: api.NewApi(dpa, nil)}
+	ta := &testAPI{api: api.NewApi(dpa, nil, nil)}
 	dpa.Start()
 	defer dpa.Stop()
 

--- a/swarm/storage/resource.go
+++ b/swarm/storage/resource.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math/big"
 	"path/filepath"
@@ -192,7 +193,7 @@ func (self *ResourceHandler) HashSize() int {
 func (self *ResourceHandler) GetContent(name string) (Key, []byte, error) {
 	rsrc := self.getResource(name)
 	if rsrc == nil || !rsrc.isSynced() {
-		return nil, nil, fmt.Errorf("Resource does not exist or is not synced")
+		return nil, nil, errors.New("Resource does not exist or is not synced")
 	}
 	return rsrc.lastKey, rsrc.data, nil
 }
@@ -201,7 +202,7 @@ func (self *ResourceHandler) GetLastPeriod(name string) (uint32, error) {
 	rsrc := self.getResource(name)
 
 	if rsrc == nil || !rsrc.isSynced() {
-		return 0, fmt.Errorf("Resource does not exist or is not synced")
+		return 0, errors.New("Resource does not exist or is not synced")
 	}
 	return rsrc.lastPeriod, nil
 }
@@ -209,7 +210,7 @@ func (self *ResourceHandler) GetLastPeriod(name string) (uint32, error) {
 func (self *ResourceHandler) GetVersion(name string) (uint32, error) {
 	rsrc := self.getResource(name)
 	if rsrc == nil || !rsrc.isSynced() {
-		return 0, fmt.Errorf("Resource does not exist or is not synced")
+		return 0, errors.New("Resource does not exist or is not synced")
 	}
 	return rsrc.version, nil
 }
@@ -228,7 +229,7 @@ func (self *ResourceHandler) NewResource(name string, frequency uint64) (*resour
 
 	// frequency 0 is invalid
 	if frequency == 0 {
-		return nil, fmt.Errorf("Frequency cannot be 0")
+		return nil, errors.New("Frequency cannot be 0")
 	}
 
 	if !isSafeName(name) {
@@ -360,7 +361,7 @@ func (self *ResourceHandler) LookupLatest(nameHash common.Hash, name string, ref
 func (self *ResourceHandler) lookup(rsrc *resource, period uint32, version uint32, refresh bool) (*resource, error) {
 
 	if period == 0 {
-		return nil, fmt.Errorf("period must be >0")
+		return nil, errors.New("period must be >0")
 	}
 
 	// start from the last possible block period, and iterate previous ones until we find a match
@@ -396,7 +397,7 @@ func (self *ResourceHandler) lookup(rsrc *resource, period uint32, version uint3
 		log.Trace("rsrc update not found, checking previous period", "period", period, "key", key)
 		period--
 	}
-	return nil, fmt.Errorf("no updates found")
+	return nil, errors.New("no updates found")
 }
 
 // load existing mutable resource into resource struct
@@ -525,10 +526,10 @@ func (self *ResourceHandler) Update(name string, data []byte) (Key, error) {
 	// get the cached information
 	rsrc := self.getResource(name)
 	if rsrc == nil {
-		return nil, fmt.Errorf("Resource object not in index")
+		return nil, errors.New("Resource object not in index")
 	}
 	if !rsrc.isSynced() {
-		return nil, fmt.Errorf("Resource object not in sync")
+		return nil, errors.New("Resource object not in sync")
 	}
 
 	// an update can be only one chunk long
@@ -747,7 +748,7 @@ func (r *resourceChunkStore) Get(key Key) (*Chunk, error) {
 	t := time.NewTimer(time.Second * 1)
 	select {
 	case <-t.C:
-		return nil, fmt.Errorf("timeout")
+		return nil, errors.New("timeout")
 	case <-chunk.C:
 		log.Trace("Received resource update chunk", "peer", chunk.Req.Source)
 	}

--- a/swarm/storage/resource.go
+++ b/swarm/storage/resource.go
@@ -665,10 +665,7 @@ func (self *ResourceHandler) resourceHash(period uint32, version uint32, namehas
 }
 
 func (self *ResourceHandler) hasUpdate(name string, period uint32) bool {
-	if self.resources[name].lastPeriod == period {
-		return true
-	}
-	return false
+	return self.resources[name].lastPeriod == period
 }
 
 func getAddressFromDataSig(datahash common.Hash, signature Signature) (common.Address, error) {

--- a/swarm/storage/resource.go
+++ b/swarm/storage/resource.go
@@ -703,7 +703,7 @@ func newUpdateChunk(key Key, signature *Signature, period uint32, version uint32
 	datalength := len(data)
 
 	chunk := NewChunk(key, nil)
-	chunk.SData = make([]byte, 4+signaturelength+headerlength+datalength)
+	chunk.SData = make([]byte, 4+signaturelength+headerlength+datalength) // initial 4 are uint16 length descriptors for headerlength and datalength
 
 	// data header length does NOT include the header length prefix bytes themselves
 	cursor := 0

--- a/swarm/storage/resource.go
+++ b/swarm/storage/resource.go
@@ -625,8 +625,7 @@ func (self *ResourceHandler) Close() {
 }
 
 func (self *ResourceHandler) GetBlock() (uint64, error) {
-	ctx, cancel := context.WithCancel(self.ctx)
-	defer cancel()
+	ctx, _ := context.WithCancel(self.ctx)
 	blockheader, err := self.ethClient.HeaderByNumber(ctx, nil)
 	if err != nil {
 		return 0, err

--- a/swarm/storage/resource.go
+++ b/swarm/storage/resource.go
@@ -52,6 +52,10 @@ func (self *resource) isSynced() bool {
 	return !self.updated.IsZero()
 }
 
+func (self *resource) NameHash() common.Hash {
+	return self.nameHash
+}
+
 // Implement to activate validation of resource updates
 // Specifically signing data and verification of signatures
 type ResourceValidator interface {
@@ -178,7 +182,9 @@ func NewResourceHandler(datadir string, cloudStore CloudStore, ethClient ethApi,
 			defer rh.hashPool.Put(hasher)
 			hasher.Reset()
 			hasher.Write([]byte(name))
-			return common.BytesToHash(hasher.Sum(nil))
+			hashval := common.BytesToHash(hasher.Sum(nil))
+			log.Debug("generic namehasher", "name", name, "hash", hashval)
+			return hashval
 		}
 	}
 

--- a/swarm/storage/resource.go
+++ b/swarm/storage/resource.go
@@ -625,7 +625,8 @@ func (self *ResourceHandler) Close() {
 }
 
 func (self *ResourceHandler) GetBlock() (uint64, error) {
-	ctx, _ := context.WithCancel(self.ctx)
+	ctx, cancel := context.WithCancel(self.ctx)
+	defer cancel()
 	blockheader, err := self.ethClient.HeaderByNumber(ctx, nil)
 	if err != nil {
 		return 0, err

--- a/swarm/storage/resource.go
+++ b/swarm/storage/resource.go
@@ -231,7 +231,7 @@ func (self *ResourceHandler) NewResource(name string, frequency uint64) (*resour
 	}
 
 	// get our blockheight at this time
-	currentblock, err := self.getBlock()
+	currentblock, err := self.GetBlock()
 	if err != nil {
 		return nil, err
 	}
@@ -310,7 +310,7 @@ func (self *ResourceHandler) LookupLatest(name string, refresh bool) (*resource,
 	if err != nil {
 		return nil, err
 	}
-	currentblock, err := self.getBlock()
+	currentblock, err := self.GetBlock()
 	if err != nil {
 		return nil, err
 	}
@@ -492,7 +492,7 @@ func (self *ResourceHandler) Update(name string, data []byte) (Key, error) {
 	}
 
 	// get our blockheight at this time and the next block of the update period
-	currentblock, err := self.getBlock()
+	currentblock, err := self.GetBlock()
 	if err != nil {
 		return nil, err
 	}
@@ -560,7 +560,7 @@ func (self *ResourceHandler) Close() {
 	self.ChunkStore.Close()
 }
 
-func (self *ResourceHandler) getBlock() (uint64, error) {
+func (self *ResourceHandler) GetBlock() (uint64, error) {
 	// get the block height and convert to uint64
 	var currentblock string
 	err := self.rpcClient.Call(&currentblock, "eth_blockNumber")

--- a/swarm/storage/resource.go
+++ b/swarm/storage/resource.go
@@ -752,14 +752,16 @@ func (r *resourceChunkStore) Get(key Key) (*Chunk, error) {
 	select {
 	case <-t.C:
 		return nil, errors.New("timeout")
-	case <-chunk.C:
+	case <-chunk.Req.C:
 		log.Trace("Received resource update chunk", "peer", chunk.Req.Source)
 	}
 	return chunk, nil
 }
 
 func (r *resourceChunkStore) Put(chunk *Chunk) {
+	chunk.wg = &sync.WaitGroup{}
 	r.netStore.Put(chunk)
+	chunk.wg.Wait()
 }
 
 func (r *resourceChunkStore) Close() {

--- a/swarm/storage/resource.go
+++ b/swarm/storage/resource.go
@@ -44,8 +44,8 @@ type resource struct {
 }
 
 // TODO Expire content after a defined period (to force resync)
-func (r *resource) isSynced() bool {
-	return !r.updated.IsZero()
+func (self *resource) isSynced() bool {
+	return !self.updated.IsZero()
 }
 
 // Implement to activate validation of resource updates
@@ -164,6 +164,30 @@ func NewResourceHandler(datadir string, cloudStore CloudStore, rpcClient *rpc.Cl
 	}
 
 	return rh, nil
+}
+
+func (self *ResourceHandler) GetData(name string) []byte {
+	rsrc := self.getResource(name)
+	if rsrc == nil {
+		return nil
+	}
+	return rsrc.data
+}
+
+func (self *ResourceHandler) GetLastPeriod(name string) uint32 {
+	rsrc := self.getResource(name)
+	if rsrc == nil {
+		return 0
+	}
+	return rsrc.lastPeriod
+}
+
+func (self *ResourceHandler) GetVersion(name string) uint32 {
+	rsrc := self.getResource(name)
+	if rsrc == nil {
+		return 0
+	}
+	return rsrc.version
 }
 
 // \TODO should be hashsize * branches from the chosen chunker, implement with dpa

--- a/swarm/storage/resource_ens.go
+++ b/swarm/storage/resource_ens.go
@@ -1,7 +1,7 @@
 package storage
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -15,7 +15,7 @@ type baseValidator struct {
 
 func (b *baseValidator) sign(datahash common.Hash) (signature Signature, err error) {
 	if b.signFunc == nil {
-		return signature, fmt.Errorf("No signature function")
+		return signature, errors.New("No signature function")
 	}
 	return b.signFunc(datahash)
 }

--- a/swarm/storage/resource_ens.go
+++ b/swarm/storage/resource_ens.go
@@ -10,6 +10,7 @@ import (
 
 type baseValidator struct {
 	signFunc SignFunc
+	hashsize int
 }
 
 func (b *baseValidator) sign(datahash common.Hash) (signature Signature, err error) {
@@ -17,6 +18,10 @@ func (b *baseValidator) sign(datahash common.Hash) (signature Signature, err err
 		return signature, fmt.Errorf("No signature function")
 	}
 	return b.signFunc(datahash)
+}
+
+func (b *baseValidator) hashSize() int {
+	return b.hashsize
 }
 
 // ENS validation of mutable resource owners
@@ -30,6 +35,7 @@ func NewENSValidator(contractaddress common.Address, backend bind.ContractBacken
 	validator := &ENSValidator{
 		baseValidator: &baseValidator{
 			signFunc: signFunc,
+			hashsize: common.HashLength,
 		},
 	}
 	validator.api, err = ens.NewENS(transactOpts, contractaddress, backend)

--- a/swarm/storage/resource_ens.go
+++ b/swarm/storage/resource_ens.go
@@ -36,6 +36,7 @@ func NewENSValidator(contractaddress common.Address, backend bind.ContractBacken
 	if err != nil {
 		return nil, err
 	}
+	validator.hashlength = len(ens.EnsNode(dbDirName).Bytes())
 	return validator, nil
 }
 

--- a/swarm/storage/resource_ens.go
+++ b/swarm/storage/resource_ens.go
@@ -36,7 +36,6 @@ func NewENSValidator(contractaddress common.Address, backend bind.ContractBacken
 	if err != nil {
 		return nil, err
 	}
-	validator.hashlength = len(ens.EnsNode(dbDirName).Bytes())
 	return validator, nil
 }
 

--- a/swarm/storage/resource_sign.go
+++ b/swarm/storage/resource_sign.go
@@ -1,0 +1,20 @@
+package storage
+
+import (
+	"crypto/ecdsa"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// matches the SignFunc type
+func NewGenericResourceSigner(privKey *ecdsa.PrivateKey) SignFunc {
+	return func(data common.Hash) (signature Signature, err error) {
+		signaturebytes, err := crypto.Sign(data.Bytes(), privKey)
+		if err != nil {
+			return
+		}
+		copy(signature[:], signaturebytes)
+		return
+	}
+}

--- a/swarm/storage/resource_test.go
+++ b/swarm/storage/resource_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum/go-ethereum/contracts/ens"
 	"github.com/ethereum/go-ethereum/contracts/ens/contract"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -57,10 +58,12 @@ func (f *fakeBackend) Commit() {
 	f.blocknumber++
 }
 
-func (f *fakeBackend) BlockNumber(context context.Context) (big.Int, error) {
+func (f *fakeBackend) HeaderByNumber(context context.Context, bigblock *big.Int) (*types.Header, error) {
 	f.blocknumber++
 	biggie := big.NewInt(f.blocknumber)
-	return *biggie, nil
+	return &types.Header{
+		Number: biggie,
+	}, nil
 }
 
 // check that signature address matches update signer address

--- a/swarm/storage/resource_test.go
+++ b/swarm/storage/resource_test.go
@@ -106,6 +106,9 @@ func TestResourceReverse(t *testing.T) {
 
 	// check that we can recover the owner account from the update chunk's signature
 	checksig, checkperiod, checkversion, checkname, checkdata, err := rh.parseUpdate(chunk.SData)
+	if err != nil {
+		t.Fatal(err)
+	}
 	checkdigest := rh.keyDataHash(chunk.Key, checkdata)
 	recoveredaddress, err := getAddressFromDataSig(checkdigest, *checksig)
 	if err != nil {

--- a/swarm/storage/resource_test.go
+++ b/swarm/storage/resource_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"encoding/binary"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"math/big"
@@ -37,7 +38,11 @@ var (
 
 func init() {
 	var err error
-	log.Root().SetHandler(log.CallerFileHandler(log.LvlFilterHandler(log.LvlTrace, log.StreamHandler(os.Stderr, log.TerminalFormat(true)))))
+	verbose := flag.Bool("v", false, "verbose")
+	flag.Parse()
+	if *verbose {
+		log.Root().SetHandler(log.CallerFileHandler(log.LvlFilterHandler(log.LvlTrace, log.StreamHandler(os.Stderr, log.TerminalFormat(true)))))
+	}
 	safeName, err = ToSafeName(domainName)
 	if err != nil {
 		panic(err)

--- a/swarm/storage/resource_test.go
+++ b/swarm/storage/resource_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"bytes"
+	"context"
 	"crypto/ecdsa"
 	"crypto/rand"
 	"encoding/binary"
@@ -9,8 +10,6 @@ import (
 	"io/ioutil"
 	"math/big"
 	"os"
-	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -22,9 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/contracts/ens/contract"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/rpc"
 )
 
 var (
@@ -50,7 +47,7 @@ func init() {
 // so we use this wrapper to fake returning the block count
 type fakeBackend struct {
 	*backends.SimulatedBackend
-	blocknumber uint64
+	blocknumber int64
 }
 
 func (f *fakeBackend) Commit() {
@@ -60,13 +57,10 @@ func (f *fakeBackend) Commit() {
 	f.blocknumber++
 }
 
-// for faking the rpc service, since we don't need the whole node stack
-type FakeRPC struct {
-	backend *fakeBackend
-}
-
-func (r *FakeRPC) BlockNumber() (string, error) {
-	return strconv.FormatUint(r.backend.blocknumber, 10), nil
+func (f *fakeBackend) BlockNumber(context context.Context) (big.Int, error) {
+	f.blocknumber++
+	biggie := big.NewInt(f.blocknumber)
+	return *biggie, nil
 }
 
 // check that signature address matches update signer address
@@ -84,8 +78,9 @@ func TestResourceReverse(t *testing.T) {
 	// set up rpc and create resourcehandler
 	rh, _, _, teardownTest, err := setupTest(nil, newTestValidator(signer.signContent))
 	if err != nil {
-		teardownTest(t, err)
+		t.Fatal(err)
 	}
+	defer teardownTest()
 
 	// generate a hash for block 4200 version 1
 	key := rh.resourceHash(period, version, rh.nameHash(safeName))
@@ -94,14 +89,14 @@ func TestResourceReverse(t *testing.T) {
 	data := make([]byte, 8)
 	_, err = rand.Read(data)
 	if err != nil {
-		teardownTest(t, err)
+		t.Fatal(err)
 	}
 	testHasher.Reset()
 	testHasher.Write(data)
 	digest := rh.keyDataHash(key, data)
 	sig, err := rh.validator.sign(digest)
 	if err != nil {
-		teardownTest(t, err)
+		t.Fatal(err)
 	}
 
 	chunk := newUpdateChunk(key, &sig, period, version, safeName, data)
@@ -111,31 +106,30 @@ func TestResourceReverse(t *testing.T) {
 	checkdigest := rh.keyDataHash(chunk.Key, checkdata)
 	recoveredaddress, err := getAddressFromDataSig(checkdigest, *checksig)
 	if err != nil {
-		teardownTest(t, fmt.Errorf("Retrieve address from signature fail: %v", err))
+		t.Fatalf("Retrieve address from signature fail: %v", err)
 	}
 	originaladdress := crypto.PubkeyToAddress(signer.privKey.PublicKey)
 
 	// check that the metadata retrieved from the chunk matches what we gave it
 	if recoveredaddress != originaladdress {
-		teardownTest(t, fmt.Errorf("addresses dont match: %x != %x", originaladdress, recoveredaddress))
+		t.Fatalf("addresses dont match: %x != %x", originaladdress, recoveredaddress)
 	}
 
 	if !bytes.Equal(key[:], chunk.Key[:]) {
-		teardownTest(t, fmt.Errorf("Expected chunk key '%x', was '%x'", key, chunk.Key))
+		t.Fatalf("Expected chunk key '%x', was '%x'", key, chunk.Key)
 	}
 	if period != checkperiod {
-		teardownTest(t, fmt.Errorf("Expected period '%d', was '%d'", period, checkperiod))
+		t.Fatalf("Expected period '%d', was '%d'", period, checkperiod)
 	}
 	if version != checkversion {
-		teardownTest(t, fmt.Errorf("Expected version '%d', was '%d'", version, checkversion))
+		t.Fatalf("Expected version '%d', was '%d'", version, checkversion)
 	}
 	if safeName != checkname {
-		teardownTest(t, fmt.Errorf("Expected name '%s', was '%s'", safeName, checkname))
+		t.Fatalf("Expected name '%s', was '%s'", safeName, checkname)
 	}
 	if !bytes.Equal(data, checkdata) {
-		teardownTest(t, fmt.Errorf("Expectedn data '%x', was '%x'", data, checkdata))
+		t.Fatalf("Expectedn data '%x', was '%x'", data, checkdata)
 	}
-	teardownTest(t, nil)
 }
 
 // make updates and retrieve them based on periods and versions
@@ -143,34 +137,35 @@ func TestResourceHandler(t *testing.T) {
 
 	// make fake backend, set up rpc and create resourcehandler
 	backend := &fakeBackend{
-		blocknumber: startBlock,
+		blocknumber: int64(startBlock),
 	}
 	rh, datadir, _, teardownTest, err := setupTest(backend, nil)
 	if err != nil {
-		teardownTest(t, err)
+		t.Fatal(err)
 	}
+	defer teardownTest()
 
 	// create a new resource
 	_, err = rh.NewResource(safeName, resourceFrequency)
 	if err != nil {
-		teardownTest(t, err)
+		t.Fatal(err)
 	}
 
 	// check that the new resource is stored correctly
 	namehash := rh.nameHash(safeName)
 	chunk, err := rh.ChunkStore.(*resourceChunkStore).localStore.(*LocalStore).memStore.Get(Key(namehash[:]))
 	if err != nil {
-		teardownTest(t, err)
+		t.Fatal(err)
 	} else if len(chunk.SData) < 16 {
-		teardownTest(t, fmt.Errorf("chunk data must be minimum 16 bytes, is %d", len(chunk.SData)))
+		t.Fatalf("chunk data must be minimum 16 bytes, is %d", len(chunk.SData))
 	}
 	startblocknumber := binary.LittleEndian.Uint64(chunk.SData[:8])
 	chunkfrequency := binary.LittleEndian.Uint64(chunk.SData[8:])
-	if startblocknumber != backend.blocknumber {
-		teardownTest(t, fmt.Errorf("stored block number %d does not match provided block number %d", startblocknumber, backend.blocknumber))
+	if startblocknumber != uint64(backend.blocknumber) {
+		t.Fatalf("stored block number %d does not match provided block number %d", startblocknumber, backend.blocknumber)
 	}
 	if chunkfrequency != resourceFrequency {
-		teardownTest(t, fmt.Errorf("stored frequency %d does not match provided frequency %d", chunkfrequency, resourceFrequency))
+		t.Fatalf("stored frequency %d does not match provided frequency %d", chunkfrequency, resourceFrequency)
 	}
 
 	// update halfway to first period
@@ -179,7 +174,7 @@ func TestResourceHandler(t *testing.T) {
 	data := []byte("blinky")
 	resourcekey["blinky"], err = rh.Update(safeName, data)
 	if err != nil {
-		teardownTest(t, err)
+		t.Fatal(err)
 	}
 
 	// update on first period
@@ -187,7 +182,7 @@ func TestResourceHandler(t *testing.T) {
 	data = []byte("pinky")
 	resourcekey["pinky"], err = rh.Update(safeName, data)
 	if err != nil {
-		teardownTest(t, err)
+		t.Fatal(err)
 	}
 
 	// update on second period
@@ -195,7 +190,7 @@ func TestResourceHandler(t *testing.T) {
 	data = []byte("inky")
 	resourcekey["inky"], err = rh.Update(safeName, data)
 	if err != nil {
-		teardownTest(t, err)
+		t.Fatal(err)
 	}
 
 	// update just after second period
@@ -203,7 +198,7 @@ func TestResourceHandler(t *testing.T) {
 	data = []byte("clyde")
 	resourcekey["clyde"], err = rh.Update(safeName, data)
 	if err != nil {
-		teardownTest(t, err)
+		t.Fatal(err)
 	}
 	time.Sleep(time.Second)
 	rh.Close()
@@ -215,43 +210,42 @@ func TestResourceHandler(t *testing.T) {
 	rh2, err := NewResourceHandler(datadir, &testCloudStore{}, rh.ethClient, nil)
 	_, err = rh2.LookupLatestByName(safeName, true)
 	if err != nil {
-		teardownTest(t, err)
+		t.Fatal(err)
 	}
 
 	// last update should be "clyde", version two, blockheight startblocknumber + (resourcefrequency * 3)
 	if !bytes.Equal(rh2.resources[safeName].data, []byte("clyde")) {
-		teardownTest(t, fmt.Errorf("resource data was %v, expected %v", rh2.resources[safeName].data, []byte("clyde")))
+		t.Fatalf("resource data was %v, expected %v", rh2.resources[safeName].data, []byte("clyde"))
 	}
 	if rh2.resources[safeName].version != 2 {
-		teardownTest(t, fmt.Errorf("resource version was %d, expected 2", rh2.resources[safeName].version))
+		t.Fatalf("resource version was %d, expected 2", rh2.resources[safeName].version)
 	}
 	if rh2.resources[safeName].lastPeriod != 3 {
-		teardownTest(t, fmt.Errorf("resource period was %d, expected 3", rh2.resources[safeName].lastPeriod))
+		t.Fatalf("resource period was %d, expected 3", rh2.resources[safeName].lastPeriod)
 	}
 	log.Debug("Latest lookup", "period", rh2.resources[safeName].lastPeriod, "version", rh2.resources[safeName].version, "data", rh2.resources[safeName].data)
 
 	// specific block, latest version
 	rsrc, err := rh2.LookupHistoricalByName(safeName, 3, true)
 	if err != nil {
-		teardownTest(t, err)
+		t.Fatal(err)
 	}
 	// check data
 	if !bytes.Equal(rsrc.data, []byte("clyde")) {
-		teardownTest(t, fmt.Errorf("resource data (historical) was %v, expected %v", rh2.resources[domainName].data, []byte("clyde")))
+		t.Fatalf("resource data (historical) was %v, expected %v", rh2.resources[domainName].data, []byte("clyde"))
 	}
 	log.Debug("Historical lookup", "period", rh2.resources[safeName].lastPeriod, "version", rh2.resources[safeName].version, "data", rh2.resources[safeName].data)
 
 	// specific block, specific version
 	rsrc, err = rh2.LookupVersionByName(safeName, 3, 1, true)
 	if err != nil {
-		teardownTest(t, err)
+		t.Fatal(err)
 	}
 	// check data
 	if !bytes.Equal(rsrc.data, []byte("inky")) {
-		teardownTest(t, fmt.Errorf("resource data (historical) was %v, expected %v", rh2.resources[domainName].data, []byte("inky")))
+		t.Fatalf("resource data (historical) was %v, expected %v", rh2.resources[domainName].data, []byte("inky"))
 	}
 	log.Debug("Specific version lookup", "period", rh2.resources[safeName].lastPeriod, "version", rh2.resources[safeName].version, "data", rh2.resources[safeName].data)
-	teardownTest(t, nil)
 
 }
 
@@ -283,34 +277,33 @@ func TestResourceENSOwner(t *testing.T) {
 	// set up rpc and create resourcehandler with ENS sim backend
 	rh, _, _, teardownTest, err := setupTest(contractbackend, validator)
 	if err != nil {
-		teardownTest(t, err)
+		t.Fatal(err)
 	}
+	defer teardownTest()
 
 	// create new resource when we are owner = ok
 	_, err = rh.NewResource(safeName, resourceFrequency)
 	if err != nil {
-		teardownTest(t, fmt.Errorf("Create resource fail: %v", err))
+		t.Fatalf("Create resource fail: %v", err)
 	}
 
 	data := []byte("foo")
 	// update resource when we are owner = ok
 	_, err = rh.Update(safeName, data)
 	if err != nil {
-		teardownTest(t, fmt.Errorf("Update resource fail: %v", err))
+		t.Fatalf("Update resource fail: %v", err)
 	}
 
 	// update resource when we are owner = ok
 	signertwo, err := newTestSigner()
 	if err != nil {
-		teardownTest(t, err)
+		t.Fatal(err)
 	}
 	rh.validator.(*ENSValidator).signFunc = signertwo.signContent
 	_, err = rh.Update(safeName, data)
 	if err == nil {
-		teardownTest(t, fmt.Errorf("Expected resource update fail due to owner mismatch"))
+		t.Fatalf("Expected resource update fail due to owner mismatch")
 	}
-
-	teardownTest(t, nil)
 }
 
 // fast-forward blockheight
@@ -321,7 +314,7 @@ func fwdBlocks(count int, backend *fakeBackend) {
 }
 
 // create rpc and resourcehandler
-func setupTest(contractbackend bind.ContractBackend, validator ResourceValidator) (rh *ResourceHandler, datadir string, signer *testSigner, teardown func(*testing.T, error), err error) {
+func setupTest(backend ethApi, validator ResourceValidator) (rh *ResourceHandler, datadir string, signer *testSigner, teardown func(), err error) {
 
 	var fsClean func()
 	var rpcClean func()
@@ -337,55 +330,18 @@ func setupTest(contractbackend bind.ContractBackend, validator ResourceValidator
 	// temp datadir
 	datadir, err = ioutil.TempDir("", "rh")
 	if err != nil {
-		return
+		return nil, "", nil, nil, err
 	}
 	fsClean = func() {
 		os.RemoveAll(datadir)
 	}
 
-	// starting the whole stack just to get blocknumbers is too cumbersome
-	// so we fake the rpc server to get blocknumbers for testing
-	ipcpath := filepath.Join(datadir, "test.ipc")
-	ipcl, err := rpc.CreateIPCListener(ipcpath)
-	if err != nil {
-		return
-	}
-	rpcserver := rpc.NewServer()
-	var fake *fakeBackend
-	if contractbackend != nil {
-		fake = contractbackend.(*fakeBackend)
-	}
-	rpcserver.RegisterName("eth", &FakeRPC{
-		backend: fake,
-	})
-	go func() {
-		rpcserver.ServeListener(ipcl)
-	}()
-	rpcClean = func() {
-		rpcserver.Stop()
-	}
-
-	// connect to fake rpc
-	rpcClient, err := rpc.Dial(ipcpath)
-	if err != nil {
-		return
-	}
-
-	ethClient := ethclient.NewClient(rpcClient)
-
-	rh, err = NewResourceHandler(datadir, &testCloudStore{}, ethClient, validator)
-	teardown = func(t *testing.T, err error) {
-		cleanF()
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	return
+	rh, err = NewResourceHandler(datadir, &testCloudStore{}, backend, validator)
+	return rh, datadir, signer, cleanF, nil
 }
 
 // Set up simulated ENS backend for use with ENSResourceHandler tests
-func setupENS(addr common.Address, transactOpts *bind.TransactOpts, sub string, top string) (common.Address, bind.ContractBackend, error) {
+func setupENS(addr common.Address, transactOpts *bind.TransactOpts, sub string, top string) (common.Address, *fakeBackend, error) {
 
 	// create the domain hash values to pass to the ENS contract methods
 	var tophash [32]byte

--- a/swarm/storage/resource_test.go
+++ b/swarm/storage/resource_test.go
@@ -333,6 +333,15 @@ func setupTest(contractbackend bind.ContractBackend, validator ResourceValidator
 		}
 	}
 
+	if validator == nil {
+		// create a new signer, which creates the private key
+		signer, err = newTestSigner()
+		if err != nil {
+			return
+		}
+		validator = NewGenericValidator(testHashFunc, signer.signContent)
+	}
+
 	// temp datadir
 	datadir, err = ioutil.TempDir("", "rh")
 	if err != nil {

--- a/swarm/storage/resource_test.go
+++ b/swarm/storage/resource_test.go
@@ -333,15 +333,6 @@ func setupTest(contractbackend bind.ContractBackend, validator ResourceValidator
 		}
 	}
 
-	if validator == nil {
-		// create a new signer, which creates the private key
-		signer, err = newTestSigner()
-		if err != nil {
-			return
-		}
-		validator = NewGenericValidator(testHashFunc, signer.signContent)
-	}
-
 	// temp datadir
 	datadir, err = ioutil.TempDir("", "rh")
 	if err != nil {

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -144,8 +144,7 @@ func NewSwarm(ctx *node.ServiceContext, backend chequebook.Backend, ensClient *e
 		}
 	}
 
-	// SET UP high level api
-	fmt.Fprintf(os.Stderr, "privkey %v\nswap %v\nswapendabled %v\n", self.privateKey, config.Swap, config.SwapEnabled)
+	// set up high level api
 	transactOpts := bind.NewKeyedTransactor(self.privateKey)
 
 	if ensClient == nil {

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -22,6 +22,7 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"net"
+	"os"
 	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -93,7 +94,7 @@ func NewSwarm(ctx *node.ServiceContext, backend chequebook.Backend, ensClient *e
 	self = &Swarm{
 		config:     config,
 		backend:    backend,
-		privateKey: config.Swap.PrivateKey(),
+		privateKey: config.ShiftPrivateKey(),
 	}
 	log.Debug(fmt.Sprintf("Setting up Swarm service components"))
 
@@ -143,7 +144,8 @@ func NewSwarm(ctx *node.ServiceContext, backend chequebook.Backend, ensClient *e
 		}
 	}
 
-	// set up high level api
+	// SET UP high level api
+	fmt.Fprintf(os.Stderr, "privkey %v\nswap %v\nswapendabled %v\n", self.privateKey, config.Swap, config.SwapEnabled)
 	transactOpts := bind.NewKeyedTransactor(self.privateKey)
 
 	if ensClient == nil {

--- a/swarm/testutil/http.go
+++ b/swarm/testutil/http.go
@@ -51,7 +51,7 @@ func NewTestSwarmServer(t *testing.T) *TestSwarmServer {
 		CacheCapacity: 5000,
 		Radius:        0,
 	}
-	localStore, err := storage.NewLocalStore(storage.MakeHashFunc(storage.SHA3Hash), storeparams)
+	localStore, err := storage.NewLocalStore(storage.MakeHashFunc(storage.SHA3Hash), storeparams, nil)
 	if err != nil {
 		os.RemoveAll(dir)
 		t.Fatal(err)

--- a/swarm/testutil/http.go
+++ b/swarm/testutil/http.go
@@ -22,7 +22,6 @@ import (
 	"math/big"
 	"net/http/httptest"
 	"os"
-	"strconv"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/core/types"
@@ -116,13 +115,4 @@ func (c *testCloudStore) Deliver(*storage.Chunk) {
 }
 
 func (c *testCloudStore) Retrieve(*storage.Chunk) {
-}
-
-// for faking the rpc service, since we don't need the whole node stack
-type FakeRPC struct {
-	blocknumber uint64
-}
-
-func (r *FakeRPC) BlockNumber() (string, error) {
-	return strconv.FormatUint(r.blocknumber, 10), nil
 }

--- a/swarm/testutil/http.go
+++ b/swarm/testutil/http.go
@@ -82,7 +82,7 @@ func NewTestSwarmServer(t *testing.T) *TestSwarmServer {
 		Server: srv,
 		Dpa:    dpa,
 		dir:    dir,
-		hasher: storage.MakeHashFunc(storage.SHA3Hash)(),
+		Hasher: storage.MakeHashFunc(storage.SHA3Hash)(),
 		cleanup: func() {
 			srv.Close()
 			rh.Close()
@@ -95,7 +95,7 @@ func NewTestSwarmServer(t *testing.T) *TestSwarmServer {
 
 type TestSwarmServer struct {
 	*httptest.Server
-	hasher  storage.SwarmHash
+	Hasher  storage.SwarmHash
 	Dpa     *storage.DPA
 	dir     string
 	cleanup func()

--- a/swarm/testutil/http.go
+++ b/swarm/testutil/http.go
@@ -89,7 +89,7 @@ func NewTestSwarmServer(t *testing.T) *TestSwarmServer {
 		Server: srv,
 		Dpa:    dpa,
 		dir:    dir,
-		hasher: storage.MakeHashFunc("SHA3")(),
+		hasher: storage.MakeHashFunc(storage.SHA3Hash)(),
 		cleanup: func() {
 			rh.Close()
 			rpcClean()

--- a/swarm/testutil/http.go
+++ b/swarm/testutil/http.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/swarm/api"
 	httpapi "github.com/ethereum/go-ethereum/swarm/api/http"
 	"github.com/ethereum/go-ethereum/swarm/storage"
@@ -34,10 +35,12 @@ type fakeBackend struct {
 	blocknumber int64
 }
 
-func (f *fakeBackend) BlockNumber(ctx context.Context) (big.Int, error) {
+func (f *fakeBackend) HeaderByNumber(context context.Context, bigblock *big.Int) (*types.Header, error) {
 	f.blocknumber++
 	biggie := big.NewInt(f.blocknumber)
-	return *biggie, nil
+	return &types.Header{
+		Number: biggie,
+	}, nil
 }
 
 func NewTestSwarmServer(t *testing.T) *TestSwarmServer {

--- a/swarm/testutil/http.go
+++ b/swarm/testutil/http.go
@@ -17,11 +17,15 @@
 package testutil
 
 import (
+	"crypto/ecdsa"
 	"io/ioutil"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
+	"strconv"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/swarm/api"
 	httpapi "github.com/ethereum/go-ethereum/swarm/api/http"
 	"github.com/ethereum/go-ethereum/swarm/storage"
@@ -38,7 +42,7 @@ func NewTestSwarmServer(t *testing.T) *TestSwarmServer {
 		CacheCapacity: 5000,
 		Radius:        0,
 	}
-	localStore, err := storage.NewLocalStore(storage.MakeHashFunc("SHA3"), storeparams, nil)
+	localStore, err := storage.NewLocalStore(storage.MakeHashFunc(storage.SHA3Hash), storeparams)
 	if err != nil {
 		os.RemoveAll(dir)
 		t.Fatal(err)
@@ -49,24 +53,84 @@ func NewTestSwarmServer(t *testing.T) *TestSwarmServer {
 		ChunkStore: localStore,
 	}
 	dpa.Start()
-	a := api.NewApi(dpa, nil)
+
+	// mutable resources test setup
+	resourcedir, err := ioutil.TempDir("", "swarm-resource-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ipcpath := filepath.Join(resourcedir, "test.ipc")
+	ipcl, err := rpc.CreateIPCListener(ipcpath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rpcserver := rpc.NewServer()
+	rpcserver.RegisterName("eth", &FakeRPC{})
+	go func() {
+		rpcserver.ServeListener(ipcl)
+	}()
+	rpcClean := func() {
+		rpcserver.Stop()
+	}
+
+	// connect to fake rpc
+	rpcclient, err := rpc.Dial(ipcpath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rh, err := storage.NewResourceHandler(resourcedir, &testCloudStore{}, rpcclient, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a := api.NewApi(dpa, nil, rh)
 	srv := httptest.NewServer(httpapi.NewServer(a))
 	return &TestSwarmServer{
 		Server: srv,
 		Dpa:    dpa,
 		dir:    dir,
+		hasher: storage.MakeHashFunc("SHA3")(),
+		cleanup: func() {
+			rh.Close()
+			rpcClean()
+			os.RemoveAll(dir)
+			os.RemoveAll(resourcedir)
+		},
 	}
 }
 
 type TestSwarmServer struct {
 	*httptest.Server
-
-	Dpa *storage.DPA
-	dir string
+	hasher     storage.SwarmHash
+	privatekey *ecdsa.PrivateKey
+	Dpa        *storage.DPA
+	dir        string
+	cleanup    func()
 }
 
 func (t *TestSwarmServer) Close() {
 	t.Server.Close()
 	t.Dpa.Stop()
 	os.RemoveAll(t.dir)
+}
+
+type testCloudStore struct {
+}
+
+func (c *testCloudStore) Store(*storage.Chunk) {
+}
+
+func (c *testCloudStore) Deliver(*storage.Chunk) {
+}
+
+func (c *testCloudStore) Retrieve(*storage.Chunk) {
+}
+
+// for faking the rpc service, since we don't need the whole node stack
+type FakeRPC struct {
+	blocknumber uint64
+}
+
+func (r *FakeRPC) BlockNumber() (string, error) {
+	return strconv.FormatUint(r.blocknumber, 10), nil
 }


### PR DESCRIPTION
This pr adds ResourceHandler API in the swarm HTTP layer, with a placeholder implementation of manifests. It introduces two new schemes: `bzz-db` and `bzz-db-raw`, which are for manifest view and raw data view of resource updates respectively. 

GET methods map as follows:
```
* <scheme>:/<id>/ -  ResourceHandler.LookupLatest(<id>, true)
* <scheme>:/<id>/n - ResourceHandler.LookupHistorical(<id>, n, true)
* <scheme>:/<id>/n/m - ResourceHandler.LookupVersion(<id>, n, m, true)
```

POST path is always `<scheme>:/<id>/` and the message body (current only raw data) is the data of the update.

`<id>` can be either ENS name or hash.

---

A new method `ethclient.Client.BlockNumber()` is added for convenience to enable passing the `ensClient` from `swarm/swarm.go.NewSwarm(..)` (otherwise we use an extra ?`rpc.Client` so we can access the `eth_blockNumber` RPC directly).