### PR TITLE
swarm/pss: Restore lost expiry handler for incoming messages

### DIFF
--- a/swarm/pss/pss.go
+++ b/swarm/pss/pss.go
@@ -325,6 +325,10 @@ func (self *Pss) handlePssMsg(msg interface{}) error {
 	pssmsg, ok := msg.(*PssMsg)
 
 	if ok {
+		if int64(pssmsg.Expire) < time.Now().Unix() {
+			log.Trace(fmt.Sprintf("pss filtered expired message FROM %x TO %x", self.Overlay.BaseAddr(), common.ToHex(pssmsg.To)))
+			return nil
+		}
 		if self.checkFwdCache(pssmsg) {
 			log.Trace(fmt.Sprintf("pss relay block-cache match (process): FROM %x TO %x", self.Overlay.BaseAddr(), common.ToHex(pssmsg.To)))
 			return nil

--- a/swarm/pss/pss.go
+++ b/swarm/pss/pss.go
@@ -324,33 +324,33 @@ func (self *Pss) getHandlers(topic Topic) map[*Handler]bool {
 func (self *Pss) handlePssMsg(msg interface{}) error {
 	pssmsg, ok := msg.(*PssMsg)
 
-	if ok {
-		if int64(pssmsg.Expire) < time.Now().Unix() {
-			log.Trace(fmt.Sprintf("pss filtered expired message FROM %x TO %x", self.Overlay.BaseAddr(), common.ToHex(pssmsg.To)))
-			return nil
-		}
-		if self.checkFwdCache(pssmsg) {
-			log.Trace(fmt.Sprintf("pss relay block-cache match (process): FROM %x TO %x", self.Overlay.BaseAddr(), common.ToHex(pssmsg.To)))
-			return nil
-		}
-		self.addFwdCache(pssmsg)
-
-		if !self.isSelfPossibleRecipient(pssmsg) {
-			log.Trace("pss was for someone else :'( ... forwarding", "pss", common.ToHex(self.BaseAddr()))
-			return self.enqueue(pssmsg)
-		}
-
-		log.Trace("pss for us, yay! ... let's process!", "pss", common.ToHex(self.BaseAddr()))
-		if err := self.process(pssmsg); err != nil {
-			qerr := self.enqueue(pssmsg)
-			if qerr != nil {
-				return fmt.Errorf("process fail: processerr %v, queueerr: %v", err, qerr)
-			}
-		}
+	if !ok {
+		return fmt.Errorf("invalid message type. Expected *PssMsg, got %T ", msg)
+	}
+	if int64(pssmsg.Expire) < time.Now().Unix() {
+		log.Trace(fmt.Sprintf("pss filtered expired message FROM %x TO %x", self.Overlay.BaseAddr(), common.ToHex(pssmsg.To)))
 		return nil
 	}
+	if self.checkFwdCache(pssmsg) {
+		log.Trace(fmt.Sprintf("pss relay block-cache match (process): FROM %x TO %x", self.Overlay.BaseAddr(), common.ToHex(pssmsg.To)))
+		return nil
+	}
+	self.addFwdCache(pssmsg)
 
-	return fmt.Errorf("invalid message type. Expected *PssMsg, got %T ", msg)
+	if !self.isSelfPossibleRecipient(pssmsg) {
+		log.Trace("pss was for someone else :'( ... forwarding", "pss", common.ToHex(self.BaseAddr()))
+		return self.enqueue(pssmsg)
+	}
+
+	log.Trace("pss for us, yay! ... let's process!", "pss", common.ToHex(self.BaseAddr()))
+	if err := self.process(pssmsg); err != nil {
+		qerr := self.enqueue(pssmsg)
+		if qerr != nil {
+			return fmt.Errorf("process fail: processerr %v, queueerr: %v", err, qerr)
+		}
+	}
+	return nil
+
 }
 
 // Entry point to processing a message for which the current node can be the intended recipient.

--- a/swarm/pss/pss_test.go
+++ b/swarm/pss/pss_test.go
@@ -299,10 +299,11 @@ func TestHandlerConditions(t *testing.T) {
 	var outmsg *PssMsg
 	select {
 	case outmsg = <-ps.outbox:
+	case <-tmr.C:
 	default:
 	}
 	if outmsg != nil {
-		t.Fatalf("expected outbox empty after full address on msg, but had message %v", msg)
+		t.Fatalf("expected outbox empty after full address on msg, but had message %s", msg)
 	}
 
 	// message should pass and queue due to partial length
@@ -361,6 +362,7 @@ func TestHandlerConditions(t *testing.T) {
 	outmsg = nil
 	select {
 	case outmsg = <-ps.outbox:
+	case <-tmr.C:
 	default:
 	}
 	if outmsg != nil {


### PR DESCRIPTION
Message expiry is under suspicion of having been lost in a commit mixup somewhere. So this it makes its appearance in this PR.