### PR TITLE
Manifest panic fix

### DIFF
--- a/swarm/api/manifest.go
+++ b/swarm/api/manifest.go
@@ -500,7 +500,7 @@ func (self *manifestTrie) findPrefixOf(path string, quitC chan bool) (entry *man
 			pos = epl
 		}
 	}
-	return
+	return nil, 0
 }
 
 // file system manifest always contains regularized paths


### PR DESCRIPTION
Closes https://github.com/ethersphere/go-ethereum/issues/452.

Method manifestTrie.findPrefixOf returns the manifest from the path first letter if the path is not found. This change makes it return nil entry.