### PR TITLE
swarm/storage: Enable remote retrieval for mutable resource

### DIFF
--- a/swarm/storage/error.go
+++ b/swarm/storage/error.go
@@ -15,6 +15,7 @@ const (
 	ErrInvalidSignature
 	ErrNotSynced
 	ErrPeriodDepth
+	ErrTimeout
 	ErrCnt
 )
 


### PR DESCRIPTION
In the current implementation, Resource Update lookups will only look for update chunks locally. This PR enables remote retrieval when chunk is not found locally.