### PR TITLE
Enable Discovery tests

### DIFF
--- a/p2p/simulations/adapters/exec.go
+++ b/p2p/simulations/adapters/exec.go
@@ -201,7 +201,7 @@ func (n *ExecNode) Start(snapshots map[string][]byte) (err error) {
 	go func() {
 		s := bufio.NewScanner(stderrR)
 		for s.Scan() {
-			if strings.Contains(s.Text(), "WebSocket endpoint opened:") {
+			if strings.Contains(s.Text(), "WebSocket endpoint opened") {
 				wsAddrC <- wsAddrPattern.FindString(s.Text())
 			}
 		}

--- a/swarm/network/simulations/discovery/discovery_test.go
+++ b/swarm/network/simulations/discovery/discovery_test.go
@@ -87,7 +87,6 @@ func testDiscoverySimulationDockerAdapter(t *testing.T, nodes, conns int) {
 }
 
 func TestDiscoverySimulationExecAdapter(t *testing.T) {
-	t.Skip("broken (times out)")
 	testDiscoverySimulationExecAdapter(t, *nodeCount, *initCount)
 }
 


### PR DESCRIPTION
These tests are stable, and should not be disabled.

I believe someone changed the logger, which broke the functionality which picks up the websocket port, which resulted in these tests being broken.

They should work now.