### PR TITLE
swarm: syncer and snaphot_sync tests can use mockstore

### DIFF
--- a/bmt/bmt_r.go
+++ b/bmt/bmt_r.go
@@ -29,9 +29,9 @@ import (
 
 // RefHasher is the non-optimized easy to read reference implementation of BMT
 type RefHasher struct {
-	span    int		// c * 32, where c = 2 ^ ceil(log2(count)), where count = ceil(length / 32)
-	section int		// 64
-	cap     int		// 4096
+	span    int // c * 32, where c = 2 ^ ceil(log2(count)), where count = ceil(length / 32)
+	section int // 64
+	cap     int // 4096
 	h       hash.Hash
 }
 

--- a/swarm/network/stream/common_test.go
+++ b/swarm/network/stream/common_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/ethereum/go-ethereum/swarm/network"
 	"github.com/ethereum/go-ethereum/swarm/state"
 	"github.com/ethereum/go-ethereum/swarm/storage"
+	"github.com/ethereum/go-ethereum/swarm/storage/mock"
 	"github.com/ethereum/go-ethereum/swarm/storage/mock/db"
 	colorable "github.com/mattn/go-colorable"
 )
@@ -53,7 +54,7 @@ var (
 	loglevel     = flag.Int("loglevel", 2, "verbosity of logs")
 	nodes        = flag.Int("nodes", 0, "number of nodes")
 	chunks       = flag.Int("chunks", 0, "number of chunks")
-	useMockStore = flag.Bool("mockStore", false, "disabled mock store (default: enabled)")
+	useMockStore = flag.Bool("mockstore", false, "disabled mock store (default: enabled)")
 )
 
 var (
@@ -64,7 +65,7 @@ var (
 	createStoreFunc   func(id discover.NodeID, addr *network.BzzAddr) (storage.ChunkStore, error)
 	getRetrieveFunc   = defaultRetrieveFunc
 	subscriptionCount = 0
-	globalStore       *db.GlobalStore
+	globalStore       mock.GlobalStorer
 	globalStoreDir    string
 )
 

--- a/swarm/network/stream/common_test.go
+++ b/swarm/network/stream/common_test.go
@@ -40,18 +40,20 @@ import (
 	"github.com/ethereum/go-ethereum/swarm/network"
 	"github.com/ethereum/go-ethereum/swarm/state"
 	"github.com/ethereum/go-ethereum/swarm/storage"
+	"github.com/ethereum/go-ethereum/swarm/storage/mock/db"
 	colorable "github.com/mattn/go-colorable"
 )
 
 var (
-	deliveries map[discover.NodeID]*Delivery
-	stores     map[discover.NodeID]storage.ChunkStore
-	toAddr     func(discover.NodeID) *network.BzzAddr
-	peerCount  func(discover.NodeID) int
-	adapter    = flag.String("adapter", "sim", "type of simulation: sim|socket|exec|docker")
-	loglevel   = flag.Int("loglevel", 2, "verbosity of logs")
-	nodes      = flag.Int("nodes", 0, "number of nodes")
-	chunks     = flag.Int("chunks", 0, "number of chunks")
+	deliveries   map[discover.NodeID]*Delivery
+	stores       map[discover.NodeID]storage.ChunkStore
+	toAddr       func(discover.NodeID) *network.BzzAddr
+	peerCount    func(discover.NodeID) int
+	adapter      = flag.String("adapter", "sim", "type of simulation: sim|socket|exec|docker")
+	loglevel     = flag.Int("loglevel", 2, "verbosity of logs")
+	nodes        = flag.Int("nodes", 0, "number of nodes")
+	chunks       = flag.Int("chunks", 0, "number of chunks")
+	useMockStore = flag.Bool("mockStore", false, "disabled mock store (default: enabled)")
 )
 
 var (
@@ -62,6 +64,8 @@ var (
 	createStoreFunc   func(id discover.NodeID, addr *network.BzzAddr) (storage.ChunkStore, error)
 	getRetrieveFunc   = defaultRetrieveFunc
 	subscriptionCount = 0
+	globalStore       *db.GlobalStore
+	globalStoreDir    string
 )
 
 var services = adapters.Services{
@@ -77,6 +81,19 @@ func init() {
 
 	log.PrintOrigins(true)
 	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(*loglevel), log.StreamHandler(colorable.NewColorableStderr(), log.TerminalFormat(true))))
+}
+
+func createGlobalStore() {
+	var err error
+	globalStoreDir, err = ioutil.TempDir("", "global.store")
+	if err != nil {
+		log.Error("Error initiating global store temp directory!", "err", err)
+		return
+	}
+	globalStore, err = db.NewGlobalStore(globalStoreDir)
+	if err != nil {
+		log.Error("Error initiating global store!", "err", err)
+	}
 }
 
 // NewStreamerService
@@ -115,6 +132,9 @@ func defaultRetrieveFunc(id discover.NodeID) func(chunk *storage.Chunk) error {
 func datadirsCleanup() {
 	for _, id := range ids {
 		os.RemoveAll(datadirs[id])
+	}
+	if globalStoreDir != "" {
+		os.RemoveAll(globalStoreDir)
 	}
 }
 

--- a/swarm/network/stream/snapshot_sync_test.go
+++ b/swarm/network/stream/snapshot_sync_test.go
@@ -48,11 +48,10 @@ const MaxTimeout = 600
 var (
 	pof = pot.DefaultPof(256)
 
-	conf      *synctestConfig
-	startTime time.Time
-	ids       []discover.NodeID
-	datadirs  map[discover.NodeID]string
-	ppmap     map[string]*network.PeerPot
+	conf     *synctestConfig
+	ids      []discover.NodeID
+	datadirs map[discover.NodeID]string
+	ppmap    map[string]*network.PeerPot
 
 	live    bool
 	history bool

--- a/swarm/network/stream/snapshot_sync_test.go
+++ b/swarm/network/stream/snapshot_sync_test.go
@@ -48,10 +48,11 @@ const MaxTimeout = 600
 var (
 	pof = pot.DefaultPof(256)
 
-	conf     *synctestConfig
-	ids      []discover.NodeID
-	datadirs map[discover.NodeID]string
-	ppmap    map[string]*network.PeerPot
+	conf      *synctestConfig
+	startTime time.Time
+	ids       []discover.NodeID
+	datadirs  map[discover.NodeID]string
+	ppmap     map[string]*network.PeerPot
 
 	live    bool
 	history bool
@@ -82,7 +83,11 @@ func initSyncTest() {
 		return addr
 	}
 	//global func to create local store
-	createStoreFunc = createTestLocalStorageForId
+	if *useMockStore {
+		createStoreFunc = createMockStore
+	} else {
+		createStoreFunc = createTestLocalStorageForId
+	}
 	//local stores
 	stores = make(map[discover.NodeID]storage.ChunkStore)
 	//data directories for each node and store
@@ -100,6 +105,9 @@ func initSyncTest() {
 		}
 		return 2
 	}
+	if *useMockStore {
+		createGlobalStore()
+	}
 }
 
 //This test is a syncing test for nodes.
@@ -116,15 +124,17 @@ func TestSyncing(t *testing.T) {
 		log.Info(fmt.Sprintf("Running test with %d chunks and %d nodes...", *chunks, *nodes))
 		testSyncing(t, *chunks, *nodes)
 	} else {
-		chnkCnt := []int{128}
-		nodeCnt := []int{32}
+		var nodeCnt []int
+		var chnkCnt []int
 		//if the `longrunning` flag has been provided
 		//run more test combinations
 		if *longrunning {
-			chnkCnt = append(chnkCnt, 256, 1024)
-			nodeCnt = append(nodeCnt, 64, 128, 256)
+			chnkCnt = []int{1, 8, 32, 256, 1024}
+			nodeCnt = []int{16, 32, 64, 128, 256}
 		} else {
 			//default test
+			chnkCnt = []int{4, 32}
+			nodeCnt = []int{32, 16}
 		}
 		for _, chnk := range chnkCnt {
 			for _, n := range nodeCnt {
@@ -406,7 +416,6 @@ func runSyncTest(chunkCount int, nodeCount int, live bool, history bool) error {
 		}
 		log.Trace(fmt.Sprintf("Checking node: %s", id))
 		//select the local store for the given node
-		lstore := stores[id]
 		//if there are more than one chunk, test only succeeds if all expected chunks are found
 		allSuccess := true
 
@@ -418,8 +427,21 @@ func runSyncTest(chunkCount int, nodeCount int, live bool, history bool) error {
 			chunk := conf.hashes[ch]
 			log.Trace(fmt.Sprintf("node has chunk: %s:", chunk))
 			//check if the expected chunk is indeed in the localstore
-			if _, err := lstore.Get(chunk); err != nil {
-				log.Debug(fmt.Sprintf("Chunk %s NOT found for id %s", chunk, id))
+			var err error
+			if *useMockStore {
+				if globalStore == nil {
+					return false, fmt.Errorf("Something went wrong; using mockStore enabled but globalStore is nil")
+				}
+				//use the globalStore if the mockStore should be used; in that case,
+				//the complete localStore stack is bypassed for getting the chunk
+				_, err = globalStore.Get(common.BytesToAddress(id.Bytes()), chunk)
+			} else {
+				//use the actual localstore
+				lstore := stores[id]
+				_, err = lstore.Get(chunk)
+			}
+			if err != nil {
+				log.Warn(fmt.Sprintf("Chunk %s NOT found for id %s", chunk, id))
 				allSuccess = false
 			} else {
 				log.Debug(fmt.Sprintf("Chunk %s IS FOUND for id %s", chunk, id))

--- a/swarm/network/stream/syncer_test.go
+++ b/swarm/network/stream/syncer_test.go
@@ -21,11 +21,14 @@ import (
 	crand "crypto/rand"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"math"
+	//"os"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/ethereum/go-ethereum/p2p/simulations"
@@ -44,9 +47,33 @@ func TestSyncerSimulation(t *testing.T) {
 	testSyncBetweenNodes(t, 16, 1, dataChunkCount, true, 1)
 }
 
+func createMockStore(id discover.NodeID, addr *network.BzzAddr) (storage.ChunkStore, error) {
+	var err error
+	address := common.BytesToAddress(id.Bytes())
+	mockStore := globalStore.NewNodeStore(address)
+	params := storage.NewDefaultLocalStoreParams()
+	datadirs[id], err = ioutil.TempDir("", "localMockStore-"+id.TerminalString())
+	if err != nil {
+		return nil, err
+	}
+	params.Init(datadirs[id])
+	params.BaseKey = addr.Over()
+	lstore, err := storage.NewLocalStore(params, mockStore)
+	return lstore, nil
+}
+
 func testSyncBetweenNodes(t *testing.T, nodes, conns, chunkCount int, skipCheck bool, po uint8) {
 	defaultSkipCheck = skipCheck
-	createStoreFunc = createTestLocalStorageFromSim
+	//data directories for each node and store
+	datadirs = make(map[discover.NodeID]string)
+	if *useMockStore {
+		createStoreFunc = createMockStore
+		createGlobalStore()
+	} else {
+		createStoreFunc = createTestLocalStorageFromSim
+	}
+	defer datadirsCleanup()
+
 	registries = make(map[discover.NodeID]*TestRegistry)
 	toAddr = func(id discover.NodeID) *network.BzzAddr {
 		addr := network.NewAddrFromNodeID(id)
@@ -62,6 +89,12 @@ func testSyncBetweenNodes(t *testing.T, nodes, conns, chunkCount int, skipCheck 
 		Services:        services,
 		EnableMsgEvents: false,
 	}
+	// HACK: these are global variables in the test so that they are available for
+	// the service constructor function
+	// TODO: will this work with exec/docker adapter?
+	// localstore of nodes made available for action and check calls
+	stores = make(map[discover.NodeID]storage.ChunkStore)
+	deliveries = make(map[discover.NodeID]*Delivery)
 	// create context for simulation run
 	timeout := 30 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -79,17 +112,14 @@ func testSyncBetweenNodes(t *testing.T, nodes, conns, chunkCount int, skipCheck 
 		t.Fatal(err.Error())
 	}
 
-	// HACK: these are global variables in the test so that they are available for
-	// the service constructor function
-	// TODO: will this work with exec/docker adapter?
-	// localstore of nodes made available for action and check calls
-	stores = make(map[discover.NodeID]storage.ChunkStore)
 	nodeIndex := make(map[discover.NodeID]int)
 	for i, id := range sim.IDs {
 		nodeIndex[id] = i
-		stores[id] = sim.Stores[i]
+		if !*useMockStore {
+			stores[id] = sim.Stores[i]
+			sim.Stores[i] = stores[id]
+		}
 	}
-	deliveries = make(map[discover.NodeID]*Delivery)
 	// peerCount function gives the number of peer connections for a nodeID
 	// this is needed for the service run function to wait until
 	// each protocol  instance runs and the streamer peers are available
@@ -100,16 +130,6 @@ func testSyncBetweenNodes(t *testing.T, nodes, conns, chunkCount int, skipCheck 
 		return 2
 	}
 	waitPeerErrC = make(chan error)
-
-	// here we distribute chunks of a random file into stores 1...nodes
-	rrdpa := storage.NewDPA(newRoundRobinStore(sim.Stores[1:]...), storage.NewDPAParams())
-	size := chunkCount * chunkSize
-	_, wait, err := rrdpa.Store(io.LimitReader(crand.Reader, int64(size)), int64(size), false)
-	// need to wait cos we then immediately collect the relevant bin content
-	wait()
-	if err != nil {
-		t.Fatal(err.Error())
-	}
 
 	// create DBAPI-s for all nodes
 	dbs := make([]*storage.DBAPI, nodes)
@@ -157,6 +177,7 @@ func testSyncBetweenNodes(t *testing.T, nodes, conns, chunkCount int, skipCheck 
 		// each node Subscribes to each other's swarmChunkServerStreamName
 		for j := 0; j < nodes-1; j++ {
 			id := sim.IDs[j]
+			sim.Stores[j] = stores[id]
 			err := sim.CallClient(id, func(client *rpc.Client) error {
 				// report disconnect events to the error channel cos peers should not disconnect
 				doneC, err := streamTesting.WatchDisconnections(id, client, errc, quitC)
@@ -178,6 +199,16 @@ func testSyncBetweenNodes(t *testing.T, nodes, conns, chunkCount int, skipCheck 
 				return err
 			}
 		}
+		// here we distribute chunks of a random file into stores 1...nodes
+		rrdpa := storage.NewDPA(newRoundRobinStore(sim.Stores[1:]...), storage.NewDPAParams())
+		size := chunkCount * chunkSize
+		_, wait, err := rrdpa.Store(io.LimitReader(crand.Reader, int64(size)), int64(size), false)
+		// need to wait cos we then immediately collect the relevant bin content
+		wait()
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+
 		return nil
 	}
 
@@ -193,6 +224,7 @@ func testSyncBetweenNodes(t *testing.T, nodes, conns, chunkCount int, skipCheck 
 
 		i := nodeIndex[id]
 		var total, found int
+
 		for j := i; j < nodes; j++ {
 			total += len(hashes[j])
 			for _, key := range hashes[j] {

--- a/swarm/network/stream/syncer_test.go
+++ b/swarm/network/stream/syncer_test.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"io/ioutil"
 	"math"
-	//"os"
 	"sync"
 	"testing"
 	"time"


### PR DESCRIPTION
This PR optionally adds `mockStore` functionality to syncing test. Specifically, `snapshot_sync_test.go` and `syncer_test.go` can be run with a `mockStore`. For this to work, provide a `-mockstore true` flag when starting a test, i.e.

` go test -v github.com/ethereum/go-ethereum/swarm/network/stream -run TestSyncerSimulation -loglevel 3 -mockstore true`