### PR TITLE
Add DeliverySkipCheck flag and tests

### DIFF
--- a/cmd/swarm/config.go
+++ b/cmd/swarm/config.go
@@ -68,6 +68,7 @@ const (
 	SWARM_ENV_SWAP_API             = "SWARM_SWAP_API"
 	SWARM_ENV_SYNC_DISABLE         = "SWARM_SYNC_DISABLE"
 	SWARM_ENV_SYNC_UPDATE_DELAY    = "SWARM_ENV_SYNC_UPDATE_DELAY"
+	SWARM_ENV_DELIVERY_SKIP_CHECK  = "SWARM_DELIVERY_SKIP_CHECK"
 	SWARM_ENV_ENS_API              = "SWARM_ENS_API"
 	SWARM_ENV_ENS_ADDR             = "SWARM_ENS_ADDR"
 	SWARM_ENV_CORS                 = "SWARM_CORS"
@@ -203,6 +204,10 @@ func cmdLineOverride(currentConfig *bzzapi.Config, ctx *cli.Context) *bzzapi.Con
 		currentConfig.SyncUpdateDelay = d
 	}
 
+	if ctx.GlobalIsSet(SwarmDeliverySkipCheckFlag.Name) {
+		currentConfig.DeliverySkipCheck = true
+	}
+
 	currentConfig.SwapApi = ctx.GlobalString(SwarmSwapAPIFlag.Name)
 	if currentConfig.SwapEnabled && currentConfig.SwapApi == "" {
 		utils.Fatalf(SWARM_ERR_SWAP_SET_NO_API)
@@ -281,6 +286,12 @@ func envVarsOverride(currentConfig *bzzapi.Config) (config *bzzapi.Config) {
 	if syncdisable := os.Getenv(SWARM_ENV_SYNC_DISABLE); syncdisable != "" {
 		if sync, err := strconv.ParseBool(syncdisable); err != nil {
 			currentConfig.SyncEnabled = !sync
+		}
+	}
+
+	if v := os.Getenv(SWARM_ENV_DELIVERY_SKIP_CHECK); v != "" {
+		if skipCheck, err := strconv.ParseBool(v); err != nil {
+			currentConfig.DeliverySkipCheck = skipCheck
 		}
 	}
 

--- a/cmd/swarm/config_test.go
+++ b/cmd/swarm/config_test.go
@@ -88,6 +88,7 @@ func TestConfigCmdLineOverrides(t *testing.T) {
 		fmt.Sprintf("--%s", SwarmSyncDisabledFlag.Name),
 		fmt.Sprintf("--%s", CorsStringFlag.Name), "*",
 		fmt.Sprintf("--%s", SwarmAccountFlag.Name), account.Address.String(),
+		fmt.Sprintf("--%s", SwarmDeliverySkipCheckFlag.Name),
 		fmt.Sprintf("--%s", EnsAPIFlag.Name), "",
 		"--datadir", dir,
 		"--ipcpath", conf.IPCPath,
@@ -128,6 +129,10 @@ func TestConfigCmdLineOverrides(t *testing.T) {
 		t.Fatal("Expected Sync to be disabled, but is true")
 	}
 
+	if !info.DeliverySkipCheck {
+		t.Fatal("Expected DeliverySkipCheck to be enabled, but it is not")
+	}
+
 	if info.Cors != "*" {
 		t.Fatalf("Expected Cors flag to be set to %s, got %s", "*", info.Cors)
 	}
@@ -148,6 +153,7 @@ func TestConfigFileOverrides(t *testing.T) {
 	defaultConf := api.NewConfig()
 	//change some values in order to test if they have been loaded
 	defaultConf.SyncEnabled = false
+	defaultConf.DeliverySkipCheck = true
 	defaultConf.NetworkId = 54
 	defaultConf.Port = httpPort
 	defaultConf.DbCapacity = 9000000
@@ -222,6 +228,10 @@ func TestConfigFileOverrides(t *testing.T) {
 		t.Fatal("Expected Sync to be disabled, but is true")
 	}
 
+	if !info.DeliverySkipCheck {
+		t.Fatal("Expected DeliverySkipCheck to be enabled, but it is not")
+	}
+
 	if info.DbCapacity != 9000000 {
 		t.Fatalf("Expected network ID to be %d, got %d", 54, info.NetworkId)
 	}
@@ -253,6 +263,7 @@ func TestConfigEnvVars(t *testing.T) {
 	envVars = append(envVars, fmt.Sprintf("%s=%s", SwarmNetworkIdFlag.EnvVar, "999"))
 	envVars = append(envVars, fmt.Sprintf("%s=%s", CorsStringFlag.EnvVar, "*"))
 	envVars = append(envVars, fmt.Sprintf("%s=%s", SwarmSyncDisabledFlag.EnvVar, "true"))
+	envVars = append(envVars, fmt.Sprintf("%s=%s", SwarmDeliverySkipCheckFlag.EnvVar, "true"))
 
 	dir, err := ioutil.TempDir("", "bzztest")
 	if err != nil {
@@ -331,6 +342,10 @@ func TestConfigEnvVars(t *testing.T) {
 
 	if info.SyncEnabled {
 		t.Fatal("Expected Sync to be disabled, but is true")
+	}
+
+	if !info.DeliverySkipCheck {
+		t.Fatal("Expected DeliverySkipCheck to be enabled, but it is not")
 	}
 
 	node.Shutdown()

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -107,6 +107,11 @@ var (
 		Usage:  "Duration for sync subscriptions update after no new peers are added (default 15s)",
 		EnvVar: SWARM_ENV_SYNC_UPDATE_DELAY,
 	}
+	SwarmDeliverySkipCheckFlag = cli.BoolFlag{
+		Name:   "delivery-skip-check",
+		Usage:  "Skip chunk delivery check (default false)",
+		EnvVar: SWARM_ENV_DELIVERY_SKIP_CHECK,
+	}
 	EnsAPIFlag = cli.StringSliceFlag{
 		Name:   "ens-api",
 		Usage:  "ENS API endpoint for a TLD and with contract address, can be repeated, format [tld:][contract-addr@]url",
@@ -343,6 +348,7 @@ Remove corrupt entries from a local chunk database.
 		SwarmSwapAPIFlag,
 		SwarmSyncDisabledFlag,
 		SwarmSyncUpdateDelay,
+		SwarmDeliverySkipCheckFlag,
 		SwarmListenAddrFlag,
 		SwarmPortFlag,
 		SwarmAccountFlag,

--- a/swarm/api/config.go
+++ b/swarm/api/config.go
@@ -50,24 +50,25 @@ type Config struct {
 	Swap *swap.SwapParams
 	Pss  *pss.PssParams
 	//*network.SyncParams
-	Contract        common.Address
-	EnsRoot         common.Address
-	EnsAPIs         []string
-	Path            string
-	ListenAddr      string
-	Port            string
-	PublicKey       string
-	BzzKey          string
-	NodeID          string
-	NetworkId       uint64
-	SwapEnabled     bool
-	SyncEnabled     bool
-	SyncUpdateDelay time.Duration
-	SwapApi         string
-	Cors            string
-	BzzAccount      string
-	BootNodes       string
-	privateKey      *ecdsa.PrivateKey
+	Contract          common.Address
+	EnsRoot           common.Address
+	EnsAPIs           []string
+	Path              string
+	ListenAddr        string
+	Port              string
+	PublicKey         string
+	BzzKey            string
+	NodeID            string
+	NetworkId         uint64
+	SwapEnabled       bool
+	SyncEnabled       bool
+	DeliverySkipCheck bool
+	SyncUpdateDelay   time.Duration
+	SwapApi           string
+	Cors              string
+	BzzAccount        string
+	BootNodes         string
+	privateKey        *ecdsa.PrivateKey
 }
 
 //create a default config with all parameters to set to defaults
@@ -78,19 +79,20 @@ func NewConfig() (self *Config) {
 		DPAParams:        storage.NewDPAParams(),
 		HiveParams:       network.NewHiveParams(),
 		//SyncParams:    network.NewDefaultSyncParams(),
-		Swap:            swap.NewDefaultSwapParams(),
-		Pss:             pss.NewPssParams(),
-		ListenAddr:      DefaultHTTPListenAddr,
-		Port:            DefaultHTTPPort,
-		Path:            node.DefaultDataDir(),
-		EnsAPIs:         nil,
-		EnsRoot:         ens.TestNetAddress,
-		NetworkId:       network.NetworkID,
-		SwapEnabled:     false,
-		SyncEnabled:     true,
-		SyncUpdateDelay: 15 * time.Second,
-		SwapApi:         "",
-		BootNodes:       "",
+		Swap:              swap.NewDefaultSwapParams(),
+		Pss:               pss.NewPssParams(),
+		ListenAddr:        DefaultHTTPListenAddr,
+		Port:              DefaultHTTPPort,
+		Path:              node.DefaultDataDir(),
+		EnsAPIs:           nil,
+		EnsRoot:           ens.TestNetAddress,
+		NetworkId:         network.NetworkID,
+		SwapEnabled:       false,
+		SyncEnabled:       true,
+		DeliverySkipCheck: false,
+		SyncUpdateDelay:   15 * time.Second,
+		SwapApi:           "",
+		BootNodes:         "",
 	}
 
 	return

--- a/swarm/network/stream/common_test.go
+++ b/swarm/network/stream/common_test.go
@@ -413,3 +413,16 @@ func (s *testExternalServer) GetData([]byte) ([]byte, error) {
 }
 
 func (s *testExternalServer) Close() {}
+
+// Sets the global value defaultSkipCheck.
+// It should be used in test function defer to reset the global value
+// to the original value.
+//
+// defer setDefaultSkipCheck(defaultSkipCheck)
+// defaultSkipCheck = skipCheck
+//
+// This works as defer function arguments evaluations are evaluated as ususal,
+// but only the function body invocation is deferred.
+func setDefaultSkipCheck(skipCheck bool) {
+	defaultSkipCheck = skipCheck
+}

--- a/swarm/network/stream/intervals_test.go
+++ b/swarm/network/stream/intervals_test.go
@@ -69,17 +69,22 @@ func newIntervalsStreamerService(ctx *adapters.ServiceContext) (node.Service, er
 }
 
 func TestIntervals(t *testing.T) {
-	testIntervals(t, true, nil)
-	testIntervals(t, false, NewRange(9, 26))
-	testIntervals(t, true, NewRange(9, 26))
+	testIntervals(t, true, nil, false)
+	testIntervals(t, false, NewRange(9, 26), false)
+	testIntervals(t, true, NewRange(9, 26), false)
+
+	testIntervals(t, true, nil, true)
+	testIntervals(t, false, NewRange(9, 26), true)
+	testIntervals(t, true, NewRange(9, 26), true)
 }
 
-func testIntervals(t *testing.T, live bool, history *Range) {
+func testIntervals(t *testing.T, live bool, history *Range, skipCheck bool) {
 	nodes := 2
 	chunkCount := dataChunkCount
-	skipCheck := false
 
+	defer setDefaultSkipCheck(defaultSkipCheck)
 	defaultSkipCheck = skipCheck
+
 	toAddr = network.NewAddrFromNodeID
 	conf := &streamTesting.RunConfig{
 		Adapter:        *adapter,

--- a/swarm/network/stream/syncer_test.go
+++ b/swarm/network/stream/syncer_test.go
@@ -45,6 +45,7 @@ func TestSyncerSimulation(t *testing.T) {
 }
 
 func testSyncBetweenNodes(t *testing.T, nodes, conns, chunkCount int, skipCheck bool, po uint8) {
+	defer setDefaultSkipCheck(defaultSkipCheck)
 	defaultSkipCheck = skipCheck
 	createStoreFunc = createTestLocalStorageFromSim
 	registries = make(map[discover.NodeID]*TestRegistry)

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -179,6 +179,7 @@ func NewSwarm(ctx *node.ServiceContext, backend chequebook.Backend, config *api.
 	delivery := stream.NewDelivery(to, db)
 
 	self.streamer = stream.NewRegistry(addr, delivery, db, stateStore, &stream.RegistryOptions{
+		SkipCheck:       config.DeliverySkipCheck,
 		DoSync:          config.SyncEnabled,
 		DoRetrieve:      true,
 		SyncUpdateDelay: config.SyncUpdateDelay,


### PR DESCRIPTION
Closes https://github.com/ethersphere/go-ethereum/issues/403.

New CLI flag DeliverySkipCheck is added with tests.
Tests swarm.TestSwarmNetwork and stream.TestIntervals is updated with tests where SkipCheck is enabled.