### PR TITLE
Command line encryption api

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -218,9 +218,18 @@ The output of this command is supposed to be machine-readable.
 `,
 		},
 		{
-			Action:    upload,
+			Action:    nonEncryptedUpload,
 			Name:      "up",
 			Usage:     "upload a file or directory to swarm using the HTTP API",
+			ArgsUsage: " <file>",
+			Description: `
+"upload a file or directory to swarm using the HTTP API and prints the root hash",
+`,
+		},
+		{
+			Action:    encryptedUpload,
+			Name:      "encrypted-up",
+			Usage:     "Upload a file or directory with encryption to swarm using the HTTP API. NOTE: Currently the reference for the uploaded content is non-deterministic, so you will receive different references if you upload it twice.",
 			ArgsUsage: " <file>",
 			Description: `
 "upload a file or directory to swarm using the HTTP API and prints the root hash",

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -141,6 +141,10 @@ var (
 		Name:  "mime",
 		Usage: "force mime type",
 	}
+	SwarmEncryptedFlag = cli.BoolFlag{
+		Name:  "encrypted",
+		Usage: "use encrypted upload",
+	}
 	SwarmPssEnabledFlag = cli.BoolFlag{
 		Name:  "pss",
 		Usage: "Enable pss (message passing over swarm)",
@@ -218,19 +222,11 @@ The output of this command is supposed to be machine-readable.
 `,
 		},
 		{
-			Action:    nonEncryptedUpload,
+			Action:    upload,
 			Name:      "up",
 			Usage:     "upload a file or directory to swarm using the HTTP API",
 			ArgsUsage: " <file>",
-			Description: `
-"upload a file or directory to swarm using the HTTP API and prints the root hash",
-`,
-		},
-		{
-			Action:    encryptedUpload,
-			Name:      "encrypted-up",
-			Usage:     "Upload a file or directory with encryption to swarm using the HTTP API. NOTE: Currently the reference for the uploaded content is non-deterministic, so you will receive different references if you upload it twice.",
-			ArgsUsage: " <file>",
+			Flags:     []cli.Flag{SwarmEncryptedFlag},
 			Description: `
 "upload a file or directory to swarm using the HTTP API and prints the root hash",
 `,

--- a/cmd/swarm/manifest.go
+++ b/cmd/swarm/manifest.go
@@ -131,13 +131,13 @@ func addEntryToManifest(ctx *cli.Context, mhash, path, hash, ctype string) strin
 		longestPathEntry = api.ManifestEntry{}
 	)
 
-	mroot, err := client.DownloadManifest(mhash)
+	mroot, isEncrypted, err := client.DownloadManifest(mhash)
 	if err != nil {
 		utils.Fatalf("Manifest download failed: %v", err)
 	}
 
 	//TODO: check if the "hash" to add is valid and present in swarm
-	_, err = client.DownloadManifest(hash)
+	_, _, err = client.DownloadManifest(hash)
 	if err != nil {
 		utils.Fatalf("Hash to add is not present: %v", err)
 	}
@@ -180,7 +180,7 @@ func addEntryToManifest(ctx *cli.Context, mhash, path, hash, ctype string) strin
 		mroot.Entries = append(mroot.Entries, newEntry)
 	}
 
-	newManifestHash, err := client.UploadManifest(mroot)
+	newManifestHash, err := client.UploadManifest(mroot, isEncrypted)
 	if err != nil {
 		utils.Fatalf("Manifest upload failed: %v", err)
 	}
@@ -197,7 +197,7 @@ func updateEntryInManifest(ctx *cli.Context, mhash, path, hash, ctype string) st
 		longestPathEntry = api.ManifestEntry{}
 	)
 
-	mroot, err := client.DownloadManifest(mhash)
+	mroot, isEncrypted, err := client.DownloadManifest(mhash)
 	if err != nil {
 		utils.Fatalf("Manifest download failed: %v", err)
 	}
@@ -257,7 +257,7 @@ func updateEntryInManifest(ctx *cli.Context, mhash, path, hash, ctype string) st
 		mroot = newMRoot
 	}
 
-	newManifestHash, err := client.UploadManifest(mroot)
+	newManifestHash, err := client.UploadManifest(mroot, isEncrypted)
 	if err != nil {
 		utils.Fatalf("Manifest upload failed: %v", err)
 	}
@@ -273,7 +273,7 @@ func removeEntryFromManifest(ctx *cli.Context, mhash, path string) string {
 		longestPathEntry = api.ManifestEntry{}
 	)
 
-	mroot, err := client.DownloadManifest(mhash)
+	mroot, isEncrypted, err := client.DownloadManifest(mhash)
 	if err != nil {
 		utils.Fatalf("Manifest download failed: %v", err)
 	}
@@ -323,7 +323,7 @@ func removeEntryFromManifest(ctx *cli.Context, mhash, path string) string {
 		mroot = newMRoot
 	}
 
-	newManifestHash, err := client.UploadManifest(mroot)
+	newManifestHash, err := client.UploadManifest(mroot, isEncrypted)
 	if err != nil {
 		utils.Fatalf("Manifest upload failed: %v", err)
 	}

--- a/cmd/swarm/upload.go
+++ b/cmd/swarm/upload.go
@@ -35,15 +35,7 @@ import (
 	"gopkg.in/urfave/cli.v1"
 )
 
-func encryptedUpload(ctx *cli.Context) {
-	upload(ctx, true)
-}
-
-func nonEncryptedUpload(ctx *cli.Context) {
-	upload(ctx, false)
-}
-
-func upload(ctx *cli.Context, toEncrypt bool) {
+func upload(ctx *cli.Context) {
 
 	args := ctx.Args()
 	var (
@@ -54,6 +46,7 @@ func upload(ctx *cli.Context, toEncrypt bool) {
 		fromStdin    = ctx.GlobalBool(SwarmUpFromStdinFlag.Name)
 		mimeType     = ctx.GlobalString(SwarmUploadMimeType.Name)
 		client       = swarm.NewClient(bzzapi)
+		toEncrypt    = ctx.Bool(SwarmEncryptedFlag.Name)
 		file         string
 	)
 

--- a/cmd/swarm/upload.go
+++ b/cmd/swarm/upload.go
@@ -35,7 +35,15 @@ import (
 	"gopkg.in/urfave/cli.v1"
 )
 
-func upload(ctx *cli.Context) {
+func encryptedUpload(ctx *cli.Context) {
+	upload(ctx, true)
+}
+
+func nonEncryptedUpload(ctx *cli.Context) {
+	upload(ctx, false)
+}
+
+func upload(ctx *cli.Context, toEncrypt bool) {
 
 	args := ctx.Args()
 	var (
@@ -97,7 +105,7 @@ func upload(ctx *cli.Context) {
 			if !recursive {
 				return "", errors.New("Argument is a directory and recursive upload is disabled")
 			}
-			return client.UploadDirectory(file, defaultPath, "")
+			return client.UploadDirectory(file, defaultPath, "", toEncrypt)
 		}
 	} else {
 		doUpload = func() (string, error) {
@@ -110,7 +118,7 @@ func upload(ctx *cli.Context) {
 				mimeType = detectMimeType(file)
 			}
 			f.ContentType = mimeType
-			return client.Upload(f, "")
+			return client.Upload(f, "", toEncrypt)
 		}
 	}
 	hash, err := doUpload()

--- a/cmd/swarm/upload.go
+++ b/cmd/swarm/upload.go
@@ -84,7 +84,7 @@ func upload(ctx *cli.Context, toEncrypt bool) {
 			utils.Fatalf("Error opening file: %s", err)
 		}
 		defer f.Close()
-		hash, err := client.UploadRaw(f, f.Size)
+		hash, err := client.UploadRaw(f, f.Size, toEncrypt)
 		if err != nil {
 			utils.Fatalf("Upload failed: %s", err)
 		}

--- a/cmd/swarm/upload_test.go
+++ b/cmd/swarm/upload_test.go
@@ -59,15 +59,22 @@ func testCLISwarmUp(toEncrypt bool, t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cmd := "up"
 	hashRegexp := `[a-f\d]{64}`
+	flags := []string{
+		"--bzzapi", cluster.Nodes[0].URL,
+		"up",
+		tmp.Name()}
 	if toEncrypt {
-		cmd = "encrypted-up"
 		hashRegexp = `[a-f\d]{128}`
+		flags = []string{
+			"--bzzapi", cluster.Nodes[0].URL,
+			"up",
+			"--encrypted",
+			tmp.Name()}
 	}
-	// upload the file with 'swarm up' or 'swarm encrypted-up' and expect a hash
-	log.Info(fmt.Sprintf("uploading file with '%s'", cmd))
-	up := runSwarm(t, "--bzzapi", cluster.Nodes[0].URL, cmd, tmp.Name())
+	// upload the file with 'swarm up' and expect a hash
+	log.Info(fmt.Sprintf("uploading file with 'swarm up'"))
+	up := runSwarm(t, flags...)
 	_, matches := up.ExpectRegexp(hashRegexp)
 	up.ExpectExit()
 	hash := matches[0]

--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -238,7 +238,7 @@ func (self *Api) Upload(uploadDir, index string, toEncrypt bool) (hash string, e
 }
 
 // DPA reader API
-func (self *Api) Retrieve(key storage.Key) storage.LazySectionReader {
+func (self *Api) Retrieve(key storage.Key) (reader storage.LazySectionReader, isEncrypted bool) {
 	return self.dpa.Retrieve(key)
 }
 
@@ -344,7 +344,7 @@ func (self *Api) Get(key storage.Key, path string) (reader storage.LazySectionRe
 		} else {
 			mimeType = entry.ContentType
 			log.Trace("content lookup key", "key", key, "mimetype", mimeType)
-			reader = self.dpa.Retrieve(key)
+			reader, _ = self.dpa.Retrieve(key)
 		}
 	} else {
 		status = http.StatusNotFound
@@ -482,7 +482,7 @@ func (self *Api) AppendFile(mhash, path, fname string, existingSize int64, conte
 
 	buf := make([]byte, buffSize)
 
-	oldReader := self.Retrieve(oldKey)
+	oldReader, _ := self.Retrieve(oldKey)
 	io.ReadAtLeast(oldReader, buf, int(offset))
 
 	newReader := bytes.NewReader(content)

--- a/swarm/api/client/client.go
+++ b/swarm/api/client/client.go
@@ -94,7 +94,7 @@ func (c *Client) DownloadRaw(hash string) (io.ReadCloser, bool, error) {
 		res.Body.Close()
 		return nil, false, fmt.Errorf("unexpected HTTP status: %s", res.Status)
 	}
-	isEncrypted := (res.Header.Get("X-Encrypted") == "true")
+	isEncrypted := (res.Header.Get("X-Decrypted") == "true")
 	return res.Body, isEncrypted, nil
 }
 

--- a/swarm/api/client/client_test.go
+++ b/swarm/api/client/client_test.go
@@ -61,6 +61,14 @@ func TestClientUploadDownloadRaw(t *testing.T) {
 // TestClientUploadDownloadFiles test uploading and downloading files to swarm
 // manifests
 func TestClientUploadDownloadFiles(t *testing.T) {
+	testClientUploadDownloadFiles(false, t)
+}
+
+func TestClientUploadDownloadFilesEncrypted(t *testing.T) {
+	testClientUploadDownloadFiles(true, t)
+}
+
+func testClientUploadDownloadFiles(toEncrypt bool, t *testing.T) {
 	srv := testutil.NewTestSwarmServer(t)
 	defer srv.Close()
 
@@ -74,7 +82,7 @@ func TestClientUploadDownloadFiles(t *testing.T) {
 				Size:        int64(len(data)),
 			},
 		}
-		hash, err := client.Upload(file, manifest, false)
+		hash, err := client.Upload(file, manifest, toEncrypt)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -217,6 +225,14 @@ func TestClientUploadDownloadDirectory(t *testing.T) {
 
 // TestClientFileList tests listing files in a swarm manifest
 func TestClientFileList(t *testing.T) {
+	testClientFileList(false, t)
+}
+
+func TestClientFileListEncrypted(t *testing.T) {
+	testClientFileList(true, t)
+}
+
+func testClientFileList(toEncrypt bool, t *testing.T) {
 	srv := testutil.NewTestSwarmServer(t)
 	defer srv.Close()
 
@@ -224,7 +240,7 @@ func TestClientFileList(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	client := NewClient(srv.URL)
-	hash, err := client.UploadDirectory(dir, "", "", false)
+	hash, err := client.UploadDirectory(dir, "", "", toEncrypt)
 	if err != nil {
 		t.Fatalf("error uploading directory: %s", err)
 	}

--- a/swarm/api/client/client_test.go
+++ b/swarm/api/client/client_test.go
@@ -31,6 +31,13 @@ import (
 
 // TestClientUploadDownloadRaw test uploading and downloading raw data to swarm
 func TestClientUploadDownloadRaw(t *testing.T) {
+	testClientUploadDownloadRaw(false, t)
+}
+func TestClientUploadDownloadRawEncrypted(t *testing.T) {
+	testClientUploadDownloadRaw(true, t)
+}
+
+func testClientUploadDownloadRaw(toEncrypt bool, t *testing.T) {
 	srv := testutil.NewTestSwarmServer(t)
 	defer srv.Close()
 
@@ -38,15 +45,18 @@ func TestClientUploadDownloadRaw(t *testing.T) {
 
 	// upload some raw data
 	data := []byte("foo123")
-	hash, err := client.UploadRaw(bytes.NewReader(data), int64(len(data)))
+	hash, err := client.UploadRaw(bytes.NewReader(data), int64(len(data)), toEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// check we can download the same data
-	res, err := client.DownloadRaw(hash)
+	res, isEncrypted, err := client.DownloadRaw(hash)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if isEncrypted != toEncrypt {
+		t.Fatalf("Expected encyption status %v got %v", toEncrypt, isEncrypted)
 	}
 	defer res.Close()
 	gotData, err := ioutil.ReadAll(res)

--- a/swarm/api/client/client_test.go
+++ b/swarm/api/client/client_test.go
@@ -74,7 +74,7 @@ func TestClientUploadDownloadFiles(t *testing.T) {
 				Size:        int64(len(data)),
 			},
 		}
-		hash, err := client.Upload(file, manifest)
+		hash, err := client.Upload(file, manifest, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -168,7 +168,7 @@ func TestClientUploadDownloadDirectory(t *testing.T) {
 	// upload the directory
 	client := NewClient(srv.URL)
 	defaultPath := filepath.Join(dir, testDirFiles[0])
-	hash, err := client.UploadDirectory(dir, defaultPath, "")
+	hash, err := client.UploadDirectory(dir, defaultPath, "", false)
 	if err != nil {
 		t.Fatalf("error uploading directory: %s", err)
 	}
@@ -224,7 +224,7 @@ func TestClientFileList(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	client := NewClient(srv.URL)
-	hash, err := client.UploadDirectory(dir, "", "")
+	hash, err := client.UploadDirectory(dir, "", "", false)
 	if err != nil {
 		t.Fatalf("error uploading directory: %s", err)
 	}

--- a/swarm/api/filesystem.go
+++ b/swarm/api/filesystem.go
@@ -273,7 +273,7 @@ func retrieveToFile(quitC chan bool, dpa *storage.DPA, key storage.Key, path str
 	if err != nil {
 		return err
 	}
-	reader := dpa.Retrieve(key)
+	reader, _ := dpa.Retrieve(key)
 	writer := bufio.NewWriter(f)
 	size, err := reader.Size(quitC)
 	if err != nil {

--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -563,7 +563,7 @@ func (s *Server) HandleGet(w http.ResponseWriter, r *Request) {
 		return
 	}
 
-	w.Header().Set("X-Encrypted", fmt.Sprintf("%v", isEncrypted))
+	w.Header().Set("X-Decrypted", fmt.Sprintf("%v", isEncrypted))
 
 	switch {
 	case r.uri.Raw() || r.uri.DeprecatedRaw():
@@ -626,7 +626,7 @@ func (s *Server) HandleGetFiles(w http.ResponseWriter, r *Request) {
 		if err != nil {
 			return err
 		}
-		w.Header().Set("X-Encrypted", fmt.Sprintf("%v", isEncrypted))
+		w.Header().Set("X-Decrypted", fmt.Sprintf("%v", isEncrypted))
 
 		// write a tar header for the entry
 		hdr := &tar.Header{

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -472,7 +472,7 @@ func TestBzzRootRedirect(t *testing.T) {
 			Size:        int64(len(data)),
 		},
 	}
-	hash, err := client.Upload(file, "")
+	hash, err := client.Upload(file, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -458,6 +458,13 @@ func testBzzGetPath(encrypted bool, t *testing.T) {
 // a trailing slash gets redirected to include the trailing slash so that
 // relative URLs work as expected.
 func TestBzzRootRedirect(t *testing.T) {
+	testBzzRootRedirect(false, t)
+}
+func TestBzzRootRedirectEncrypted(t *testing.T) {
+	testBzzRootRedirect(true, t)
+}
+
+func testBzzRootRedirect(toEncrypt bool, t *testing.T) {
 	srv := testutil.NewTestSwarmServer(t)
 	defer srv.Close()
 
@@ -472,7 +479,7 @@ func TestBzzRootRedirect(t *testing.T) {
 			Size:        int64(len(data)),
 		},
 	}
-	hash, err := client.Upload(file, "", false)
+	hash, err := client.Upload(file, "", toEncrypt)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -257,7 +257,6 @@ func testBzzGetPath(encrypted bool, t *testing.T) {
 			t.Fatal(err)
 		}
 		wait()
-		fmt.Println("!!!!!!!!!!", i, key[i])
 	}
 
 	rootRef := key[2].Hex()

--- a/swarm/api/manifest.go
+++ b/swarm/api/manifest.go
@@ -205,12 +205,12 @@ type manifestTrieEntry struct {
 func loadManifest(dpa *storage.DPA, hash storage.Key, quitC chan bool) (trie *manifestTrie, err error) { // non-recursive, subtrees are downloaded on-demand
 	log.Trace("manifest lookup", "key", hash)
 	// retrieve manifest via DPA
-	manifestReader := dpa.Retrieve(hash)
+	manifestReader, isEncrypted := dpa.Retrieve(hash)
 	log.Trace("reader retrieved", "key", hash)
-	return readManifest(manifestReader, hash, dpa, quitC)
+	return readManifest(manifestReader, hash, dpa, isEncrypted, quitC)
 }
 
-func readManifest(manifestReader storage.LazySectionReader, hash storage.Key, dpa *storage.DPA, quitC chan bool) (trie *manifestTrie, err error) { // non-recursive, subtrees are downloaded on-demand
+func readManifest(manifestReader storage.LazySectionReader, hash storage.Key, dpa *storage.DPA, isEncrypted bool, quitC chan bool) (trie *manifestTrie, err error) { // non-recursive, subtrees are downloaded on-demand
 
 	// TODO check size for oversized manifests
 	size, err := manifestReader.Size(quitC)
@@ -245,7 +245,7 @@ func readManifest(manifestReader storage.LazySectionReader, hash storage.Key, dp
 
 	trie = &manifestTrie{
 		dpa:       dpa,
-		encrypted: (len(hash) > dpa.HashSize()),
+		encrypted: isEncrypted,
 	}
 	for _, entry := range man.Entries {
 		trie.addEntry(entry, quitC)

--- a/swarm/api/manifest_test.go
+++ b/swarm/api/manifest_test.go
@@ -44,7 +44,7 @@ func testGetEntry(t *testing.T, path, match string, multiple bool, paths ...stri
 	quitC := make(chan bool)
 	dpa := storage.NewDPA(nil, storage.NewDPAParams())
 	ref := make([]byte, dpa.HashSize())
-	trie, err := readManifest(manifest(paths...), ref, dpa, quitC)
+	trie, err := readManifest(manifest(paths...), ref, dpa, false, quitC)
 	if err != nil {
 		t.Errorf("unexpected error making manifest: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestExactMatch(t *testing.T) {
 	mf := manifest("shouldBeExactMatch.css", "shouldBeExactMatch.css.map")
 	dpa := storage.NewDPA(nil, storage.NewDPAParams())
 	ref := make([]byte, dpa.HashSize())
-	trie, err := readManifest(mf, ref, dpa, quitC)
+	trie, err := readManifest(mf, ref, dpa, false, quitC)
 	if err != nil {
 		t.Errorf("unexpected error making manifest: %v", err)
 	}
@@ -134,7 +134,7 @@ func TestAddFileWithManifestPath(t *testing.T) {
 	}
 	dpa := storage.NewDPA(nil, storage.NewDPAParams())
 	ref := make([]byte, dpa.HashSize())
-	trie, err := readManifest(reader, ref, dpa, nil)
+	trie, err := readManifest(reader, ref, dpa, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swarm/fuse/fuse_file.go
+++ b/swarm/fuse/fuse_file.go
@@ -82,7 +82,7 @@ func (file *SwarmFile) Attr(ctx context.Context, a *fuse.Attr) error {
 	a.Gid = uint32(os.Getegid())
 
 	if file.fileSize == -1 {
-		reader := file.mountInfo.swarmApi.Retrieve(file.key)
+		reader, _ := file.mountInfo.swarmApi.Retrieve(file.key)
 		quitC := make(chan bool)
 		size, err := reader.Size(quitC)
 		if err != nil {
@@ -99,7 +99,7 @@ func (sf *SwarmFile) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse
 	sf.lock.RLock()
 	defer sf.lock.RUnlock()
 	if sf.reader == nil {
-		sf.reader = sf.mountInfo.swarmApi.Retrieve(sf.key)
+		sf.reader, _ = sf.mountInfo.swarmApi.Retrieve(sf.key)
 	}
 	buf := make([]byte, req.Size)
 	n, err := sf.reader.ReadAt(buf, req.Offset)

--- a/swarm/network/stream/common_test.go
+++ b/swarm/network/stream/common_test.go
@@ -216,7 +216,7 @@ func (r *TestRegistry) APIs() []rpc.API {
 }
 
 func readAll(dpa *storage.DPA, hash []byte) (int64, error) {
-	r := dpa.Retrieve(hash)
+	r, _ := dpa.Retrieve(hash)
 	buf := make([]byte, 1024)
 	var n int
 	var total int64

--- a/swarm/storage/dpa.go
+++ b/swarm/storage/dpa.go
@@ -89,9 +89,12 @@ func NewDPA(store ChunkStore, params *DPAParams) *DPA {
 // FS-aware API and httpaccess
 // Chunk retrieval blocks on netStore requests with a timeout so reader will
 // report error if retrieval of chunks within requested range time out.
-func (self *DPA) Retrieve(key Key) LazySectionReader {
-	getter := NewHasherStore(self.ChunkStore, self.hashFunc, len(key) > self.hashFunc().Size())
-	return TreeJoin(key, getter, 0)
+// It returns a reader with the chunk data and whether the content was encrypted
+func (self *DPA) Retrieve(key Key) (reader LazySectionReader, isEncrypted bool) {
+	isEncrypted = len(key) > self.hashFunc().Size()
+	getter := NewHasherStore(self.ChunkStore, self.hashFunc, isEncrypted)
+	reader = TreeJoin(key, getter, 0)
+	return
 }
 
 // Public API. Main entry point for document storage directly. Used by the

--- a/swarm/storage/dpa_test.go
+++ b/swarm/storage/dpa_test.go
@@ -54,7 +54,10 @@ func testDpaRandom(toEncrypt bool, t *testing.T) {
 		t.Errorf("Store error: %v", err)
 	}
 	wait()
-	resultReader := dpa.Retrieve(key)
+	resultReader, isEncrypted := dpa.Retrieve(key)
+	if isEncrypted != toEncrypt {
+		t.Fatalf("isEncrypted expected %v got %v", toEncrypt, isEncrypted)
+	}
 	resultSlice := make([]byte, len(slice))
 	n, err := resultReader.ReadAt(resultSlice, 0)
 	if err != io.EOF {
@@ -69,7 +72,10 @@ func testDpaRandom(toEncrypt bool, t *testing.T) {
 	ioutil.WriteFile("/tmp/slice.bzz.16M", slice, 0666)
 	ioutil.WriteFile("/tmp/result.bzz.16M", resultSlice, 0666)
 	localStore.memStore = NewMemStore(db, defaultCacheCapacity)
-	resultReader = dpa.Retrieve(key)
+	resultReader, isEncrypted = dpa.Retrieve(key)
+	if isEncrypted != toEncrypt {
+		t.Fatalf("isEncrypted expected %v got %v", toEncrypt, isEncrypted)
+	}
 	for i := range resultSlice {
 		resultSlice[i] = 0
 	}
@@ -109,7 +115,10 @@ func testDPA_capacity(toEncrypt bool, t *testing.T) {
 		t.Errorf("Store error: %v", err)
 	}
 	wait()
-	resultReader := dpa.Retrieve(key)
+	resultReader, isEncrypted := dpa.Retrieve(key)
+	if isEncrypted != toEncrypt {
+		t.Fatalf("isEncrypted expected %v got %v", toEncrypt, isEncrypted)
+	}
 	resultSlice := make([]byte, len(slice))
 	n, err := resultReader.ReadAt(resultSlice, 0)
 	if err != io.EOF {
@@ -125,14 +134,20 @@ func testDPA_capacity(toEncrypt bool, t *testing.T) {
 	memStore.setCapacity(0)
 	// check whether it is, indeed, empty
 	dpa.ChunkStore = memStore
-	resultReader = dpa.Retrieve(key)
+	resultReader, isEncrypted = dpa.Retrieve(key)
+	if isEncrypted != toEncrypt {
+		t.Fatalf("isEncrypted expected %v got %v", toEncrypt, isEncrypted)
+	}
 	if _, err = resultReader.ReadAt(resultSlice, 0); err == nil {
 		t.Errorf("Was able to read %d bytes from an empty memStore.", len(slice))
 	}
 	// check how it works with localStore
 	dpa.ChunkStore = localStore
 	//	localStore.dbStore.setCapacity(0)
-	resultReader = dpa.Retrieve(key)
+	resultReader, isEncrypted = dpa.Retrieve(key)
+	if isEncrypted != toEncrypt {
+		t.Fatalf("isEncrypted expected %v got %v", toEncrypt, isEncrypted)
+	}
 	for i := range resultSlice {
 		resultSlice[i] = 0
 	}


### PR DESCRIPTION
We need to add encryption support to the command line swarm api.
I introduced the following new command:
`swarm encrypted-up`
Later this can replace the `swarm up` when we change to encryption by default.

To implement the manifest update commands I needed to know whether a downloaded content was encrypted or not. To achieve this without making expectations about the hash length (and just using the reference length to decided whether it includes an encryption key or not), I introduced a new response header named `X-Encrypted`, which returns `true` or `false` depending on the encryption.

There are two TODO-s remaining
- Extend our documentation with the encryption related changes (https://github.com/ethersphere/go-ethereum/issues/386)
- Check if the command line code can be greatly simplified according to @lmars 's suggestion: "I'm just wondering why the client needs to know anything about manifests. If all the client wants to do is make a file available at bzz://<hash>/<path> then it can do that with a POST request to bzz://<hash>/<path> rather than messing with JSON manifests"
Also
"it's that simple yes, I implemented the equivalent of add / remove in the API, which uses the ManifestWriter: https://github.com/ethersphere/go-ethereum/blob/master/swarm/api/manifest.go#L78-L102
you can also add multiple files at once by posting a tarball / multipart form"
"we even have tests that it works via the API: https://github.com/ethersphere/go-ethereum/blob/master/swarm/api/client/client_test.go#L104-L124"
