### PR TITLE
Fix flaky FUSE tests

### DIFF
--- a/swarm/fuse/swarmfs_test.go
+++ b/swarm/fuse/swarmfs_test.go
@@ -960,8 +960,8 @@ func TestFUSE(t *testing.T) {
 	}
 	ta := &testAPI{api: api.NewApi(dpa, nil, nil)}
 
-	t.Run("mountListAndUmountEncrypted", ta.mountListAndUnmountEncrypted)
-	t.Run("mountListAndUmountNonEncrypted", ta.mountListAndUnmountNonEncrypted)
+	t.Run("mountListAndUnmountEncrypted", ta.mountListAndUnmountEncrypted)
+	t.Run("mountListAndUnmountNonEncrypted", ta.mountListAndUnmountNonEncrypted)
 	t.Run("maxMountsEncrypted", ta.maxMountsEncrypted)
 	t.Run("maxMountsNonEncrypted", ta.maxMountsNonEncrypted)
 	t.Run("remountEncrypted", ta.remountEncrypted)

--- a/swarm/fuse/swarmfs_test.go
+++ b/swarm/fuse/swarmfs_test.go
@@ -210,14 +210,14 @@ type testAPI struct {
 }
 
 func (ta *testAPI) mountListAndUnmountEncrypted(t *testing.T) {
-	ta.mountListAndUnmount(true, t)
+	ta.mountListAndUnmount(t, true)
 }
 
 func (ta *testAPI) mountListAndUnmountNonEncrypted(t *testing.T) {
-	ta.mountListAndUnmount(false, t)
+	ta.mountListAndUnmount(t, false)
 }
 
-func (ta *testAPI) mountListAndUnmount(toEncrypt bool, t *testing.T) {
+func (ta *testAPI) mountListAndUnmount(t *testing.T, toEncrypt bool) {
 	files := make(map[string]fileInfo)
 	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "fuse-source")
 	testMountDir, _ := ioutil.TempDir(os.TempDir(), "fuse-dest")
@@ -255,14 +255,14 @@ func (ta *testAPI) mountListAndUnmount(toEncrypt bool, t *testing.T) {
 }
 
 func (ta *testAPI) maxMountsEncrypted(t *testing.T) {
-	ta.runMaxMounts(true, t)
+	ta.runMaxMounts(t, true)
 }
 
 func (ta *testAPI) maxMountsNonEncrypted(t *testing.T) {
-	ta.runMaxMounts(false, t)
+	ta.runMaxMounts(t, false)
 }
 
-func (ta *testAPI) runMaxMounts(toEncrypt bool, t *testing.T) {
+func (ta *testAPI) runMaxMounts(t *testing.T, toEncrypt bool) {
 	files := make(map[string]fileInfo)
 	files["1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
 	uploadDir1, _ := ioutil.TempDir(os.TempDir(), "max-upload1")
@@ -313,13 +313,13 @@ func (ta *testAPI) runMaxMounts(toEncrypt bool, t *testing.T) {
 }
 
 func (ta *testAPI) remountEncrypted(t *testing.T) {
-	ta.remount(true, t)
+	ta.remount(t, true)
 }
 func (ta *testAPI) remountNonEncrypted(t *testing.T) {
-	ta.remount(false, t)
+	ta.remount(t, false)
 }
 
-func (ta *testAPI) remount(toEncrypt bool, t *testing.T) {
+func (ta *testAPI) remount(t *testing.T, toEncrypt bool) {
 	files := make(map[string]fileInfo)
 	files["1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
 	uploadDir1, _ := ioutil.TempDir(os.TempDir(), "re-upload1")
@@ -354,14 +354,14 @@ func (ta *testAPI) remount(toEncrypt bool, t *testing.T) {
 }
 
 func (ta *testAPI) unmountEncrypted(t *testing.T) {
-	ta.unmount(true, t)
+	ta.unmount(t, true)
 }
 
 func (ta *testAPI) unmountNonEncrypted(t *testing.T) {
-	ta.unmount(false, t)
+	ta.unmount(t, false)
 }
 
-func (ta *testAPI) unmount(toEncrypt bool, t *testing.T) {
+func (ta *testAPI) unmount(t *testing.T, toEncrypt bool) {
 	files := make(map[string]fileInfo)
 	uploadDir, _ := ioutil.TempDir(os.TempDir(), "ex-upload")
 	testMountDir, _ := ioutil.TempDir(os.TempDir(), "ex-mount")
@@ -383,13 +383,13 @@ func (ta *testAPI) unmount(toEncrypt bool, t *testing.T) {
 }
 
 func (ta *testAPI) unmountWhenResourceBusyEncrypted(t *testing.T) {
-	ta.unmountWhenResourceBusy(true, t)
+	ta.unmountWhenResourceBusy(t, true)
 }
 func (ta *testAPI) unmountWhenResourceBusyNonEncrypted(t *testing.T) {
-	ta.unmountWhenResourceBusy(false, t)
+	ta.unmountWhenResourceBusy(t, false)
 }
 
-func (ta *testAPI) unmountWhenResourceBusy(toEncrypt bool, t *testing.T) {
+func (ta *testAPI) unmountWhenResourceBusy(t *testing.T, toEncrypt bool) {
 	files := make(map[string]fileInfo)
 	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "ex-upload")
 	testMountDir, _ := ioutil.TempDir(os.TempDir(), "ex-mount")
@@ -419,14 +419,14 @@ func (ta *testAPI) unmountWhenResourceBusy(toEncrypt bool, t *testing.T) {
 }
 
 func (ta *testAPI) seekInMultiChunkFileEncrypted(t *testing.T) {
-	ta.seekInMultiChunkFile(true, t)
+	ta.seekInMultiChunkFile(t, true)
 }
 
 func (ta *testAPI) seekInMultiChunkFileNonEncrypted(t *testing.T) {
-	ta.seekInMultiChunkFile(false, t)
+	ta.seekInMultiChunkFile(t, false)
 }
 
-func (ta *testAPI) seekInMultiChunkFile(toEncrypt bool, t *testing.T) {
+func (ta *testAPI) seekInMultiChunkFile(t *testing.T, toEncrypt bool) {
 	files := make(map[string]fileInfo)
 	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "seek-upload")
 	testMountDir, _ := ioutil.TempDir(os.TempDir(), "seek-mount")
@@ -454,14 +454,14 @@ func (ta *testAPI) seekInMultiChunkFile(toEncrypt bool, t *testing.T) {
 }
 
 func (ta *testAPI) createNewFileEncrypted(t *testing.T) {
-	ta.createNewFile(true, t)
+	ta.createNewFile(t, true)
 }
 
 func (ta *testAPI) createNewFileNonEncrypted(t *testing.T) {
-	ta.createNewFile(false, t)
+	ta.createNewFile(t, false)
 }
 
-func (ta *testAPI) createNewFile(toEncrypt bool, t *testing.T) {
+func (ta *testAPI) createNewFile(t *testing.T, toEncrypt bool) {
 	files := make(map[string]fileInfo)
 	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "create-upload")
 	testMountDir, _ := ioutil.TempDir(os.TempDir(), "create-mount")
@@ -499,14 +499,14 @@ func (ta *testAPI) createNewFile(toEncrypt bool, t *testing.T) {
 }
 
 func (ta *testAPI) createNewFileInsideDirectoryEncrypted(t *testing.T) {
-	ta.createNewFileInsideDirectory(true, t)
+	ta.createNewFileInsideDirectory(t, true)
 }
 
 func (ta *testAPI) createNewFileInsideDirectoryNonEncrypted(t *testing.T) {
-	ta.createNewFileInsideDirectory(false, t)
+	ta.createNewFileInsideDirectory(t, false)
 }
 
-func (ta *testAPI) createNewFileInsideDirectory(toEncrypt bool, t *testing.T) {
+func (ta *testAPI) createNewFileInsideDirectory(t *testing.T, toEncrypt bool) {
 	files := make(map[string]fileInfo)
 	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "createinsidedir-upload")
 	testMountDir, _ := ioutil.TempDir(os.TempDir(), "createinsidedir-mount")
@@ -543,14 +543,14 @@ func (ta *testAPI) createNewFileInsideDirectory(toEncrypt bool, t *testing.T) {
 }
 
 func (ta *testAPI) createNewFileInsideNewDirectoryEncrypted(t *testing.T) {
-	ta.createNewFileInsideNewDirectory(true, t)
+	ta.createNewFileInsideNewDirectory(t, true)
 }
 
 func (ta *testAPI) createNewFileInsideNewDirectoryNonEncrypted(t *testing.T) {
-	ta.createNewFileInsideNewDirectory(false, t)
+	ta.createNewFileInsideNewDirectory(t, false)
 }
 
-func (ta *testAPI) createNewFileInsideNewDirectory(toEncrypt bool, t *testing.T) {
+func (ta *testAPI) createNewFileInsideNewDirectory(t *testing.T, toEncrypt bool) {
 	files := make(map[string]fileInfo)
 	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "createinsidenewdir-upload")
 	testMountDir, _ := ioutil.TempDir(os.TempDir(), "createinsidenewdir-mount")
@@ -588,14 +588,14 @@ func (ta *testAPI) createNewFileInsideNewDirectory(toEncrypt bool, t *testing.T)
 }
 
 func (ta *testAPI) removeExistingFileEncrypted(t *testing.T) {
-	ta.removeExistingFile(true, t)
+	ta.removeExistingFile(t, true)
 }
 
 func (ta *testAPI) removeExistingFileNonEncrypted(t *testing.T) {
-	ta.removeExistingFile(false, t)
+	ta.removeExistingFile(t, false)
 }
 
-func (ta *testAPI) removeExistingFile(toEncrypt bool, t *testing.T) {
+func (ta *testAPI) removeExistingFile(t *testing.T, toEncrypt bool) {
 	files := make(map[string]fileInfo)
 	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "remove-upload")
 	testMountDir, _ := ioutil.TempDir(os.TempDir(), "remove-mount")
@@ -624,14 +624,14 @@ func (ta *testAPI) removeExistingFile(toEncrypt bool, t *testing.T) {
 }
 
 func (ta *testAPI) removeExistingFileInsideDirEncrypted(t *testing.T) {
-	ta.removeExistingFileInsideDir(true, t)
+	ta.removeExistingFileInsideDir(t, true)
 }
 
 func (ta *testAPI) removeExistingFileInsideDirNonEncrypted(t *testing.T) {
-	ta.removeExistingFileInsideDir(false, t)
+	ta.removeExistingFileInsideDir(t, false)
 }
 
-func (ta *testAPI) removeExistingFileInsideDir(toEncrypt bool, t *testing.T) {
+func (ta *testAPI) removeExistingFileInsideDir(t *testing.T, toEncrypt bool) {
 	files := make(map[string]fileInfo)
 	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "remove-upload")
 	testMountDir, _ := ioutil.TempDir(os.TempDir(), "remove-mount")
@@ -660,14 +660,14 @@ func (ta *testAPI) removeExistingFileInsideDir(toEncrypt bool, t *testing.T) {
 }
 
 func (ta *testAPI) removeNewlyAddedFileEncrypted(t *testing.T) {
-	ta.removeNewlyAddedFile(true, t)
+	ta.removeNewlyAddedFile(t, true)
 }
 
 func (ta *testAPI) removeNewlyAddedFileNonEncrypted(t *testing.T) {
-	ta.removeNewlyAddedFile(false, t)
+	ta.removeNewlyAddedFile(t, false)
 }
 
-func (ta *testAPI) removeNewlyAddedFile(toEncrypt bool, t *testing.T) {
+func (ta *testAPI) removeNewlyAddedFile(t *testing.T, toEncrypt bool) {
 	files := make(map[string]fileInfo)
 	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "removenew-upload")
 	testMountDir, _ := ioutil.TempDir(os.TempDir(), "removenew-mount")
@@ -712,14 +712,14 @@ func (ta *testAPI) removeNewlyAddedFile(toEncrypt bool, t *testing.T) {
 }
 
 func (ta *testAPI) addNewFileAndModifyContentsEncrypted(t *testing.T) {
-	ta.addNewFileAndModifyContents(true, t)
+	ta.addNewFileAndModifyContents(t, true)
 }
 
 func (ta *testAPI) addNewFileAndModifyContentsNonEncrypted(t *testing.T) {
-	ta.addNewFileAndModifyContents(false, t)
+	ta.addNewFileAndModifyContents(t, false)
 }
 
-func (ta *testAPI) addNewFileAndModifyContents(toEncrypt bool, t *testing.T) {
+func (ta *testAPI) addNewFileAndModifyContents(t *testing.T, toEncrypt bool) {
 	files := make(map[string]fileInfo)
 	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "modifyfile-upload")
 	testMountDir, _ := ioutil.TempDir(os.TempDir(), "modifyfile-mount")
@@ -790,14 +790,14 @@ func (ta *testAPI) addNewFileAndModifyContents(toEncrypt bool, t *testing.T) {
 }
 
 func (ta *testAPI) removeEmptyDirEncrypted(t *testing.T) {
-	ta.removeEmptyDir(true, t)
+	ta.removeEmptyDir(t, true)
 }
 
 func (ta *testAPI) removeEmptyDirNonEncrypted(t *testing.T) {
-	ta.removeEmptyDir(false, t)
+	ta.removeEmptyDir(t, false)
 }
 
-func (ta *testAPI) removeEmptyDir(toEncrypt bool, t *testing.T) {
+func (ta *testAPI) removeEmptyDir(t *testing.T, toEncrypt bool) {
 	files := make(map[string]fileInfo)
 	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "rmdir-upload")
 	testMountDir, _ := ioutil.TempDir(os.TempDir(), "rmdir-mount")
@@ -822,13 +822,13 @@ func (ta *testAPI) removeEmptyDir(toEncrypt bool, t *testing.T) {
 }
 
 func (ta *testAPI) removeDirWhichHasFilesEncrypted(t *testing.T) {
-	ta.removeDirWhichHasFiles(true, t)
+	ta.removeDirWhichHasFiles(t, true)
 }
 func (ta *testAPI) removeDirWhichHasFilesNonEncrypted(t *testing.T) {
-	ta.removeDirWhichHasFiles(false, t)
+	ta.removeDirWhichHasFiles(t, false)
 }
 
-func (ta *testAPI) removeDirWhichHasFiles(toEncrypt bool, t *testing.T) {
+func (ta *testAPI) removeDirWhichHasFiles(t *testing.T, toEncrypt bool) {
 	files := make(map[string]fileInfo)
 	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "rmdir-upload")
 	testMountDir, _ := ioutil.TempDir(os.TempDir(), "rmdir-mount")
@@ -858,13 +858,13 @@ func (ta *testAPI) removeDirWhichHasFiles(toEncrypt bool, t *testing.T) {
 }
 
 func (ta *testAPI) removeDirWhichHasSubDirsEncrypted(t *testing.T) {
-	ta.removeDirWhichHasSubDirs(true, t)
+	ta.removeDirWhichHasSubDirs(t, true)
 }
 
 func (ta *testAPI) removeDirWhichHasSubDirsNonEncrypted(t *testing.T) {
-	ta.removeDirWhichHasSubDirs(false, t)
+	ta.removeDirWhichHasSubDirs(t, false)
 }
-func (ta *testAPI) removeDirWhichHasSubDirs(toEncrypt bool, t *testing.T) {
+func (ta *testAPI) removeDirWhichHasSubDirs(t *testing.T, toEncrypt bool) {
 	files := make(map[string]fileInfo)
 	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "rmsubdir-upload")
 	testMountDir, _ := ioutil.TempDir(os.TempDir(), "rmsubdir-mount")
@@ -901,14 +901,14 @@ func (ta *testAPI) removeDirWhichHasSubDirs(toEncrypt bool, t *testing.T) {
 }
 
 func (ta *testAPI) appendFileContentsToEndEncrypted(t *testing.T) {
-	ta.appendFileContentsToEnd(true, t)
+	ta.appendFileContentsToEnd(t, true)
 }
 
 func (ta *testAPI) appendFileContentsToEndNonEncrypted(t *testing.T) {
-	ta.appendFileContentsToEnd(false, t)
+	ta.appendFileContentsToEnd(t, false)
 }
 
-func (ta *testAPI) appendFileContentsToEnd(toEncrypt bool, t *testing.T) {
+func (ta *testAPI) appendFileContentsToEnd(t *testing.T, toEncrypt bool) {
 	files := make(map[string]fileInfo)
 	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "appendlargefile-upload")
 	testMountDir, _ := ioutil.TempDir(os.TempDir(), "appendlargefile-mount")

--- a/swarm/fuse/swarmfs_test.go
+++ b/swarm/fuse/swarmfs_test.go
@@ -209,7 +209,15 @@ type testAPI struct {
 	api *api.Api
 }
 
-func (ta *testAPI) mountListAndUnmount(t *testing.T) {
+func (ta *testAPI) mountListAndUnmountEncrypted(t *testing.T) {
+	ta.mountListAndUnmount(true, t)
+}
+
+func (ta *testAPI) mountListAndUnmountNonEncrypted(t *testing.T) {
+	ta.mountListAndUnmount(false, t)
+}
+
+func (ta *testAPI) mountListAndUnmount(toEncrypt bool, t *testing.T) {
 	files := make(map[string]fileInfo)
 	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "fuse-source")
 	testMountDir, _ := ioutil.TempDir(os.TempDir(), "fuse-dest")
@@ -231,27 +239,27 @@ func (ta *testAPI) mountListAndUnmount(t *testing.T) {
 	files["one/two/three/four/five/six/seven/eight/nine/10.txt"] = fileInfo{0777, 333, 444, getRandomBytes(10240)}
 	files["one/two/three/four/five/six/six"] = fileInfo{0777, 333, 444, getRandomBytes(10)}
 
-	for _, toEncrypt := range []bool{false, true} {
-		bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
+	bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
 
-		swarmfs := mountDir(t, ta.api, files, bzzHash, testMountDir)
-		defer swarmfs.Stop()
+	swarmfs := mountDir(t, ta.api, files, bzzHash, testMountDir)
+	defer swarmfs.Stop()
 
-		// Check unmount
-		_, err := swarmfs.Unmount(testMountDir)
-		if err != nil {
-			t.Fatalf("could not unmount  %v", bzzHash)
-		}
-		if !isDirEmpty(testMountDir) {
-			t.Fatalf("unmount didnt work for %v", testMountDir)
-		}
+	// Check unmount
+	_, err := swarmfs.Unmount(testMountDir)
+	if err != nil {
+		t.Fatalf("could not unmount  %v", bzzHash)
 	}
-
+	if !isDirEmpty(testMountDir) {
+		t.Fatalf("unmount didnt work for %v", testMountDir)
+	}
 }
 
-func (ta *testAPI) maxMounts(t *testing.T) {
-	ta.runMaxMounts(false, t)
+func (ta *testAPI) maxMountsEncrypted(t *testing.T) {
 	ta.runMaxMounts(true, t)
+}
+
+func (ta *testAPI) maxMountsNonEncrypted(t *testing.T) {
+	ta.runMaxMounts(false, t)
 }
 
 func (ta *testAPI) runMaxMounts(toEncrypt bool, t *testing.T) {
@@ -304,553 +312,639 @@ func (ta *testAPI) runMaxMounts(toEncrypt bool, t *testing.T) {
 	}
 }
 
-func (ta *testAPI) remount(t *testing.T) {
-	for _, toEncrypt := range []bool{false, true} {
-		files := make(map[string]fileInfo)
-		files["1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		uploadDir1, _ := ioutil.TempDir(os.TempDir(), "re-upload1")
-		bzzHash1 := createTestFilesAndUploadToSwarm(t, ta.api, files, uploadDir1, toEncrypt)
-		testMountDir1, _ := ioutil.TempDir(os.TempDir(), "re-mount1")
-		swarmfs := mountDir(t, ta.api, files, bzzHash1, testMountDir1)
-		defer swarmfs.Stop()
+func (ta *testAPI) remountEncrypted(t *testing.T) {
+	ta.remount(true, t)
+}
+func (ta *testAPI) remountNonEncrypted(t *testing.T) {
+	ta.remount(false, t)
+}
 
-		uploadDir2, _ := ioutil.TempDir(os.TempDir(), "re-upload2")
-		bzzHash2 := createTestFilesAndUploadToSwarm(t, ta.api, files, uploadDir2, toEncrypt)
-		testMountDir2, _ := ioutil.TempDir(os.TempDir(), "re-mount2")
+func (ta *testAPI) remount(toEncrypt bool, t *testing.T) {
+	files := make(map[string]fileInfo)
+	files["1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	uploadDir1, _ := ioutil.TempDir(os.TempDir(), "re-upload1")
+	bzzHash1 := createTestFilesAndUploadToSwarm(t, ta.api, files, uploadDir1, toEncrypt)
+	testMountDir1, _ := ioutil.TempDir(os.TempDir(), "re-mount1")
+	swarmfs := mountDir(t, ta.api, files, bzzHash1, testMountDir1)
+	defer swarmfs.Stop()
 
-		// try mounting the same hash second time
-		os.RemoveAll(testMountDir2)
-		os.MkdirAll(testMountDir2, 0777)
-		_, err := swarmfs.Mount(bzzHash1, testMountDir2)
-		if err != nil {
-			t.Fatalf("Error mounting hash  %v", bzzHash1)
-		}
+	uploadDir2, _ := ioutil.TempDir(os.TempDir(), "re-upload2")
+	bzzHash2 := createTestFilesAndUploadToSwarm(t, ta.api, files, uploadDir2, toEncrypt)
+	testMountDir2, _ := ioutil.TempDir(os.TempDir(), "re-mount2")
 
-		// mount a different hash in already mounted point
-		_, err = swarmfs.Mount(bzzHash2, testMountDir1)
-		if err == nil {
-			t.Fatalf("Error mounting hash  %v", bzzHash2)
-		}
+	// try mounting the same hash second time
+	os.RemoveAll(testMountDir2)
+	os.MkdirAll(testMountDir2, 0777)
+	_, err := swarmfs.Mount(bzzHash1, testMountDir2)
+	if err != nil {
+		t.Fatalf("Error mounting hash  %v", bzzHash1)
+	}
 
-		// mount nonexistent hash
-		_, err = swarmfs.Mount("0xfea11223344", testMountDir1)
-		if err == nil {
-			t.Fatalf("Error mounting hash  %v", bzzHash2)
+	// mount a different hash in already mounted point
+	_, err = swarmfs.Mount(bzzHash2, testMountDir1)
+	if err == nil {
+		t.Fatalf("Error mounting hash  %v", bzzHash2)
+	}
+
+	// mount nonexistent hash
+	_, err = swarmfs.Mount("0xfea11223344", testMountDir1)
+	if err == nil {
+		t.Fatalf("Error mounting hash  %v", bzzHash2)
+	}
+}
+
+func (ta *testAPI) unmountEncrypted(t *testing.T) {
+	ta.unmount(true, t)
+}
+
+func (ta *testAPI) unmountNonEncrypted(t *testing.T) {
+	ta.unmount(false, t)
+}
+
+func (ta *testAPI) unmount(toEncrypt bool, t *testing.T) {
+	files := make(map[string]fileInfo)
+	uploadDir, _ := ioutil.TempDir(os.TempDir(), "ex-upload")
+	testMountDir, _ := ioutil.TempDir(os.TempDir(), "ex-mount")
+
+	files["1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, uploadDir, toEncrypt)
+
+	swarmfs := mountDir(t, ta.api, files, bzzHash, testMountDir)
+	defer swarmfs.Stop()
+
+	swarmfs.Unmount(testMountDir)
+
+	mi := swarmfs.Listmounts()
+	for _, minfo := range mi {
+		if minfo.MountPoint == testMountDir {
+			t.Fatalf("mount state not cleaned up in unmount case %v", testMountDir)
 		}
 	}
 }
 
-func (ta *testAPI) unmount(t *testing.T) {
-	for _, toEncrypt := range []bool{false, true} {
-		files := make(map[string]fileInfo)
-		uploadDir, _ := ioutil.TempDir(os.TempDir(), "ex-upload")
-		testMountDir, _ := ioutil.TempDir(os.TempDir(), "ex-mount")
+func (ta *testAPI) unmountWhenResourceBusyEncrypted(t *testing.T) {
+	ta.unmountWhenResourceBusy(true, t)
+}
+func (ta *testAPI) unmountWhenResourceBusyNonEncrypted(t *testing.T) {
+	ta.unmountWhenResourceBusy(false, t)
+}
 
-		files["1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, uploadDir, toEncrypt)
+func (ta *testAPI) unmountWhenResourceBusy(toEncrypt bool, t *testing.T) {
+	files := make(map[string]fileInfo)
+	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "ex-upload")
+	testMountDir, _ := ioutil.TempDir(os.TempDir(), "ex-mount")
 
-		swarmfs := mountDir(t, ta.api, files, bzzHash, testMountDir)
-		defer swarmfs.Stop()
+	files["1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
 
-		swarmfs.Unmount(testMountDir)
+	swarmfs := mountDir(t, ta.api, files, bzzHash, testMountDir)
+	defer swarmfs.Stop()
 
-		mi := swarmfs.Listmounts()
-		for _, minfo := range mi {
-			if minfo.MountPoint == testMountDir {
-				t.Fatalf("mount state not cleaned up in unmount case %v", testMountDir)
-			}
+	actualPath := filepath.Join(testMountDir, "2.txt")
+	d, err := os.OpenFile(actualPath, os.O_RDWR, os.FileMode(0700))
+	d.Write(getRandomBytes(10))
+
+	_, err = swarmfs.Unmount(testMountDir)
+	if err != nil {
+		t.Fatalf("could not unmount  %v", bzzHash)
+	}
+	d.Close()
+
+	mi := swarmfs.Listmounts()
+	for _, minfo := range mi {
+		if minfo.MountPoint == testMountDir {
+			t.Fatalf("mount state not cleaned up in unmount case %v", testMountDir)
 		}
 	}
 }
 
-func (ta *testAPI) unmountWhenResourceBusy(t *testing.T) {
-	for _, toEncrypt := range []bool{false, true} {
-		files := make(map[string]fileInfo)
-		testUploadDir, _ := ioutil.TempDir(os.TempDir(), "ex-upload")
-		testMountDir, _ := ioutil.TempDir(os.TempDir(), "ex-mount")
+func (ta *testAPI) seekInMultiChunkFileEncrypted(t *testing.T) {
+	ta.seekInMultiChunkFile(true, t)
+}
 
-		files["1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
+func (ta *testAPI) seekInMultiChunkFileNonEncrypted(t *testing.T) {
+	ta.seekInMultiChunkFile(false, t)
+}
 
-		swarmfs := mountDir(t, ta.api, files, bzzHash, testMountDir)
-		defer swarmfs.Stop()
+func (ta *testAPI) seekInMultiChunkFile(toEncrypt bool, t *testing.T) {
+	files := make(map[string]fileInfo)
+	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "seek-upload")
+	testMountDir, _ := ioutil.TempDir(os.TempDir(), "seek-mount")
 
-		actualPath := filepath.Join(testMountDir, "2.txt")
-		d, err := os.OpenFile(actualPath, os.O_RDWR, os.FileMode(0700))
-		d.Write(getRandomBytes(10))
+	files["1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10240)}
+	bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
 
-		_, err = swarmfs.Unmount(testMountDir)
-		if err != nil {
-			t.Fatalf("could not unmount  %v", bzzHash)
-		}
-		d.Close()
+	swarmfs := mountDir(t, ta.api, files, bzzHash, testMountDir)
+	defer swarmfs.Stop()
 
-		mi := swarmfs.Listmounts()
-		for _, minfo := range mi {
-			if minfo.MountPoint == testMountDir {
-				t.Fatalf("mount state not cleaned up in unmount case %v", testMountDir)
-			}
-		}
+	// Create a new file seek the second chunk
+	actualPath := filepath.Join(testMountDir, "1.txt")
+	d, _ := os.OpenFile(actualPath, os.O_RDONLY, os.FileMode(0700))
+
+	d.Seek(5000, 0)
+
+	contents := make([]byte, 1024)
+	d.Read(contents)
+	finfo := files["1.txt"]
+
+	if !bytes.Equal(finfo.contents[:6024][5000:], contents) {
+		t.Fatalf("File seek contents mismatch")
+	}
+	d.Close()
+}
+
+func (ta *testAPI) createNewFileEncrypted(t *testing.T) {
+	ta.createNewFile(true, t)
+}
+
+func (ta *testAPI) createNewFileNonEncrypted(t *testing.T) {
+	ta.createNewFile(false, t)
+}
+
+func (ta *testAPI) createNewFile(toEncrypt bool, t *testing.T) {
+	files := make(map[string]fileInfo)
+	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "create-upload")
+	testMountDir, _ := ioutil.TempDir(os.TempDir(), "create-mount")
+
+	files["1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	files["five.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	files["six.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
+
+	swarmfs1 := mountDir(t, ta.api, files, bzzHash, testMountDir)
+	defer swarmfs1.Stop()
+
+	// Create a new file in the root dir and check
+	actualPath := filepath.Join(testMountDir, "2.txt")
+	d, err1 := os.OpenFile(actualPath, os.O_RDWR|os.O_CREATE, os.FileMode(0665))
+	if err1 != nil {
+		t.Fatalf("Could not create file %s : %v", actualPath, err1)
+	}
+	contents := make([]byte, 11)
+	rand.Read(contents)
+	d.Write(contents)
+	d.Close()
+
+	mi, err2 := swarmfs1.Unmount(testMountDir)
+	if err2 != nil {
+		t.Fatalf("Could not unmount %v", err2)
+	}
+
+	// mount again and see if things are okay
+	files["2.txt"] = fileInfo{0700, 333, 444, contents}
+	swarmfs2 := mountDir(t, ta.api, files, mi.LatestManifest, testMountDir)
+	defer swarmfs2.Stop()
+
+	checkFile(t, testMountDir, "2.txt", contents)
+}
+
+func (ta *testAPI) createNewFileInsideDirectoryEncrypted(t *testing.T) {
+	ta.createNewFileInsideDirectory(true, t)
+}
+
+func (ta *testAPI) createNewFileInsideDirectoryNonEncrypted(t *testing.T) {
+	ta.createNewFileInsideDirectory(false, t)
+}
+
+func (ta *testAPI) createNewFileInsideDirectory(toEncrypt bool, t *testing.T) {
+	files := make(map[string]fileInfo)
+	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "createinsidedir-upload")
+	testMountDir, _ := ioutil.TempDir(os.TempDir(), "createinsidedir-mount")
+
+	files["one/1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
+
+	swarmfs1 := mountDir(t, ta.api, files, bzzHash, testMountDir)
+	defer swarmfs1.Stop()
+
+	// Create a new file inside a existing dir and check
+	dirToCreate := filepath.Join(testMountDir, "one")
+	actualPath := filepath.Join(dirToCreate, "2.txt")
+	d, err1 := os.OpenFile(actualPath, os.O_RDWR|os.O_CREATE, os.FileMode(0665))
+	if err1 != nil {
+		t.Fatalf("Could not create file %s : %v", actualPath, err1)
+	}
+	contents := make([]byte, 11)
+	rand.Read(contents)
+	d.Write(contents)
+	d.Close()
+
+	mi, err2 := swarmfs1.Unmount(testMountDir)
+	if err2 != nil {
+		t.Fatalf("Could not unmount %v", err2)
+	}
+
+	// mount again and see if things are okay
+	files["one/2.txt"] = fileInfo{0700, 333, 444, contents}
+	swarmfs2 := mountDir(t, ta.api, files, mi.LatestManifest, testMountDir)
+	defer swarmfs2.Stop()
+
+	checkFile(t, testMountDir, "one/2.txt", contents)
+}
+
+func (ta *testAPI) createNewFileInsideNewDirectoryEncrypted(t *testing.T) {
+	ta.createNewFileInsideNewDirectory(true, t)
+}
+
+func (ta *testAPI) createNewFileInsideNewDirectoryNonEncrypted(t *testing.T) {
+	ta.createNewFileInsideNewDirectory(false, t)
+}
+
+func (ta *testAPI) createNewFileInsideNewDirectory(toEncrypt bool, t *testing.T) {
+	files := make(map[string]fileInfo)
+	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "createinsidenewdir-upload")
+	testMountDir, _ := ioutil.TempDir(os.TempDir(), "createinsidenewdir-mount")
+
+	files["1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
+
+	swarmfs1 := mountDir(t, ta.api, files, bzzHash, testMountDir)
+	defer swarmfs1.Stop()
+
+	// Create a new file inside a existing dir and check
+	dirToCreate := filepath.Join(testMountDir, "one")
+	os.MkdirAll(dirToCreate, 0777)
+	actualPath := filepath.Join(dirToCreate, "2.txt")
+	d, err1 := os.OpenFile(actualPath, os.O_RDWR|os.O_CREATE, os.FileMode(0665))
+	if err1 != nil {
+		t.Fatalf("Could not create file %s : %v", actualPath, err1)
+	}
+	contents := make([]byte, 11)
+	rand.Read(contents)
+	d.Write(contents)
+	d.Close()
+
+	mi, err2 := swarmfs1.Unmount(testMountDir)
+	if err2 != nil {
+		t.Fatalf("Could not unmount %v", err2)
+	}
+
+	// mount again and see if things are okay
+	files["one/2.txt"] = fileInfo{0700, 333, 444, contents}
+	swarmfs2 := mountDir(t, ta.api, files, mi.LatestManifest, testMountDir)
+	defer swarmfs2.Stop()
+
+	checkFile(t, testMountDir, "one/2.txt", contents)
+}
+
+func (ta *testAPI) removeExistingFileEncrypted(t *testing.T) {
+	ta.removeExistingFile(true, t)
+}
+
+func (ta *testAPI) removeExistingFileNonEncrypted(t *testing.T) {
+	ta.removeExistingFile(false, t)
+}
+
+func (ta *testAPI) removeExistingFile(toEncrypt bool, t *testing.T) {
+	files := make(map[string]fileInfo)
+	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "remove-upload")
+	testMountDir, _ := ioutil.TempDir(os.TempDir(), "remove-mount")
+
+	files["1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	files["five.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	files["six.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
+
+	swarmfs1 := mountDir(t, ta.api, files, bzzHash, testMountDir)
+	defer swarmfs1.Stop()
+
+	// Remove a file in the root dir and check
+	actualPath := filepath.Join(testMountDir, "five.txt")
+	os.Remove(actualPath)
+
+	mi, err2 := swarmfs1.Unmount(testMountDir)
+	if err2 != nil {
+		t.Fatalf("Could not unmount %v", err2)
+	}
+
+	// mount again and see if things are okay
+	delete(files, "five.txt")
+	swarmfs2 := mountDir(t, ta.api, files, mi.LatestManifest, testMountDir)
+	defer swarmfs2.Stop()
+}
+
+func (ta *testAPI) removeExistingFileInsideDirEncrypted(t *testing.T) {
+	ta.removeExistingFileInsideDir(true, t)
+}
+
+func (ta *testAPI) removeExistingFileInsideDirNonEncrypted(t *testing.T) {
+	ta.removeExistingFileInsideDir(false, t)
+}
+
+func (ta *testAPI) removeExistingFileInsideDir(toEncrypt bool, t *testing.T) {
+	files := make(map[string]fileInfo)
+	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "remove-upload")
+	testMountDir, _ := ioutil.TempDir(os.TempDir(), "remove-mount")
+
+	files["1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	files["one/five.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	files["one/six.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
+
+	swarmfs1 := mountDir(t, ta.api, files, bzzHash, testMountDir)
+	defer swarmfs1.Stop()
+
+	// Remove a file in the root dir and check
+	actualPath := filepath.Join(testMountDir, "one/five.txt")
+	os.Remove(actualPath)
+
+	mi, err2 := swarmfs1.Unmount(testMountDir)
+	if err2 != nil {
+		t.Fatalf("Could not unmount %v", err2)
+	}
+
+	// mount again and see if things are okay
+	delete(files, "one/five.txt")
+	swarmfs2 := mountDir(t, ta.api, files, mi.LatestManifest, testMountDir)
+	defer swarmfs2.Stop()
+}
+
+func (ta *testAPI) removeNewlyAddedFileEncrypted(t *testing.T) {
+	ta.removeNewlyAddedFile(true, t)
+}
+
+func (ta *testAPI) removeNewlyAddedFileNonEncrypted(t *testing.T) {
+	ta.removeNewlyAddedFile(false, t)
+}
+
+func (ta *testAPI) removeNewlyAddedFile(toEncrypt bool, t *testing.T) {
+	files := make(map[string]fileInfo)
+	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "removenew-upload")
+	testMountDir, _ := ioutil.TempDir(os.TempDir(), "removenew-mount")
+
+	files["1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	files["five.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	files["six.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
+
+	swarmfs1 := mountDir(t, ta.api, files, bzzHash, testMountDir)
+	defer swarmfs1.Stop()
+
+	// Adda a new file and remove it
+	dirToCreate := filepath.Join(testMountDir, "one")
+	os.MkdirAll(dirToCreate, os.FileMode(0665))
+	actualPath := filepath.Join(dirToCreate, "2.txt")
+	d, err1 := os.OpenFile(actualPath, os.O_RDWR|os.O_CREATE, os.FileMode(0665))
+	if err1 != nil {
+		t.Fatalf("Could not create file %s : %v", actualPath, err1)
+	}
+	contents := make([]byte, 11)
+	rand.Read(contents)
+	d.Write(contents)
+	d.Close()
+
+	checkFile(t, testMountDir, "one/2.txt", contents)
+
+	os.Remove(actualPath)
+
+	mi, err2 := swarmfs1.Unmount(testMountDir)
+	if err2 != nil {
+		t.Fatalf("Could not unmount %v", err2)
+	}
+
+	// mount again and see if things are okay
+	swarmfs2 := mountDir(t, ta.api, files, mi.LatestManifest, testMountDir)
+	defer swarmfs2.Stop()
+
+	if bzzHash != mi.LatestManifest {
+		t.Fatalf("same contents different hash orig(%v): new(%v)", bzzHash, mi.LatestManifest)
 	}
 }
 
-func (ta *testAPI) seekInMultiChunkFile(t *testing.T) {
-	for _, toEncrypt := range []bool{false, true} {
-		files := make(map[string]fileInfo)
-		testUploadDir, _ := ioutil.TempDir(os.TempDir(), "seek-upload")
-		testMountDir, _ := ioutil.TempDir(os.TempDir(), "seek-mount")
+func (ta *testAPI) addNewFileAndModifyContentsEncrypted(t *testing.T) {
+	ta.addNewFileAndModifyContents(true, t)
+}
 
-		files["1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10240)}
-		bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
+func (ta *testAPI) addNewFileAndModifyContentsNonEncrypted(t *testing.T) {
+	ta.addNewFileAndModifyContents(false, t)
+}
 
-		swarmfs := mountDir(t, ta.api, files, bzzHash, testMountDir)
-		defer swarmfs.Stop()
+func (ta *testAPI) addNewFileAndModifyContents(toEncrypt bool, t *testing.T) {
+	files := make(map[string]fileInfo)
+	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "modifyfile-upload")
+	testMountDir, _ := ioutil.TempDir(os.TempDir(), "modifyfile-mount")
 
-		// Create a new file seek the second chunk
-		actualPath := filepath.Join(testMountDir, "1.txt")
-		d, _ := os.OpenFile(actualPath, os.O_RDONLY, os.FileMode(0700))
+	files["1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	files["five.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	files["six.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
 
-		d.Seek(5000, 0)
+	swarmfs1 := mountDir(t, ta.api, files, bzzHash, testMountDir)
+	defer swarmfs1.Stop()
 
-		contents := make([]byte, 1024)
-		d.Read(contents)
-		finfo := files["1.txt"]
+	// Create a new file in the root dir and check
+	actualPath := filepath.Join(testMountDir, "2.txt")
+	d, err1 := os.OpenFile(actualPath, os.O_RDWR|os.O_CREATE, os.FileMode(0665))
+	if err1 != nil {
+		t.Fatalf("Could not create file %s : %v", actualPath, err1)
+	}
+	line1 := []byte("Line 1")
+	rand.Read(line1)
+	d.Write(line1)
+	d.Close()
 
-		if !bytes.Equal(finfo.contents[:6024][5000:], contents) {
-			t.Fatalf("File seek contents mismatch")
-		}
-		d.Close()
+	mi1, err2 := swarmfs1.Unmount(testMountDir)
+	if err2 != nil {
+		t.Fatalf("Could not unmount %v", err2)
+	}
+
+	// mount again and see if things are okay
+	files["2.txt"] = fileInfo{0700, 333, 444, line1}
+	swarmfs2 := mountDir(t, ta.api, files, mi1.LatestManifest, testMountDir)
+	defer swarmfs2.Stop()
+
+	checkFile(t, testMountDir, "2.txt", line1)
+
+	mi2, err3 := swarmfs2.Unmount(testMountDir)
+	if err3 != nil {
+		t.Fatalf("Could not unmount %v", err3)
+	}
+
+	// mount again and modify
+	swarmfs3 := mountDir(t, ta.api, files, mi2.LatestManifest, testMountDir)
+	defer swarmfs3.Stop()
+
+	fd, err4 := os.OpenFile(actualPath, os.O_RDWR|os.O_APPEND, os.FileMode(0665))
+	if err4 != nil {
+		t.Fatalf("Could not create file %s : %v", actualPath, err4)
+	}
+	line2 := []byte("Line 2")
+	rand.Read(line2)
+	fd.Seek(int64(len(line1)), 0)
+	fd.Write(line2)
+	fd.Close()
+
+	mi3, err5 := swarmfs3.Unmount(testMountDir)
+	if err5 != nil {
+		t.Fatalf("Could not unmount %v", err5)
+	}
+
+	// mount again and see if things are okay
+	b := [][]byte{line1, line2}
+	line1and2 := bytes.Join(b, []byte(""))
+	files["2.txt"] = fileInfo{0700, 333, 444, line1and2}
+	swarmfs4 := mountDir(t, ta.api, files, mi3.LatestManifest, testMountDir)
+	defer swarmfs4.Stop()
+
+	checkFile(t, testMountDir, "2.txt", line1and2)
+}
+
+func (ta *testAPI) removeEmptyDirEncrypted(t *testing.T) {
+	ta.removeEmptyDir(true, t)
+}
+
+func (ta *testAPI) removeEmptyDirNonEncrypted(t *testing.T) {
+	ta.removeEmptyDir(false, t)
+}
+
+func (ta *testAPI) removeEmptyDir(toEncrypt bool, t *testing.T) {
+	files := make(map[string]fileInfo)
+	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "rmdir-upload")
+	testMountDir, _ := ioutil.TempDir(os.TempDir(), "rmdir-mount")
+
+	files["1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	files["five.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	files["six.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
+
+	swarmfs1 := mountDir(t, ta.api, files, bzzHash, testMountDir)
+	defer swarmfs1.Stop()
+
+	os.MkdirAll(filepath.Join(testMountDir, "newdir"), 0777)
+
+	mi, err3 := swarmfs1.Unmount(testMountDir)
+	if err3 != nil {
+		t.Fatalf("Could not unmount %v", err3)
+	}
+	if bzzHash != mi.LatestManifest {
+		t.Fatalf("same contents different hash orig(%v): new(%v)", bzzHash, mi.LatestManifest)
 	}
 }
 
-func (ta *testAPI) createNewFile(t *testing.T) {
-	for _, toEncrypt := range []bool{false, true} {
-		files := make(map[string]fileInfo)
-		testUploadDir, _ := ioutil.TempDir(os.TempDir(), "create-upload")
-		testMountDir, _ := ioutil.TempDir(os.TempDir(), "create-mount")
-
-		files["1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		files["five.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		files["six.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
-
-		swarmfs1 := mountDir(t, ta.api, files, bzzHash, testMountDir)
-		defer swarmfs1.Stop()
-
-		// Create a new file in the root dir and check
-		actualPath := filepath.Join(testMountDir, "2.txt")
-		d, err1 := os.OpenFile(actualPath, os.O_RDWR|os.O_CREATE, os.FileMode(0665))
-		if err1 != nil {
-			t.Fatalf("Could not create file %s : %v", actualPath, err1)
-		}
-		contents := make([]byte, 11)
-		rand.Read(contents)
-		d.Write(contents)
-		d.Close()
-
-		mi, err2 := swarmfs1.Unmount(testMountDir)
-		if err2 != nil {
-			t.Fatalf("Could not unmount %v", err2)
-		}
-
-		// mount again and see if things are okay
-		files["2.txt"] = fileInfo{0700, 333, 444, contents}
-		swarmfs2 := mountDir(t, ta.api, files, mi.LatestManifest, testMountDir)
-		defer swarmfs2.Stop()
-
-		checkFile(t, testMountDir, "2.txt", contents)
-	}
+func (ta *testAPI) removeDirWhichHasFilesEncrypted(t *testing.T) {
+	ta.removeDirWhichHasFiles(true, t)
+}
+func (ta *testAPI) removeDirWhichHasFilesNonEncrypted(t *testing.T) {
+	ta.removeDirWhichHasFiles(false, t)
 }
 
-func (ta *testAPI) createNewFileInsideDirectory(t *testing.T) {
-	for _, toEncrypt := range []bool{false, true} {
-		files := make(map[string]fileInfo)
-		testUploadDir, _ := ioutil.TempDir(os.TempDir(), "createinsidedir-upload")
-		testMountDir, _ := ioutil.TempDir(os.TempDir(), "createinsidedir-mount")
+func (ta *testAPI) removeDirWhichHasFiles(toEncrypt bool, t *testing.T) {
+	files := make(map[string]fileInfo)
+	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "rmdir-upload")
+	testMountDir, _ := ioutil.TempDir(os.TempDir(), "rmdir-mount")
 
-		files["one/1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
+	files["one/1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	files["two/five.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	files["two/six.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
 
-		swarmfs1 := mountDir(t, ta.api, files, bzzHash, testMountDir)
-		defer swarmfs1.Stop()
+	swarmfs1 := mountDir(t, ta.api, files, bzzHash, testMountDir)
+	defer swarmfs1.Stop()
 
-		// Create a new file inside a existing dir and check
-		dirToCreate := filepath.Join(testMountDir, "one")
-		actualPath := filepath.Join(dirToCreate, "2.txt")
-		d, err1 := os.OpenFile(actualPath, os.O_RDWR|os.O_CREATE, os.FileMode(0665))
-		if err1 != nil {
-			t.Fatalf("Could not create file %s : %v", actualPath, err1)
-		}
-		contents := make([]byte, 11)
-		rand.Read(contents)
-		d.Write(contents)
-		d.Close()
+	dirPath := filepath.Join(testMountDir, "two")
+	os.RemoveAll(dirPath)
 
-		mi, err2 := swarmfs1.Unmount(testMountDir)
-		if err2 != nil {
-			t.Fatalf("Could not unmount %v", err2)
-		}
-
-		// mount again and see if things are okay
-		files["one/2.txt"] = fileInfo{0700, 333, 444, contents}
-		swarmfs2 := mountDir(t, ta.api, files, mi.LatestManifest, testMountDir)
-		defer swarmfs2.Stop()
-
-		checkFile(t, testMountDir, "one/2.txt", contents)
+	mi, err2 := swarmfs1.Unmount(testMountDir)
+	if err2 != nil {
+		t.Fatalf("Could not unmount %v ", err2)
 	}
+
+	// mount again and see if things are okay
+	delete(files, "two/five.txt")
+	delete(files, "two/six.txt")
+
+	swarmfs2 := mountDir(t, ta.api, files, mi.LatestManifest, testMountDir)
+	defer swarmfs2.Stop()
 }
 
-func (ta *testAPI) createNewFileInsideNewDirectory(t *testing.T) {
-	for _, toEncrypt := range []bool{false, true} {
-		files := make(map[string]fileInfo)
-		testUploadDir, _ := ioutil.TempDir(os.TempDir(), "createinsidenewdir-upload")
-		testMountDir, _ := ioutil.TempDir(os.TempDir(), "createinsidenewdir-mount")
-
-		files["1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
-
-		swarmfs1 := mountDir(t, ta.api, files, bzzHash, testMountDir)
-		defer swarmfs1.Stop()
-
-		// Create a new file inside a existing dir and check
-		dirToCreate := filepath.Join(testMountDir, "one")
-		os.MkdirAll(dirToCreate, 0777)
-		actualPath := filepath.Join(dirToCreate, "2.txt")
-		d, err1 := os.OpenFile(actualPath, os.O_RDWR|os.O_CREATE, os.FileMode(0665))
-		if err1 != nil {
-			t.Fatalf("Could not create file %s : %v", actualPath, err1)
-		}
-		contents := make([]byte, 11)
-		rand.Read(contents)
-		d.Write(contents)
-		d.Close()
-
-		mi, err2 := swarmfs1.Unmount(testMountDir)
-		if err2 != nil {
-			t.Fatalf("Could not unmount %v", err2)
-		}
-
-		// mount again and see if things are okay
-		files["one/2.txt"] = fileInfo{0700, 333, 444, contents}
-		swarmfs2 := mountDir(t, ta.api, files, mi.LatestManifest, testMountDir)
-		defer swarmfs2.Stop()
-
-		checkFile(t, testMountDir, "one/2.txt", contents)
-	}
+func (ta *testAPI) removeDirWhichHasSubDirsEncrypted(t *testing.T) {
+	ta.removeDirWhichHasSubDirs(true, t)
 }
 
-func (ta *testAPI) removeExistingFile(t *testing.T) {
-	for _, toEncrypt := range []bool{false, true} {
-		files := make(map[string]fileInfo)
-		testUploadDir, _ := ioutil.TempDir(os.TempDir(), "remove-upload")
-		testMountDir, _ := ioutil.TempDir(os.TempDir(), "remove-mount")
+func (ta *testAPI) removeDirWhichHasSubDirsNonEncrypted(t *testing.T) {
+	ta.removeDirWhichHasSubDirs(false, t)
+}
+func (ta *testAPI) removeDirWhichHasSubDirs(toEncrypt bool, t *testing.T) {
+	files := make(map[string]fileInfo)
+	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "rmsubdir-upload")
+	testMountDir, _ := ioutil.TempDir(os.TempDir(), "rmsubdir-mount")
 
-		files["1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		files["five.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		files["six.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
+	files["one/1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	files["two/three/2.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	files["two/three/3.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	files["two/four/5.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	files["two/four/6.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
+	files["two/four/six/7.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
 
-		swarmfs1 := mountDir(t, ta.api, files, bzzHash, testMountDir)
-		defer swarmfs1.Stop()
+	bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
 
-		// Remove a file in the root dir and check
-		actualPath := filepath.Join(testMountDir, "five.txt")
-		os.Remove(actualPath)
+	swarmfs1 := mountDir(t, ta.api, files, bzzHash, testMountDir)
+	defer swarmfs1.Stop()
 
-		mi, err2 := swarmfs1.Unmount(testMountDir)
-		if err2 != nil {
-			t.Fatalf("Could not unmount %v", err2)
-		}
+	dirPath := filepath.Join(testMountDir, "two")
+	os.RemoveAll(dirPath)
 
-		// mount again and see if things are okay
-		delete(files, "five.txt")
-		swarmfs2 := mountDir(t, ta.api, files, mi.LatestManifest, testMountDir)
-		defer swarmfs2.Stop()
+	mi, err2 := swarmfs1.Unmount(testMountDir)
+	if err2 != nil {
+		t.Fatalf("Could not unmount %v ", err2)
 	}
+
+	// mount again and see if things are okay
+	delete(files, "two/three/2.txt")
+	delete(files, "two/three/3.txt")
+	delete(files, "two/four/5.txt")
+	delete(files, "two/four/6.txt")
+	delete(files, "two/four/six/7.txt")
+
+	swarmfs2 := mountDir(t, ta.api, files, mi.LatestManifest, testMountDir)
+	defer swarmfs2.Stop()
 }
 
-func (ta *testAPI) removeExistingFileInsideDir(t *testing.T) {
-	for _, toEncrypt := range []bool{false, true} {
-		files := make(map[string]fileInfo)
-		testUploadDir, _ := ioutil.TempDir(os.TempDir(), "remove-upload")
-		testMountDir, _ := ioutil.TempDir(os.TempDir(), "remove-mount")
-
-		files["1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		files["one/five.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		files["one/six.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
-
-		swarmfs1 := mountDir(t, ta.api, files, bzzHash, testMountDir)
-		defer swarmfs1.Stop()
-
-		// Remove a file in the root dir and check
-		actualPath := filepath.Join(testMountDir, "one/five.txt")
-		os.Remove(actualPath)
-
-		mi, err2 := swarmfs1.Unmount(testMountDir)
-		if err2 != nil {
-			t.Fatalf("Could not unmount %v", err2)
-		}
-
-		// mount again and see if things are okay
-		delete(files, "one/five.txt")
-		swarmfs2 := mountDir(t, ta.api, files, mi.LatestManifest, testMountDir)
-		defer swarmfs2.Stop()
-	}
+func (ta *testAPI) appendFileContentsToEndEncrypted(t *testing.T) {
+	ta.appendFileContentsToEnd(true, t)
 }
 
-func (ta *testAPI) removeNewlyAddedFile(t *testing.T) {
-	for _, toEncrypt := range []bool{false, true} {
-		files := make(map[string]fileInfo)
-		testUploadDir, _ := ioutil.TempDir(os.TempDir(), "removenew-upload")
-		testMountDir, _ := ioutil.TempDir(os.TempDir(), "removenew-mount")
-
-		files["1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		files["five.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		files["six.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
-
-		swarmfs1 := mountDir(t, ta.api, files, bzzHash, testMountDir)
-		defer swarmfs1.Stop()
-
-		// Adda a new file and remove it
-		dirToCreate := filepath.Join(testMountDir, "one")
-		os.MkdirAll(dirToCreate, os.FileMode(0665))
-		actualPath := filepath.Join(dirToCreate, "2.txt")
-		d, err1 := os.OpenFile(actualPath, os.O_RDWR|os.O_CREATE, os.FileMode(0665))
-		if err1 != nil {
-			t.Fatalf("Could not create file %s : %v", actualPath, err1)
-		}
-		contents := make([]byte, 11)
-		rand.Read(contents)
-		d.Write(contents)
-		d.Close()
-
-		checkFile(t, testMountDir, "one/2.txt", contents)
-
-		os.Remove(actualPath)
-
-		mi, err2 := swarmfs1.Unmount(testMountDir)
-		if err2 != nil {
-			t.Fatalf("Could not unmount %v", err2)
-		}
-
-		// mount again and see if things are okay
-		swarmfs2 := mountDir(t, ta.api, files, mi.LatestManifest, testMountDir)
-		defer swarmfs2.Stop()
-
-		if bzzHash != mi.LatestManifest {
-			t.Fatalf("same contents different hash orig(%v): new(%v)", bzzHash, mi.LatestManifest)
-		}
-	}
+func (ta *testAPI) appendFileContentsToEndNonEncrypted(t *testing.T) {
+	ta.appendFileContentsToEnd(false, t)
 }
 
-func (ta *testAPI) addNewFileAndModifyContents(t *testing.T) {
-	for _, toEncrypt := range []bool{false, true} {
-		files := make(map[string]fileInfo)
-		testUploadDir, _ := ioutil.TempDir(os.TempDir(), "modifyfile-upload")
-		testMountDir, _ := ioutil.TempDir(os.TempDir(), "modifyfile-mount")
+func (ta *testAPI) appendFileContentsToEnd(toEncrypt bool, t *testing.T) {
+	files := make(map[string]fileInfo)
+	testUploadDir, _ := ioutil.TempDir(os.TempDir(), "appendlargefile-upload")
+	testMountDir, _ := ioutil.TempDir(os.TempDir(), "appendlargefile-mount")
 
-		files["1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		files["five.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		files["six.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
+	line1 := make([]byte, 10)
+	rand.Read(line1)
+	files["1.txt"] = fileInfo{0700, 333, 444, line1}
+	bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
 
-		swarmfs1 := mountDir(t, ta.api, files, bzzHash, testMountDir)
-		defer swarmfs1.Stop()
+	swarmfs1 := mountDir(t, ta.api, files, bzzHash, testMountDir)
+	defer swarmfs1.Stop()
 
-		// Create a new file in the root dir and check
-		actualPath := filepath.Join(testMountDir, "2.txt")
-		d, err1 := os.OpenFile(actualPath, os.O_RDWR|os.O_CREATE, os.FileMode(0665))
-		if err1 != nil {
-			t.Fatalf("Could not create file %s : %v", actualPath, err1)
-		}
-		line1 := []byte("Line 1")
-		rand.Read(line1)
-		d.Write(line1)
-		d.Close()
-
-		mi1, err2 := swarmfs1.Unmount(testMountDir)
-		if err2 != nil {
-			t.Fatalf("Could not unmount %v", err2)
-		}
-
-		// mount again and see if things are okay
-		files["2.txt"] = fileInfo{0700, 333, 444, line1}
-		swarmfs2 := mountDir(t, ta.api, files, mi1.LatestManifest, testMountDir)
-		defer swarmfs2.Stop()
-
-		checkFile(t, testMountDir, "2.txt", line1)
-
-		mi2, err3 := swarmfs2.Unmount(testMountDir)
-		if err3 != nil {
-			t.Fatalf("Could not unmount %v", err3)
-		}
-
-		// mount again and modify
-		swarmfs3 := mountDir(t, ta.api, files, mi2.LatestManifest, testMountDir)
-		defer swarmfs3.Stop()
-
-		fd, err4 := os.OpenFile(actualPath, os.O_RDWR|os.O_APPEND, os.FileMode(0665))
-		if err4 != nil {
-			t.Fatalf("Could not create file %s : %v", actualPath, err4)
-		}
-		line2 := []byte("Line 2")
-		rand.Read(line2)
-		fd.Seek(int64(len(line1)), 0)
-		fd.Write(line2)
-		fd.Close()
-
-		mi3, err5 := swarmfs3.Unmount(testMountDir)
-		if err5 != nil {
-			t.Fatalf("Could not unmount %v", err5)
-		}
-
-		// mount again and see if things are okay
-		b := [][]byte{line1, line2}
-		line1and2 := bytes.Join(b, []byte(""))
-		files["2.txt"] = fileInfo{0700, 333, 444, line1and2}
-		swarmfs4 := mountDir(t, ta.api, files, mi3.LatestManifest, testMountDir)
-		defer swarmfs4.Stop()
-
-		checkFile(t, testMountDir, "2.txt", line1and2)
+	actualPath := filepath.Join(testMountDir, "1.txt")
+	fd, err4 := os.OpenFile(actualPath, os.O_RDWR|os.O_APPEND, os.FileMode(0665))
+	if err4 != nil {
+		t.Fatalf("Could not create file %s : %v", actualPath, err4)
 	}
-}
+	line2 := make([]byte, 5)
+	rand.Read(line2)
+	fd.Seek(int64(len(line1)), 0)
+	fd.Write(line2)
+	fd.Close()
 
-func (ta *testAPI) removeEmptyDir(t *testing.T) {
-	for _, toEncrypt := range []bool{false, true} {
-		files := make(map[string]fileInfo)
-		testUploadDir, _ := ioutil.TempDir(os.TempDir(), "rmdir-upload")
-		testMountDir, _ := ioutil.TempDir(os.TempDir(), "rmdir-mount")
-
-		files["1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		files["five.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		files["six.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
-
-		swarmfs1 := mountDir(t, ta.api, files, bzzHash, testMountDir)
-		defer swarmfs1.Stop()
-
-		os.MkdirAll(filepath.Join(testMountDir, "newdir"), 0777)
-
-		mi, err3 := swarmfs1.Unmount(testMountDir)
-		if err3 != nil {
-			t.Fatalf("Could not unmount %v", err3)
-		}
-		if bzzHash != mi.LatestManifest {
-			t.Fatalf("same contents different hash orig(%v): new(%v)", bzzHash, mi.LatestManifest)
-		}
+	mi1, err5 := swarmfs1.Unmount(testMountDir)
+	if err5 != nil {
+		t.Fatalf("Could not unmount %v ", err5)
 	}
-}
 
-func (ta *testAPI) removeDirWhichHasFiles(t *testing.T) {
-	for _, toEncrypt := range []bool{false, true} {
-		files := make(map[string]fileInfo)
-		testUploadDir, _ := ioutil.TempDir(os.TempDir(), "rmdir-upload")
-		testMountDir, _ := ioutil.TempDir(os.TempDir(), "rmdir-mount")
+	// mount again and see if things are okay
+	b := [][]byte{line1, line2}
+	line1and2 := bytes.Join(b, []byte(""))
+	files["1.txt"] = fileInfo{0700, 333, 444, line1and2}
+	swarmfs2 := mountDir(t, ta.api, files, mi1.LatestManifest, testMountDir)
+	defer swarmfs2.Stop()
 
-		files["one/1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		files["two/five.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		files["two/six.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
-
-		swarmfs1 := mountDir(t, ta.api, files, bzzHash, testMountDir)
-		defer swarmfs1.Stop()
-
-		dirPath := filepath.Join(testMountDir, "two")
-		os.RemoveAll(dirPath)
-
-		mi, err2 := swarmfs1.Unmount(testMountDir)
-		if err2 != nil {
-			t.Fatalf("Could not unmount %v ", err2)
-		}
-
-		// mount again and see if things are okay
-		delete(files, "two/five.txt")
-		delete(files, "two/six.txt")
-
-		swarmfs2 := mountDir(t, ta.api, files, mi.LatestManifest, testMountDir)
-		defer swarmfs2.Stop()
-	}
-}
-
-func (ta *testAPI) removeDirWhichHasSubDirs(t *testing.T) {
-	for _, toEncrypt := range []bool{false, true} {
-		files := make(map[string]fileInfo)
-		testUploadDir, _ := ioutil.TempDir(os.TempDir(), "rmsubdir-upload")
-		testMountDir, _ := ioutil.TempDir(os.TempDir(), "rmsubdir-mount")
-
-		files["one/1.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		files["two/three/2.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		files["two/three/3.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		files["two/four/5.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		files["two/four/6.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-		files["two/four/six/7.txt"] = fileInfo{0700, 333, 444, getRandomBytes(10)}
-
-		bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
-
-		swarmfs1 := mountDir(t, ta.api, files, bzzHash, testMountDir)
-		defer swarmfs1.Stop()
-
-		dirPath := filepath.Join(testMountDir, "two")
-		os.RemoveAll(dirPath)
-
-		mi, err2 := swarmfs1.Unmount(testMountDir)
-		if err2 != nil {
-			t.Fatalf("Could not unmount %v ", err2)
-		}
-
-		// mount again and see if things are okay
-		delete(files, "two/three/2.txt")
-		delete(files, "two/three/3.txt")
-		delete(files, "two/four/5.txt")
-		delete(files, "two/four/6.txt")
-		delete(files, "two/four/six/7.txt")
-
-		swarmfs2 := mountDir(t, ta.api, files, mi.LatestManifest, testMountDir)
-		defer swarmfs2.Stop()
-	}
-}
-
-func (ta *testAPI) appendFileContentsToEnd(t *testing.T) {
-	for _, toEncrypt := range []bool{false, true} {
-		files := make(map[string]fileInfo)
-		testUploadDir, _ := ioutil.TempDir(os.TempDir(), "appendlargefile-upload")
-		testMountDir, _ := ioutil.TempDir(os.TempDir(), "appendlargefile-mount")
-
-		line1 := make([]byte, 10)
-		rand.Read(line1)
-		files["1.txt"] = fileInfo{0700, 333, 444, line1}
-		bzzHash := createTestFilesAndUploadToSwarm(t, ta.api, files, testUploadDir, toEncrypt)
-
-		swarmfs1 := mountDir(t, ta.api, files, bzzHash, testMountDir)
-		defer swarmfs1.Stop()
-
-		actualPath := filepath.Join(testMountDir, "1.txt")
-		fd, err4 := os.OpenFile(actualPath, os.O_RDWR|os.O_APPEND, os.FileMode(0665))
-		if err4 != nil {
-			t.Fatalf("Could not create file %s : %v", actualPath, err4)
-		}
-		line2 := make([]byte, 5)
-		rand.Read(line2)
-		fd.Seek(int64(len(line1)), 0)
-		fd.Write(line2)
-		fd.Close()
-
-		mi1, err5 := swarmfs1.Unmount(testMountDir)
-		if err5 != nil {
-			t.Fatalf("Could not unmount %v ", err5)
-		}
-
-		// mount again and see if things are okay
-		b := [][]byte{line1, line2}
-		line1and2 := bytes.Join(b, []byte(""))
-		files["1.txt"] = fileInfo{0700, 333, 444, line1and2}
-		swarmfs2 := mountDir(t, ta.api, files, mi1.LatestManifest, testMountDir)
-		defer swarmfs2.Stop()
-
-		checkFile(t, testMountDir, "1.txt", line1and2)
-	}
+	checkFile(t, testMountDir, "1.txt", line1and2)
 }
 
 func TestFUSE(t *testing.T) {
@@ -866,21 +960,38 @@ func TestFUSE(t *testing.T) {
 	}
 	ta := &testAPI{api: api.NewApi(dpa, nil, nil)}
 
-	t.Run("mountListAndUmount", ta.mountListAndUnmount)
-	t.Run("maxMounts", ta.maxMounts)
-	t.Run("remount", ta.remount)
-	t.Run("unmount", ta.unmount)
-	t.Run("unmountWhenResourceBusy", ta.unmountWhenResourceBusy)
-	t.Run("seekInMultiChunkFile", ta.seekInMultiChunkFile)
-	t.Run("createNewFile", ta.createNewFile)
-	t.Run("createNewFileInsideDirectory", ta.createNewFileInsideDirectory)
-	t.Run("createNewFileInsideNewDirectory", ta.createNewFileInsideNewDirectory)
-	t.Run("removeExistingFile", ta.removeExistingFile)
-	t.Run("removeExistingFileInsideDir", ta.removeExistingFileInsideDir)
-	t.Run("removeNewlyAddedFile", ta.removeNewlyAddedFile)
-	t.Run("addNewFileAndModifyContents", ta.addNewFileAndModifyContents)
-	t.Run("removeEmptyDir", ta.removeEmptyDir)
-	t.Run("removeDirWhichHasFiles", ta.removeDirWhichHasFiles)
-	t.Run("removeDirWhichHasSubDirs", ta.removeDirWhichHasSubDirs)
-	t.Run("appendFileContentsToEnd", ta.appendFileContentsToEnd)
+	t.Run("mountListAndUmountEncrypted", ta.mountListAndUnmountEncrypted)
+	t.Run("mountListAndUmountNonEncrypted", ta.mountListAndUnmountNonEncrypted)
+	t.Run("maxMountsEncrypted", ta.maxMountsEncrypted)
+	t.Run("maxMountsNonEncrypted", ta.maxMountsNonEncrypted)
+	t.Run("remountEncrypted", ta.remountEncrypted)
+	t.Run("remountNonEncrypted", ta.remountNonEncrypted)
+	t.Run("unmountEncrypted", ta.unmountEncrypted)
+	t.Run("unmountNonEncrypted", ta.unmountNonEncrypted)
+	t.Run("unmountWhenResourceBusyEncrypted", ta.unmountWhenResourceBusyEncrypted)
+	t.Run("unmountWhenResourceBusyNonEncrypted", ta.unmountWhenResourceBusyNonEncrypted)
+	t.Run("seekInMultiChunkFileEncrypted", ta.seekInMultiChunkFileEncrypted)
+	t.Run("seekInMultiChunkFileNonEncrypted", ta.seekInMultiChunkFileNonEncrypted)
+	t.Run("createNewFileEncrypted", ta.createNewFileEncrypted)
+	t.Run("createNewFileNonEncrypted", ta.createNewFileNonEncrypted)
+	t.Run("createNewFileInsideDirectoryEncrypted", ta.createNewFileInsideDirectoryEncrypted)
+	t.Run("createNewFileInsideDirectoryNonEncrypted", ta.createNewFileInsideDirectoryNonEncrypted)
+	t.Run("createNewFileInsideNewDirectoryEncrypted", ta.createNewFileInsideNewDirectoryEncrypted)
+	t.Run("createNewFileInsideNewDirectoryNonEncrypted", ta.createNewFileInsideNewDirectoryNonEncrypted)
+	t.Run("removeExistingFileEncrypted", ta.removeExistingFileEncrypted)
+	t.Run("removeExistingFileNonEncrypted", ta.removeExistingFileNonEncrypted)
+	t.Run("removeExistingFileInsideDirEncrypted", ta.removeExistingFileInsideDirEncrypted)
+	t.Run("removeExistingFileInsideDirNonEncrypted", ta.removeExistingFileInsideDirNonEncrypted)
+	t.Run("removeNewlyAddedFileEncrypted", ta.removeNewlyAddedFileEncrypted)
+	t.Run("removeNewlyAddedFileNonEncrypted", ta.removeNewlyAddedFileNonEncrypted)
+	t.Run("addNewFileAndModifyContentsEncrypted", ta.addNewFileAndModifyContentsEncrypted)
+	t.Run("addNewFileAndModifyContentsNonEncrypted", ta.addNewFileAndModifyContentsNonEncrypted)
+	t.Run("removeEmptyDirEncrypted", ta.removeEmptyDirEncrypted)
+	t.Run("removeEmptyDirNonEncrypted", ta.removeEmptyDirNonEncrypted)
+	t.Run("removeDirWhichHasFilesEncrypted", ta.removeDirWhichHasFilesEncrypted)
+	t.Run("removeDirWhichHasFilesNonEncrypted", ta.removeDirWhichHasFilesNonEncrypted)
+	t.Run("removeDirWhichHasSubDirsEncrypted", ta.removeDirWhichHasSubDirsEncrypted)
+	t.Run("removeDirWhichHasSubDirsNonEncrypted", ta.removeDirWhichHasSubDirsNonEncrypted)
+	t.Run("appendFileContentsToEndEncrypted", ta.appendFileContentsToEndEncrypted)
+	t.Run("appendFileContentsToEndNonEncrypted", ta.appendFileContentsToEndNonEncrypted)
 }


### PR DESCRIPTION
See issue https://github.com/ethersphere/go-ethereum/issues/392

Since adding encryption, FUSE tests were running encrypted/non-encrypted cases, and both cases were running in the same single tests. That could cause problems because cleanup was done with defers, so those cleanup did not run between the encrypted/non-encrypted cases.

So I separated the encrypted and non-encrypted cases into separate test functions.