### PR TITLE
storage: wrap closing chunk stored chan in mutex

### DIFF
--- a/swarm/storage/chunker.go
+++ b/swarm/storage/chunker.go
@@ -298,7 +298,7 @@ func (self *TreeChunker) hashChunk(hasher SwarmHash, job *hashJob, chunkC chan *
 		storeWg.Add(1)
 		go func() {
 			defer storeWg.Done()
-			<-newChunk.dbStored
+			<-newChunk.dbStoredC
 		}()
 	}
 }

--- a/swarm/storage/chunker_test.go
+++ b/swarm/storage/chunker_test.go
@@ -65,7 +65,7 @@ func (self *chunkerTester) Split(chunker Splitter, data io.Reader, size int64, c
 				case chunk := <-chunkC:
 					// self.chunks = append(self.chunks, chunk)
 					self.chunks[chunk.Key.Hex()] = chunk
-					close(chunk.dbStored)
+					chunk.markAsStored()
 				}
 
 			}
@@ -105,12 +105,12 @@ func (self *chunkerTester) Append(chunker Splitter, rootKey Key, data io.Reader,
 						if !success {
 							// Requesting data
 							self.chunks[chunk.Key.Hex()] = chunk
-							close(chunk.dbStored)
+							chunk.markAsStored()
 						} else {
 							// getting data
 							chunk.SData = stored.SData
 							chunk.Size = int64(binary.LittleEndian.Uint64(chunk.SData[0:8]))
-							close(chunk.dbStored)
+							chunk.markAsStored()
 							if chunk.C != nil {
 								close(chunk.C)
 							}

--- a/swarm/storage/common_test.go
+++ b/swarm/storage/common_test.go
@@ -101,7 +101,7 @@ func mput(store ChunkStore, processors int, n int, f func(i int) *Chunk) (hs []K
 
 					store.Put(chunk)
 
-					<-chunk.dbStored
+					<-chunk.dbStoredC
 				}()
 			}
 		}()
@@ -110,7 +110,7 @@ func mput(store ChunkStore, processors int, n int, f func(i int) *Chunk) (hs []K
 	if _, ok := store.(*MemStore); ok {
 		fa = func(i int) *Chunk {
 			chunk := f(i)
-			close(chunk.dbStored)
+			chunk.markAsStored()
 			return chunk
 		}
 	}

--- a/swarm/storage/ldbstore_test.go
+++ b/swarm/storage/ldbstore_test.go
@@ -182,7 +182,7 @@ func testIterator(t *testing.T, mock bool) {
 		j := i
 		go func() {
 			defer wg.Done()
-			<-chunks[j].dbStored
+			<-chunks[j].dbStoredC
 		}()
 	}
 

--- a/swarm/storage/localstore.go
+++ b/swarm/storage/localstore.go
@@ -91,10 +91,12 @@ func (self *LocalStore) Put(chunk *Chunk) {
 
 	chunk.Size = int64(binary.LittleEndian.Uint64(chunk.SData[0:8]))
 	c := &Chunk{
-		Key:      Key(append([]byte{}, chunk.Key...)),
-		SData:    append([]byte{}, chunk.SData...),
-		Size:     chunk.Size,
-		dbStored: chunk.dbStored,
+		Key:        Key(append([]byte{}, chunk.Key...)),
+		SData:      append([]byte{}, chunk.SData...),
+		Size:       chunk.Size,
+		dbStored:   chunk.dbStored,
+		dbStoredC:  chunk.dbStoredC,
+		dbStoredMu: chunk.dbStoredMu,
 	}
 
 	dbStorePutCounter.Inc(1)

--- a/swarm/storage/memstore.go
+++ b/swarm/storage/memstore.go
@@ -302,7 +302,7 @@ func (s *MemStore) removeOldest() {
 
 	if node.entry.ReqC == nil {
 		log.Trace(fmt.Sprintf("Memstore Clean: Waiting for chunk %v to be saved", node.entry.Key.Log()))
-		<-node.entry.dbStored
+		<-node.entry.dbStoredC
 		log.Trace(fmt.Sprintf("Memstore Clean: Chunk %v saved to DBStore. Ready to clear from mem.", node.entry.Key.Log()))
 
 		memstoreRemoveCounter.Inc(1)

--- a/swarm/storage/pyramid.go
+++ b/swarm/storage/pyramid.go
@@ -285,7 +285,7 @@ func (self *PyramidChunker) processChunk(id int64, hasher SwarmHash, job *chunkJ
 		storageWG.Add(1)
 		go func() {
 			defer storageWG.Done()
-			<-newChunk.dbStored
+			<-newChunk.dbStoredC
 		}()
 	}
 }

--- a/swarm/storage/resource.go
+++ b/swarm/storage/resource.go
@@ -635,7 +635,7 @@ func (self *ResourceHandler) update(ctx context.Context, name string, data []byt
 	self.Put(chunk)
 	timeout := time.NewTimer(self.storeTimeout)
 	select {
-	case <-chunk.dbStored:
+	case <-chunk.dbStoredC:
 	case <-timeout.C:
 		return nil, NewResourceError(ErrIO, "chunk store timeout")
 	}

--- a/swarm/storage/types.go
+++ b/swarm/storage/types.go
@@ -177,7 +177,7 @@ type Chunk struct {
 	C          chan bool // to signal data delivery by the dpa
 	ReqC       chan bool // to signal the request done
 	dbStoredC  chan bool // never remove a chunk from memStore before it is written to dbStore
-	dbStored   bool      // never remove a chunk from memStore before it is written to dbStore
+	dbStored   bool
 	dbStoredMu sync.Mutex
 	errored    bool // flag which is set when the chunk request has errored or timeouted
 	erroredMu  sync.Mutex

--- a/swarm/storage/types.go
+++ b/swarm/storage/types.go
@@ -178,7 +178,7 @@ type Chunk struct {
 	ReqC       chan bool // to signal the request done
 	dbStoredC  chan bool // never remove a chunk from memStore before it is written to dbStore
 	dbStored   bool
-	dbStoredMu sync.Mutex
+	dbStoredMu *sync.Mutex
 	errored    bool // flag which is set when the chunk request has errored or timeouted
 	erroredMu  sync.Mutex
 }
@@ -198,7 +198,12 @@ func (c *Chunk) GetErrored() bool {
 }
 
 func NewChunk(key Key, reqC chan bool) *Chunk {
-	return &Chunk{Key: key, ReqC: reqC, dbStoredC: make(chan bool)}
+	return &Chunk{
+		Key:        key,
+		ReqC:       reqC,
+		dbStoredC:  make(chan bool),
+		dbStoredMu: &sync.Mutex{},
+	}
 }
 
 func (c *Chunk) markAsStored() {


### PR DESCRIPTION
I did some testing to figure out what is root cause of the issue.

Chunks store in their state information if data was actually persisted (using `dbStored` chan). Operations on this state are protected by `ldbstore` mutex, but `ldbstore` has multiple instances created in code (i.e. `delivery` and `dpa`), and they don't share state between them.

Chunks are stored in `memstore` and they are indexed with their respective keys. When the message comes from two different sources, which is possible with PSS routing, first one might be stored in `memstore` already, and the second one will use cached chunk object  from the `memstore`.

The two concurrent processes try to persist chunk and update it's state at the same time, which on rare occasion will end up two instances of `ldbstore` working on the same chunk in memory.

This PR fixes #341 
