### PR TITLE
swarm/pss: Move pssparams to swarm api config

### DIFF
--- a/swarm/api/config.go
+++ b/swarm/api/config.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/ethereum/go-ethereum/swarm/network"
+	"github.com/ethereum/go-ethereum/swarm/pss"
 	"github.com/ethereum/go-ethereum/swarm/services/swap"
 	"github.com/ethereum/go-ethereum/swarm/storage"
 )
@@ -47,6 +48,7 @@ type Config struct {
 	*storage.LocalStoreParams
 	*network.HiveParams
 	Swap *swap.SwapParams
+	Pss  *pss.PssParams
 	//*network.SyncParams
 	Contract        common.Address
 	EnsRoot         common.Address
@@ -77,6 +79,7 @@ func NewConfig() (self *Config) {
 		HiveParams:       network.NewHiveParams(),
 		//SyncParams:    network.NewDefaultSyncParams(),
 		Swap:            swap.NewDefaultSwapParams(),
+		Pss:             pss.NewPssParams(),
 		ListenAddr:      DefaultHTTPListenAddr,
 		Port:            DefaultHTTPPort,
 		Path:            node.DefaultDataDir(),

--- a/swarm/pss/client/client_test.go
+++ b/swarm/pss/client/client_test.go
@@ -228,8 +228,7 @@ func newServices() adapters.Services {
 			defer cancel()
 			keys, err := wapi.NewKeyPair(ctxlocal)
 			privkey, err := w.GetPrivateKey(keys)
-			psparams := pss.NewPssParams()
-			psparams.Init(privkey)
+			psparams := pss.NewPssParams().WithPrivateKey(privkey)
 			pskad := kademlia(ctx.Config.ID)
 			ps, err := pss.NewPss(pskad, psparams)
 			if err != nil {

--- a/swarm/pss/client/client_test.go
+++ b/swarm/pss/client/client_test.go
@@ -228,9 +228,13 @@ func newServices() adapters.Services {
 			defer cancel()
 			keys, err := wapi.NewKeyPair(ctxlocal)
 			privkey, err := w.GetPrivateKey(keys)
-			psparams := pss.NewPssParams(privkey)
+			psparams := pss.NewPssParams()
+			psparams.Init(privkey)
 			pskad := kademlia(ctx.Config.ID)
-			ps := pss.NewPss(pskad, psparams)
+			ps, err := pss.NewPss(pskad, psparams)
+			if err != nil {
+				return nil, err
+			}
 			pshparams := pss.NewHandshakeParams()
 			pshparams.SymKeySendLimit = sendLimit
 			err = pss.SetHandshakeController(ps, pshparams)

--- a/swarm/pss/pss.go
+++ b/swarm/pss/pss.go
@@ -75,13 +75,16 @@ type PssParams struct {
 }
 
 // Sane defaults for Pss
-func NewPssParams(privatekey *ecdsa.PrivateKey) *PssParams {
+func NewPssParams() *PssParams {
 	return &PssParams{
 		MsgTTL:              defaultMsgTTL,
 		CacheTTL:            defaultDigestCacheTTL,
-		privateKey:          privatekey,
 		SymKeyCacheCapacity: defaultSymKeyCacheCapacity,
 	}
+}
+
+func (self *PssParams) Init(privatekey *ecdsa.PrivateKey) {
+	self.privateKey = privatekey
 }
 
 // Toplevel pss object, takes care of message sending, receiving, decryption and encryption, message handler dispatchers and message forwarding.
@@ -131,7 +134,10 @@ func (self *Pss) String() string {
 //
 // In addition to params, it takes a swarm network overlay
 // and a DPA storage for message cache storage.
-func NewPss(k network.Overlay, params *PssParams) *Pss {
+func NewPss(k network.Overlay, params *PssParams) (*Pss, error) {
+	if params.privateKey == nil {
+		return nil, errors.New("missing private key for pss")
+	}
 	cap := p2p.Cap{
 		Name:    pssProtocolName,
 		Version: pssVersion,
@@ -169,7 +175,7 @@ func NewPss(k network.Overlay, params *PssParams) *Pss {
 		ps.hashPool.Put(hashfunc)
 	}
 
-	return ps
+	return ps, nil
 }
 
 /////////////////////////////////////////////////////////////////////

--- a/swarm/pss/pss.go
+++ b/swarm/pss/pss.go
@@ -83,8 +83,9 @@ func NewPssParams() *PssParams {
 	}
 }
 
-func (self *PssParams) Init(privatekey *ecdsa.PrivateKey) {
+func (self *PssParams) WithPrivateKey(privatekey *ecdsa.PrivateKey) *PssParams {
 	self.privateKey = privatekey
+	return self
 }
 
 // Toplevel pss object, takes care of message sending, receiving, decryption and encryption, message handler dispatchers and message forwarding.

--- a/swarm/pss/pss_test.go
+++ b/swarm/pss/pss_test.go
@@ -133,7 +133,8 @@ func TestCache(t *testing.T) {
 		t.Fatal(err)
 	}
 	ps := newTestPss(privkey, nil, nil)
-	pp := NewPssParams(privkey)
+	pp := NewPssParams()
+	pp.Init(privkey)
 	data := []byte("foo")
 	datatwo := []byte("bar")
 	datathree := []byte("baz")
@@ -232,8 +233,12 @@ func TestAddressMatch(t *testing.T) {
 		t.Fatalf("Could not generate private key: %v", err)
 	}
 	privkey, err := w.GetPrivateKey(keys)
-	pssp := NewPssParams(privkey)
-	ps := NewPss(kad, pssp)
+	pssp := NewPssParams()
+	pssp.Init(privkey)
+	ps, err := NewPss(kad, pssp)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
 
 	pssmsg := &PssMsg{
 		To:      remoteaddr,
@@ -1341,11 +1346,15 @@ func newServices(allowRaw bool) adapters.Services {
 			defer cancel()
 			keys, err := wapi.NewKeyPair(ctxlocal)
 			privkey, err := w.GetPrivateKey(keys)
-			pssp := NewPssParams(privkey)
+			pssp := NewPssParams()
+			pssp.Init(privkey)
 			pssp.MsgTTL = time.Second * 30
 			pssp.AllowRaw = allowRaw
 			pskad := kademlia(ctx.Config.ID)
-			ps := NewPss(pskad, pssp)
+			ps, err := NewPss(pskad, pssp)
+			if err != nil {
+				return nil, err
+			}
 
 			ping := &Ping{
 				OutC: make(chan bool),
@@ -1405,11 +1414,15 @@ func newTestPss(privkey *ecdsa.PrivateKey, overlay network.Overlay, ppextra *Pss
 	}
 
 	// create pss
-	pp := NewPssParams(privkey)
+	pp := NewPssParams()
+	pp.Init(privkey)
 	if ppextra != nil {
 		pp.SymKeyCacheCapacity = ppextra.SymKeyCacheCapacity
 	}
-	ps := NewPss(overlay, pp)
+	ps, err := NewPss(overlay, pp)
+	if err != nil {
+		return nil
+	}
 	ps.Start(nil)
 
 	return ps

--- a/swarm/pss/pss_test.go
+++ b/swarm/pss/pss_test.go
@@ -133,8 +133,7 @@ func TestCache(t *testing.T) {
 		t.Fatal(err)
 	}
 	ps := newTestPss(privkey, nil, nil)
-	pp := NewPssParams()
-	pp.Init(privkey)
+	pp := NewPssParams().WithPrivateKey(privkey)
 	data := []byte("foo")
 	datatwo := []byte("bar")
 	datathree := []byte("baz")
@@ -233,8 +232,7 @@ func TestAddressMatch(t *testing.T) {
 		t.Fatalf("Could not generate private key: %v", err)
 	}
 	privkey, err := w.GetPrivateKey(keys)
-	pssp := NewPssParams()
-	pssp.Init(privkey)
+	pssp := NewPssParams().WithPrivateKey(privkey)
 	ps, err := NewPss(kad, pssp)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -1346,8 +1344,7 @@ func newServices(allowRaw bool) adapters.Services {
 			defer cancel()
 			keys, err := wapi.NewKeyPair(ctxlocal)
 			privkey, err := w.GetPrivateKey(keys)
-			pssp := NewPssParams()
-			pssp.Init(privkey)
+			pssp := NewPssParams().WithPrivateKey(privkey)
 			pssp.MsgTTL = time.Second * 30
 			pssp.AllowRaw = allowRaw
 			pskad := kademlia(ctx.Config.ID)
@@ -1414,8 +1411,7 @@ func newTestPss(privkey *ecdsa.PrivateKey, overlay network.Overlay, ppextra *Pss
 	}
 
 	// create pss
-	pp := NewPssParams()
-	pp.Init(privkey)
+	pp := NewPssParams().WithPrivateKey(privkey)
 	if ppextra != nil {
 		pp.SymKeyCacheCapacity = ppextra.SymKeyCacheCapacity
 	}

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -229,7 +229,7 @@ func NewSwarm(ctx *node.ServiceContext, backend chequebook.Backend, config *api.
 	self.bzz = network.NewBzz(bzzconfig, to, stateStore, stream.Spec, self.streamer.Run)
 
 	// Pss = postal service over swarm (devp2p over bzz)
-	config.Pss.WithPrivateKey(self.privateKey)
+	config.Pss = config.Pss.WithPrivateKey(self.privateKey)
 	self.ps, err = pss.NewPss(to, config.Pss)
 	if err != nil {
 		return nil, err

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -229,7 +229,7 @@ func NewSwarm(ctx *node.ServiceContext, backend chequebook.Backend, config *api.
 	self.bzz = network.NewBzz(bzzconfig, to, stateStore, stream.Spec, self.streamer.Run)
 
 	// Pss = postal service over swarm (devp2p over bzz)
-	config.Pss.Init(self.privateKey)
+	config.Pss.WithPrivateKey(self.privateKey)
 	self.ps, err = pss.NewPss(to, config.Pss)
 	if err != nil {
 		return nil, err

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -229,8 +229,11 @@ func NewSwarm(ctx *node.ServiceContext, backend chequebook.Backend, config *api.
 	self.bzz = network.NewBzz(bzzconfig, to, stateStore, stream.Spec, self.streamer.Run)
 
 	// Pss = postal service over swarm (devp2p over bzz)
-	pssparams := pss.NewPssParams(self.privateKey)
-	self.ps = pss.NewPss(to, pssparams)
+	config.Pss.Init(self.privateKey)
+	self.ps, err = pss.NewPss(to, config.Pss)
+	if err != nil {
+		return nil, err
+	}
 	if pss.IsActiveHandshake {
 		pss.SetHandshakeController(self.ps, pss.NewHandshakeParams())
 	}


### PR DESCRIPTION
This PR makes it possible to specify pss related params from outside the swarm service constructor, on the same level as swap etc.