### PR TITLE
swarm/pss: Pss tick leak fix

### DIFF
--- a/swarm/pss/pss.go
+++ b/swarm/pss/pss.go
@@ -185,13 +185,15 @@ func NewPss(k network.Overlay, params *PssParams) (*Pss, error) {
 
 func (self *Pss) Start(srv *p2p.Server) error {
 	go func() {
+		ticker := time.NewTicker(defaultCleanInterval)
+		cacheTicker := time.NewTicker(self.cacheTTL)
+		defer ticker.Stop()
+		defer cacheTicker.Stop()
 		for {
-			tickC := time.Tick(defaultCleanInterval)
-			cacheTickC := time.Tick(self.cacheTTL)
 			select {
-			case <-cacheTickC:
+			case <-cacheTicker.C:
 				self.cleanFwdCache()
-			case <-tickC:
+			case <-ticker.C:
 				self.cleanKeys()
 			case <-self.quitC:
 				return


### PR DESCRIPTION
time.Tick is inherently leaky, and in Pss.Start() it is instantiated in a loop. See the godoc of the Tick implementation: "be aware that without a way to shut it down the underlying Ticker cannot be recovered by the garbage collector; it "leaks"."

Furthermore, there is no need to instantiate new Ticks in every loop, it is enough to do it once before the loop. I also modified the code to use NewTicker, so we can properly stop it, and eliminate the memory leak.