### PR TITLE
Fix Docker discovery tests setup

### DIFF
--- a/p2p/simulations/adapters/docker.go
+++ b/p2p/simulations/adapters/docker.go
@@ -28,7 +28,6 @@ import (
 	"strings"
 
 	"github.com/docker/docker/pkg/reexec"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p/discover"
 )
@@ -99,7 +98,10 @@ func (d *DockerAdapter) NewNode(config *NodeConfig) (Node, error) {
 	conf.Stack.P2P.NoDiscovery = true
 	conf.Stack.P2P.NAT = nil
 	conf.Stack.NoUSB = true
-	conf.Stack.Logger = log.New("node.id", config.ID.String())
+
+	// listen on a localhost port, which we set when we
+	// initialise NodeConfig (usually a random port)
+	conf.Stack.P2P.ListenAddr = fmt.Sprintf(":%d", config.Port)
 
 	node := &DockerNode{
 		ExecNode: ExecNode{

--- a/p2p/simulations/adapters/docker.go
+++ b/p2p/simulations/adapters/docker.go
@@ -99,7 +99,7 @@ func (d *DockerAdapter) NewNode(config *NodeConfig) (Node, error) {
 	conf.Stack.P2P.NAT = nil
 	conf.Stack.NoUSB = true
 
-	// listen on a localhost port, which we set when we
+	// listen on all interfaces on a given port, which we set when we
 	// initialise NodeConfig (usually a random port)
 	conf.Stack.P2P.ListenAddr = fmt.Sprintf(":%d", config.Port)
 

--- a/p2p/simulations/adapters/exec.go
+++ b/p2p/simulations/adapters/exec.go
@@ -340,27 +340,17 @@ type execNodeConfig struct {
 
 // ExternalIP gets an external IP address so that Enode URL is usable
 func ExternalIP() net.IP {
-	//addrs, err := net.InterfaceAddrs()
-	//if err != nil {
-	//log.Crit("error getting IP address", "err", err)
-	//}
-	//for _, addr := range addrs {
-	//if ip, ok := addr.(*net.IPNet); ok && !ip.IP.IsLoopback() {
-	//return ip.IP
-	//}
-	//}
-	//log.Crit("unable to determine explicit IP address")
-	//return net.IP{127, 0, 0, 1}
-
-	conn, err := net.Dial("udp", "8.8.8.8:80")
+	addrs, err := net.InterfaceAddrs()
 	if err != nil {
-		panic(err)
+		log.Crit("error getting IP address", "err", err)
 	}
-	defer conn.Close()
-
-	localAddr := conn.LocalAddr().(*net.UDPAddr)
-
-	return localAddr.IP
+	for _, addr := range addrs {
+		if ip, ok := addr.(*net.IPNet); ok && !ip.IP.IsLoopback() && !ip.IP.IsLinkLocalUnicast() {
+			return ip.IP
+		}
+	}
+	log.Crit("unable to determine explicit IP address")
+	return net.IP{127, 0, 0, 1}
 }
 
 // execP2PNode starts a devp2p node when the current binary is executed with

--- a/p2p/simulations/adapters/exec.go
+++ b/p2p/simulations/adapters/exec.go
@@ -107,7 +107,7 @@ func (e *ExecAdapter) NewNode(config *NodeConfig) (Node, error) {
 
 	// listen on a localhost port, which we set when we
 	// initialise NodeConfig (usually a random port)
-	conf.Stack.P2P.ListenAddr = fmt.Sprintf("127.0.0.1:%d", config.Port)
+	conf.Stack.P2P.ListenAddr = fmt.Sprintf(":%d", config.Port)
 
 	node := &ExecNode{
 		ID:      config.ID,

--- a/p2p/simulations/adapters/exec.go
+++ b/p2p/simulations/adapters/exec.go
@@ -340,17 +340,27 @@ type execNodeConfig struct {
 
 // ExternalIP gets an external IP address so that Enode URL is usable
 func ExternalIP() net.IP {
-	addrs, err := net.InterfaceAddrs()
+	//addrs, err := net.InterfaceAddrs()
+	//if err != nil {
+	//log.Crit("error getting IP address", "err", err)
+	//}
+	//for _, addr := range addrs {
+	//if ip, ok := addr.(*net.IPNet); ok && !ip.IP.IsLoopback() {
+	//return ip.IP
+	//}
+	//}
+	//log.Crit("unable to determine explicit IP address")
+	//return net.IP{127, 0, 0, 1}
+
+	conn, err := net.Dial("udp", "8.8.8.8:80")
 	if err != nil {
-		log.Crit("error getting IP address", "err", err)
+		panic(err)
 	}
-	for _, addr := range addrs {
-		if ip, ok := addr.(*net.IPNet); ok && !ip.IP.IsLoopback() {
-			return ip.IP
-		}
-	}
-	log.Crit("unable to determine explicit IP address")
-	return net.IP{127, 0, 0, 1}
+	defer conn.Close()
+
+	localAddr := conn.LocalAddr().(*net.UDPAddr)
+
+	return localAddr.IP
 }
 
 // execP2PNode starts a devp2p node when the current binary is executed with

--- a/p2p/simulations/adapters/exec.go
+++ b/p2p/simulations/adapters/exec.go
@@ -338,6 +338,21 @@ type execNodeConfig struct {
 	PeerAddrs map[string]string `json:"peer_addrs,omitempty"`
 }
 
+// ExternalIP gets an external IP address so that Enode URL is usable
+func ExternalIP() net.IP {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		log.Crit("error getting IP address", "err", err)
+	}
+	for _, addr := range addrs {
+		if ip, ok := addr.(*net.IPNet); ok && !ip.IP.IsLoopback() {
+			return ip.IP
+		}
+	}
+	log.Crit("unable to determine explicit IP address")
+	return net.IP{127, 0, 0, 1}
+}
+
 // execP2PNode starts a devp2p node when the current binary is executed with
 // argv[0] being "p2p-node", reading the service / ID from argv[1] / argv[2]
 // and the node config from the _P2P_NODE_CONFIG environment variable
@@ -361,25 +376,11 @@ func execP2PNode() {
 	conf.Stack.P2P.PrivateKey = conf.Node.PrivateKey
 	conf.Stack.Logger = log.New("node.id", conf.Node.ID.String())
 
-	// use explicit IP address in ListenAddr so that Enode URL is usable
-	externalIP := func() string {
-		addrs, err := net.InterfaceAddrs()
-		if err != nil {
-			log.Crit("error getting IP address", "err", err)
-		}
-		for _, addr := range addrs {
-			if ip, ok := addr.(*net.IPNet); ok && !ip.IP.IsLoopback() {
-				return ip.IP.String()
-			}
-		}
-		log.Crit("unable to determine explicit IP address")
-		return ""
-	}
 	if strings.HasPrefix(conf.Stack.P2P.ListenAddr, ":") {
-		conf.Stack.P2P.ListenAddr = externalIP() + conf.Stack.P2P.ListenAddr
+		conf.Stack.P2P.ListenAddr = ExternalIP().String() + conf.Stack.P2P.ListenAddr
 	}
 	if conf.Stack.WSHost == "0.0.0.0" {
-		conf.Stack.WSHost = externalIP()
+		conf.Stack.WSHost = ExternalIP().String()
 	}
 
 	// initialize the devp2p stack

--- a/swarm/network/protocol.go
+++ b/swarm/network/protocol.go
@@ -427,10 +427,10 @@ func NewAddrFromNodeID(id discover.NodeID) *BzzAddr {
 
 // NewAddrFromNodeIDAndPort constucts a BzzAddr from a discover.NodeID and port uint16
 // the overlay address is derived as the hash of the nodeID
-func NewAddrFromNodeIDAndPort(id discover.NodeID, port uint16) *BzzAddr {
+func NewAddrFromNodeIDAndPort(id discover.NodeID, host net.IP, port uint16) *BzzAddr {
 	return &BzzAddr{
 		OAddr: ToOverlayAddr(id.Bytes()),
-		UAddr: []byte(discover.NewNode(id, net.IP{127, 0, 0, 1}, port, port).String()),
+		UAddr: []byte(discover.NewNode(id, host, port, port).String()),
 	}
 }
 

--- a/swarm/network/simulations/discovery/discovery_test.go
+++ b/swarm/network/simulations/discovery/discovery_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/rand"
+	"net"
 	"os"
 	"sync"
 	"testing"
@@ -20,6 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/simulations"
 	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
 	"github.com/ethereum/go-ethereum/swarm/network"
+	colorable "github.com/mattn/go-colorable"
 )
 
 // serviceName is used with the exec adapter so the exec'd binary knows which
@@ -44,7 +46,8 @@ func init() {
 	// protocol when using the exec adapter
 	adapters.RegisterServices(services)
 
-	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(*loglevel), log.StreamHandler(os.Stderr, log.TerminalFormat(false))))
+	log.PrintOrigins(true)
+	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(*loglevel), log.StreamHandler(colorable.NewColorableStderr(), log.TerminalFormat(true))))
 }
 
 // Benchmarks to test the average time it takes for an N-node ring
@@ -70,7 +73,7 @@ func BenchmarkDiscovery_64_4(b *testing.B)  { benchmarkDiscovery(b, 64, 4) }
 func BenchmarkDiscovery_128_4(b *testing.B) { benchmarkDiscovery(b, 128, 4) }
 func BenchmarkDiscovery_256_4(b *testing.B) { benchmarkDiscovery(b, 256, 4) }
 
-func XTestDiscoverySimulationDockerAdapter(t *testing.T) {
+func TestDiscoverySimulationDockerAdapter(t *testing.T) {
 	testDiscoverySimulationDockerAdapter(t, *nodeCount, *initCount)
 }
 
@@ -231,7 +234,7 @@ func discoverySimulation(nodes, conns int, adapter adapters.NodeAdapter) (*simul
 
 	// 64 nodes ~ 1min
 	// 128 nodes ~
-	timeout := 300 * time.Second
+	timeout := 60 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	result := simulations.NewSimulation(net).Run(ctx, &simulations.Step{
@@ -304,8 +307,23 @@ func triggerChecks(trigger chan discover.NodeID, net *simulations.Network, id di
 	return nil
 }
 
+// getOutboundIP gets preferred outbound ip of this machine/container
+func getOutboundIP() net.IP {
+	conn, err := net.Dial("udp", "8.8.8.8:80")
+	if err != nil {
+		panic(err)
+	}
+	defer conn.Close()
+
+	localAddr := conn.LocalAddr().(*net.UDPAddr)
+
+	return localAddr.IP
+}
+
 func newService(ctx *adapters.ServiceContext) (node.Service, error) {
-	addr := network.NewAddrFromNodeIDAndPort(ctx.Config.ID, ctx.Config.Port)
+	host := getOutboundIP()
+
+	addr := network.NewAddrFromNodeIDAndPort(ctx.Config.ID, host, ctx.Config.Port)
 
 	kp := network.NewKadParams()
 	kp.MinProxBinSize = testMinProxBinSize

--- a/swarm/network/simulations/discovery/discovery_test.go
+++ b/swarm/network/simulations/discovery/discovery_test.go
@@ -233,7 +233,7 @@ func discoverySimulation(nodes, conns int, adapter adapters.NodeAdapter) (*simul
 
 	// 64 nodes ~ 1min
 	// 128 nodes ~
-	timeout := 60 * time.Second
+	timeout := 300 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	result := simulations.NewSimulation(net).Run(ctx, &simulations.Step{

--- a/swarm/network/simulations/discovery/discovery_test.go
+++ b/swarm/network/simulations/discovery/discovery_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/rand"
-	"net"
 	"os"
 	"sync"
 	"testing"
@@ -307,21 +306,8 @@ func triggerChecks(trigger chan discover.NodeID, net *simulations.Network, id di
 	return nil
 }
 
-// getOutboundIP gets preferred outbound ip of this machine/container
-func getOutboundIP() net.IP {
-	conn, err := net.Dial("udp", "8.8.8.8:80")
-	if err != nil {
-		panic(err)
-	}
-	defer conn.Close()
-
-	localAddr := conn.LocalAddr().(*net.UDPAddr)
-
-	return localAddr.IP
-}
-
 func newService(ctx *adapters.ServiceContext) (node.Service, error) {
-	host := getOutboundIP()
+	host := adapters.ExternalIP()
 
 	addr := network.NewAddrFromNodeIDAndPort(ctx.Config.ID, host, ctx.Config.Port)
 


### PR DESCRIPTION
This PR is fixing the discovery tests for the `Docker` adapter. I am pretty sure this will fail on Travis, so ultimately we should disable this adapter. However it might be useful for cluster testing if we point our local docker client to a remote docker swarm - something I should try out soon.

If you want to run this test locally, you either need to be on `linux` and have `docker` installed, or you can run the tests inside a docker container with access to your docker socket:

```
docker pull nonsens3/golang_docker
docker run -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):/go/src/github.com/ethereum/go-ethereum -it nonsens3/golang_docker /bin/bash

root@dd89b5834c37:/go# cd src/github.com/ethereum/go-ethereum/
root@dd89b5834c37:/go/src/github.com/ethereum/go-ethereum# go test ./swarm/network/simulations/discovery/... -run TestDiscoverySimulationDockerAdapter
```
