### PR TITLE
swarm/storage: Add timeout to netstore private get

### DIFF
--- a/swarm/storage/netstore.go
+++ b/swarm/storage/netstore.go
@@ -84,7 +84,7 @@ func (self *NetStore) Get(key Key) (chunk *Chunk, err error) {
 		defer limiter.Stop()
 
 		for {
-			chunk, err := self.get(key)
+			chunk, err := self.get(key, 0)
 			if err != ErrChunkNotFound {
 				// break retry only if the error is nil
 				// or other error then ErrChunkNotFound
@@ -121,7 +121,10 @@ func (self *NetStore) Get(key Key) (chunk *Chunk, err error) {
 	}
 }
 
-func (self *NetStore) get(key Key) (chunk *Chunk, err error) {
+func (self *NetStore) get(key Key, timeout time.Duration) (chunk *Chunk, err error) {
+	if timeout == 0 {
+		timeout = searchTimeout
+	}
 	if self.retrieve == nil {
 		chunk, err = self.localStore.Get(key)
 		if err == nil {
@@ -148,7 +151,7 @@ func (self *NetStore) get(key Key) (chunk *Chunk, err error) {
 		}
 	}
 
-	t := time.NewTicker(searchTimeout)
+	t := time.NewTicker(timeout)
 	defer t.Stop()
 
 	select {

--- a/swarm/storage/resource_test.go
+++ b/swarm/storage/resource_test.go
@@ -163,7 +163,7 @@ func TestResourceHandler(t *testing.T) {
 
 	// check that the new resource is stored correctly
 	namehash := ens.EnsNode(safeName)
-	chunk, err := rh.chunkStore.(*LocalStore).memStore.Get(Key(namehash[:]))
+	chunk, err := rh.chunkStore.NetStore.localStore.memStore.Get(Key(namehash[:]))
 	if err != nil {
 		t.Fatal(err)
 	} else if len(chunk.SData) < 16 {
@@ -232,6 +232,8 @@ func TestResourceHandler(t *testing.T) {
 		Signer:    nil,
 		EthClient: rh.ethClient,
 	}
+
+	rh.chunkStore.NetStore.localStore.Close()
 	rh2, err := NewTestResourceHandler(datadir, rhparams)
 	if err != nil {
 		t.Fatal(err)
@@ -448,6 +450,7 @@ func TestResourceMultihash(t *testing.T) {
 		EnsClient: rh.ensClient,
 	}
 	// test with signed data
+	rh.chunkStore.NetStore.localStore.Close()
 	rh2, err := NewTestResourceHandler(datadir, rhparams)
 	if err != nil {
 		t.Fatal(err)
@@ -579,7 +582,7 @@ func setupTest(backend headerGetter, ensBackend *ens.ENS, signer ResourceSigner)
 		EnsClient: ensBackend,
 	}
 	rh, err = NewTestResourceHandler(datadir, rhparams)
-	return rh, datadir, cleanF, nil
+	return rh, datadir, cleanF, err
 }
 
 // Set up simulated ENS backend for use with ENSResourceHandler tests
@@ -636,7 +639,7 @@ func newTestSigner() (*GenericResourceSigner, error) {
 }
 
 func getUpdateDirect(rh *ResourceHandler, key Key) ([]byte, error) {
-	chunk, err := rh.chunkStore.(*LocalStore).memStore.Get(key)
+	chunk, err := rh.chunkStore.NetStore.localStore.memStore.Get(key)
 	if err != nil {
 		return nil, err
 	}

--- a/swarm/storage/resource_test.go
+++ b/swarm/storage/resource_test.go
@@ -163,7 +163,7 @@ func TestResourceHandler(t *testing.T) {
 
 	// check that the new resource is stored correctly
 	namehash := ens.EnsNode(safeName)
-	chunk, err := rh.chunkStore.NetStore.localStore.memStore.Get(Key(namehash[:]))
+	chunk, err := rh.chunkStore.localStore.memStore.Get(Key(namehash[:]))
 	if err != nil {
 		t.Fatal(err)
 	} else if len(chunk.SData) < 16 {
@@ -233,7 +233,7 @@ func TestResourceHandler(t *testing.T) {
 		EthClient: rh.ethClient,
 	}
 
-	rh.chunkStore.NetStore.localStore.Close()
+	rh.chunkStore.localStore.Close()
 	rh2, err := NewTestResourceHandler(datadir, rhparams)
 	if err != nil {
 		t.Fatal(err)
@@ -450,7 +450,7 @@ func TestResourceMultihash(t *testing.T) {
 		EnsClient: rh.ensClient,
 	}
 	// test with signed data
-	rh.chunkStore.NetStore.localStore.Close()
+	rh.chunkStore.localStore.Close()
 	rh2, err := NewTestResourceHandler(datadir, rhparams)
 	if err != nil {
 		t.Fatal(err)
@@ -639,7 +639,7 @@ func newTestSigner() (*GenericResourceSigner, error) {
 }
 
 func getUpdateDirect(rh *ResourceHandler, key Key) ([]byte, error) {
-	chunk, err := rh.chunkStore.NetStore.localStore.memStore.Get(key)
+	chunk, err := rh.chunkStore.localStore.memStore.Get(key)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR adds the possibility to set a timeout for a single attempt retrieving chunk through netstore. It is needed for smooth operation of resource update version polling.