### PR TITLE
swarm/storage, swarm/api: Fix parseUpdate for multihash

### DIFF
--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -346,7 +346,7 @@ func (self *Api) Get(manifestKey storage.Key, path string) (reader *storage.Lazy
 			if err != nil {
 				apiGetNotFound.Inc(1)
 				status = http.StatusNotFound
-				log.Warn(fmt.Sprintf("get resource content error: %v", err))
+				log.Debug(fmt.Sprintf("get resource content error: %v", err))
 				return reader, mimeType, status, nil, err
 
 			}

--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -343,6 +343,13 @@ func (self *Api) Get(manifestKey storage.Key, path string) (reader *storage.Lazy
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			rsrc, err := self.resource.LookupLatestByName(ctx, entry.Hash, true, &storage.ResourceLookupParams{})
+			if err != nil {
+				apiGetNotFound.Inc(1)
+				status = http.StatusNotFound
+				log.Warn(fmt.Sprintf("get resource content error: %v", err))
+				return reader, mimeType, status, nil, err
+
+			}
 			_, rsrcData, err := self.resource.GetContent(entry.Hash)
 			if err != nil {
 				apiGetNotFound.Inc(1)

--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -441,6 +441,9 @@ func (s *Server) HandlePostResource(w http.ResponseWriter, r *Request) {
 			Respond(w, r, err.Error(), http.StatusBadRequest)
 		}
 		_, _, _, err = s.api.ResourceUpdateMultihash(r.Context(), r.uri.Addr, bytesdata)
+		if err != nil {
+			Respond(w, r, err.Error(), http.StatusBadRequest)
+		}
 	}
 	if err != nil {
 		code, err2 := s.translateResourceError(w, r, "mutable resource update fail", err)

--- a/swarm/storage/error.go
+++ b/swarm/storage/error.go
@@ -12,6 +12,7 @@ const (
 	ErrInvalidValue
 	ErrDataOverflow
 	ErrNothingToReturn
+	ErrCorruptData
 	ErrInvalidSignature
 	ErrNotSynced
 	ErrPeriodDepth

--- a/swarm/storage/resource.go
+++ b/swarm/storage/resource.go
@@ -70,7 +70,7 @@ func NewResourceError(code int, s string) error {
 		err: s,
 	}
 	switch code {
-	case ErrNotFound, ErrIO, ErrUnauthorized, ErrInvalidValue, ErrDataOverflow, ErrNothingToReturn, ErrInvalidSignature, ErrNotSynced, ErrPeriodDepth:
+	case ErrNotFound, ErrIO, ErrUnauthorized, ErrInvalidValue, ErrDataOverflow, ErrNothingToReturn, ErrInvalidSignature, ErrNotSynced, ErrPeriodDepth, ErrCorruptData:
 		r.code = code
 	}
 	return r
@@ -604,15 +604,35 @@ func (self *ResourceHandler) parseUpdate(chunkdata []byte) (*Signature, uint32, 
 	headerlength := binary.LittleEndian.Uint16(chunkdata[cursor : cursor+2])
 	cursor += 2
 	datalength := binary.LittleEndian.Uint16(chunkdata[cursor : cursor+2])
-	exclsignlength := int(headerlength + datalength + 4)
-	if exclsignlength > len(chunkdata) || exclsignlength < 14 {
+	cursor += 2
+	var exclsignlength int
+	// we need extra magic if it's a multihash
+	// TODO: merge with isMultihash code
+	if datalength == 0 {
+		uvarintbuf := bytes.NewBuffer(chunkdata[headerlength+4:])
+		r, err := binary.ReadUvarint(uvarintbuf)
+		if err != nil {
+			return nil, 0, 0, "", nil, false, NewResourceError(ErrCorruptData, fmt.Sprintf("corrupt multihash, hash id varint could not be read: %v", err))
+
+		}
+		r, err = binary.ReadUvarint(uvarintbuf)
+		if err != nil {
+			return nil, 0, 0, "", nil, false, NewResourceError(ErrCorruptData, fmt.Sprintf("corrupt multihash, hash length field could not be read: %v", err))
+
+		}
+		exclsignlength = int(headerlength + uint16(r))
+	} else {
+		exclsignlength = int(headerlength + datalength + 4)
+	}
+	if exclsignlength > len(chunkdata) {
 		return nil, 0, 0, "", nil, false, NewResourceError(ErrNothingToReturn, fmt.Sprintf("Reported headerlength %d + datalength %d longer than actual chunk data length %d", headerlength, datalength, len(chunkdata)))
+	} else if exclsignlength < 14 {
+		return nil, 0, 0, "", nil, false, NewResourceError(ErrNothingToReturn, fmt.Sprintf("Reported headerlength %d + datalength %d is smaller than minimum valid resource chunk length %d", headerlength, datalength, 14))
 	}
 	var period uint32
 	var version uint32
 	var name string
 	var data []byte
-	cursor += 2
 	period = binary.LittleEndian.Uint32(chunkdata[cursor : cursor+4])
 	cursor += 4
 	version = binary.LittleEndian.Uint32(chunkdata[cursor : cursor+4])
@@ -748,6 +768,9 @@ func (self *ResourceHandler) update(ctx context.Context, name string, data []byt
 	timeout := time.NewTimer(self.storeTimeout)
 	select {
 	case <-chunk.dbStoredC:
+		if err := chunk.GetErrored(); err != nil {
+			return nil, NewResourceError(ErrIO, fmt.Sprintf("chunk not stored: %v", err))
+		}
 	case <-timeout.C:
 		return nil, NewResourceError(ErrIO, "chunk store timeout")
 	}

--- a/swarm/storage/resource.go
+++ b/swarm/storage/resource.go
@@ -612,12 +612,16 @@ func (self *ResourceHandler) parseUpdate(chunkdata []byte) (*Signature, uint32, 
 		uvarintbuf := bytes.NewBuffer(chunkdata[headerlength+4:])
 		r, err := binary.ReadUvarint(uvarintbuf)
 		if err != nil {
-			return nil, 0, 0, "", nil, false, NewResourceError(ErrCorruptData, fmt.Sprintf("corrupt multihash, hash id varint could not be read: %v", err))
+			errstr := fmt.Sprintf("corrupt multihash, hash id varint could not be read: %v", err)
+			log.Warn(errstr)
+			return nil, 0, 0, "", nil, false, NewResourceError(ErrCorruptData, errstr)
 
 		}
 		r, err = binary.ReadUvarint(uvarintbuf)
 		if err != nil {
-			return nil, 0, 0, "", nil, false, NewResourceError(ErrCorruptData, fmt.Sprintf("corrupt multihash, hash length field could not be read: %v", err))
+			errstr := fmt.Sprintf("corrupt multihash, hash length field could not be read: %v", err)
+			log.Warn(errstr)
+			return nil, 0, 0, "", nil, false, NewResourceError(ErrCorruptData, errstr)
 
 		}
 		exclsignlength = int(headerlength + uint16(r))


### PR DESCRIPTION
This PR fixes a condition where on creating a new resource with HTTP API using multihash content the backend would panic before storing the chunk. It revealed a bug in `parseUpdate` in the backend where data offset index for multihash content was not correctly calculated, and thus the resource validator failed on the chunk.