### PR TITLE
Fix hashMatcher

### DIFF
--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -40,7 +40,7 @@ import (
 )
 
 // TODO: this is bad, it should not be hardcoded how long is a hash
-var hashMatcher = regexp.MustCompile("^([0-9A-Fa-f]{64})([0-9A-Fa-f]{64})?")
+var hashMatcher = regexp.MustCompile("^([0-9A-Fa-f]{64})([0-9A-Fa-f]{64})?$")
 
 type ErrResourceReturn struct {
 	key string


### PR DESCRIPTION
Terminate the hashMatcher regexp at the end to have the exact URI address for hex conversion, avoiding possible arbitrary suffix. 

Fixes panic for this type of URL: http://localhost:8500/bzz:/143fd8f2affab0f7fe610255759ca1d45fcaa36e8fcca133d70b2160d7f73af0SUFFIX/, where SUFFIX is not part of the hex-encoded string.