### PR TITLE
Fix panic, discPeer can not be converted to bzzPeer

### DIFF
--- a/swarm/network/stream/delivery.go
+++ b/swarm/network/stream/delivery.go
@@ -217,7 +217,7 @@ func (d *Delivery) RequestFromPeers(hash []byte, skipCheck bool, peersToSkip ...
 	var success bool
 	var err error
 	d.overlay.EachConn(hash, 255, func(p network.OverlayConn, po int, nn bool) bool {
-		spId := p.(*network.BzzPeer).ID()
+		spId := p.(network.Peer).ID()
 		for _, p := range peersToSkip {
 			if p == spId {
 				log.Trace("Delivery.RequestFromPeers: skip peer", "peer", spId)


### PR DESCRIPTION
There was a panic:

panic: interface conversion: network.OverlayConn is *network.discPeer, not *network.BzzPeer

goroutine 83 [running]:
github.com/ethereum/go-ethereum/swarm/network/stream.(*Delivery).RequestFromPeers.func1(0x170f400, 0xc4309bb900, 0x0, 0x170f401, 0xc4309bb900)
	/go/src/github.com/ethereum/go-ethereum/swarm/network/stream/delivery.go:220 +0x4f4

A discPeer can not be converted to bzzPeer, but the network.Peer interface is good to have an ID() function