### PR TITLE
swarm/network: Bugfix swarm peer discovery

### DIFF
--- a/swarm/network/hive.go
+++ b/swarm/network/hive.go
@@ -162,9 +162,15 @@ func (h *Hive) connect() {
 func (h *Hive) Run(p *BzzPeer) error {
 	dp := newDiscovery(p, h)
 	depth, changed := h.On(dp)
-	// if we want discovery, advertise changed depth of depth
-	if h.Discovery && changed {
-		NotifyDepth(depth, h)
+	// if we want discovery, advertise change of depth
+	if h.Discovery {
+		if changed {
+			// if depth changed, send to all peers
+			NotifyDepth(depth, h)
+		} else {
+			// otherwise just send depth to new peer
+			dp.NotifyDepth(depth)
+		}
 	}
 	NotifyPeer(p.Off(), h)
 	defer h.Off(dp)

--- a/swarm/network/protocol.go
+++ b/swarm/network/protocol.go
@@ -124,10 +124,10 @@ func NewBzz(config *BzzConfig, kad Overlay, store StateStore) *Bzz {
 
 // UpdateLocalAddr updates underlayaddress of the running node
 func (b *Bzz) UpdateLocalAddr(byteaddr []byte) *BzzAddr {
-	b.localAddr.Update(&BzzAddr{
+	b.localAddr = b.localAddr.Update(&BzzAddr{
 		UAddr: byteaddr,
 		OAddr: b.localAddr.OAddr,
-	})
+	}).(*BzzAddr)
 	return b.localAddr
 }
 

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -209,7 +209,7 @@ func (self *Swarm) Start(srv *p2p.Server) error {
 
 	// update uaddr to correct enode
 	newaddr := self.bzz.UpdateLocalAddr([]byte(srv.Self().String()))
-	log.Warn("Updated bzz local addr", "oaddr", fmt.Sprintf("%x", newaddr.OAddr), "uaddr", fmt.Sprintf("%x", newaddr.UAddr))
+	log.Warn("Updated bzz local addr", "oaddr", fmt.Sprintf("%x", newaddr.OAddr), "uaddr", fmt.Sprintf("%s", newaddr.UAddr))
 
 	// set chequebook
 	if self.config.SwapEnabled {


### PR DESCRIPTION
This bug was causing nodes to share bad underlay addresses during peer discovery.
The reason is because the `Update(OverlayAddr)` interface method returns an updated copy of an `OverlayAddr` rather than mutating the existing object, so calling `UpdateLocalAddr` has no effect.