### PR TITLE
Write to LDBStore.batchesC on tryAccessIdx

### DIFF
--- a/swarm/storage/ldbstore.go
+++ b/swarm/storage/ldbstore.go
@@ -611,6 +611,10 @@ func (s *LDBStore) tryAccessIdx(ikey []byte, index *dpaDBIndex) bool {
 	index.Access = s.accessCnt
 	idata = encodeIndex(index)
 	s.batch.Put(ikey, idata)
+	select {
+	case s.batchesC <- struct{}{}:
+	default:
+	}
 	return true
 }
 


### PR DESCRIPTION
LDBStore method tryAccessIdx is putting data to the current batch, but batchesC is not triggered to write the batch to disk. This change should fix that.