### PR TITLE
swarm/storage, swarm/api: Content addressed root chunks for MRU

### DIFF
--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -406,7 +406,7 @@ func (self *Api) Get(manifestKey storage.Key, path string) (reader storage.LazyS
 		}
 
 		// regardless of resource update manifests or normal manifests we will converge at this point
-		// get the key the mamifest entry points to and serve it if it's unambiguous
+		// get the key the manifest entry points to and serve it if it's unambiguous
 		contentKey = common.Hex2Bytes(entry.Hash)
 		status = entry.Status
 		if status == http.StatusMultipleChoices {

--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -362,6 +362,7 @@ func (s *Server) HandleDelete(w http.ResponseWriter, r *Request) {
 	fmt.Fprint(w, newKey)
 }
 
+// Parses a resource update post url to corresponding action
 // possible combinations:
 // /			add multihash update to existing hash
 // /raw 		add raw update to existing hash
@@ -388,6 +389,14 @@ func resourcePostMode(path string) (isRaw bool, frequency uint64, err error) {
 	return isRaw, frequency, err
 }
 
+// Handles creation of new mutable resources and adding updates to existing mutable resources
+// There are two types of updates available, "raw" and "multihash."
+// If the latter is used, a subsequent bzz:// GET call to the manifest of the resource will return
+// the page that the multihash is pointing to, as if it held a normal swarm content manifest
+//
+// The resource name will be verbatim what is passed as the address part of the url.
+// For example, if a POST is made to /bzz-resource:/foo.eth/raw/13 a new resource with frequency 13
+// and name "foo.eth" will be created
 func (s *Server) HandlePostResource(w http.ResponseWriter, r *Request) {
 	log.Debug("handle.post.resource", "ruid", r.ruid)
 	var err error
@@ -399,8 +408,13 @@ func (s *Server) HandlePostResource(w http.ResponseWriter, r *Request) {
 		Respond(w, r, err.Error(), http.StatusBadRequest)
 		return
 	}
+
+	// new mutable resource creation will always have a frequency field larger than 0
 	if frequency > 0 {
+
 		name = r.uri.Addr
+
+		// the key is the content addressed root chunk holding mutable resource metadata information
 		key, err = s.api.ResourceCreate(r.Context(), name, frequency)
 		if err != nil {
 			code, err2 := s.translateResourceError(w, r, "resource creation fail", err)
@@ -408,26 +422,31 @@ func (s *Server) HandlePostResource(w http.ResponseWriter, r *Request) {
 			Respond(w, r, err2.Error(), code)
 			return
 		}
+
+		// we create a manifest so we can retrieve the resource with bzz:// later
+		// this manifest has a special "resource type" manifest, and its hash is the key of the mutable resource
+		// root chunk
 		m, err := s.api.NewResourceManifest(key.Hex())
 		if err != nil {
 			Respond(w, r, fmt.Sprintf("failed to create resource manifest: %v", err), http.StatusInternalServerError)
 			return
 		}
-		//		rsrcResponse := &resourceResponse{
-		//			Manifest: m,
-		//			Resource: r.uri.Addr,
-		//			Update:   key,
-		//		}
-		//e := NewManifestWalker(key)
-		outdata, err = json.Marshal(m) //rsrcResponse)
+
+		// the key to the manifest will be passed back to the client
+		// the client can access the root chunk key directly through its Hash member
+		// the manifest key should be set as content in the resolver of the ENS name
+		// \TODO update manifest key automatically in ENS
+		outdata, err = json.Marshal(m)
 		if err != nil {
 			Respond(w, r, fmt.Sprintf("failed to create json response: %s", err), http.StatusInternalServerError)
 			return
 		}
 	} else {
-		key = r.uri.Key()
-		if key == nil {
-			key, err = s.api.Resolve(r.uri)
+		// to update the resource through http we need to retrieve the key for the mutable resource root chunk
+		// that means that we retrieve the manifest and inspect its Hash member.
+		manifestKey := r.uri.Key()
+		if manifestKey == nil {
+			manifestKey, err = s.api.Resolve(r.uri)
 			if err != nil {
 				getFail.Inc(1)
 				Respond(w, r, fmt.Sprintf("cannot resolve %s: %s", r.uri.Addr, err), http.StatusNotFound)
@@ -437,7 +456,15 @@ func (s *Server) HandlePostResource(w http.ResponseWriter, r *Request) {
 			w.Header().Set("Cache-Control", "max-age=2147483648")
 		}
 
-		log.Debug("handle.post.resource: resolved", "ruid", r.ruid, "key", key)
+		// get the root chunk key from the manifest
+		key, err = s.api.ResolveResourceManifest(manifestKey)
+		if err != nil {
+			getFail.Inc(1)
+			Respond(w, r, fmt.Sprintf("error resolving resource root chunk for %s: %s", r.uri.Addr, err), http.StatusNotFound)
+			return
+		}
+
+		log.Debug("handle.post.resource: resolved", "ruid", r.ruid, "manifestkey", manifestKey, "rootchunkkey", key)
 
 		name, _, err = s.api.ResourceLookup(r.Context(), key, 0, 0, &storage.ResourceLookupParams{})
 		if err != nil {
@@ -446,30 +473,42 @@ func (s *Server) HandlePostResource(w http.ResponseWriter, r *Request) {
 		}
 	}
 
+	// Creation and update must send data aswell. This data constitutes the update data itself.
 	data, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		Respond(w, r, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
+	// Multihash will be passed as hex-encoded data, so we need to parse this to bytes
 	if isRaw {
 		_, _, _, err = s.api.ResourceUpdate(r.Context(), name, data)
+		if err != nil {
+			Respond(w, r, err.Error(), http.StatusBadRequest)
+			return
+		}
 	} else {
 		bytesdata, err := hexutil.Decode(string(data))
 		if err != nil {
 			Respond(w, r, err.Error(), http.StatusBadRequest)
+			return
 		}
-		_, _, _, err = s.api.ResourceUpdateMultihash(r.Context(), r.uri.Addr, bytesdata)
+		_, _, _, err = s.api.ResourceUpdateMultihash(r.Context(), name, bytesdata)
 		if err != nil {
 			Respond(w, r, err.Error(), http.StatusBadRequest)
+			return
 		}
 	}
-	if err != nil {
-		code, err2 := s.translateResourceError(w, r, "mutable resource update fail", err)
-		Respond(w, r, err2.Error(), code)
-		return
-	}
 
+	//
+	//	if err != nil {
+	//		code, err2 := s.translateResourceError(w, r, "mutable resource update fail", err)
+	//		Respond(w, r, err2.Error(), code)
+	//		return
+	//	}
+
+	// If we have data to return, write this now
+	// \TODO there should always be data to return here
 	if len(outdata) > 0 {
 		w.Header().Add("Content-type", "text/plain")
 		w.WriteHeader(http.StatusOK)
@@ -492,10 +531,12 @@ func (s *Server) HandleGetResource(w http.ResponseWriter, r *Request) {
 func (s *Server) handleGetResource(w http.ResponseWriter, r *Request) {
 	log.Debug("handle.get.resource", "ruid", r.ruid)
 	var err error
-	var key storage.Key
-	key = r.uri.Key()
-	if key == nil {
-		key, err = s.api.Resolve(r.uri)
+
+	// resolve the content key.
+	var manifestKey storage.Key
+	manifestKey = r.uri.Key()
+	if manifestKey == nil {
+		manifestKey, err = s.api.Resolve(r.uri)
 		if err != nil {
 			getFail.Inc(1)
 			Respond(w, r, fmt.Sprintf("cannot resolve %s: %s", r.uri.Addr, err), http.StatusNotFound)
@@ -505,8 +546,17 @@ func (s *Server) handleGetResource(w http.ResponseWriter, r *Request) {
 		w.Header().Set("Cache-Control", "max-age=2147483648")
 	}
 
-	log.Debug("handle.get.resource: resolved", "ruid", r.ruid, "key", key)
+	// get the root chunk key from the manifest
+	key, err := s.api.ResolveResourceManifest(manifestKey)
+	if err != nil {
+		getFail.Inc(1)
+		Respond(w, r, fmt.Sprintf("error resolving resource root chunk for %s: %s", r.uri.Addr, err), http.StatusNotFound)
+		return
+	}
 
+	log.Debug("handle.get.resource: resolved", "ruid", r.ruid, "manifestkey", manifestKey, "rootchunk key", key)
+
+	// determine if the query specifies period and version
 	var params []string
 	if len(r.uri.Path) > 0 {
 		params = strings.Split(r.uri.Path, "/")
@@ -516,11 +566,11 @@ func (s *Server) handleGetResource(w http.ResponseWriter, r *Request) {
 	var version uint64
 	var data []byte
 	now := time.Now()
-	log.Debug("handlegetdb", "name", name, "ruid", r.ruid)
+
 	switch len(params) {
-	case 0:
+	case 0: // latest only
 		name, data, err = s.api.ResourceLookup(r.Context(), key, 0, 0, nil)
-	case 2:
+	case 2: // specific period and version
 		version, err = strconv.ParseUint(params[1], 10, 32)
 		if err != nil {
 			break
@@ -530,21 +580,24 @@ func (s *Server) handleGetResource(w http.ResponseWriter, r *Request) {
 			break
 		}
 		name, data, err = s.api.ResourceLookup(r.Context(), key, uint32(period), uint32(version), nil)
-	case 1:
+	case 1: // last version of specific period
 		period, err = strconv.ParseUint(params[0], 10, 32)
 		if err != nil {
 			break
 		}
 		name, data, err = s.api.ResourceLookup(r.Context(), key, uint32(period), uint32(version), nil)
-	default:
-		Respond(w, r, "invalid mutable resource request", http.StatusBadRequest)
-		return
+	default: // bogus
+		err = storage.NewResourceError(storage.ErrInvalidValue, "invalid mutable resource request")
 	}
+
+	// any error from the switch statement will end up here
 	if err != nil {
 		code, err2 := s.translateResourceError(w, r, "mutable resource lookup fail", err)
 		Respond(w, r, err2.Error(), code)
 		return
 	}
+
+	// All ok, serve the retrieved update
 	log.Debug("Found update", "name", name, "ruid", r.ruid)
 	w.Header().Set("Content-Type", "application/octet-stream")
 	http.ServeContent(w, &r.Request, "", now, bytes.NewReader(data))

--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -500,13 +500,6 @@ func (s *Server) HandlePostResource(w http.ResponseWriter, r *Request) {
 		}
 	}
 
-	//
-	//	if err != nil {
-	//		code, err2 := s.translateResourceError(w, r, "mutable resource update fail", err)
-	//		Respond(w, r, err2.Error(), code)
-	//		return
-	//	}
-
 	// If we have data to return, write this now
 	// \TODO there should always be data to return here
 	if len(outdata) > 0 {
@@ -946,12 +939,6 @@ func (s *Server) HandleGetFile(w http.ResponseWriter, r *Request) {
 	}
 
 	if err != nil {
-		// cheeky, cheeky hack. See swarm/api/api.go:Api.Get() for an explanation
-		//		if rsrcErr, ok := err.(*api.ErrResourceReturn); ok {
-		//			log.Trace("getting resource proxy", "err", rsrcErr.Key())
-		//			s.handleGetResource(w, r)
-		//			return
-		//		}
 		switch status {
 		case http.StatusNotFound:
 			getFileNotFound.Inc(1)

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -175,8 +175,8 @@ func TestBzzResourceMultihash(t *testing.T) {
 	}
 }
 
-// Test resource updates using the raw methods
-func TestBzzResourceRaw(t *testing.T) {
+// Test resource updates using the raw update methods
+func TestBzzResource(t *testing.T) {
 	srv := testutil.NewTestSwarmServer(t, serverFunc)
 	defer srv.Close()
 
@@ -205,8 +205,6 @@ func TestBzzResourceRaw(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	//rsrcResp := &resourceResponse{}
-	//rsrcResp := &api.ManifestEntry{}
 	rsrcResp := &storage.Key{}
 	err = json.Unmarshal(b, rsrcResp)
 	if err != nil {
@@ -218,7 +216,7 @@ func TestBzzResourceRaw(t *testing.T) {
 		t.Fatalf("Response resource key mismatch, expected '%s', got '%s'", correctManifestKeyHex, rsrcResp.Hex())
 	}
 
-	// get manifest
+	// get the manifest
 	url = fmt.Sprintf("%s/bzz-raw:/%s", srv.URL, rsrcResp)
 	resp, err = http.Get(url)
 	if err != nil {
@@ -261,7 +259,7 @@ func TestBzzResourceRaw(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// get non-existent name
+	// get non-existent name, should fail
 	url = fmt.Sprintf("%s/bzz-resource:/bar", srv.URL)
 	resp, err = http.Get(url)
 	if err != nil {
@@ -270,8 +268,8 @@ func TestBzzResourceRaw(t *testing.T) {
 	resp.Body.Close()
 
 	// get latest update (1.1) through resource directly
-	log.Info("get update 1.1", "addr", correctRootKeyHex)
-	url = fmt.Sprintf("%s/bzz-resource:/%s", srv.URL, correctRootKeyHex)
+	log.Info("get update latest = 1.1", "addr", correctManifestKeyHex)
+	url = fmt.Sprintf("%s/bzz-resource:/%s", srv.URL, correctManifestKeyHex)
 	resp, err = http.Get(url)
 	if err != nil {
 		t.Fatal(err)
@@ -290,7 +288,7 @@ func TestBzzResourceRaw(t *testing.T) {
 
 	// update 2
 	log.Info("update 2")
-	url = fmt.Sprintf("%s/bzz-resource:/%s/raw", srv.URL, correctRootKeyHex)
+	url = fmt.Sprintf("%s/bzz-resource:/%s/raw", srv.URL, correctManifestKeyHex)
 	data := []byte("foo")
 	resp, err = http.Post(url, "application/octet-stream", bytes.NewReader(data))
 	if err != nil {
@@ -303,7 +301,7 @@ func TestBzzResourceRaw(t *testing.T) {
 
 	// get latest update (1.2) through resource directly
 	log.Info("get update 1.2")
-	url = fmt.Sprintf("%s/bzz-resource:/%s", srv.URL, correctRootKeyHex)
+	url = fmt.Sprintf("%s/bzz-resource:/%s", srv.URL, correctManifestKeyHex)
 	resp, err = http.Get(url)
 	if err != nil {
 		t.Fatal(err)
@@ -321,7 +319,8 @@ func TestBzzResourceRaw(t *testing.T) {
 	}
 
 	// get latest update (1.2) with specified period
-	url = fmt.Sprintf("%s/bzz-resource:/%s/1", srv.URL, correctRootKeyHex)
+	log.Info("get update latest = 1.2")
+	url = fmt.Sprintf("%s/bzz-resource:/%s/1", srv.URL, correctManifestKeyHex)
 	resp, err = http.Get(url)
 	if err != nil {
 		t.Fatal(err)
@@ -339,7 +338,8 @@ func TestBzzResourceRaw(t *testing.T) {
 	}
 
 	// get first update (1.1) with specified period and version
-	url = fmt.Sprintf("%s/bzz-resource:/%s/1/1", srv.URL, correctRootKeyHex)
+	log.Info("get first update 1.1")
+	url = fmt.Sprintf("%s/bzz-resource:/%s/1/1", srv.URL, correctManifestKeyHex)
 	resp, err = http.Get(url)
 	if err != nil {
 		t.Fatal(err)

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -97,7 +97,6 @@ func serverFunc(api *api.Api) testutil.TestServer {
 // and raw retrieve of that hash should return the data
 func TestBzzResourceMultihash(t *testing.T) {
 
-	//t.Skip("fixed in different branch to be merged after this PR")
 	srv := testutil.NewTestSwarmServer(t, serverFunc)
 	defer srv.Close()
 
@@ -143,7 +142,6 @@ func TestBzzResourceMultihash(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	//rsrcResp := &resourceResponse{}
 	rsrcResp := &storage.Key{}
 	err = json.Unmarshal(b, rsrcResp)
 	if err != nil {
@@ -152,7 +150,6 @@ func TestBzzResourceMultihash(t *testing.T) {
 
 	correctManifestKeyHex := "b606e1c22cae0b5173caf2c7b2bd429acd925285133b66a50d2999c388c1d48b"
 	if rsrcResp.Hex() != correctManifestKeyHex {
-		//if !bytes.Equal(rsrcResp.Update, keybyteshash.Bytes()) {
 		t.Fatalf("Response resource key mismatch, expected '%s', got '%s'", correctManifestKeyHex, rsrcResp)
 	}
 
@@ -182,7 +179,6 @@ func TestBzzResource(t *testing.T) {
 
 	// our mutable resource "name"
 	keybytes := "foo.eth"
-	//	keybyteshash := ens.EnsNode(keybytes)
 
 	// data of update 1
 	databytes := make([]byte, 666)

--- a/swarm/storage/resource.go
+++ b/swarm/storage/resource.go
@@ -991,7 +991,7 @@ func getNextPeriod(start uint64, current uint64, frequency uint64) (uint32, erro
 	return uint32(period + 1), nil
 }
 
-// Helper function to create an ascii-only value of a given resource update name
+// ToSafeName is a helper function to create an valid idna of a given resource update name
 func ToSafeName(name string) (string, error) {
 	return idna.ToASCII(name)
 }
@@ -1034,7 +1034,6 @@ func isMultihash(data []byte) int {
 	return cursor + inthashlength
 }
 
-// TODO: this should ideally not be exposed, but swarm/testutil/http.go needs it.
 func NewTestResourceHandler(datadir string, params *ResourceHandlerParams) (*ResourceHandler, error) {
 	path := filepath.Join(datadir, DbDirName)
 	rh, err := NewResourceHandler(params)

--- a/swarm/storage/resource.go
+++ b/swarm/storage/resource.go
@@ -584,7 +584,7 @@ func (self *ResourceHandler) lookup(rsrc *resource, period uint32, version uint3
 func (self *ResourceHandler) LoadResource(key Key) (*resource, error) {
 	chunk, err := self.chunkStore.get(key, defaultRetrieveTimeout)
 	if err != nil {
-		return nil, err
+		return nil, NewResourceError(ErrNotFound, err.Error())
 	}
 
 	// minimum sanity check for chunk data (an update chunk first two bytes is headerlength uint16, and cannot be 0)

--- a/swarm/storage/resource_test.go
+++ b/swarm/storage/resource_test.go
@@ -541,7 +541,18 @@ func TestResourceChunkValidator(t *testing.T) {
 	}
 	chunk := newUpdateChunk(key, &sig, 1, 1, safeName, data, len(data))
 	if !rh.Validate(chunk.Key, chunk.SData) {
-		t.Fatal("Chunk validator fail")
+		t.Fatal("Chunk validator fail on update chunk")
+	}
+
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	startBlock, err := rh.getBlock(ctx, safeName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	chunk = rh.newMetaChunk(safeName, startBlock, resourceFrequency)
+	if !rh.Validate(chunk.Key, chunk.SData) {
+		t.Fatal("Chunk validator fail on metadata chunk")
 	}
 }
 

--- a/swarm/storage/resource_test.go
+++ b/swarm/storage/resource_test.go
@@ -239,13 +239,13 @@ func TestResourceHandler(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = rh2.LookupLatest(ctx, rootChunkKey, true, nil)
+	rsrc2, err := rh2.LoadResource(rootChunkKey)
+	_, err = rh2.LookupLatest(ctx, nameHash, true, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// last update should be "clyde", version two, blockheight startblocknumber + (resourcefrequency * 3)
-	rsrc2 := rh2.getResource(nameHash.Hex())
 	if !bytes.Equal(rsrc2.data, []byte(updates[len(updates)-1])) {
 		t.Fatalf("resource data was %v, expected %v", rsrc2.data, updates[len(updates)-1])
 	}
@@ -258,7 +258,7 @@ func TestResourceHandler(t *testing.T) {
 	log.Debug("Latest lookup", "period", rsrc2.lastPeriod, "version", rsrc2.version, "data", rsrc2.data)
 
 	// specific block, latest version
-	rsrc, err := rh2.LookupHistorical(ctx, rootChunkKey, 3, true, rh2.queryMaxPeriods)
+	rsrc, err := rh2.LookupHistorical(ctx, nameHash, 3, true, rh2.queryMaxPeriods)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -269,7 +269,7 @@ func TestResourceHandler(t *testing.T) {
 	log.Debug("Historical lookup", "period", rsrc2.lastPeriod, "version", rsrc2.version, "data", rsrc2.data)
 
 	// specific block, specific version
-	rsrc, err = rh2.LookupVersion(ctx, rootChunkKey, 3, 1, true, rh2.queryMaxPeriods)
+	rsrc, err = rh2.LookupVersion(ctx, nameHash, 3, 1, true, rh2.queryMaxPeriods)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swarm/testutil/http.go
+++ b/swarm/testutil/http.go
@@ -69,7 +69,9 @@ func NewTestSwarmServer(t *testing.T, serverFunc func(*api.Api) TestServer) *Tes
 	}
 	rhparams := &storage.ResourceHandlerParams{
 		QueryMaxPeriods: &storage.ResourceLookupParams{},
-		HeaderGetter:    &fakeBackend{},
+		HeaderGetter: &fakeBackend{
+			blocknumber: 42,
+		},
 	}
 	rh, err := storage.NewTestResourceHandler(resourceDir, rhparams)
 	if err != nil {


### PR DESCRIPTION
Mutable Resources use a root chunk for metadata; starting block and frequency. This chunk is currently stored under the key `ens.EnsNode(name)` which means it cannot be overwritten or replaced later.

This PR makes the root chunk content addressed. The pointer to this root chunk will then be resolved externally; `bzz-*` retrievals will use normal ENS, which low-level retrievals can be resolved by any desired custom implementation.

The PR also removed the error return hack when retrieving MRU through `bzz://`, using a custom `storage.LazySectionReader` object instead.

It also enforces that using `bzz-resource://` methods it is the *resource manifest key* that has to be passed as a selector, *not* the root update chunk. Upon creating a new resource, only the *resource manifest key* will be returned. 