### PR TITLE
swarm: Change sync params to neg. assert + remove optnl pss/resource

### DIFF
--- a/cmd/swarm/config.go
+++ b/cmd/swarm/config.go
@@ -66,7 +66,7 @@ const (
 	SWARM_ENV_NETWORK_ID           = "SWARM_NETWORK_ID"
 	SWARM_ENV_SWAP_ENABLE          = "SWARM_SWAP_ENABLE"
 	SWARM_ENV_SWAP_API             = "SWARM_SWAP_API"
-	SWARM_ENV_SYNC_ENABLE          = "SWARM_SYNC_ENABLE"
+	SWARM_ENV_SYNC_DISABLE         = "SWARM_SYNC_DISABLE"
 	SWARM_ENV_SYNC_UPDATE_DELAY    = "SWARM_ENV_SYNC_UPDATE_DELAY"
 	SWARM_ENV_ENS_API              = "SWARM_ENS_API"
 	SWARM_ENV_ENS_ADDR             = "SWARM_ENS_ADDR"
@@ -197,8 +197,8 @@ func cmdLineOverride(currentConfig *bzzapi.Config, ctx *cli.Context) *bzzapi.Con
 		currentConfig.SwapEnabled = true
 	}
 
-	if ctx.GlobalIsSet(SwarmSyncEnabledFlag.Name) {
-		currentConfig.SyncEnabled = true
+	if ctx.GlobalIsSet(SwarmSyncDisabledFlag.Name) {
+		currentConfig.SyncEnabled = false
 	}
 
 	if d := ctx.GlobalDuration(SwarmSyncUpdateDelay.Name); d > 0 {
@@ -229,10 +229,6 @@ func cmdLineOverride(currentConfig *bzzapi.Config, ctx *cli.Context) *bzzapi.Con
 
 	if ctx.GlobalIsSet(utils.BootnodesFlag.Name) {
 		currentConfig.BootNodes = ctx.GlobalString(utils.BootnodesFlag.Name)
-	}
-
-	if ctx.GlobalIsSet(SwarmPssEnabledFlag.Name) {
-		currentConfig.PssEnabled = true
 	}
 
 	if storePath := ctx.GlobalString(SwarmStorePath.Name); storePath != "" {
@@ -288,9 +284,9 @@ func envVarsOverride(currentConfig *bzzapi.Config) (config *bzzapi.Config) {
 		}
 	}
 
-	if syncenable := os.Getenv(SWARM_ENV_SYNC_ENABLE); syncenable != "" {
-		if sync, err := strconv.ParseBool(syncenable); err != nil {
-			currentConfig.SyncEnabled = sync
+	if syncdisable := os.Getenv(SWARM_ENV_SYNC_DISABLE); syncdisable != "" {
+		if sync, err := strconv.ParseBool(syncdisable); err != nil {
+			currentConfig.SyncEnabled = !sync
 		}
 	}
 
@@ -322,12 +318,6 @@ func envVarsOverride(currentConfig *bzzapi.Config) (config *bzzapi.Config) {
 
 	if bootnodes := os.Getenv(SWARM_ENV_BOOTNODES); bootnodes != "" {
 		currentConfig.BootNodes = bootnodes
-	}
-
-	if pssenable := os.Getenv(SWARM_ENV_PSS_ENABLE); pssenable != "" {
-		if ps, err := strconv.ParseBool(pssenable); err != nil {
-			currentConfig.PssEnabled = ps
-		}
 	}
 
 	return currentConfig

--- a/cmd/swarm/config_test.go
+++ b/cmd/swarm/config_test.go
@@ -85,8 +85,7 @@ func TestConfigCmdLineOverrides(t *testing.T) {
 	flags := []string{
 		fmt.Sprintf("--%s", SwarmNetworkIdFlag.Name), "42",
 		fmt.Sprintf("--%s", SwarmPortFlag.Name), httpPort,
-		fmt.Sprintf("--%s", SwarmSyncEnabledFlag.Name),
-		fmt.Sprintf("--%s", SwarmPssEnabledFlag.Name),
+		fmt.Sprintf("--%s", SwarmSyncDisabledFlag.Name),
 		fmt.Sprintf("--%s", CorsStringFlag.Name), "*",
 		fmt.Sprintf("--%s", SwarmAccountFlag.Name), account.Address.String(),
 		fmt.Sprintf("--%s", EnsAPIFlag.Name), "",
@@ -125,12 +124,8 @@ func TestConfigCmdLineOverrides(t *testing.T) {
 		t.Fatalf("Expected network ID to be %d, got %d", 42, info.NetworkId)
 	}
 
-	if !info.SyncEnabled {
-		t.Fatal("Expected Sync to be enabled, but is false")
-	}
-
-	if !info.PssEnabled {
-		t.Fatal("Expected Pss to be enabled, but is false")
+	if info.SyncEnabled {
+		t.Fatal("Expected Sync to be disabled, but is true")
 	}
 
 	if info.Cors != "*" {
@@ -152,8 +147,7 @@ func TestConfigFileOverrides(t *testing.T) {
 	//first, create a default conf
 	defaultConf := api.NewConfig()
 	//change some values in order to test if they have been loaded
-	defaultConf.SyncEnabled = true
-	defaultConf.PssEnabled = true
+	defaultConf.SyncEnabled = false
 	defaultConf.NetworkId = 54
 	defaultConf.Port = httpPort
 	defaultConf.DbCapacity = 9000000
@@ -224,12 +218,8 @@ func TestConfigFileOverrides(t *testing.T) {
 		t.Fatalf("Expected network ID to be %d, got %d", 54, info.NetworkId)
 	}
 
-	if !info.SyncEnabled {
-		t.Fatal("Expected Sync to be enabled, but is false")
-	}
-
-	if !info.PssEnabled {
-		t.Fatal("Expected Pss to be enabled, but is false")
+	if info.SyncEnabled {
+		t.Fatal("Expected Sync to be disabled, but is true")
 	}
 
 	if info.DbCapacity != 9000000 {
@@ -262,8 +252,7 @@ func TestConfigEnvVars(t *testing.T) {
 	envVars = append(envVars, fmt.Sprintf("%s=%s", SwarmPortFlag.EnvVar, httpPort))
 	envVars = append(envVars, fmt.Sprintf("%s=%s", SwarmNetworkIdFlag.EnvVar, "999"))
 	envVars = append(envVars, fmt.Sprintf("%s=%s", CorsStringFlag.EnvVar, "*"))
-	envVars = append(envVars, fmt.Sprintf("%s=%s", SwarmSyncEnabledFlag.EnvVar, "true"))
-	envVars = append(envVars, fmt.Sprintf("%s=%s", SwarmPssEnabledFlag.EnvVar, "true"))
+	envVars = append(envVars, fmt.Sprintf("%s=%s", SwarmSyncDisabledFlag.EnvVar, "true"))
 
 	dir, err := ioutil.TempDir("", "bzztest")
 	if err != nil {
@@ -340,12 +329,8 @@ func TestConfigEnvVars(t *testing.T) {
 		t.Fatalf("Expected Cors flag to be set to %s, got %s", "*", info.Cors)
 	}
 
-	if !info.SyncEnabled {
-		t.Fatal("Expected Sync to be enabled, but is false")
-	}
-
-	if !info.PssEnabled {
-		t.Fatal("Expected Pss to be enabled, but is false")
+	if info.SyncEnabled {
+		t.Fatal("Expected Sync to be disabled, but is true")
 	}
 
 	node.Shutdown()
@@ -364,8 +349,7 @@ func TestConfigCmdLineOverridesFile(t *testing.T) {
 	//first, create a default conf
 	defaultConf := api.NewConfig()
 	//change some values in order to test if they have been loaded
-	defaultConf.SyncEnabled = false
-	defaultConf.PssEnabled = false
+	defaultConf.SyncEnabled = true
 	defaultConf.NetworkId = 54
 	defaultConf.Port = "8588"
 	defaultConf.DbCapacity = 9000000
@@ -404,8 +388,7 @@ func TestConfigCmdLineOverridesFile(t *testing.T) {
 	flags := []string{
 		fmt.Sprintf("--%s", SwarmNetworkIdFlag.Name), "77",
 		fmt.Sprintf("--%s", SwarmPortFlag.Name), httpPort,
-		fmt.Sprintf("--%s", SwarmSyncEnabledFlag.Name),
-		fmt.Sprintf("--%s", SwarmPssEnabledFlag.Name),
+		fmt.Sprintf("--%s", SwarmSyncDisabledFlag.Name),
 		fmt.Sprintf("--%s", SwarmTomlConfigPathFlag.Name), f.Name(),
 		fmt.Sprintf("--%s", SwarmAccountFlag.Name), account.Address.String(),
 		"--ens-api", "",
@@ -444,8 +427,8 @@ func TestConfigCmdLineOverridesFile(t *testing.T) {
 		t.Fatalf("Expected network ID to be %d, got %d", expectNetworkId, info.NetworkId)
 	}
 
-	if !info.SyncEnabled {
-		t.Fatal("Expected Sync to be enabled, but is false")
+	if info.SyncEnabled {
+		t.Fatal("Expected Sync to be disabled, but is true")
 	}
 
 	if info.LocalStoreParams.DbCapacity != 9000000 {
@@ -458,10 +441,6 @@ func TestConfigCmdLineOverridesFile(t *testing.T) {
 
 	if info.Swap.Params.Strategy.AutoCashInterval != 600*time.Second {
 		t.Fatalf("Expected SwapParams AutoCashInterval to be %ds, got %d", 600, info.Swap.Params.Strategy.AutoCashInterval)
-	}
-
-	if !info.PssEnabled {
-		t.Fatal("Expected Pss to be enabled, but is false")
 	}
 
 	//	if info.SyncParams.KeyBufferSize != 512 {

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -101,10 +101,10 @@ var (
 		Usage:  "URL of the Ethereum API provider to use to settle SWAP payments",
 		EnvVar: SWARM_ENV_SWAP_API,
 	}
-	SwarmSyncEnabledFlag = cli.BoolTFlag{
-		Name:   "sync",
-		Usage:  "Swarm Syncing enabled (default true)",
-		EnvVar: SWARM_ENV_SYNC_ENABLE,
+	SwarmSyncDisabledFlag = cli.BoolTFlag{
+		Name:   "nosync",
+		Usage:  "Disable swarm syncing",
+		EnvVar: SWARM_ENV_SYNC_DISABLE,
 	}
 	SwarmSyncUpdateDelay = cli.DurationFlag{
 		Name:   "sync-update-delay",
@@ -144,10 +144,6 @@ var (
 	SwarmEncryptedFlag = cli.BoolFlag{
 		Name:  "encrypted",
 		Usage: "use encrypted upload",
-	}
-	SwarmPssEnabledFlag = cli.BoolFlag{
-		Name:  "pss",
-		Usage: "Enable pss (message passing over swarm)",
 	}
 	CorsStringFlag = cli.StringFlag{
 		Name:   "corsdomain",
@@ -360,7 +356,7 @@ Remove corrupt entries from a local chunk database.
 		SwarmConfigPathFlag,
 		SwarmSwapEnabledFlag,
 		SwarmSwapAPIFlag,
-		SwarmSyncEnabledFlag,
+		SwarmSyncDisabledFlag,
 		SwarmSyncUpdateDelay,
 		SwarmListenAddrFlag,
 		SwarmPortFlag,
@@ -374,8 +370,6 @@ Remove corrupt entries from a local chunk database.
 		SwarmUploadDefaultPath,
 		SwarmUpFromStdinFlag,
 		SwarmUploadMimeType,
-		// pss flags
-		SwarmPssEnabledFlag,
 		// storage flags
 		SwarmStorePath,
 		SwarmStoreCapacity,
@@ -440,9 +434,7 @@ func bzzd(ctx *cli.Context) error {
 	cfg := defaultNodeConfig
 
 	//pss operates on ws
-	if bzzconfig.PssEnabled {
-		cfg.WSModules = append(cfg.WSModules, "pss")
-	}
+	cfg.WSModules = append(cfg.WSModules, "pss")
 
 	//geth only supports --datadir via command line
 	//in order to be consistent within swarm, if we pass --datadir via environment variable

--- a/swarm/api/config.go
+++ b/swarm/api/config.go
@@ -61,8 +61,6 @@ type Config struct {
 	SwapEnabled     bool
 	SyncEnabled     bool
 	SyncUpdateDelay time.Duration
-	PssEnabled      bool
-	ResourceEnabled bool
 	SwapApi         string
 	Cors            string
 	BzzAccount      string
@@ -88,8 +86,6 @@ func NewConfig() (self *Config) {
 		SwapEnabled:     false,
 		SyncEnabled:     true,
 		SyncUpdateDelay: 15 * time.Second,
-		PssEnabled:      true,
-		ResourceEnabled: true,
 		SwapApi:         "",
 		BootNodes:       "",
 	}

--- a/swarm/network_test.go
+++ b/swarm/network_test.go
@@ -211,7 +211,6 @@ func testSwarmNetwork(t *testing.T, timeout time.Duration, steps ...testSwarmNet
 	services := map[string]adapters.ServiceFunc{
 		"swarm": func(ctx *adapters.ServiceContext) (node.Service, error) {
 			config := api.NewConfig()
-			config.PssEnabled = false
 
 			dir, err := ioutil.TempDir(dir, "node")
 			if err != nil {

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -196,6 +196,8 @@ func NewSwarm(ctx *node.ServiceContext, backend chequebook.Backend, config *api.
 			return nil, err
 		}
 		resourceHandler.SetStore(self.lstore)
+	} else {
+		log.Warn("No ENS API specified, resource updates will be disabled")
 	}
 
 	var validators []storage.ChunkValidator

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -178,7 +178,7 @@ func NewSwarm(ctx *node.ServiceContext, backend chequebook.Backend, config *api.
 	var resourceHandler *storage.ResourceHandler
 	// if use resource updates
 
-	if self.config.ResourceEnabled && resolver != nil {
+	if resolver != nil {
 		resolver.SetNameHash(ens.EnsNode)
 		rhparams := &storage.ResourceHandlerParams{
 			// TODO: config parameter to set limits
@@ -227,12 +227,10 @@ func NewSwarm(ctx *node.ServiceContext, backend chequebook.Backend, config *api.
 	self.bzz = network.NewBzz(bzzconfig, to, stateStore, stream.Spec, self.streamer.Run)
 
 	// Pss = postal service over swarm (devp2p over bzz)
-	if config.PssEnabled {
-		pssparams := pss.NewPssParams(self.privateKey)
-		self.ps = pss.NewPss(to, pssparams)
-		if pss.IsActiveHandshake {
-			pss.SetHandshakeController(self.ps, pss.NewHandshakeParams())
-		}
+	pssparams := pss.NewPssParams(self.privateKey)
+	self.ps = pss.NewPss(to, pssparams)
+	if pss.IsActiveHandshake {
+		pss.SetHandshakeController(self.ps, pss.NewHandshakeParams())
 	}
 
 	self.api = api.NewApi(self.dpa, self.dns, resourceHandler)


### PR DESCRIPTION
Issue https://github.com/ethersphere/go-ethereum/issues/423

This changes the `--sync` flag of the swarm binary to `--nosync`. It also renames the corresponding env var to `SWARM_SYNC_DISABLE`.

It also removes the `--pss` flag, and the `PssEnabled` and `ResourceEnabled` config options for swarm (both should always be enabled).

Note that Mutable Resources needs the `--ens-api` set and will be disabled otherwise. That means the node will _not_ relay resource update chunks.