### PR TITLE
swarm/storage: Add method for getting previous resource update

### DIFF
--- a/swarm/storage/resource.go
+++ b/swarm/storage/resource.go
@@ -422,6 +422,9 @@ func (self *ResourceHandler) LookupLatest(ctx context.Context, nameHash common.H
 
 // Returns the resource before the one currently loaded in the resource object
 //
+// This is useful where resource updates are used incrementally in contrast to
+// merely replacing content.
+//
 // Requires a synced resource object
 func (self *ResourceHandler) LookupPreviousByName(ctx context.Context, name string, maxLookup *ResourceLookupParams) (*resource, error) {
 	return self.LookupPrevious(ctx, ens.EnsNode(name), name, maxLookup)

--- a/swarm/storage/resource_test.go
+++ b/swarm/storage/resource_test.go
@@ -178,35 +178,43 @@ func TestResourceHandler(t *testing.T) {
 		t.Fatalf("stored frequency %d does not match provided frequency %d", chunkfrequency, resourceFrequency)
 	}
 
+	// data for updates:
+	updates := []string{
+		"blinky",
+		"pinky",
+		"inky",
+		"clyde",
+	}
+
 	// update halfway to first period
 	resourcekey := make(map[string]Key)
 	fwdBlocks(int(resourceFrequency/2), backend)
-	data := []byte("blinky")
-	resourcekey["blinky"], err = rh.Update(ctx, safeName, data)
+	data := []byte(updates[0])
+	resourcekey[updates[0]], err = rh.Update(ctx, safeName, data)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// update on first period
 	fwdBlocks(int(resourceFrequency/2), backend)
-	data = []byte("pinky")
-	resourcekey["pinky"], err = rh.Update(ctx, safeName, data)
+	data = []byte(updates[1])
+	resourcekey[updates[1]], err = rh.Update(ctx, safeName, data)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// update on second period
 	fwdBlocks(int(resourceFrequency), backend)
-	data = []byte("inky")
-	resourcekey["inky"], err = rh.Update(ctx, safeName, data)
+	data = []byte(updates[2])
+	resourcekey[updates[2]], err = rh.Update(ctx, safeName, data)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// update just after second period
 	fwdBlocks(1, backend)
-	data = []byte("clyde")
-	resourcekey["clyde"], err = rh.Update(ctx, safeName, data)
+	data = []byte(updates[3])
+	resourcekey[updates[3]], err = rh.Update(ctx, safeName, data)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -234,8 +242,8 @@ func TestResourceHandler(t *testing.T) {
 	}
 
 	// last update should be "clyde", version two, blockheight startblocknumber + (resourcefrequency * 3)
-	if !bytes.Equal(rh2.resources[safeName].data, []byte("clyde")) {
-		t.Fatalf("resource data was %v, expected %v", rh2.resources[safeName].data, []byte("clyde"))
+	if !bytes.Equal(rh2.resources[safeName].data, []byte(updates[len(updates)-1])) {
+		t.Fatalf("resource data was %v, expected %v", rh2.resources[safeName].data, updates[len(updates)-1])
 	}
 	if rh2.resources[safeName].version != 2 {
 		t.Fatalf("resource version was %d, expected 2", rh2.resources[safeName].version)
@@ -251,8 +259,8 @@ func TestResourceHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 	// check data
-	if !bytes.Equal(rsrc.data, []byte("clyde")) {
-		t.Fatalf("resource data (historical) was %v, expected %v", rh2.resources[domainName].data, []byte("clyde"))
+	if !bytes.Equal(rsrc.data, []byte(updates[len(updates)-1])) {
+		t.Fatalf("resource data (historical) was %v, expected %v", rh2.resources[domainName].data, updates[len(updates)-1])
 	}
 	log.Debug("Historical lookup", "period", rh2.resources[safeName].lastPeriod, "version", rh2.resources[safeName].version, "data", rh2.resources[safeName].data)
 
@@ -262,10 +270,29 @@ func TestResourceHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 	// check data
-	if !bytes.Equal(rsrc.data, []byte("inky")) {
-		t.Fatalf("resource data (historical) was %v, expected %v", rh2.resources[domainName].data, []byte("inky"))
+	if !bytes.Equal(rsrc.data, []byte(updates[2])) {
+		t.Fatalf("resource data (historical) was %v, expected %v", rh2.resources[domainName].data, updates[2])
 	}
 	log.Debug("Specific version lookup", "period", rh2.resources[safeName].lastPeriod, "version", rh2.resources[safeName].version, "data", rh2.resources[safeName].data)
+
+	// we are now at third update
+	// check backwards stepping to the first
+	for i := 1; i >= 0; i-- {
+		rsrc, err := rh2.LookupPreviousByName(ctx, safeName, rh2.queryMaxPeriods)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(rsrc.data, []byte(updates[i])) {
+			t.Fatalf("resource data (previous) was %v, expected %v", rh2.resources[domainName].data, updates[i])
+
+		}
+	}
+
+	// beyond the first should yield an error
+	rsrc, err = rh2.LookupPreviousByName(ctx, safeName, rh2.queryMaxPeriods)
+	if err == nil {
+		t.Fatalf("expeected previous to fail, returned period %d version %d data %v", rh2.resources[domainName].lastPeriod, rh2.resources[domainName].version, rh2.resources[domainName].data)
+	}
 
 }
 


### PR DESCRIPTION
This PR adds a convenience function for retrieving the update before the one currently loaded (the last one looked up).