### PR TITLE
swarm/network: debug wanted hashes len

### DIFF
--- a/swarm/network/stream/messages.go
+++ b/swarm/network/stream/messages.go
@@ -303,6 +303,8 @@ func (p *Peer) handleWantedHashesMsg(req *WantedHashesMsg) error {
 	}()
 	// go p.SendOfferedHashes(s, req.From, req.To)
 	l := len(hashes) / HashSize
+
+	log.Debug("wanted batch length", "peer", p.ID(), "stream", req.Stream, "from", req.From, "to", req.To, "lenhashes", len(hashes), "l", l)
 	want, err := bv.NewFromBytes(req.Want, l)
 	if err != nil {
 		return fmt.Errorf("error initiaising bitvector of length %v: %v", l, err)


### PR DESCRIPTION
I am trying to understand why the `actual get` calls are so low:

![screen shot 2018-05-09 at 11 16 37](https://user-images.githubusercontent.com/50459/39806546-79cc0ef8-537a-11e8-9232-eaa87ee4f578.png)
