### PR TITLE
cmd/swarm, swarm: get rid of mockStore from production code

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -502,8 +502,7 @@ func registerBzzService(bzzconfig *bzzapi.Config, ctx *cli.Context, stack *node.
 			}
 		}
 
-		// In production, mockStore must be always nil.
-		return swarm.NewSwarm(ctx, swapClient, bzzconfig, nil)
+		return swarm.NewSwarm(ctx, swapClient, bzzconfig)
 	}
 	//register within the ethereum node
 	if err := stack.Register(boot); err != nil {

--- a/swarm/storage/ldbstore.go
+++ b/swarm/storage/ldbstore.go
@@ -107,7 +107,7 @@ type LDBStore struct {
 // to avoid the appearance of a pluggable distance metric and opportunities of bugs associated with providing
 // a function different from the one that is actually used.
 func NewLDBStore(path string, hash SwarmHasher, capacity uint64, po func(Key) uint8) (s *LDBStore, err error) {
-	s = new(LDBStore)
+	s = &LDBStore{}
 	s.hashfunc = hash
 
 	s.batchC = make(chan bool)

--- a/swarm/storage/localstore.go
+++ b/swarm/storage/localstore.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
-	"github.com/ethereum/go-ethereum/swarm/storage/mock"
 )
 
 var (
@@ -54,8 +53,8 @@ type LocalStore struct {
 }
 
 // This constructor uses MemStore and DbStore as components
-func NewLocalStore(hash SwarmHasher, params *StoreParams, basekey []byte, mockStore *mock.NodeStore) (*LocalStore, error) {
-	dbStore, err := NewMockDbStore(params.ChunkDbPath, hash, params.DbCapacity, func(k Key) (ret uint8) { return uint8(Proximity(basekey[:], k[:])) }, mockStore)
+func NewLocalStore(hash SwarmHasher, params *StoreParams, basekey []byte) (*LocalStore, error) {
+	dbStore, err := NewMockDbStore(params.ChunkDbPath, hash, params.DbCapacity, func(k Key) (ret uint8) { return uint8(Proximity(basekey[:], k[:])) }, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/swarm/storage/localstore.go
+++ b/swarm/storage/localstore.go
@@ -54,13 +54,13 @@ type LocalStore struct {
 
 // This constructor uses MemStore and DbStore as components
 func NewLocalStore(hash SwarmHasher, params *StoreParams, basekey []byte) (*LocalStore, error) {
-	dbStore, err := NewMockDbStore(params.ChunkDbPath, hash, params.DbCapacity, func(k Key) (ret uint8) { return uint8(Proximity(basekey[:], k[:])) }, nil)
+	ldbStore, err := NewLDBStore(params.ChunkDbPath, hash, params.DbCapacity, func(k Key) (ret uint8) { return uint8(Proximity(basekey[:], k[:])) })
 	if err != nil {
 		return nil, err
 	}
 	return &LocalStore{
-		memStore: NewMemStore(dbStore, params.CacheCapacity),
-		DbStore:  dbStore,
+		memStore: NewMemStore(ldbStore, params.CacheCapacity),
+		DbStore:  ldbStore,
 	}, nil
 }
 

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -115,7 +115,7 @@ func NewSwarm(ctx *node.ServiceContext, backend chequebook.Backend, config *api.
 	log.Debug(fmt.Sprintf("Setting up Swarm service components"))
 
 	hash := storage.MakeHashFunc(config.ChunkerParams.Hash)
-	self.lstore, err = storage.NewLocalStore(hash, config.StoreParams, common.Hex2Bytes(config.BzzKey), nil)
+	self.lstore, err = storage.NewLocalStore(hash, config.StoreParams, common.Hex2Bytes(config.BzzKey))
 	if err != nil {
 		return
 	}

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -50,7 +50,6 @@ import (
 	"github.com/ethereum/go-ethereum/swarm/pss"
 	"github.com/ethereum/go-ethereum/swarm/state"
 	"github.com/ethereum/go-ethereum/swarm/storage"
-	"github.com/ethereum/go-ethereum/swarm/storage/mock"
 )
 
 var (
@@ -99,9 +98,7 @@ func (self *Swarm) API() *SwarmAPI {
 
 // creates a new swarm service instance
 // implements node.Service
-// If mockStore is not nil, it will be used as the storage for chunk data.
-// MockStore should be used only for testing.
-func NewSwarm(ctx *node.ServiceContext, backend chequebook.Backend, config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err error) {
+func NewSwarm(ctx *node.ServiceContext, backend chequebook.Backend, config *api.Config) (self *Swarm, err error) {
 
 	if bytes.Equal(common.FromHex(config.PublicKey), storage.ZeroKey) {
 		return nil, fmt.Errorf("empty public key")
@@ -118,7 +115,7 @@ func NewSwarm(ctx *node.ServiceContext, backend chequebook.Backend, config *api.
 	log.Debug(fmt.Sprintf("Setting up Swarm service components"))
 
 	hash := storage.MakeHashFunc(config.ChunkerParams.Hash)
-	self.lstore, err = storage.NewLocalStore(hash, config.StoreParams, common.Hex2Bytes(config.BzzKey), mockStore)
+	self.lstore, err = storage.NewLocalStore(hash, config.StoreParams, common.Hex2Bytes(config.BzzKey), nil)
 	if err != nil {
 		return
 	}

--- a/swarm/testutil/http.go
+++ b/swarm/testutil/http.go
@@ -52,7 +52,7 @@ func NewTestSwarmServer(t *testing.T) *TestSwarmServer {
 		DbCapacity:    5000000,
 		CacheCapacity: 5000,
 	}
-	localStore, err := storage.NewLocalStore(storage.MakeHashFunc(storage.SHA3Hash), storeparams, make([]byte, 32), nil)
+	localStore, err := storage.NewLocalStore(storage.MakeHashFunc(storage.SHA3Hash), storeparams, make([]byte, 32))
 	if err != nil {
 		os.RemoveAll(dir)
 		t.Fatal(err)


### PR DESCRIPTION
`NewSwarm` is used only in production code, so no point having a `mockStore` parameter, which is always nil.

`NewLocalStore` is also always used with `nil` for `mockStore`, so we don't need this parameter.