### PR TITLE
swarm/api: add resetting timer for HTTP requests

### DIFF
--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -861,6 +861,7 @@ func (s *Server) HandleGetFile(w http.ResponseWriter, r *Request) {
 }
 
 func (s *Server) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	defer metrics.GetOrRegisterResettingTimer(fmt.Sprintf("http.request.%s.time", r.Method), nil).UpdateSince(time.Now())
 	req := &Request{Request: *r, ruid: uuid.New()[:8]}
 	metrics.GetOrRegisterCounter(fmt.Sprintf("http.request.%s", r.Method), nil).Inc(1)
 	log.Info("serving request", "ruid", req.ruid, "method", r.Method, "url", r.RequestURI)


### PR DESCRIPTION
I am not sure why/when this timer was removed, but I am reverting it back.