### PR TITLE
swarm/network: revert change in timer

### DIFF
--- a/swarm/network/stream/syncer.go
+++ b/swarm/network/stream/syncer.go
@@ -108,7 +108,7 @@ func (s *SwarmSyncerServer) SetNextBatch(from, to uint64) ([]byte, uint64, uint6
 	for {
 		if wait {
 			if ticker == nil {
-				ticker = time.NewTicker(10000 * time.Millisecond)
+				ticker = time.NewTicker(1000 * time.Millisecond)
 			}
 			select {
 			case <-ticker.C:


### PR DESCRIPTION
This is reverting the change in the timer we introduced a day ago in order to debug the 100% disk load.