### PR TITLE
swarm/network: bump versions for protocols bzz, hive and stream to 3

### DIFF
--- a/swarm/network/protocol.go
+++ b/swarm/network/protocol.go
@@ -59,7 +59,7 @@ const (
 // BzzSpec is the spec of the generic swarm handshake
 var BzzSpec = &protocols.Spec{
 	Name:       "bzz",
-	Version:    1,
+	Version:    2,
 	MaxMsgSize: 10 * 1024 * 1024,
 	Messages: []interface{}{
 		HandshakeMsg{},
@@ -69,7 +69,7 @@ var BzzSpec = &protocols.Spec{
 // DiscoverySpec is the spec for the bzz discovery subprotocols
 var DiscoverySpec = &protocols.Spec{
 	Name:       "hive",
-	Version:    1,
+	Version:    2,
 	MaxMsgSize: 10 * 1024 * 1024,
 	Messages: []interface{}{
 		peersMsg{},

--- a/swarm/network/protocol.go
+++ b/swarm/network/protocol.go
@@ -59,7 +59,7 @@ const (
 // BzzSpec is the spec of the generic swarm handshake
 var BzzSpec = &protocols.Spec{
 	Name:       "bzz",
-	Version:    2,
+	Version:    3,
 	MaxMsgSize: 10 * 1024 * 1024,
 	Messages: []interface{}{
 		HandshakeMsg{},
@@ -69,7 +69,7 @@ var BzzSpec = &protocols.Spec{
 // DiscoverySpec is the spec for the bzz discovery subprotocols
 var DiscoverySpec = &protocols.Spec{
 	Name:       "hive",
-	Version:    2,
+	Version:    3,
 	MaxMsgSize: 10 * 1024 * 1024,
 	Messages: []interface{}{
 		peersMsg{},
@@ -188,7 +188,7 @@ func (b *Bzz) Protocols() []p2p.Protocol {
 func (b *Bzz) APIs() []rpc.API {
 	return []rpc.API{{
 		Namespace: "hive",
-		Version:   "1.0",
+		Version:   "3.0",
 		Service:   b.Hive,
 	}}
 }

--- a/swarm/network/protocol_test.go
+++ b/swarm/network/protocol_test.go
@@ -186,7 +186,7 @@ func (s *bzzTester) testHandshake(lhs, rhs *HandshakeMsg, disconnects ...*p2ptes
 
 func correctBzzHandshake(addr *BzzAddr) *HandshakeMsg {
 	return &HandshakeMsg{
-		Version:   1,
+		Version:   3,
 		NetworkID: 322,
 		Addr:      addr,
 	}
@@ -199,7 +199,7 @@ func TestBzzHandshakeNetworkIDMismatch(t *testing.T) {
 
 	err := s.testHandshake(
 		correctBzzHandshake(addr),
-		&HandshakeMsg{Version: 1, NetworkID: 321, Addr: NewAddrFromNodeID(id)},
+		&HandshakeMsg{Version: 3, NetworkID: 321, Addr: NewAddrFromNodeID(id)},
 		&p2ptest.Disconnect{Peer: id, Error: fmt.Errorf("Handshake error: Message handler error: (msg code 0): network id mismatch 321 (!= 322)")},
 	)
 
@@ -216,7 +216,7 @@ func TestBzzHandshakeVersionMismatch(t *testing.T) {
 	err := s.testHandshake(
 		correctBzzHandshake(addr),
 		&HandshakeMsg{Version: 0, NetworkID: 322, Addr: NewAddrFromNodeID(id)},
-		&p2ptest.Disconnect{Peer: id, Error: fmt.Errorf("Handshake error: Message handler error: (msg code 0): version mismatch 0 (!= 1)")},
+		&p2ptest.Disconnect{Peer: id, Error: fmt.Errorf("Handshake error: Message handler error: (msg code 0): version mismatch 0 (!= 3)")},
 	)
 
 	if err != nil {
@@ -231,7 +231,7 @@ func TestBzzHandshakeSuccess(t *testing.T) {
 
 	err := s.testHandshake(
 		correctBzzHandshake(addr),
-		&HandshakeMsg{Version: 1, NetworkID: 322, Addr: NewAddrFromNodeID(id)},
+		&HandshakeMsg{Version: 3, NetworkID: 322, Addr: NewAddrFromNodeID(id)},
 	)
 
 	if err != nil {

--- a/swarm/network/stream/common_test.go
+++ b/swarm/network/stream/common_test.go
@@ -221,7 +221,7 @@ func (r *TestRegistry) APIs() []rpc.API {
 	a := r.Registry.APIs()
 	a = append(a, rpc.API{
 		Namespace: "stream",
-		Version:   "0.1",
+		Version:   "3.0",
 		Service:   r,
 		Public:    true,
 	})
@@ -264,7 +264,7 @@ func (r *TestExternalRegistry) APIs() []rpc.API {
 	a := r.Registry.APIs()
 	a = append(a, rpc.API{
 		Namespace: "stream",
-		Version:   "0.1",
+		Version:   "3.0",
 		Service:   r,
 		Public:    true,
 	})

--- a/swarm/network/stream/stream.go
+++ b/swarm/network/stream/stream.go
@@ -642,7 +642,7 @@ func (c *clientParams) clientCreated() {
 // Spec is the spec of the streamer protocol
 var Spec = &protocols.Spec{
 	Name:       "stream",
-	Version:    1,
+	Version:    2,
 	MaxMsgSize: 10 * 1024 * 1024,
 	Messages: []interface{}{
 		UnsubscribeMsg{},

--- a/swarm/network/stream/stream.go
+++ b/swarm/network/stream/stream.go
@@ -642,7 +642,7 @@ func (c *clientParams) clientCreated() {
 // Spec is the spec of the streamer protocol
 var Spec = &protocols.Spec{
 	Name:       "stream",
-	Version:    2,
+	Version:    3,
 	MaxMsgSize: 10 * 1024 * 1024,
 	Messages: []interface{}{
 		UnsubscribeMsg{},
@@ -675,7 +675,7 @@ func (r *Registry) APIs() []rpc.API {
 	return []rpc.API{
 		{
 			Namespace: "stream",
-			Version:   "0.1",
+			Version:   "3.0",
 			Service:   r.api,
 			Public:    true,
 		},

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -468,14 +468,14 @@ func (self *Swarm) APIs() []rpc.API {
 		// public APIs
 		{
 			Namespace: "bzz",
-			Version:   "0.1",
+			Version:   "3.0",
 			Service:   &Info{self.config, chequebook.ContractParams},
 			Public:    true,
 		},
 		// admin APIs
 		{
 			Namespace: "bzz",
-			Version:   "0.1",
+			Version:   "3.0",
 			Service:   api.NewControl(self.api, self.bzz.Hive),
 			Public:    false,
 		},


### PR DESCRIPTION
Raise version for bzz, hive and stream protocols to 2 in order not keep off older nodes.