### PR TITLE
swarm: improve tests on swarm-network-rewrite-syncer

### DIFF
--- a/p2p/simulations/adapters/docker.go
+++ b/p2p/simulations/adapters/docker.go
@@ -33,6 +33,10 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/discover"
 )
 
+var (
+	ErrLinuxOnly = errors.New("DockerAdapter can only be used on Linux as it uses the current binary (which must be a Linux binary)")
+)
+
 // DockerAdapter is a NodeAdapter which runs simulation nodes inside Docker
 // containers.
 //
@@ -52,7 +56,7 @@ func NewDockerAdapter() (*DockerAdapter, error) {
 	// It is reasonable to require this because the caller can just
 	// compile the current binary in a Docker container.
 	if runtime.GOOS != "linux" {
-		return nil, errors.New("DockerAdapter can only be used on Linux as it uses the current binary (which must be a Linux binary)")
+		return nil, ErrLinuxOnly
 	}
 
 	if err := buildDockerImage(); err != nil {

--- a/swarm/network/priorityqueue/priorityqueue_test.go
+++ b/swarm/network/priorityqueue/priorityqueue_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func Test(t *testing.T) {
+func TestPriorityQueue(t *testing.T) {
 	var results []string
 	wg := sync.WaitGroup{}
 	pq := New(3, 2)

--- a/swarm/network/simulations/discovery/discovery_test.go
+++ b/swarm/network/simulations/discovery/discovery_test.go
@@ -77,7 +77,11 @@ func TestDiscoverySimulationDockerAdapter(t *testing.T) {
 func testDiscoverySimulationDockerAdapter(t *testing.T, nodes, conns int) {
 	adapter, err := adapters.NewDockerAdapter()
 	if err != nil {
-		t.Fatal(err)
+		if err == adapters.ErrLinuxOnly {
+			t.Skip(err)
+		} else {
+			t.Fatal(err)
+		}
 	}
 	testDiscoverySimulation(t, nodes, conns, adapter)
 }


### PR DESCRIPTION
1. Better name for priority queue tests.
2. Do not error when running tests for docker adapter on OS X or Windows, but rather skip them.