### PR TITLE
rename DbStore to LDBStore

### DIFF
--- a/cmd/swarm/db.go
+++ b/cmd/swarm/db.go
@@ -35,7 +35,7 @@ func dbExport(ctx *cli.Context) {
 		utils.Fatalf("invalid arguments, please specify both <chunkdb> (path to a local chunk database), <file> (path to write the tar archive to, - for stdout) and the base key")
 	}
 
-	store, err := openDbStore(args[0], common.Hex2Bytes(args[2]))
+	store, err := openLDBStore(args[0], common.Hex2Bytes(args[2]))
 	if err != nil {
 		utils.Fatalf("error opening local chunk database: %s", err)
 	}
@@ -67,7 +67,7 @@ func dbImport(ctx *cli.Context) {
 		utils.Fatalf("invalid arguments, please specify both <chunkdb> (path to a local chunk database), <file> (path to read the tar archive from, - for stdin) and the base key")
 	}
 
-	store, err := openDbStore(args[0], common.Hex2Bytes(args[2]))
+	store, err := openLDBStore(args[0], common.Hex2Bytes(args[2]))
 	if err != nil {
 		utils.Fatalf("error opening local chunk database: %s", err)
 	}
@@ -99,7 +99,7 @@ func dbClean(ctx *cli.Context) {
 		utils.Fatalf("invalid arguments, please specify <chunkdb> (path to a local chunk database) and the base key")
 	}
 
-	store, err := openDbStore(args[0], common.Hex2Bytes(args[1]))
+	store, err := openLDBStore(args[0], common.Hex2Bytes(args[1]))
 	if err != nil {
 		utils.Fatalf("error opening local chunk database: %s", err)
 	}
@@ -108,10 +108,10 @@ func dbClean(ctx *cli.Context) {
 	store.Cleanup()
 }
 
-func openDbStore(path string, basekey []byte) (*storage.DbStore, error) {
+func openLDBStore(path string, basekey []byte) (*storage.LDBStore, error) {
 	if _, err := os.Stat(filepath.Join(path, "CURRENT")); err != nil {
 		return nil, fmt.Errorf("invalid chunkdb path: %s", err)
 	}
 	hash := storage.MakeHashFunc("SHA3")
-	return storage.NewDbStore(path, hash, 10000000, func(k storage.Key) (ret uint8) { return uint8(storage.Proximity(basekey[:], k[:])) })
+	return storage.NewLDBStore(path, hash, 10000000, func(k storage.Key) (ret uint8) { return uint8(storage.Proximity(basekey[:], k[:])) })
 }

--- a/swarm/storage/dbapi.go
+++ b/swarm/storage/dbapi.go
@@ -18,12 +18,12 @@ package storage
 
 // wrapper of db-s to provide mockable custom local chunk store access to syncer
 type DBAPI struct {
-	db  *DbStore
+	db  *LDBStore
 	loc *LocalStore
 }
 
 func NewDBAPI(loc *LocalStore) *DBAPI {
-	return &DBAPI{loc.DbStore.(*DbStore), loc}
+	return &DBAPI{loc.DbStore.(*LDBStore), loc}
 }
 
 // to obtain the chunks from key or request db entry only

--- a/swarm/storage/dpa.go
+++ b/swarm/storage/dpa.go
@@ -71,7 +71,7 @@ func NewLocalDPA(datadir string, basekey []byte) (*DPA, error) {
 
 	hash := MakeHashFunc("SHA3")
 
-	dbStore, err := NewDbStore(datadir, hash, singletonSwarmDbCapacity, func(k Key) (ret uint8) { return uint8(Proximity(basekey[:], k[:])) })
+	dbStore, err := NewLDBStore(datadir, hash, singletonSwarmDbCapacity, func(k Key) (ret uint8) { return uint8(Proximity(basekey[:], k[:])) })
 	if err != nil {
 		return nil, err
 	}

--- a/swarm/storage/dpa_test.go
+++ b/swarm/storage/dpa_test.go
@@ -32,7 +32,7 @@ func TestDPArandom(t *testing.T) {
 		t.Fatalf("init dbStore failed: %v", err)
 	}
 	defer tdb.close()
-	db := tdb.DbStore
+	db := tdb.LDBStore
 	db.setCapacity(50000)
 	memStore := NewMemStore(db, defaultCacheCapacity)
 	localStore := &LocalStore{
@@ -91,7 +91,7 @@ func TestDPA_capacity(t *testing.T) {
 		t.Fatalf("init dbStore failed: %v", err)
 	}
 	defer tdb.close()
-	db := tdb.DbStore
+	db := tdb.LDBStore
 	memStore := NewMemStore(db, 0)
 	localStore := &LocalStore{
 		memStore,

--- a/swarm/storage/ldbstore_test.go
+++ b/swarm/storage/ldbstore_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 type testDbStore struct {
-	*DbStore
+	*LDBStore
 	dir string
 }
 
@@ -40,7 +40,7 @@ func newTestDbStore(mock bool) (*testDbStore, error) {
 		return nil, err
 	}
 
-	var db *DbStore
+	var db *LDBStore
 	if mock {
 		globalStore := mem.NewGlobalStore()
 		addr := common.HexToAddress("0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed")
@@ -48,7 +48,7 @@ func newTestDbStore(mock bool) (*testDbStore, error) {
 
 		db, err = NewMockDbStore(dir, MakeHashFunc(SHA3Hash), defaultDbCapacity, testPoFunc, mockStore)
 	} else {
-		db, err = NewDbStore(dir, MakeHashFunc(SHA3Hash), defaultDbCapacity, testPoFunc)
+		db, err = NewLDBStore(dir, MakeHashFunc(SHA3Hash), defaultDbCapacity, testPoFunc)
 	}
 
 	return &testDbStore{db, dir}, err

--- a/swarm/storage/localstore.go
+++ b/swarm/storage/localstore.go
@@ -66,7 +66,7 @@ func NewLocalStore(hash SwarmHasher, params *StoreParams, basekey []byte, mockSt
 func NewTestLocalStore(path string) (*LocalStore, error) {
 	basekey := make([]byte, 32)
 	hasher := MakeHashFunc("SHA3")
-	dbStore, err := NewDbStore(path, hasher, singletonSwarmDbCapacity, func(k Key) (ret uint8) { return uint8(Proximity(basekey[:], k[:])) })
+	dbStore, err := NewLDBStore(path, hasher, singletonSwarmDbCapacity, func(k Key) (ret uint8) { return uint8(Proximity(basekey[:], k[:])) })
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func NewTestLocalStore(path string) (*LocalStore, error) {
 
 func NewTestLocalStoreForAddr(path string, basekey []byte) (*LocalStore, error) {
 	hasher := MakeHashFunc("SHA3")
-	dbStore, err := NewDbStore(path, hasher, singletonSwarmDbCapacity, func(k Key) (ret uint8) { return uint8(Proximity(basekey[:], k[:])) })
+	dbStore, err := NewLDBStore(path, hasher, singletonSwarmDbCapacity, func(k Key) (ret uint8) { return uint8(Proximity(basekey[:], k[:])) })
 	if err != nil {
 		return nil, err
 	}

--- a/swarm/storage/memstore.go
+++ b/swarm/storage/memstore.go
@@ -44,7 +44,7 @@ type MemStore struct {
 	entryCnt, capacity uint   // stored entries
 	accessCnt          uint64 // access counter; oldest is thrown away when full
 	dbAccessCnt        uint64
-	dbStore            *DbStore
+	ldbStore           *LDBStore
 	lock               sync.Mutex
 }
 
@@ -61,10 +61,10 @@ a hash prefix subtree containing subtrees or one storage entry (but never both)
   (access[] is a binary tree inside the multi-bit leveled hash tree)
 */
 
-func NewMemStore(d *DbStore, capacity uint) (m *MemStore) {
+func NewMemStore(d *LDBStore, capacity uint) (m *MemStore) {
 	m = &MemStore{}
 	m.memtree = newMemTree(memTreeFLW, nil, 0)
-	m.dbStore = d
+	m.ldbStore = d
 	m.setCapacity(capacity)
 	return
 }
@@ -240,8 +240,8 @@ func (s *MemStore) Get(hash Key) (chunk *Chunk, err error) {
 		if s.dbAccessCnt-node.lastDBaccess > dbForceUpdateAccessCnt {
 			s.dbAccessCnt++
 			node.lastDBaccess = s.dbAccessCnt
-			if s.dbStore != nil {
-				s.dbStore.updateAccessCnt(hash)
+			if s.ldbStore != nil {
+				s.ldbStore.updateAccessCnt(hash)
 			}
 		}
 	} else {

--- a/swarm/storage/resource.go
+++ b/swarm/storage/resource.go
@@ -870,7 +870,7 @@ func NewTestResourceHandler(datadir string, ethClient headerGetter, validator Re
 	path := filepath.Join(datadir, DbDirName)
 	basekey := make([]byte, 32)
 	hasher := MakeHashFunc(SHA3Hash)
-	dbStore, err := NewDbStore(path, hasher, singletonSwarmDbCapacity, func(k Key) (ret uint8) { return uint8(Proximity(basekey[:], k[:])) })
+	dbStore, err := NewLDBStore(path, hasher, singletonSwarmDbCapacity, func(k Key) (ret uint8) { return uint8(Proximity(basekey[:], k[:])) })
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Renaming the concrete DbStore, which is actually a LevelDBStore, in order to differentiate types and interfaces and fields a bit easily.

I hope this will help to differentiate with `LocalStore.DbStore` field which currently is an interface, and generally points to the `LDBStore`