### PR TITLE
swarm/pss: Forward-failsafe outbox

### DIFF
--- a/swarm/pss/handshake.go
+++ b/swarm/pss/handshake.go
@@ -307,7 +307,7 @@ func (self *HandshakeController) handleKeys(pubkeyid string, keymsg *handshakeMs
 			copy(sendsymkey, key)
 			var address PssAddress
 			copy(address[:], keymsg.From)
-			sendsymkeyid, err := self.pss.SetSymmetricKey(sendsymkey, keymsg.Topic, &address, false)
+			sendsymkeyid, err := self.pss.setSymmetricKey(sendsymkey, keymsg.Topic, &address, false, false)
 			if err != nil {
 				return err
 			}

--- a/swarm/pss/pss_test.go
+++ b/swarm/pss/pss_test.go
@@ -477,7 +477,7 @@ func testSymSend(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = clients[1].Call(&rkeyids, "psstest_setSymKeys", rpubkeyhex, rrecvkey, lrecvkey, defaultSymKeySendLimit, topic, loaddrhex)
+	err = clients[1].Call(&rkeyids, "psstest_setSymKeys", lpubkeyhex, rrecvkey, lrecvkey, defaultSymKeySendLimit, topic, loaddrhex)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -504,7 +504,7 @@ func testSymSend(t *testing.T) {
 	select {
 	case recvmsg := <-rmsgC:
 		if !bytes.Equal(recvmsg.Msg, rmsg) {
-			t.Fatalf("node 2 received payload mismatch: expected %v, got %v", rmsg, recvmsg.Msg)
+			t.Fatalf("node 2 received payload mismatch: expected %x, got %v", rmsg, recvmsg.Msg)
 		}
 	case cerr := <-rctx.Done():
 		t.Fatalf("test message timed out: %v", cerr)


### PR DESCRIPTION
https://github.com/ethersphere/go-ethereum/issues/339

Previous calls to `forward` now calls `enqueue` which adds message to queue for sending. Sending (forwarding) is done by a loop started with the service calling `dequeue`.

The (handshake) symkey memory cleaner was not a loop due to previous omission. Adding the loop revealed a bug where directly added symkeys weren't protected from deletion.