### PR TITLE
swarm/storage: remove redundant counter

### DIFF
--- a/swarm/storage/ldbstore.go
+++ b/swarm/storage/ldbstore.go
@@ -41,11 +41,6 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/opt"
 )
 
-//metrics variables
-var (
-	dbStoreDeleteCounter = metrics.NewRegisteredCounter("storage.db.dbstore.rm.count", nil)
-)
-
 const (
 	gcArrayFreeRatio = 0.1
 	maxGCitems       = 5000 // max number of items to be gc'd per call to collectGarbage()
@@ -468,10 +463,11 @@ func (s *LDBStore) ReIndex() {
 }
 
 func (s *LDBStore) delete(idx uint64, idxKey []byte, po uint8) {
+	metrics.GetOrRegisterCounter("ldbstore.delete", nil).Inc(1)
+
 	batch := new(leveldb.Batch)
 	batch.Delete(idxKey)
 	batch.Delete(getDataKey(idx, po))
-	dbStoreDeleteCounter.Inc(1)
 	s.entryCnt--
 	s.bucketCnt[po]--
 	cntKey := make([]byte, 2)

--- a/swarm/storage/localstore.go
+++ b/swarm/storage/localstore.go
@@ -23,12 +23,7 @@ import (
 	"sync"
 
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/swarm/storage/mock"
-)
-
-var (
-	dbStorePutCounter = metrics.NewRegisteredCounter("storage.db.dbstore.put.count", nil)
 )
 
 type LocalStoreParams struct {
@@ -138,7 +133,6 @@ func (self *LocalStore) Put(chunk *Chunk) {
 		close(memChunk.ReqC)
 	}
 
-	dbStorePutCounter.Inc(1)
 	self.DbStore.Put(chunk)
 
 	newc := NewChunk(chunk.Key, nil)


### PR DESCRIPTION
Removing redundant counter, which we have at a different place with a better name. Also changing the name of the `delete` counter.