### PR TITLE
deadlock on retrieve chunk + more tracing for internal swarm components

### DIFF
--- a/log/format.go
+++ b/log/format.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	timeFormat     = "2006-01-02T15:04:05-0700"
-	termTimeFormat = "01-02|15:04:05"
+	termTimeFormat = "01-02|15:04:05.999999"
 	floatFormat    = 'f'
 	termMsgJust    = 40
 )

--- a/swarm/storage/ldbstore.go
+++ b/swarm/storage/ldbstore.go
@@ -662,7 +662,7 @@ func (s *LDBStore) tryAccessIdx(ikey []byte, index *dpaDBIndex) bool {
 }
 
 func (s *LDBStore) Get(key Key) (chunk *Chunk, err error) {
-	//log.Trace("ldbstore.get", "key", chunk.Key) - seems like chunk is nil sometimes
+	log.Trace("ldbstore.get", "key", key)
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	return s.get(key)
@@ -700,9 +700,9 @@ func (s *LDBStore) get(key Key) (chunk *Chunk, err error) {
 			hash := hasher.Sum(nil)
 
 			if !bytes.Equal(hash, key) {
-				log.Error(fmt.Sprintf("Apparent key/hash mismatch. Hash %x, key %v", hash, key[:]))
+				log.Error("apparent key/hash mismatch", "hash", hash, "key", key[:])
 				s.delete(indx.Idx, getIndexKey(key), s.po(key))
-				log.Error("Invalid Chunk in Database. Please repair with command: 'swarm cleandb'")
+				log.Error("invalid chunk in database.")
 			}
 		}
 

--- a/swarm/storage/ldbstore.go
+++ b/swarm/storage/ldbstore.go
@@ -707,6 +707,7 @@ func (s *LDBStore) get(key Key) (chunk *Chunk, err error) {
 		}
 
 		chunk = NewChunk(key, nil)
+		close(chunk.dbStored)
 		decodeData(data, chunk)
 	} else {
 		err = ErrChunkNotFound

--- a/swarm/storage/localstore.go
+++ b/swarm/storage/localstore.go
@@ -85,6 +85,7 @@ func (self *LocalStore) CacheCounter() uint64 {
 // LocalStore is itself a chunk store
 // unsafe, in that the data is not integrity checked
 func (self *LocalStore) Put(chunk *Chunk) {
+	log.Trace("localstore.put", "key", chunk.Key)
 	self.mu.Lock()
 	defer self.mu.Unlock()
 

--- a/swarm/storage/memstore.go
+++ b/swarm/storage/memstore.go
@@ -144,6 +144,7 @@ func (s *MemStore) Counter() uint {
 
 // entry (not its copy) is going to be in MemStore
 func (s *MemStore) Put(entry *Chunk) {
+	log.Trace("memstore.put", "key", entry.Key)
 	if s.capacity == 0 {
 		return
 	}
@@ -219,6 +220,7 @@ func (s *MemStore) Put(entry *Chunk) {
 }
 
 func (s *MemStore) Get(hash Key) (chunk *Chunk, err error) {
+	log.Trace("memstore.get", "key", hash)
 	s.lock.Lock()
 	defer s.lock.Unlock()
 

--- a/swarm/storage/memstore.go
+++ b/swarm/storage/memstore.go
@@ -230,6 +230,7 @@ func (s *MemStore) Get(hash Key) (chunk *Chunk, err error) {
 		l := hash.bits(bitpos, node.bits)
 		st := node.subtree[l]
 		if st == nil {
+			log.Trace("memstore.get ErrChunkNotFound", "key", hash)
 			return nil, ErrChunkNotFound
 		}
 		bitpos += node.bits
@@ -251,6 +252,7 @@ func (s *MemStore) Get(hash Key) (chunk *Chunk, err error) {
 		err = ErrChunkNotFound
 	}
 
+	log.Trace("memstore.get return", "key", hash, "chunk", chunk, "err", err)
 	return
 }
 
@@ -298,11 +300,11 @@ func (s *MemStore) removeOldest() {
 
 	}
 
-	log.Trace(fmt.Sprintf("Memstore Clean: Waiting for chunk %v to be saved", node.entry.Key.Log()))
-	<-node.entry.dbStored
-	log.Trace(fmt.Sprintf("Memstore Clean: Chunk %v saved to DBStore. Ready to clear from mem.", node.entry.Key.Log()))
-
 	if node.entry.ReqC == nil {
+		log.Trace(fmt.Sprintf("Memstore Clean: Waiting for chunk %v to be saved", node.entry.Key.Log()))
+		<-node.entry.dbStored
+		log.Trace(fmt.Sprintf("Memstore Clean: Chunk %v saved to DBStore. Ready to clear from mem.", node.entry.Key.Log()))
+
 		memstoreRemoveCounter.Inc(1)
 		node.entry = nil
 		s.entryCnt--

--- a/swarm/storage/pyramid.go
+++ b/swarm/storage/pyramid.go
@@ -266,8 +266,6 @@ func (self *PyramidChunker) processor(id int64, jobC chan *chunkJob, chunkC chan
 }
 
 func (self *PyramidChunker) processChunk(id int64, hasher SwarmHash, job *chunkJob, chunkC chan *Chunk, storageWG *sync.WaitGroup) {
-	log.Debug("pyramid.chunker: processChunk()", "id", id)
-
 	hasher.ResetWithLength(job.chunk[:8]) // 8 bytes of length
 	hasher.Write(job.chunk[8:])           // minus 8 []byte length
 	h := hasher.Sum(nil)


### PR DESCRIPTION
This PR is mostly related to two issues:

1. This is a continuation for https://github.com/ethersphere/go-ethereum/pull/334 - adding more tracing to common code paths so that we have easier time debugging

2. Solving a deadlock, where we try to upload big files to Swarm, which are bigger than the memstore cache.

TODO:
- [ ] add automated test