### PR TITLE
Kad simulation race fixes and sync priority setting

### DIFF
--- a/p2p/simulations/adapters/exec.go
+++ b/p2p/simulations/adapters/exec.go
@@ -349,7 +349,7 @@ func ExternalIP() net.IP {
 			return ip.IP
 		}
 	}
-	log.Crit("unable to determine explicit IP address")
+	log.Warn("unable to determine explicit IP address, falling back to loopback")
 	return net.IP{127, 0, 0, 1}
 }
 

--- a/swarm/network/common.go
+++ b/swarm/network/common.go
@@ -1,0 +1,14 @@
+package network
+
+import (
+	"fmt"
+	"strings"
+)
+
+func LogAddrs(nns [][]byte) string {
+	var nnsa []string
+	for _, nn := range nns {
+		nnsa = append(nnsa, fmt.Sprintf("%08x", nn[:4]))
+	}
+	return strings.Join(nnsa, ", ")
+}

--- a/swarm/network/hive.go
+++ b/swarm/network/hive.go
@@ -138,6 +138,7 @@ func (h *Hive) Stop() error {
 		p.Drop(nil)
 		return true
 	})
+
 	log.Info(fmt.Sprintf("%08x all peers dropped", h.BaseAddr()[:4]))
 	return nil
 }
@@ -147,7 +148,6 @@ func (h *Hive) Stop() error {
 // as well as advertises saturation depth if needed
 func (h *Hive) connect() {
 	for range h.ticker.C {
-		log.Trace(fmt.Sprintf("%08x hive connect()", h.BaseAddr()[:4]))
 
 		addr, depth, changed := h.SuggestPeer()
 		if h.Discovery && changed {
@@ -156,6 +156,8 @@ func (h *Hive) connect() {
 		if addr == nil {
 			continue
 		}
+
+		log.Trace(fmt.Sprintf("%08x hive connect() suggested %08x", h.BaseAddr()[:4], addr.Address()[:4]))
 		under, err := discover.ParseNode(string(addr.(Addr).Under()))
 		if err != nil {
 			log.Warn(fmt.Sprintf("%08x unable to connect to bee %08x: invalid node URL: %v", h.BaseAddr()[:4], addr.Address()[:4], err))

--- a/swarm/network/kademlia.go
+++ b/swarm/network/kademlia.go
@@ -146,7 +146,7 @@ func (e *entry) Bin() string {
 }
 
 // Label is a short tag for the entry for debug
-func Label(e *entry) string {
+func Label(e entry) string {
 	return fmt.Sprintf("%s (%d)", e.Hex()[:4], e.retries)
 }
 
@@ -213,8 +213,8 @@ func (k *Kademlia) Register(peers []OverlayAddr) error {
 // lowest bincount below depth
 // naturally if there is an empty row it returns a peer for that
 func (k *Kademlia) SuggestPeer() (a OverlayAddr, o int, want bool) {
-	k.lock.RLock()
-	defer k.lock.RUnlock()
+	k.lock.Lock()
+	defer k.lock.Unlock()
 	minsize := k.MinBinSize
 	depth := k.neighbourhoodDepth()
 	// if there is a callable neighbour within the current proxBin, connect
@@ -369,6 +369,7 @@ func (k *Kademlia) Off(p OverlayConn) {
 		del = true
 		return newEntry(p.Off())
 	})
+
 	if del {
 		k.conns, _, _, _ = pot.Swap(k.conns, p, pof, func(_ pot.Val) pot.Val {
 			// v cannot be nil, but no need to check
@@ -486,7 +487,6 @@ func (k *Kademlia) callable(val pot.Val) OverlayAddr {
 	for delta := timeAgo; delta > k.RetryInterval; delta /= div {
 		retries++
 	}
-
 	// this is never called concurrently, so safe to increment
 	// peer can be retried again
 	if retries < e.retries {
@@ -560,7 +560,8 @@ func (k *Kademlia) string() string {
 		row := []string{fmt.Sprintf("%2d", size)}
 		// we are displaying live peers too
 		f(func(val pot.Val, vpo int) bool {
-			row = append(row, Label(val.(*entry)))
+			e := val.(*entry)
+			row = append(row, Label(*e))
 			rowlen++
 			return rowlen < 4
 		})
@@ -631,7 +632,7 @@ func NewPeerPotMap(kadMinProxSize int, addrs [][]byte) map[string]*PeerPot {
 		for j := prev; j >= 0; j-- {
 			emptyBins = append(emptyBins, j)
 		}
-		log.Trace(fmt.Sprintf("%x NNS: %s", addrs[i][:4], logNNS(nns)))
+		log.Trace(fmt.Sprintf("%x NNS: %s", addrs[i][:4], LogAddrs(nns)))
 		ppmap[common.Bytes2Hex(a)] = &PeerPot{nns, emptyBins}
 	}
 	return ppmap
@@ -708,7 +709,7 @@ func (k *Kademlia) knowNearestNeighbours(peers [][]byte) bool {
 	return true
 }
 
-func (k *Kademlia) gotNearestNeighbours(peers [][]byte) bool {
+func (k *Kademlia) gotNearestNeighbours(peers [][]byte) (bool, int, [][]byte) {
 	pm := make(map[string]bool)
 
 	k.eachConn(nil, 255, func(p OverlayConn, po int, nn bool) bool {
@@ -719,22 +720,28 @@ func (k *Kademlia) gotNearestNeighbours(peers [][]byte) bool {
 		pm[pk] = true
 		return true
 	})
+	var gots int
+	var culprits [][]byte
 	for _, p := range peers {
 		pk := fmt.Sprintf("%x", p)
-		if !pm[pk] {
+		if pm[pk] {
+			gots++
+		} else {
 			log.Trace(fmt.Sprintf("%08x: ExpNN: %s not found", k.BaseAddr()[:4], pk[:8]))
-			return false
+			culprits = append(culprits, p)
 		}
 	}
-	return true
+	return gots == len(peers), gots, culprits
 }
 
 // Health state of the Kademlia
 type Health struct {
-	KnowNN bool // whether node knows all its nearest neighbours
-	GotNN  bool // whether node is connected to all its nearest neighbours
-	Full   bool // whether node has a peer in each kademlia bin (where there is such a peer)
-	Hive   string
+	KnowNN     bool     // whether node knows all its nearest neighbours
+	GotNN      bool     // whether node is connected to all its nearest neighbours
+	CountNN    int      // amount of nearest neighbors connected to
+	CulpritsNN [][]byte // which known NNs are missing
+	Full       bool     // whether node has a peer in each kademlia bin (where there is such a peer)
+	Hive       string
 }
 
 // Healthy reports the health state of the kademlia connectivity
@@ -742,19 +749,11 @@ type Health struct {
 func (k *Kademlia) Healthy(pp *PeerPot) *Health {
 	k.lock.RLock()
 	defer k.lock.RUnlock()
-	gotnn := k.gotNearestNeighbours(pp.NNSet)
+	gotnn, countnn, culpritsnn := k.gotNearestNeighbours(pp.NNSet)
 	knownn := k.knowNearestNeighbours(pp.NNSet)
 	full := k.full(pp.EmptyBins)
-	log.Trace(fmt.Sprintf("%08x: healthy: knowNNs: %v, gotNNs: %v, full: %v\n%v", k.BaseAddr()[:4], knownn, gotnn, full, k.string()))
-	return &Health{knownn, gotnn, full, k.string()}
-}
-
-func logNNS(nns [][]byte) string {
-	var nnsa []string
-	for _, nn := range nns {
-		nnsa = append(nnsa, fmt.Sprintf("%08x", nn[:4]))
-	}
-	return strings.Join(nnsa, ", ")
+	log.Trace(fmt.Sprintf("%08x: healthy: knowNNs: %v, gotNNs: %v, full: %v\n", k.BaseAddr()[:4], knownn, gotnn, full))
+	return &Health{knownn, gotnn, countnn, culpritsnn, full, k.string()}
 }
 
 func logEmptyBins(ebs []int) string {

--- a/swarm/network/kademlia.go
+++ b/swarm/network/kademlia.go
@@ -146,7 +146,7 @@ func (e *entry) Bin() string {
 }
 
 // Label is a short tag for the entry for debug
-func Label(e entry) string {
+func Label(e *entry) string {
 	return fmt.Sprintf("%s (%d)", e.Hex()[:4], e.retries)
 }
 
@@ -561,7 +561,7 @@ func (k *Kademlia) string() string {
 		// we are displaying live peers too
 		f(func(val pot.Val, vpo int) bool {
 			e := val.(*entry)
-			row = append(row, Label(*e))
+			row = append(row, Label(e))
 			rowlen++
 			return rowlen < 4
 		})
@@ -709,7 +709,7 @@ func (k *Kademlia) knowNearestNeighbours(peers [][]byte) bool {
 	return true
 }
 
-func (k *Kademlia) gotNearestNeighbours(peers [][]byte) (bool, int, [][]byte) {
+func (k *Kademlia) gotNearestNeighbours(peers [][]byte) (got bool, n int, missing [][]byte) {
 	pm := make(map[string]bool)
 
 	k.eachConn(nil, 255, func(p OverlayConn, po int, nn bool) bool {

--- a/swarm/network/simulations/discovery/discovery_test.go
+++ b/swarm/network/simulations/discovery/discovery_test.go
@@ -74,6 +74,7 @@ var (
 	initCount    = flag.Int("conns", 1, "number of originally connected peers	 (default 1)")
 	snapshotFile = flag.String("snapshot", "", "create snapshot")
 	loglevel     = flag.Int("loglevel", 3, "verbosity of logs")
+	rawlog       = flag.Bool("rawlog", false, "remove terminal formatting from logs")
 )
 
 func init() {
@@ -83,7 +84,7 @@ func init() {
 	adapters.RegisterServices(services)
 
 	log.PrintOrigins(true)
-	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(*loglevel), log.StreamHandler(colorable.NewColorableStderr(), log.TerminalFormat(true))))
+	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(*loglevel), log.StreamHandler(colorable.NewColorableStderr(), log.TerminalFormat(!*rawlog))))
 }
 
 // Benchmarks to test the average time it takes for an N-node ring

--- a/swarm/network/stream/snapshot_retrieval_test.go
+++ b/swarm/network/stream/snapshot_retrieval_test.go
@@ -83,14 +83,11 @@ func TestFileRetrieval(t *testing.T) {
 	if *nodes != 0 {
 		fileRetrievalTest(t, *nodes)
 	} else {
-		var nodeCnt []int
+		nodeCnt := []int{32}
 		//if the `longrunning` flag has been provided
 		//run more test combinations
 		if *longrunning {
-			nodeCnt = []int{16, 32, 128}
-		} else {
-			//default test
-			nodeCnt = []int{16}
+			nodeCnt = append(nodeCnt, 64, 128)
 		}
 		for _, n := range nodeCnt {
 			fileRetrievalTest(t, n)

--- a/swarm/network/stream/snapshot_sync_test.go
+++ b/swarm/network/stream/snapshot_sync_test.go
@@ -116,17 +116,15 @@ func TestSyncing(t *testing.T) {
 		log.Info(fmt.Sprintf("Running test with %d chunks and %d nodes...", *chunks, *nodes))
 		testSyncing(t, *chunks, *nodes)
 	} else {
-		var nodeCnt []int
-		var chnkCnt []int
+		chnkCnt := []int{128}
+		nodeCnt := []int{32}
 		//if the `longrunning` flag has been provided
 		//run more test combinations
 		if *longrunning {
-			chnkCnt = []int{1, 8, 32, 256, 1024}
-			nodeCnt = []int{16, 32, 64, 128, 256}
+			chnkCnt = append(chnkCnt, 256, 1024)
+			nodeCnt = append(nodeCnt, 64, 128, 256)
 		} else {
 			//default test
-			chnkCnt = []int{4, 32}
-			nodeCnt = []int{32, 16}
 		}
 		for _, chnk := range chnkCnt {
 			for _, n := range nodeCnt {
@@ -421,7 +419,7 @@ func runSyncTest(chunkCount int, nodeCount int, live bool, history bool) error {
 			log.Trace(fmt.Sprintf("node has chunk: %s:", chunk))
 			//check if the expected chunk is indeed in the localstore
 			if _, err := lstore.Get(chunk); err != nil {
-				log.Warn(fmt.Sprintf("Chunk %s NOT found for id %s", chunk, id))
+				log.Debug(fmt.Sprintf("Chunk %s NOT found for id %s", chunk, id))
 				allSuccess = false
 			} else {
 				log.Debug(fmt.Sprintf("Chunk %s IS FOUND for id %s", chunk, id))

--- a/swarm/network/stream/stream.go
+++ b/swarm/network/stream/stream.go
@@ -421,7 +421,7 @@ func (r *Registry) updateSyncing() {
 			delete(streams, stream)
 			delete(streams, getHistoryStream(stream))
 		}
-		err := r.RequestSubscription(p.ID(), stream, NewRange(0, 0), Top)
+		err := r.RequestSubscription(p.ID(), stream, NewRange(0, 0), High)
 		if err != nil {
 			log.Error("Request subscription", "err", err, "peer", p.ID(), "stream", stream)
 			return false

--- a/swarm/network_test.go
+++ b/swarm/network_test.go
@@ -42,7 +42,7 @@ import (
 )
 
 var (
-	loglevel     = flag.Int("loglevel", 4, "verbosity of logs")
+	loglevel     = flag.Int("loglevel", 2, "verbosity of logs")
 	longrunning  = flag.Bool("longrunning", false, "do run long-running tests")
 	waitKademlia = flag.Bool("waitkademlia", false, "wait for healthy kademlia before checking files availability")
 )


### PR DESCRIPTION
This PR extracts all the race condition fixes from #370 
all tests pass, even `-longrunning` ones (with `ulimit -n 5000`)

Crucially in the last commit it resets syncing priority to High. I believe that since it was Top, syncing delayed retrieval, potentially slowing down browser requests.