### PR TITLE
NetStore Get retry

### DIFF
--- a/swarm/storage/dpa.go
+++ b/swarm/storage/dpa.go
@@ -18,7 +18,6 @@ package storage
 
 import (
 	"io"
-	"time"
 )
 
 /*
@@ -37,11 +36,6 @@ const (
 	defaultLDBCapacity                = 5000000 // capacity for LevelDB, by default 5*10^6*4096 bytes == 20GB
 	defaultCacheCapacity              = 500     // capacity for in-memory chunks' cache
 	defaultChunkRequestsCacheCapacity = 5000000 // capacity for container holding outgoing requests for chunks. should be set to LevelDB capacity
-)
-
-var (
-	// timeout interval before retrieval is timed out
-	searchTimeout = 30 * time.Second
 )
 
 type DPA struct {

--- a/swarm/storage/netstore_test.go
+++ b/swarm/storage/netstore_test.go
@@ -91,12 +91,13 @@ func TestNetstoreFailedRequest(t *testing.T) {
 	r := NewMockRetrieve()
 	netStore := NewNetStore(localStore, r.retrieve)
 
-	// first call
 	key := Key{}
-	_, err = netStore.Get(key)
-	if err == nil || err != ErrChunkNotFound {
-		t.Fatalf("expected to get ErrChunkNotFound, but got: %s", err)
-	}
+
+	// first call is done by the retry on ErrChunkNotFound, no need to do it here
+	// _, err = netStore.Get(key)
+	// if err == nil || err != ErrChunkNotFound {
+	// 	t.Fatalf("expected to get ErrChunkNotFound, but got: %s", err)
+	// }
 
 	// second call
 	_, err = netStore.Get(key)


### PR DESCRIPTION
This PR implements retry for NetStore.Get as a workaround for https://github.com/ethersphere/go-ethereum/issues/373. Increasing searchTimeout does help, but sometimes fails, and rerequesting the chunk may make it available.