### PR TITLE
swarm/network: Remove pruning implementation

### DIFF
--- a/swarm/network/simulations/overlay.go
+++ b/swarm/network/simulations/overlay.go
@@ -53,10 +53,7 @@ func (s *Simulation) NewService(ctx *adapters.ServiceContext) (node.Service, err
 	kp.MaxRetries = 1000
 	kp.RetryExponent = 2
 	kp.RetryInterval = 1000000
-	kp.PruneInterval = 2000
 	kad := network.NewKademlia(addr.Over(), kp)
-	ticker := time.NewTicker(time.Duration(kad.PruneInterval) * time.Millisecond)
-	kad.Prune(ticker.C)
 	hp := network.NewHiveParams()
 	hp.Discovery = !*noDiscovery
 	hp.KeepAliveInterval = 300 * time.Millisecond


### PR DESCRIPTION
While developing a dynamic pruning test, it became apparent that the current pruning implementation has shortcomings.

See https://github.com/ethersphere/go-ethereum/wiki/Pruning,-planning-20180419 for an outline.