### PR TITLE
swarm/pss: Allow transmission of raw messages

### DIFF
--- a/swarm/pss/api.go
+++ b/swarm/pss/api.go
@@ -2,6 +2,7 @@ package pss
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -122,7 +123,11 @@ func (pssapi *API) GetAsymmetricAddressHint(topic Topic, pubkeyid string) (PssAd
 }
 
 func (pssapi *API) StringToTopic(topicstring string) (Topic, error) {
-	return BytesToTopic([]byte(topicstring)), nil
+	topicbytes := BytesToTopic([]byte(topicstring))
+	if topicbytes == rawTopic {
+		return rawTopic, errors.New("Topic string hashes to 0x00000000 and cannot be used")
+	}
+	return topicbytes, nil
 }
 
 func (pssapi *API) SendAsym(pubkeyhex string, topic Topic, msg hexutil.Bytes) error {

--- a/swarm/pss/protocol_test.go
+++ b/swarm/pss/protocol_test.go
@@ -22,9 +22,9 @@ type protoCtrl struct {
 
 // simple ping pong protocol test for the pss devp2p emulation
 func TestProtocol(t *testing.T) {
-	//t.Run("32", testProtocol)
+	t.Run("32", testProtocol)
 	t.Run("8", testProtocol)
-	//t.Run("0", testProtocol)
+	t.Run("0", testProtocol)
 }
 
 func testProtocol(t *testing.T) {

--- a/swarm/pss/protocol_test.go
+++ b/swarm/pss/protocol_test.go
@@ -37,7 +37,7 @@ func testProtocol(t *testing.T) {
 
 	topic := PingTopic.String()
 
-	clients, err := setupNetwork(2)
+	clients, err := setupNetwork(2, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swarm/pss/protocol_test.go
+++ b/swarm/pss/protocol_test.go
@@ -22,9 +22,9 @@ type protoCtrl struct {
 
 // simple ping pong protocol test for the pss devp2p emulation
 func TestProtocol(t *testing.T) {
-	t.Run("32", testProtocol)
+	//t.Run("32", testProtocol)
 	t.Run("8", testProtocol)
-	t.Run("0", testProtocol)
+	//t.Run("0", testProtocol)
 }
 
 func testProtocol(t *testing.T) {

--- a/swarm/pss/pss.go
+++ b/swarm/pss/pss.go
@@ -687,6 +687,12 @@ func (self *Pss) forward(msg *PssMsg) {
 	to := make([]byte, addressLength)
 	copy(to[:len(msg.To)], msg.To)
 
+	// message hash
+	digest, err := self.storeMsg(msg)
+	if err != nil {
+		log.Warn(fmt.Sprintf("could not store message %v to cache: %v", msg, err))
+	}
+
 	// send with kademlia
 	// find the closest peer to the recipient and attempt to send
 	sent := 0
@@ -817,6 +823,20 @@ func (self *Pss) digest(msg *PssMsg) pssDigest {
 
 func (self *Pss) isMsgExpired(msg *PssMsg) bool {
 	msgexp := time.Unix(int64(msg.Expire), 0)
+	if msgexp.Before(time.Now()) || msgexp.After(time.Now().Add(self.msgTTL)) {
+		return true
+	}
+	return false
+}
+
+func (self *Pss) isMsgExpired(msg *PssMsg) bool {
+	msgexp := time.Unix(int64(msg.Expire), 0)
+	//	if msgexp.Before(time.Now()) {
+	//		log.Trace("pss expired :/ ... dropping")
+	//		return nil
+	//	} else if msgexp.After(time.Now().Add(self.msgTTL)) {
+	//		return errors.New("Invalid TTL")
+	//	}
 	if msgexp.Before(time.Now()) || msgexp.After(time.Now().Add(self.msgTTL)) {
 		return true
 	}

--- a/swarm/pss/pss.go
+++ b/swarm/pss/pss.go
@@ -72,7 +72,7 @@ type PssParams struct {
 	CacheTTL            time.Duration
 	privateKey          *ecdsa.PrivateKey
 	SymKeyCacheCapacity int
-	AllowRaw            bool
+	AllowRaw            bool // If true, enables sending and receiving messages without builtin pss encryption
 }
 
 // Sane defaults for Pss

--- a/swarm/pss/pss_test.go
+++ b/swarm/pss/pss_test.go
@@ -1192,7 +1192,7 @@ func benchmarkSymkeyBruteforceChangeaddr(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if !ps.process(pssmsgs[len(pssmsgs)-(i%len(pssmsgs))-1]) {
+		if err := ps.process(pssmsgs[len(pssmsgs)-(i%len(pssmsgs))-1]); err != nil {
 			b.Fatalf("pss processing failed: %v", err)
 		}
 	}
@@ -1274,7 +1274,7 @@ func benchmarkSymkeyBruteforceSameaddr(b *testing.B) {
 		Payload: env,
 	}
 	for i := 0; i < b.N; i++ {
-		if !ps.process(pssmsg) {
+		if err := ps.process(pssmsg); err != nil {
 			b.Fatalf("pss processing failed: %v", err)
 		}
 	}

--- a/swarm/pss/pss_test.go
+++ b/swarm/pss/pss_test.go
@@ -419,13 +419,13 @@ func TestMismatch(t *testing.T) {
 
 }
 
-func TestRawSend(t *testing.T) {
-	t.Run("32", testRawSend)
-	t.Run("8", testRawSend)
-	t.Run("0", testRawSend)
+func TestSendRaw(t *testing.T) {
+	t.Run("32", testSendRaw)
+	t.Run("8", testSendRaw)
+	t.Run("0", testSendRaw)
 }
 
-func testRawSend(t *testing.T) {
+func testSendRaw(t *testing.T) {
 
 	var addrsize int64
 	var err error
@@ -502,13 +502,13 @@ func testRawSend(t *testing.T) {
 }
 
 // send symmetrically encrypted message between two directly connected peers
-func TestSymSend(t *testing.T) {
-	t.Run("32", testSymSend)
-	t.Run("8", testSymSend)
-	t.Run("0", testSymSend)
+func TestSendSym(t *testing.T) {
+	t.Run("32", testSendSym)
+	t.Run("8", testSendSym)
+	t.Run("0", testSendSym)
 }
 
-func testSymSend(t *testing.T) {
+func testSendSym(t *testing.T) {
 
 	// address hint size
 	var addrsize int64
@@ -617,13 +617,13 @@ func testSymSend(t *testing.T) {
 }
 
 // send asymmetrically encrypted message between two directly connected peers
-func TestAsymSend(t *testing.T) {
-	t.Run("32", testAsymSend)
-	t.Run("8", testAsymSend)
-	t.Run("0", testAsymSend)
+func TestSendAsym(t *testing.T) {
+	t.Run("32", testSendAsym)
+	t.Run("8", testSendAsym)
+	t.Run("0", testSendAsym)
 }
 
-func testAsymSend(t *testing.T) {
+func testSendAsym(t *testing.T) {
 
 	// address hint size
 	var addrsize int64

--- a/swarm/pss/pss_test.go
+++ b/swarm/pss/pss_test.go
@@ -792,11 +792,11 @@ func testNetwork(t *testing.T) {
 		}
 		a = adapters.NewExecAdapter(dirname)
 	} else if adapter == "sock" {
-		a = adapters.NewSocketAdapter(newServices())
+		a = adapters.NewSocketAdapter(newServices(false))
 	} else if adapter == "tcp" {
-		a = adapters.NewTCPAdapter(newServices())
+		a = adapters.NewTCPAdapter(newServices(false))
 	} else if adapter == "sim" {
-		a = adapters.NewSimAdapter(newServices())
+		a = adapters.NewSimAdapter(newServices(false))
 	}
 	net := simulations.NewNetwork(a, &simulations.NetworkConfig{
 		ID: "0",

--- a/swarm/pss/pss_test.go
+++ b/swarm/pss/pss_test.go
@@ -946,6 +946,8 @@ outer:
 
 }
 
+// check that in a network of a -> b -> c -> a
+// a doesn't receive a sent message twice
 func TestDeduplication(t *testing.T) {
 	var err error
 
@@ -1278,7 +1280,9 @@ func benchmarkSymkeyBruteforceSameaddr(b *testing.B) {
 	}
 }
 
-// setup simulated network and connect nodes in circle
+// setup simulated network with bzz/discovery and pss services.
+// connects nodes in a circle
+// if allowRaw is set, omission of builtin pss encryption is enabled (see PssParams)
 func setupNetwork(numnodes int, allowRaw bool) (clients []*rpc.Client, err error) {
 	nodes := make([]*simulations.Node, numnodes)
 	clients = make([]*rpc.Client, numnodes)

--- a/swarm/pss/types.go
+++ b/swarm/pss/types.go
@@ -20,6 +20,7 @@ const (
 var (
 	topicHashMutex = sync.Mutex{}
 	topicHashFunc  = storage.MakeHashFunc("SHA256")()
+	rawTopic       = Topic{}
 )
 
 type Topic whisper.TopicType


### PR DESCRIPTION
This PR enables sending and receiving of raw messages, bypassing the builtin pss encryption mechanisms.

The intended usage is for applications that prefer to handle encryption themselves.

It also makes it possible to use the pss node as a multiplexing node, in essence handling several clients with different public keys, something that is not currently possible in a pss node since the public key is unique for this node.

It also introduces a protected topic value `0x0` which, if set, denotes an unencrypted message, and is passed to the raw message handler before decryption is attempted.

---

The PR also introduces outbox capacity handling code, which errs on failed attempt of message enqueueing.