### PR TITLE
swarm/pss: Remove fallthrough when not intended recipient

### DIFF
--- a/swarm/pss/pss.go
+++ b/swarm/pss/pss.go
@@ -334,9 +334,7 @@ func (self *Pss) handlePssMsg(msg interface{}) error {
 		var err error
 		if !self.isSelfPossibleRecipient(pssmsg) {
 			log.Trace("pss was for someone else :'( ... forwarding", "pss", common.ToHex(self.BaseAddr()))
-			if err := self.enqueue(pssmsg); err != nil {
-				return err
-			}
+			return self.enqueue(pssmsg)
 		}
 		log.Trace("pss for us, yay! ... let's process!", "pss", common.ToHex(self.BaseAddr()))
 


### PR DESCRIPTION
Thanks to Shane Howley:

```
Shane Howley @howleysv May 01 18:10
@nolash I was just looking at the PSS code and noticed this
https://github.com/ethersphere/go-ethereum/blob/swarm-network-rewrite/swarm/pss/pss.go#L337-L339

It seems like it shouldn't drop through this if here and should just be
return self.enqueue(pssmsg)
```