### PR TITLE
swarm/pss: Remove redundant run func param to addpeer

### DIFF
--- a/swarm/pss/protocol.go
+++ b/swarm/pss/protocol.go
@@ -147,7 +147,7 @@ func (self *Protocol) Handle(msg []byte, p *p2p.Peer, asymmetric bool, keyid str
 	} else if (!self.isActiveSymKey(keyid, *self.topic) && !asymmetric) ||
 		(!self.isActiveAsymKey(keyid, *self.topic) && asymmetric) {
 
-		rw, err := self.AddPeer(p, self.proto.Run, *self.topic, asymmetric, keyid)
+		rw, err := self.AddPeer(p, *self.topic, asymmetric, keyid)
 		if err != nil {
 			return err
 		}
@@ -197,7 +197,8 @@ func ToP2pMsg(msg []byte) (p2p.Msg, error) {
 // `key` and `asymmetric` specifies what encryption key
 // to link the peer to.
 // The key must exist in the pss store prior to adding the peer.
-func (self *Protocol) AddPeer(p *p2p.Peer, run func(*p2p.Peer, p2p.MsgReadWriter) error, topic Topic, asymmetric bool, key string) (p2p.MsgReadWriter, error) {
+//func (self *Protocol) AddPeer(p *p2p.Peer, run func(*p2p.Peer, p2p.MsgReadWriter) error, topic Topic, asymmetric bool, key string) (p2p.MsgReadWriter, error) {
+func (self *Protocol) AddPeer(p *p2p.Peer, topic Topic, asymmetric bool, key string) (p2p.MsgReadWriter, error) {
 	rw := &PssReadWriter{
 		Pss:   self.Pss,
 		rw:    make(chan p2p.Msg),
@@ -226,7 +227,7 @@ func (self *Protocol) AddPeer(p *p2p.Peer, run func(*p2p.Peer, p2p.MsgReadWriter
 		self.symKeyRWPool[key] = rw
 	}
 	go func() {
-		err := run(p, rw)
+		err := self.proto.Run(p, rw)
 		log.Warn(fmt.Sprintf("pss vprotocol quit on %v topic %v: %v", p, topic, err))
 	}()
 	return rw, nil

--- a/swarm/pss/protocol_test.go
+++ b/swarm/pss/protocol_test.go
@@ -96,7 +96,7 @@ func testProtocol(t *testing.T) {
 	// add right peer's public key as protocol peer on left
 	nid, _ := discover.HexID("0x00") // this hack is needed to satisfy the p2p method
 	p := p2p.NewPeer(nid, fmt.Sprintf("%x", common.FromHex(loaddrhex)), []p2p.Cap{})
-	_, err = pssprotocols[lnodeinfo.ID].protocol.AddPeer(p, pssprotocols[lnodeinfo.ID].run, PingTopic, true, rpubkey)
+	_, err = pssprotocols[lnodeinfo.ID].protocol.AddPeer(p, PingTopic, true, rpubkey)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The `run` function is already within the `pss.Protocol` object, redundant (and problematic) to pass it again.