### PR TITLE
swarm/api: Support If-None-Match conditional HTTP requests

### DIFF
--- a/swarm/api/http/error.go
+++ b/swarm/api/http/error.go
@@ -150,6 +150,11 @@ func Respond(w http.ResponseWriter, req *Request, msg string, code int) {
 		log.Output(msg, log.LvlDebug, 3, "ruid", req.ruid, "code", code)
 	}
 
+	if code >= 400 {
+		w.Header().Del("Cache-Control") //avoid sending cache headers for errors!
+		w.Header().Del("ETag")
+	}
+
 	respond(w, &req.Request, &ResponseParams{
 		Code:      code,
 		Msg:       msg,


### PR DESCRIPTION
To celebrate today's hackathon in the Swarm Orange Summit 2018, I am submitting this PR to add support for conditional HTTP requests. 🙂

In my previous PR #383, an `ETag` header was added to the response headers. As a consequence, browser or downstream proxies requesting the same content again will then send an `If-None-Match` conditional request with the originally received `ETag`.

With this patch, the Swarm API now checks if content has changed, and if it hasn't, then a `304 Not Modified` short response is sent, as opposed to having to acquire the entire file and send it to the client, resulting in bandwidth savings for both the node and the end user.