### PR TITLE
p2p/simulations: Simulation up eventmon

### DIFF
--- a/p2p/simulations/util.go
+++ b/p2p/simulations/util.go
@@ -1,0 +1,220 @@
+package simulations
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/p2p/discover"
+)
+
+const (
+	UpModeBootnode = iota
+	UpModeCircle
+)
+
+type up struct {
+	net    *Network
+	nids   []discover.NodeID
+	sim    *Simulation
+	conns  []*Conn
+	events chan *Event
+	ctx    context.Context
+}
+
+func Up(ctx context.Context, net *Network, nids []discover.NodeID, mode int) error {
+
+	eventC := make(chan *Event)
+	defer close(eventC)
+	u := &up{
+		nids:   nids,
+		net:    net,
+		sim:    NewSimulation(net),
+		ctx:    ctx,
+		events: eventC,
+	}
+
+	switch mode {
+	case UpModeBootnode:
+		u.conns = modeBootnode(nids)
+	case UpModeCircle:
+		u.conns = modeCircle(nids)
+	}
+
+	err := u.upWithConfig()
+	if err != nil {
+		return err
+	}
+	return u.connWithConfig()
+}
+
+func (u *up) upWithConfig() error {
+	quitC := make(chan struct{})
+	trigger := make(chan discover.NodeID)
+	sub := u.net.Events().Subscribe(u.events)
+	// event sink on quit
+	log.Warn("checking", "nids", u.nids)
+	defer func() {
+		sub.Unsubscribe()
+		close(quitC)
+		select {
+		case <-u.events:
+		default:
+		}
+		return
+	}()
+	action := func(ctx context.Context) error {
+		go func() {
+			for {
+				select {
+				case e := <-u.events:
+					if e.Type == EventTypeNode {
+						if e.Node.Up {
+							log.Warn("got nid", "nid", e.Node.ID())
+							trigger <- e.Node.ID()
+						}
+					}
+				case <-ctx.Done():
+					return
+				case <-quitC:
+					return
+				}
+			}
+		}()
+		go func() {
+			for _, n := range u.nids {
+				err := u.net.Start(n)
+				if err != nil {
+					return
+				}
+			}
+		}()
+		return nil
+	}
+	check := func(ctx context.Context, nid discover.NodeID) (bool, error) {
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		default:
+		}
+		log.Warn("ok")
+		return true, nil
+	}
+
+	d, err := time.ParseDuration(fmt.Sprintf("%dms", 10*len(u.nids)))
+	if err != nil {
+		return err
+	}
+	localctx, cancel := context.WithTimeout(u.ctx, d)
+	defer cancel()
+
+	step := u.sim.Run(localctx, &Step{
+		Action:  action,
+		Trigger: trigger,
+		Expect: &Expectation{
+			Nodes: u.nids,
+			Check: check,
+		},
+	})
+	return step.Error
+}
+
+func (u *up) connWithConfig() error {
+	quitC := make(chan struct{})
+	trigger := make(chan discover.NodeID)
+	sub := u.net.Events().Subscribe(u.events)
+	// event sink on quit
+	log.Warn("checking", "nids", u.nids)
+	defer func() {
+		sub.Unsubscribe()
+		close(quitC)
+		select {
+		case <-u.events:
+		default:
+		}
+		return
+	}()
+	action := func(ctx context.Context) error {
+		go func() {
+			for {
+				select {
+				case e := <-u.events:
+					if e.Type == EventTypeConn {
+						if e.Conn.Up {
+							trigger <- e.Conn.One
+							trigger <- e.Conn.Other
+						}
+					}
+				case <-ctx.Done():
+					return
+				case <-quitC:
+					return
+				}
+			}
+		}()
+		go func() {
+			for _, n := range u.conns {
+				err := u.net.Connect(n.One, n.Other)
+				if err != nil {
+					return
+				}
+			}
+		}()
+		return nil
+	}
+	check := func(ctx context.Context, nid discover.NodeID) (bool, error) {
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		default:
+		}
+		log.Warn("ok")
+		return true, nil
+	}
+
+	d, err := time.ParseDuration(fmt.Sprintf("%dms", 10*len(u.nids)))
+	if err != nil {
+		return err
+	}
+	localctx, cancel := context.WithTimeout(u.ctx, d)
+	defer cancel()
+
+	step := u.sim.Run(localctx, &Step{
+		Action:  action,
+		Trigger: trigger,
+		Expect: &Expectation{
+			Nodes: u.nids,
+			Check: check,
+		},
+	})
+	return step.Error
+}
+
+func modeBootnode(nids []discover.NodeID) (conns []*Conn) {
+	for i, n := range nids {
+		if i > 0 {
+			conns = append(conns, &Conn{
+				One:   n,
+				Other: nids[0],
+			})
+		}
+	}
+	return
+}
+
+func modeCircle(nids []discover.NodeID) (conns []*Conn) {
+	for i, n := range nids {
+		var otherIdx int
+		if i == 0 {
+			otherIdx = len(nids) - 1
+		} else {
+			otherIdx = i - 1
+		}
+		conns = append(conns, &Conn{
+			One:   n,
+			Other: nids[otherIdx],
+		})
+	}
+	return
+}

--- a/p2p/simulations/util.go
+++ b/p2p/simulations/util.go
@@ -99,7 +99,7 @@ func (u *up) upWithConfig() error {
 		return true, nil
 	}
 
-	d, err := time.ParseDuration(fmt.Sprintf("%dms", 10*len(u.nids)))
+	d, err := time.ParseDuration(fmt.Sprintf("%dms", 100*len(u.nids)))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR is an attempt (and encouragement) to collect reusable code for common operations in simulations in one place. 

Is addresses specfically the up-and-connect part of simulations startup, implementing event listening to determine when the procedure is complete, with safe shutdowns of subscriptions and channels.

It is based on work from https://github.com/ethersphere/go-ethereum/pull/370