### PR TITLE
configurable EnableMsgEvents ; enable TestDeliveryFromNodes and TestSyncerSimulation

### DIFF
--- a/contracts/chequebook/cheque_test.go
+++ b/contracts/chequebook/cheque_test.go
@@ -219,7 +219,7 @@ func TestVerifyErrors(t *testing.T) {
 
 }
 
-func XTestDeposit(t *testing.T) {
+func TestDeposit(t *testing.T) {
 	path0 := filepath.Join(os.TempDir(), "chequebook-test-0.json")
 	backend := newTestBackend()
 	contr0, _ := deploy(key0, new(big.Int), backend)
@@ -281,8 +281,8 @@ func XTestDeposit(t *testing.T) {
 		t.Fatalf("expected balance %v, got %v", exp, chbook.Balance())
 	}
 
-	// autodeposit every 30ms if new cheque issued
-	interval := 30 * time.Millisecond
+	// autodeposit every 200ms if new cheque issued
+	interval := 200 * time.Millisecond
 	chbook.AutoDeposit(interval, common.Big1, balance)
 	_, err = chbook.Issue(addr1, amount)
 	if err != nil {

--- a/p2p/simulations/adapters/inproc.go
+++ b/p2p/simulations/adapters/inproc.go
@@ -107,7 +107,7 @@ func (s *SimAdapter) NewNode(config *NodeConfig) (Node, error) {
 			MaxPeers:        math.MaxInt32,
 			NoDiscovery:     true,
 			Dialer:          s,
-			EnableMsgEvents: true,
+			EnableMsgEvents: config.EnableMsgEvents,
 		},
 		NoUSB:  true,
 		Logger: log.New("node.id", id.String()),

--- a/p2p/simulations/adapters/types.go
+++ b/p2p/simulations/adapters/types.go
@@ -105,21 +105,23 @@ type NodeConfig struct {
 // nodeConfigJSON is used to encode and decode NodeConfig as JSON by encoding
 // all fields as strings
 type nodeConfigJSON struct {
-	ID         string   `json:"id"`
-	PrivateKey string   `json:"private_key"`
-	Name       string   `json:"name"`
-	Services   []string `json:"services"`
-	Port       uint16   `json:"port"`
+	ID              string   `json:"id"`
+	PrivateKey      string   `json:"private_key"`
+	Name            string   `json:"name"`
+	Services        []string `json:"services"`
+	EnableMsgEvents bool     `json:"enable_msg_events"`
+	Port            uint16   `json:"port"`
 }
 
 // MarshalJSON implements the json.Marshaler interface by encoding the config
 // fields as strings
 func (n *NodeConfig) MarshalJSON() ([]byte, error) {
 	confJSON := nodeConfigJSON{
-		ID:       n.ID.String(),
-		Name:     n.Name,
-		Services: n.Services,
-		Port:     n.Port,
+		ID:              n.ID.String(),
+		Name:            n.Name,
+		Services:        n.Services,
+		Port:            n.Port,
+		EnableMsgEvents: n.EnableMsgEvents,
 	}
 	if n.PrivateKey != nil {
 		confJSON.PrivateKey = hex.EncodeToString(crypto.FromECDSA(n.PrivateKey))
@@ -158,6 +160,7 @@ func (n *NodeConfig) UnmarshalJSON(data []byte) error {
 	n.Name = confJSON.Name
 	n.Services = confJSON.Services
 	n.Port = confJSON.Port
+	n.EnableMsgEvents = confJSON.EnableMsgEvents
 
 	return nil
 }
@@ -176,10 +179,11 @@ func RandomNodeConfig() *NodeConfig {
 		panic("unable to assign tcp port")
 	}
 	return &NodeConfig{
-		ID:         id,
-		Name:       fmt.Sprintf("node_%s", id.String()),
-		PrivateKey: key,
-		Port:       port,
+		ID:              id,
+		Name:            fmt.Sprintf("node_%s", id.String()),
+		PrivateKey:      key,
+		Port:            port,
+		EnableMsgEvents: true,
 	}
 }
 

--- a/p2p/simulations/adapters/types.go
+++ b/p2p/simulations/adapters/types.go
@@ -177,6 +177,7 @@ func RandomNodeConfig() *NodeConfig {
 	}
 	return &NodeConfig{
 		ID:         id,
+		Name:       fmt.Sprintf("node_%s", id.String()),
 		PrivateKey: key,
 		Port:       port,
 	}

--- a/p2p/simulations/http.go
+++ b/p2p/simulations/http.go
@@ -561,7 +561,8 @@ func (s *Server) LoadSnapshot(w http.ResponseWriter, req *http.Request) {
 
 // CreateNode creates a node in the network using the given configuration
 func (s *Server) CreateNode(w http.ResponseWriter, req *http.Request) {
-	config := adapters.RandomNodeConfig()
+	config := &adapters.NodeConfig{}
+
 	err := json.NewDecoder(req.Body).Decode(config)
 	if err != nil && err != io.EOF {
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/p2p/simulations/http_test.go
+++ b/p2p/simulations/http_test.go
@@ -348,7 +348,8 @@ func startTestNetwork(t *testing.T, client *Client) []string {
 	nodeCount := 2
 	nodeIDs := make([]string, nodeCount)
 	for i := 0; i < nodeCount; i++ {
-		node, err := client.CreateNode(nil)
+		config := adapters.RandomNodeConfig()
+		node, err := client.CreateNode(config)
 		if err != nil {
 			t.Fatalf("error creating node: %s", err)
 		}
@@ -527,7 +528,9 @@ func TestHTTPNodeRPC(t *testing.T) {
 
 	// start a node in the network
 	client := NewClient(s.URL)
-	node, err := client.CreateNode(nil)
+
+	config := adapters.RandomNodeConfig()
+	node, err := client.CreateNode(config)
 	if err != nil {
 		t.Fatalf("error creating node: %s", err)
 	}
@@ -589,7 +592,8 @@ func TestHTTPSnapshot(t *testing.T) {
 	nodeCount := 2
 	nodes := make([]*p2p.NodeInfo, nodeCount)
 	for i := 0; i < nodeCount; i++ {
-		node, err := client.CreateNode(nil)
+		config := adapters.RandomNodeConfig()
+		node, err := client.CreateNode(config)
 		if err != nil {
 			t.Fatalf("error creating node: %s", err)
 		}

--- a/p2p/simulations/mocker.go
+++ b/p2p/simulations/mocker.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/discover"
+	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
 )
 
 //a map of mocker names to its function
@@ -165,7 +166,8 @@ func probabilistic(net *Network, quit chan struct{}, nodeCount int) {
 func connectNodesInRing(net *Network, nodeCount int) ([]discover.NodeID, error) {
 	ids := make([]discover.NodeID, nodeCount)
 	for i := 0; i < nodeCount; i++ {
-		node, err := net.NewNode()
+		conf := adapters.RandomNodeConfig()
+		node, err := net.NewNodeWithConfig(conf)
 		if err != nil {
 			log.Error("Error creating a node! %s", err)
 			return nil, err

--- a/p2p/simulations/network.go
+++ b/p2p/simulations/network.go
@@ -78,13 +78,6 @@ func (self *Network) Events() *event.Feed {
 	return &self.events
 }
 
-// NewNode adds a new node to the network with a random ID
-func (self *Network) NewNode() (*Node, error) {
-	conf := adapters.RandomNodeConfig()
-	conf.Services = []string{self.DefaultService}
-	return self.NewNodeWithConfig(conf)
-}
-
 // NewNodeWithConfig adds a new node to the network with the given config,
 // returning an error if a node with the same ID or name already exists
 func (self *Network) NewNodeWithConfig(conf *adapters.NodeConfig) (*Node, error) {

--- a/p2p/simulations/network.go
+++ b/p2p/simulations/network.go
@@ -91,13 +91,6 @@ func (self *Network) NewNodeWithConfig(conf *adapters.NodeConfig) (*Node, error)
 	self.lock.Lock()
 	defer self.lock.Unlock()
 
-	// create a random ID and PrivateKey if not set
-	if conf.ID == (discover.NodeID{}) {
-		c := adapters.RandomNodeConfig()
-		conf.ID = c.ID
-		conf.PrivateKey = c.PrivateKey
-	}
-	id := conf.ID
 	if conf.Reachable == nil {
 		conf.Reachable = func(otherID discover.NodeID) bool {
 			_, err := self.InitConn(conf.ID, otherID)
@@ -105,14 +98,9 @@ func (self *Network) NewNodeWithConfig(conf *adapters.NodeConfig) (*Node, error)
 		}
 	}
 
-	// assign a name to the node if not set
-	if conf.Name == "" {
-		conf.Name = fmt.Sprintf("node%02d", len(self.Nodes)+1)
-	}
-
 	// check the node doesn't already exist
-	if node := self.getNode(id); node != nil {
-		return nil, fmt.Errorf("node with ID %q already exists", id)
+	if node := self.getNode(conf.ID); node != nil {
+		return nil, fmt.Errorf("node with ID %q already exists", conf.ID)
 	}
 	if node := self.getNodeByName(conf.Name); node != nil {
 		return nil, fmt.Errorf("node with name %q already exists", conf.Name)
@@ -132,8 +120,8 @@ func (self *Network) NewNodeWithConfig(conf *adapters.NodeConfig) (*Node, error)
 		Node:   adapterNode,
 		Config: conf,
 	}
-	log.Trace(fmt.Sprintf("node %v created", id))
-	self.nodeMap[id] = len(self.Nodes)
+	log.Trace(fmt.Sprintf("node %v created", conf.ID))
+	self.nodeMap[conf.ID] = len(self.Nodes)
 	self.Nodes = append(self.Nodes, node)
 
 	// emit a "control" event

--- a/p2p/simulations/network_test.go
+++ b/p2p/simulations/network_test.go
@@ -41,7 +41,8 @@ func TestNetworkSimulation(t *testing.T) {
 	nodeCount := 20
 	ids := make([]discover.NodeID, nodeCount)
 	for i := 0; i < nodeCount; i++ {
-		node, err := network.NewNode()
+		conf := adapters.RandomNodeConfig()
+		node, err := network.NewNodeWithConfig(conf)
 		if err != nil {
 			t.Fatalf("error creating node: %s", err)
 		}

--- a/swarm/network/simulations/discovery/discovery_test.go
+++ b/swarm/network/simulations/discovery/discovery_test.go
@@ -164,7 +164,8 @@ func discoverySimulation(nodes, conns int, adapter adapters.NodeAdapter) (*simul
 	trigger := make(chan discover.NodeID)
 	ids := make([]discover.NodeID, nodes)
 	for i := 0; i < nodes; i++ {
-		node, err := net.NewNode()
+		conf := adapters.RandomNodeConfig()
+		node, err := net.NewNodeWithConfig(conf)
 		if err != nil {
 			return nil, fmt.Errorf("error starting node: %s", err)
 		}

--- a/swarm/network/stream/delivery_test.go
+++ b/swarm/network/stream/delivery_test.go
@@ -306,7 +306,7 @@ func TestStreamerDownstreamChunkDeliveryMsgExchange(t *testing.T) {
 
 }
 
-func XTestDeliveryFromNodes(t *testing.T) {
+func TestDeliveryFromNodes(t *testing.T) {
 	testDeliveryFromNodes(t, 2, 1, dataChunkCount, true)
 	testDeliveryFromNodes(t, 2, 1, dataChunkCount, false)
 	testDeliveryFromNodes(t, 4, 1, dataChunkCount, true)
@@ -321,11 +321,12 @@ func testDeliveryFromNodes(t *testing.T, nodes, conns, chunkCount int, skipCheck
 	defaultSkipCheck = skipCheck
 	toAddr = network.NewAddrFromNodeID
 	conf := &streamTesting.RunConfig{
-		Adapter:   *adapter,
-		NodeCount: nodes,
-		ConnLevel: conns,
-		ToAddr:    toAddr,
-		Services:  services,
+		Adapter:         *adapter,
+		NodeCount:       nodes,
+		ConnLevel:       conns,
+		ToAddr:          toAddr,
+		Services:        services,
+		EnableMsgEvents: false,
 	}
 
 	sim, teardown, err := streamTesting.NewSimulation(conf)
@@ -495,11 +496,12 @@ func benchmarkDeliveryFromNodes(b *testing.B, nodes, conns, chunkCount int, skip
 	defer cancel()
 
 	conf := &streamTesting.RunConfig{
-		Adapter:   *adapter,
-		NodeCount: nodes,
-		ConnLevel: conns,
-		ToAddr:    toAddr,
-		Services:  services,
+		Adapter:         *adapter,
+		NodeCount:       nodes,
+		ConnLevel:       conns,
+		ToAddr:          toAddr,
+		Services:        services,
+		EnableMsgEvents: false,
 	}
 	sim, teardown, err := streamTesting.NewSimulation(conf)
 	defer teardown()

--- a/swarm/network/stream/syncer_test.go
+++ b/swarm/network/stream/syncer_test.go
@@ -36,7 +36,7 @@ import (
 
 const dataChunkCount = 500
 
-func XTestSyncerSimulation(t *testing.T) {
+func TestSyncerSimulation(t *testing.T) {
 	testSyncBetweenNodes(t, 2, 1, dataChunkCount, true, 1)
 	testSyncBetweenNodes(t, 4, 1, dataChunkCount, true, 1)
 	testSyncBetweenNodes(t, 8, 1, dataChunkCount, true, 1)
@@ -51,11 +51,12 @@ func testSyncBetweenNodes(t *testing.T, nodes, conns, chunkCount int, skipCheck 
 		return addr
 	}
 	conf := &streamTesting.RunConfig{
-		Adapter:   *adapter,
-		NodeCount: nodes,
-		ConnLevel: conns,
-		ToAddr:    toAddr,
-		Services:  services,
+		Adapter:         *adapter,
+		NodeCount:       nodes,
+		ConnLevel:       conns,
+		ToAddr:          toAddr,
+		Services:        services,
+		EnableMsgEvents: false,
 	}
 	// create context for simulation run
 	timeout := 30 * time.Second

--- a/swarm/network/stream/testing/testing.go
+++ b/swarm/network/stream/testing/testing.go
@@ -117,12 +117,13 @@ func CheckResult(t *testing.T, result *simulations.StepResult, startedAt, finish
 }
 
 type RunConfig struct {
-	Adapter   string
-	Step      *simulations.Step
-	NodeCount int
-	ConnLevel int
-	ToAddr    func(discover.NodeID) *network.BzzAddr
-	Services  adapters.Services
+	Adapter         string
+	Step            *simulations.Step
+	NodeCount       int
+	ConnLevel       int
+	ToAddr          func(discover.NodeID) *network.BzzAddr
+	Services        adapters.Services
+	EnableMsgEvents bool
 }
 
 func NewSimulation(conf *RunConfig) (*Simulation, func(), error) {
@@ -144,7 +145,9 @@ func NewSimulation(conf *RunConfig) (*Simulation, func(), error) {
 	addrs := make([]network.Addr, nodes)
 	// start nodes
 	for i := 0; i < nodes; i++ {
-		node, err := net.NewNode()
+		nodeconf := adapters.RandomNodeConfig()
+		nodeconf.EnableMsgEvents = conf.EnableMsgEvents
+		node, err := net.NewNodeWithConfig(nodeconf)
 		if err != nil {
 			return nil, teardown, fmt.Errorf("error creating node: %s", err)
 		}

--- a/swarm/pss/client/client_test.go
+++ b/swarm/pss/client/client_test.go
@@ -180,9 +180,9 @@ func setupNetwork(numnodes int) (clients []*rpc.Client, err error) {
 		DefaultService: "bzz",
 	})
 	for i := 0; i < numnodes; i++ {
-		nodes[i], err = net.NewNodeWithConfig(&adapters.NodeConfig{
-			Services: []string{"bzz", "pss"},
-		})
+		nodeconf := adapters.RandomNodeConfig()
+		nodeconf.Services = []string{"bzz", "pss"}
+		nodes[i], err = net.NewNodeWithConfig(nodeconf)
 		if err != nil {
 			return nil, fmt.Errorf("error creating node 1: %v", err)
 		}

--- a/swarm/pss/pss_test.go
+++ b/swarm/pss/pss_test.go
@@ -1081,9 +1081,9 @@ func setupNetwork(numnodes int) (clients []*rpc.Client, err error) {
 		DefaultService: "bzz",
 	})
 	for i := 0; i < numnodes; i++ {
-		nodes[i], err = net.NewNodeWithConfig(&adapters.NodeConfig{
-			Services: []string{"bzz", pssProtocolName},
-		})
+		nodeconf := adapters.RandomNodeConfig()
+		nodeconf.Services = []string{"bzz", pssProtocolName}
+		nodes[i], err = net.NewNodeWithConfig(nodeconf)
 		if err != nil {
 			return nil, fmt.Errorf("error creating node 1: %v", err)
 		}


### PR DESCRIPTION
This PR is addressing https://github.com/ethersphere/go-ethereum/issues/253 , by making `EnableMsgEvents` configurable, and enabling some of the disabled tests from previous PRs.