### PR TITLE
Increase overlay sim test timeout

### DIFF
--- a/swarm/network/simulations/overlay_test.go
+++ b/swarm/network/simulations/overlay_test.go
@@ -88,7 +88,7 @@ func TestOverlaySim(t *testing.T) {
 	trigger := make(chan discover.NodeID)
 
 	//wait for all nodes to be up
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	//start watching node up events...


### PR DESCRIPTION
Overlay sim test often times out with this message:
```
-- FAIL: TestOverlaySim (3.05s)
	overlay_test.go:109: Timed out waiting for up events
```
e.g.: https://travis-ci.org/ethersphere/go-ethereum/jobs/379187507

I increased the timeout make this test more stable