### PR TITLE
swarm: Added cache-control headers to maximize downstream caching of immutable content

### DIFF
--- a/swarm/api/api_test.go
+++ b/swarm/api/api_test.go
@@ -86,7 +86,7 @@ func expResponse(content string, mimeType string, status int) *Response {
 // func testGet(t *testing.T, api *Api, bzzhash string) *testResponse {
 func testGet(t *testing.T, api *Api, bzzhash, path string) *testResponse {
 	key := storage.Key(common.Hex2Bytes(bzzhash))
-	reader, mimeType, status, err := api.Get(key, path)
+	reader, mimeType, status, _, err := api.Get(key, path)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/swarm/api/filesystem_test.go
+++ b/swarm/api/filesystem_test.go
@@ -63,7 +63,7 @@ func TestApiDirUpload0(t *testing.T) {
 		checkResponse(t, resp, exp)
 
 		key := storage.Key(common.Hex2Bytes(bzzhash))
-		_, _, _, err = api.Get(key, "")
+		_, _, _, _, err = api.Get(key, "")
 		if err == nil {
 			t.Fatalf("expected error: %v", err)
 		}
@@ -137,7 +137,7 @@ func TestApiDirUploadModify(t *testing.T) {
 		exp = expResponse(content, "text/css", 0)
 		checkResponse(t, resp, exp)
 
-		_, _, _, err = api.Get(key, "")
+		_, _, _, _, err = api.Get(key, "")
 		if err == nil {
 			t.Errorf("expected error: %v", err)
 		}

--- a/swarm/api/storage.go
+++ b/swarm/api/storage.go
@@ -66,7 +66,7 @@ func (self *Storage) Get(bzzpath string) (*Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	reader, mimeType, status, err := self.api.Get(key, uri.Path)
+	reader, mimeType, status, _, err := self.api.Get(key, uri.Path)
 	if err != nil {
 		return nil, err
 	}

--- a/swarm/network_test.go
+++ b/swarm/network_test.go
@@ -495,7 +495,7 @@ func retrieve(
 
 				log.Debug("api get: check file", "node", id.String(), "key", f.key.String(), "total files found", atomic.LoadUint64(totalFoundCount))
 
-				r, _, _, err := swarm.api.Get(f.key, "/")
+				r, _, _, _, err := swarm.api.Get(f.key, "/")
 				if err != nil {
 					errc <- fmt.Errorf("api get: node %s, key %s, kademlia %s: %v", id, f.key, swarm.bzz.Hive, err)
 					return


### PR DESCRIPTION
Related to #381

This PR adds cache-control headers to maximize caching in the browser when we know the object is immutable. This instructs downstream cache servers and the browser to reuse content instead of requesting it again.

In particular, the following cases are covered:

* `bzz-raw:/<hash>` and `bzz-raw:/<hash>/path`
* `bzz-immutable:/<hash>` and `bzz-immutable:/<hash>/path`
* `bzz:/<hash>` and `bzz:/<hash>/path`

If instead of a hash, an ENS name is provided, the headers work as before. If possible, an ETag with the hash of the actually delivered content is provided. This will help serving `If-Modified` requests more easily (to be done).

