### PR TITLE
swarm/storage: Resource block-heuristics

### DIFF
--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -369,8 +369,6 @@ func (self *Api) Get(key storage.Key, path string) (reader *storage.LazyChunkRea
 				}
 				key = storage.Key(decodedMultihash.Digest)
 				log.Debug("resouce is multihash", "key", key)
-				// is it correct to increment again here?
-				apiGetCount.Inc(1)
 
 				// get the manifest the multihash digest points to
 				trie, err := loadManifest(self.dpa, key, nil)
@@ -378,21 +376,20 @@ func (self *Api) Get(key storage.Key, path string) (reader *storage.LazyChunkRea
 					apiGetNotFound.Inc(1)
 					status = http.StatusNotFound
 					log.Warn(fmt.Sprintf("loadManifestTrie (resource multihash) error: %v", err))
-
 					return reader, mimeType, status, err
 				}
 
-				log.Trace("trie resolving resource multihash entry", "key", key, "path", path)
+				log.Trace("trie getting resource multihash entry", "key", key, "path", path)
 				entry, _ := trie.getEntry(path)
-				log.Trace("trie resolving resource multihash entry", "key", key, "path", path)
+				log.Trace("trie got resource multihash entry", "key", key, "path", path)
 
 				if entry == nil {
 					status = http.StatusNotFound
 					apiGetNotFound.Inc(1)
 					err = fmt.Errorf("manifest (resource multihash) entry for '%s' not found", path)
 					log.Trace("manifest (resource multihash) entry not found", "key", key, "path", path)
+					return reader, mimeType, status, err
 				}
-				log.Warn("entry", "entry", entry)
 
 			} else {
 				return nil, entry.ContentType, http.StatusOK, &ErrResourceReturn{entry.Hash}

--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -351,24 +351,22 @@ func (self *Api) Get(key storage.Key, path string) (reader *storage.LazyChunkRea
 				return reader, mimeType, status, err
 			}
 			if rsrc.Multihash {
-				var fail bool
 
 				// validate data as multihash
 				decodedMultihash, err := multihash.Decode(rsrcData)
 				if err != nil {
-					fail = true
-				} else if decodedMultihash.Code != multihash.SHA3_256 {
-					err = fmt.Errorf("wrong hash type '%s'", decodedMultihash.Name)
-				}
-				if fail {
+					apiGetInvalid.Inc(1)
+					status = http.StatusInternalServerError
+					log.Warn(fmt.Sprintf("could not decode resource multihash: %v", err))
+					return reader, mimeType, status, err
+				} else if decodedMultihash.Code != multihash.KECCAK_256 {
 					apiGetInvalid.Inc(1)
 					status = http.StatusUnprocessableEntity
-					log.Warn(fmt.Sprintf("invalid resource multihash: %v", err))
-
+					log.Warn(fmt.Sprintf("invalid resource multihash code: %x", decodedMultihash.Code))
 					return reader, mimeType, status, err
 				}
 				key = storage.Key(decodedMultihash.Digest)
-				log.Debug("resouce is multihash", "key", key)
+				log.Trace("resource is multihash", "key", key)
 
 				// get the manifest the multihash digest points to
 				trie, err := loadManifest(self.dpa, key, nil)
@@ -400,7 +398,7 @@ func (self *Api) Get(key storage.Key, path string) (reader *storage.LazyChunkRea
 		status = entry.Status
 		if status == http.StatusMultipleChoices {
 			apiGetHttp300.Inc(1)
-			return
+			return nil, entry.ContentType, status, err
 		} else {
 			mimeType = entry.ContentType
 			log.Trace("content lookup key", "key", key, "mimetype", mimeType)

--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethereum/go-ethereum/swarm/multihash"
 	"github.com/ethereum/go-ethereum/swarm/storage"
 )
 
@@ -70,6 +71,7 @@ var (
 	apiRmFileFail      = metrics.NewRegisteredCounter("api.removefile.fail", nil)
 	apiAppendFileCount = metrics.NewRegisteredCounter("api.appendfile.count", nil)
 	apiAppendFileFail  = metrics.NewRegisteredCounter("api.appendfile.fail", nil)
+	apiGetInvalid      = metrics.NewRegisteredCounter("api.get.invalid", nil)
 )
 
 type Resolver interface {
@@ -330,13 +332,74 @@ func (self *Api) Get(key storage.Key, path string) (reader *storage.LazyChunkRea
 		// is set as the hash of the manifest (see swarm/api/manifest.go:NewResourceManifest)
 		//
 		// to avoid taking a performance hit hacking a storage.LazySectionReader to wrap the resource key,
+		// if the resource update is of raw type:
 		// we return a typed error instead. Since for all other purposes this is an invalid manifest,
 		// any normal interfacing code will just see an error fail accordingly.
+		//
+		// if the resource update is of multihash type:
+		// we validate the multihash and retrieve the manifest behind it, and resume normal operations from there
 		if entry.ContentType == ResourceContentType {
 			log.Warn("resource type", "key", key, "hash", entry.Hash)
-			return nil, entry.ContentType, http.StatusOK, &ErrResourceReturn{entry.Hash}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			rsrc, err := self.resource.LookupLatestByName(ctx, entry.Hash, true, &storage.ResourceLookupParams{})
+			_, rsrcData, err := self.resource.GetContent(entry.Hash)
+			if err != nil {
+				apiGetNotFound.Inc(1)
+				status = http.StatusNotFound
+				log.Warn(fmt.Sprintf("get resource content error: %v", err))
+				return reader, mimeType, status, err
+			}
+			if rsrc.Multihash {
+				var fail bool
+
+				// validate data as multihash
+				decodedMultihash, err := multihash.Decode(rsrcData)
+				if err != nil {
+					fail = true
+				} else if decodedMultihash.Code != multihash.SHA3_256 {
+					err = fmt.Errorf("wrong hash type '%s'", decodedMultihash.Name)
+				}
+				if fail {
+					apiGetInvalid.Inc(1)
+					status = http.StatusUnprocessableEntity
+					log.Warn(fmt.Sprintf("invalid resource multihash: %v", err))
+
+					return reader, mimeType, status, err
+				}
+				key = storage.Key(decodedMultihash.Digest)
+				log.Debug("resouce is multihash", "key", key)
+				// is it correct to increment again here?
+				apiGetCount.Inc(1)
+
+				// get the manifest the multihash digest points to
+				trie, err := loadManifest(self.dpa, key, nil)
+				if err != nil {
+					apiGetNotFound.Inc(1)
+					status = http.StatusNotFound
+					log.Warn(fmt.Sprintf("loadManifestTrie (resource multihash) error: %v", err))
+
+					return reader, mimeType, status, err
+				}
+
+				log.Trace("trie resolving resource multihash entry", "key", key, "path", path)
+				entry, _ := trie.getEntry(path)
+				log.Trace("trie resolving resource multihash entry", "key", key, "path", path)
+
+				if entry == nil {
+					status = http.StatusNotFound
+					apiGetNotFound.Inc(1)
+					err = fmt.Errorf("manifest (resource multihash) entry for '%s' not found", path)
+					log.Trace("manifest (resource multihash) entry not found", "key", key, "path", path)
+				}
+				log.Warn("entry", "entry", entry)
+
+			} else {
+				return nil, entry.ContentType, http.StatusOK, &ErrResourceReturn{entry.Hash}
+			}
+		} else {
+			key = common.Hex2Bytes(entry.Hash)
 		}
-		key = common.Hex2Bytes(entry.Hash)
 		status = entry.Status
 		if status == http.StatusMultipleChoices {
 			apiGetHttp300.Inc(1)

--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -609,8 +609,21 @@ func (self *Api) ResourceCreate(ctx context.Context, name string, frequency uint
 	return storage.Key(h[:]), nil
 }
 
+func (self *Api) ResourceUpdateMultihash(ctx context.Context, name string, data []byte) (storage.Key, uint32, uint32, error) {
+	return self.resourceUpdate(ctx, name, data, true)
+}
 func (self *Api) ResourceUpdate(ctx context.Context, name string, data []byte) (storage.Key, uint32, uint32, error) {
-	key, err := self.resource.Update(ctx, name, data)
+	return self.resourceUpdate(ctx, name, data, false)
+}
+
+func (self *Api) resourceUpdate(ctx context.Context, name string, data []byte, multihash bool) (storage.Key, uint32, uint32, error) {
+	var key storage.Key
+	var err error
+	if multihash {
+		key, err = self.resource.UpdateMultihash(ctx, name, data)
+	} else {
+		key, err = self.resource.Update(ctx, name, data)
+	}
 	period, _ := self.resource.GetLastPeriod(name)
 	version, _ := self.resource.GetVersion(name)
 	return key, period, version, err

--- a/swarm/api/http/error_test.go
+++ b/swarm/api/http/error_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-package http_test
+package http
 
 import (
 	"encoding/json"
@@ -30,7 +30,7 @@ import (
 
 func TestError(t *testing.T) {
 
-	srv := testutil.NewTestSwarmServer(t)
+	srv := testutil.NewTestSwarmServer(t, serverFunc)
 	defer srv.Close()
 
 	var resp *http.Response
@@ -56,7 +56,7 @@ func TestError(t *testing.T) {
 }
 
 func Test404Page(t *testing.T) {
-	srv := testutil.NewTestSwarmServer(t)
+	srv := testutil.NewTestSwarmServer(t, serverFunc)
 	defer srv.Close()
 
 	var resp *http.Response
@@ -82,7 +82,7 @@ func Test404Page(t *testing.T) {
 }
 
 func Test500Page(t *testing.T) {
-	srv := testutil.NewTestSwarmServer(t)
+	srv := testutil.NewTestSwarmServer(t, serverFunc)
 	defer srv.Close()
 
 	var resp *http.Response
@@ -107,7 +107,7 @@ func Test500Page(t *testing.T) {
 	}
 }
 func Test500PageWith0xHashPrefix(t *testing.T) {
-	srv := testutil.NewTestSwarmServer(t)
+	srv := testutil.NewTestSwarmServer(t, serverFunc)
 	defer srv.Close()
 
 	var resp *http.Response
@@ -137,7 +137,7 @@ func Test500PageWith0xHashPrefix(t *testing.T) {
 }
 
 func TestJsonResponse(t *testing.T) {
-	srv := testutil.NewTestSwarmServer(t)
+	srv := testutil.NewTestSwarmServer(t, serverFunc)
 	defer srv.Close()
 
 	var resp *http.Response

--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -370,6 +370,11 @@ func (s *Server) HandlePostResource(w http.ResponseWriter, r *Request) {
 	var outdata []byte
 	var isRaw bool
 
+	// possible combinations:
+	// /			add multihash update to existing hash
+	// /raw 		add raw update to existing hash
+	// /#			create new resource with first update as mulitihash
+	// /raw/#		create new resource with first update raw
 	fields := strings.Split(r.uri.Path, "/")
 	freqUrlIdx := -1
 	if len(fields) > 0 {

--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -398,9 +398,9 @@ func (s *Server) HandlePostResource(w http.ResponseWriter, r *Request) {
 	isRaw, frequency, err := resourcePostMode(r.uri.Path)
 	if err != nil {
 		Respond(w, r, err.Error(), http.StatusBadRequest)
+		return
 	}
 	if frequency > 0 {
-
 		key, err := s.api.ResourceCreate(r.Context(), r.uri.Addr, frequency)
 		if err != nil {
 			code, err2 := s.translateResourceError(w, r, "resource creation fail", err)
@@ -421,6 +421,12 @@ func (s *Server) HandlePostResource(w http.ResponseWriter, r *Request) {
 		outdata, err = json.Marshal(rsrcResponse)
 		if err != nil {
 			Respond(w, r, fmt.Sprintf("failed to create json response: %s", err), http.StatusInternalServerError)
+			return
+		}
+	} else {
+		_, _, err := s.api.ResourceLookup(r.Context(), r.uri.Addr, 0, 0, &storage.ResourceLookupParams{})
+		if err != nil {
+			Respond(w, r, err.Error(), http.StatusNotFound)
 			return
 		}
 	}

--- a/swarm/storage/error.go
+++ b/swarm/storage/error.go
@@ -15,6 +15,7 @@ const (
 	ErrInvalidSignature
 	ErrNotSynced
 	ErrPeriodDepth
+	ErrBlockchain
 	ErrCnt
 )
 

--- a/swarm/storage/resource.go
+++ b/swarm/storage/resource.go
@@ -30,6 +30,25 @@ const (
 	resourceHash        = SHA3Hash
 )
 
+type blockEstimator struct {
+	Start   time.Time
+	Average time.Duration
+}
+
+func NewBlockEstimator() *blockEstimator {
+	ropstenStart, _ := time.Parse(time.RFC3339, "2016-11-20T11:48:50Z")
+	return &blockEstimator{
+		Start:   ropstenStart,
+		Average: time.Second * 10,
+	}
+}
+
+func (b *blockEstimator) HeaderByNumber(context.Context, string, *big.Int) (*types.Header, error) {
+	return &types.Header{
+		Number: big.NewInt(int64(time.Now().Sub(b.Start).Seconds() / b.Average.Seconds())),
+	}, nil
+}
+
 type ResourceError struct {
 	code int
 	err  string
@@ -51,7 +70,7 @@ func NewResourceError(code int, s string) error {
 		err: s,
 	}
 	switch code {
-	case ErrNotFound, ErrIO, ErrUnauthorized, ErrInvalidValue, ErrDataOverflow, ErrNothingToReturn, ErrInvalidSignature, ErrNotSynced, ErrPeriodDepth:
+	case ErrNotFound, ErrIO, ErrUnauthorized, ErrInvalidValue, ErrDataOverflow, ErrNothingToReturn, ErrInvalidSignature, ErrNotSynced, ErrPeriodDepth, ErrBlockchain:
 		r.code = code
 	}
 	return r

--- a/swarm/storage/resource.go
+++ b/swarm/storage/resource.go
@@ -700,7 +700,7 @@ func (self *ResourceHandler) update(ctx context.Context, name string, data []byt
 	case <-timeout.C:
 		return nil, NewResourceError(ErrIO, "chunk store timeout")
 	}
-	log.Trace("resource update", "name", name, "key", key, "currentblock", currentblock, "lastperiod", nextperiod, "version", version, "data", chunk.SData)
+	log.Trace("resource update", "name", name, "key", key, "currentblock", currentblock, "lastperiod", nextperiod, "version", version, "data", chunk.SData, "multihash", multihash)
 
 	// update our resources map entry and return the new key
 	rsrc.lastPeriod = nextperiod

--- a/swarm/storage/resource.go
+++ b/swarm/storage/resource.go
@@ -67,6 +67,7 @@ type ResourceLookupParams struct {
 // Encapsulates an specific resource update. When synced it contains the most recent
 // version of the resource update data.
 type resource struct {
+	Multihash  bool
 	name       *string
 	nameHash   common.Hash
 	startBlock uint64
@@ -205,7 +206,7 @@ func (self *ResourceHandler) SetStore(store ChunkStore) {
 // If parsed signature is nil, validates automatically
 // If not resource update, it validates are root chunk if length is indexSize and first two bytes are 0
 func (self *ResourceHandler) Validate(key Key, data []byte) bool {
-	signature, period, version, name, parseddata, err := self.parseUpdate(data)
+	signature, period, version, name, parseddata, _, err := self.parseUpdate(data)
 	if err != nil {
 		if len(data) == indexSize {
 			if bytes.Equal(data[:2], []byte{0, 0}) {
@@ -518,7 +519,7 @@ func (self *ResourceHandler) loadResource(nameHash common.Hash, name string, ref
 func (self *ResourceHandler) updateResourceIndex(rsrc *resource, chunk *Chunk) (*resource, error) {
 
 	// retrieve metadata from chunk data and check that it matches this mutable resource
-	signature, period, version, name, data, err := self.parseUpdate(chunk.SData)
+	signature, period, version, name, data, multihash, err := self.parseUpdate(chunk.SData)
 	if *rsrc.name != name {
 		return nil, NewResourceError(ErrNothingToReturn, fmt.Sprintf("Update belongs to '%s', but have '%s'", name, *rsrc.name))
 	}
@@ -538,6 +539,7 @@ func (self *ResourceHandler) updateResourceIndex(rsrc *resource, chunk *Chunk) (
 	rsrc.version = version
 	rsrc.updated = time.Now()
 	rsrc.data = make([]byte, len(data))
+	rsrc.Multihash = multihash
 	copy(rsrc.data, data)
 	log.Debug("Resource synced", "name", *rsrc.name, "key", chunk.Key, "period", rsrc.lastPeriod, "version", rsrc.version)
 	self.setResource(*rsrc.name, rsrc)
@@ -546,10 +548,10 @@ func (self *ResourceHandler) updateResourceIndex(rsrc *resource, chunk *Chunk) (
 
 // retrieve update metadata from chunk data
 // mirrors newUpdateChunk()
-func (self *ResourceHandler) parseUpdate(chunkdata []byte) (*Signature, uint32, uint32, string, []byte, error) {
+func (self *ResourceHandler) parseUpdate(chunkdata []byte) (*Signature, uint32, uint32, string, []byte, bool, error) {
 	// 14 = header + one byte of name + one byte of data
 	if len(chunkdata) < 14 {
-		return nil, 0, 0, "", nil, NewResourceError(ErrNothingToReturn, "chunk less than 13 bytes cannot be a resource update chunk")
+		return nil, 0, 0, "", nil, false, NewResourceError(ErrNothingToReturn, "chunk less than 13 bytes cannot be a resource update chunk")
 	}
 	cursor := 0
 	headerlength := binary.LittleEndian.Uint16(chunkdata[cursor : cursor+2])
@@ -557,7 +559,7 @@ func (self *ResourceHandler) parseUpdate(chunkdata []byte) (*Signature, uint32, 
 	datalength := binary.LittleEndian.Uint16(chunkdata[cursor : cursor+2])
 	exclsignlength := int(headerlength + datalength + 4)
 	if exclsignlength > len(chunkdata) || exclsignlength < 14 {
-		return nil, 0, 0, "", nil, NewResourceError(ErrNothingToReturn, fmt.Sprintf("Reported headerlength %d + datalength %d longer than actual chunk data length %d", headerlength, datalength, len(chunkdata)))
+		return nil, 0, 0, "", nil, false, NewResourceError(ErrNothingToReturn, fmt.Sprintf("Reported headerlength %d + datalength %d longer than actual chunk data length %d", headerlength, datalength, len(chunkdata)))
 	}
 	var period uint32
 	var version uint32
@@ -572,13 +574,15 @@ func (self *ResourceHandler) parseUpdate(chunkdata []byte) (*Signature, uint32, 
 	name = string(chunkdata[cursor : cursor+namelength])
 	cursor += namelength
 	var intdatalength int
+	var multihash bool
 	if datalength == 0 {
 		intdatalength = isMultihash(chunkdata[cursor:])
 		multihashboundary := cursor + intdatalength
 		if len(chunkdata) != multihashboundary && len(chunkdata) < multihashboundary+signatureLength {
 			log.Debug("multihash error", "chunkdatalen", len(chunkdata), "multihashboundary", multihashboundary)
-			return nil, 0, 0, "", nil, errors.New("Corrupt multihash data")
+			return nil, 0, 0, "", nil, false, errors.New("Corrupt multihash data")
 		}
+		multihash = true
 	} else {
 		intdatalength = int(datalength)
 	}
@@ -596,7 +600,7 @@ func (self *ResourceHandler) parseUpdate(chunkdata []byte) (*Signature, uint32, 
 		}
 	}
 
-	return signature, period, version, name, data, nil
+	return signature, period, version, name, data, multihash, nil
 }
 
 // Adds an actual data update

--- a/swarm/storage/resource_test.go
+++ b/swarm/storage/resource_test.go
@@ -107,7 +107,7 @@ func TestResourceReverse(t *testing.T) {
 	chunk := newUpdateChunk(key, &sig, period, version, safeName, data, len(data))
 
 	// check that we can recover the owner account from the update chunk's signature
-	checksig, checkperiod, checkversion, checkname, checkdata, err := rh.parseUpdate(chunk.SData)
+	checksig, checkperiod, checkversion, checkname, checkdata, _, err := rh.parseUpdate(chunk.SData)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -613,7 +613,7 @@ func getUpdateDirect(rh *ResourceHandler, key Key) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	_, _, _, _, data, err := rh.parseUpdate(chunk.SData)
+	_, _, _, _, data, _, err := rh.parseUpdate(chunk.SData)
 	if err != nil {
 		return nil, err
 	}

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -178,27 +178,31 @@ func NewSwarm(ctx *node.ServiceContext, backend chequebook.Backend, config *api.
 	var resourceHandler *storage.ResourceHandler
 	// if use resource updates
 
+	if ensresolver == nil {
+		log.Warn("No ENS API specified, resource updates will NOT validate resource update chunks")
+	}
+	rhparams := &storage.ResourceHandlerParams{
+		// TODO: config parameter to set limits
+		QueryMaxPeriods: &storage.ResourceLookupParams{
+			Limit: false,
+		},
+		Signer: &storage.GenericResourceSigner{
+			PrivKey: self.privateKey,
+		},
+		EthClient: resolver,
+		EnsClient: ensresolver,
+	}
 	if resolver != nil {
 		resolver.SetNameHash(ens.EnsNode)
-		rhparams := &storage.ResourceHandlerParams{
-			// TODO: config parameter to set limits
-			QueryMaxPeriods: &storage.ResourceLookupParams{
-				Limit: false,
-			},
-			Signer: &storage.GenericResourceSigner{
-				PrivKey: self.privateKey,
-			},
-			EthClient: resolver,
-			EnsClient: ensresolver,
-		}
-		resourceHandler, err = storage.NewResourceHandler(rhparams)
-		if err != nil {
-			return nil, err
-		}
-		resourceHandler.SetStore(self.lstore)
 	} else {
-		log.Warn("No ENS API specified, resource updates will be disabled")
+		log.Warn("No ETH API specified, resource updates will use block height approximation")
+		rhparams.EthClient = storage.NewBlockEstimator()
 	}
+	resourceHandler, err = storage.NewResourceHandler(rhparams)
+	if err != nil {
+		return nil, err
+	}
+	resourceHandler.SetStore(self.lstore)
 
 	var validators []storage.ChunkValidator
 	validators = append(validators, storage.NewContentAddressValidator(storage.MakeHashFunc(storage.DefaultHash)))

--- a/swarm/testutil/http.go
+++ b/swarm/testutil/http.go
@@ -20,15 +20,19 @@ import (
 	"context"
 	"io/ioutil"
 	"math/big"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/swarm/api"
-	httpapi "github.com/ethereum/go-ethereum/swarm/api/http"
 	"github.com/ethereum/go-ethereum/swarm/storage"
 )
+
+type TestServer interface {
+	ServeHTTP(http.ResponseWriter, *http.Request)
+}
 
 type fakeBackend struct {
 	blocknumber int64
@@ -42,7 +46,7 @@ func (f *fakeBackend) HeaderByNumber(context context.Context, _ string, bigblock
 	}, nil
 }
 
-func NewTestSwarmServer(t *testing.T) *TestSwarmServer {
+func NewTestSwarmServer(t *testing.T, serverFunc func(*api.Api) TestServer) *TestSwarmServer {
 	dir, err := ioutil.TempDir("", "swarm-storage-test")
 	if err != nil {
 		t.Fatal(err)
@@ -73,7 +77,7 @@ func NewTestSwarmServer(t *testing.T) *TestSwarmServer {
 	}
 
 	a := api.NewApi(dpa, nil, rh)
-	srv := httptest.NewServer(httpapi.NewServer(a))
+	srv := httptest.NewServer(serverFunc(a))
 	return &TestSwarmServer{
 		Server: srv,
 		Dpa:    dpa,


### PR DESCRIPTION
**NB This branch is rebased on `resource-api-multihash` - changes in that branch will also be displayed here until it is merged.**

In case of missing ethClient for resource handler, this implements an alternative method to determine the block height, using simple heuristics based on average block time and starting date. The default is Ropsten genesis block date and frequency of 10 seconds. It can be overridden in the constructor.

----

The PR also fixes a bug where resource requested through http api was not loaded in the resource index, and therefore returned not found.