### PR TITLE
swarm/pss, swarm/resource: Pss notifications for MRUs

### DIFF
--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -37,6 +37,7 @@ import (
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/swarm/multihash"
 	"github.com/ethereum/go-ethereum/swarm/storage"
+	"github.com/ethereum/go-ethereum/swarm/storage/resource"
 )
 
 type ErrResourceReturn struct {
@@ -213,13 +214,13 @@ on top of the dpa
 it is the public interface of the dpa which is included in the ethereum stack
 */
 type Api struct {
-	resource *storage.ResourceHandler
+	resource *resource.ResourceHandler
 	dpa      *storage.DPA
 	dns      Resolver
 }
 
 //the api constructor initialises
-func NewApi(dpa *storage.DPA, dns Resolver, resourceHandler *storage.ResourceHandler) (self *Api) {
+func NewApi(dpa *storage.DPA, dns Resolver, resourceHandler *resource.ResourceHandler) (self *Api) {
 	self = &Api{
 		dpa:      dpa,
 		dns:      dns,
@@ -342,7 +343,7 @@ func (self *Api) Get(manifestKey storage.Key, path string) (reader *storage.Lazy
 			log.Trace("resource type", "key", manifestKey, "hash", entry.Hash)
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			rsrc, err := self.resource.LookupLatestByName(ctx, entry.Hash, true, &storage.ResourceLookupParams{})
+			rsrc, err := self.resource.LookupLatestByName(ctx, entry.Hash, true, &resource.ResourceLookupParams{})
 			if err != nil {
 				apiGetNotFound.Inc(1)
 				status = http.StatusNotFound
@@ -648,11 +649,11 @@ func (self *Api) BuildDirectoryTree(mhash string, nameresolver bool) (key storag
 }
 
 // Look up mutable resource updates at specific periods and versions
-func (self *Api) ResourceLookup(ctx context.Context, name string, period uint32, version uint32, maxLookup *storage.ResourceLookupParams) (storage.Key, []byte, error) {
+func (self *Api) ResourceLookup(ctx context.Context, name string, period uint32, version uint32, maxLookup *resource.ResourceLookupParams) (storage.Key, []byte, error) {
 	var err error
 	if version != 0 {
 		if period == 0 {
-			return nil, nil, storage.NewResourceError(storage.ErrInvalidValue, "Period can't be 0")
+			return nil, nil, resource.NewResourceError(resource.ErrInvalidValue, "Period can't be 0")
 		}
 		_, err = self.resource.LookupVersionByName(ctx, name, period, version, true, maxLookup)
 	} else if period != 0 {

--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -43,6 +43,7 @@ import (
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/swarm/api"
 	"github.com/ethereum/go-ethereum/swarm/storage"
+	"github.com/ethereum/go-ethereum/swarm/storage/resource"
 	"github.com/pborman/uuid"
 	"github.com/rs/cors"
 )
@@ -421,7 +422,7 @@ func (s *Server) HandlePostResource(w http.ResponseWriter, r *Request) {
 			return
 		}
 	} else {
-		_, _, err := s.api.ResourceLookup(r.Context(), r.uri.Addr, 0, 0, &storage.ResourceLookupParams{})
+		_, _, err := s.api.ResourceLookup(r.Context(), r.uri.Addr, 0, 0, &resource.ResourceLookupParams{})
 		if err != nil {
 			Respond(w, r, err.Error(), http.StatusNotFound)
 			return
@@ -520,18 +521,18 @@ func (s *Server) handleGetResource(w http.ResponseWriter, r *Request, name strin
 func (s *Server) translateResourceError(w http.ResponseWriter, r *Request, supErr string, err error) (int, error) {
 	code := 0
 	defaultErr := fmt.Errorf("%s: %v", supErr, err)
-	rsrcErr, ok := err.(*storage.ResourceError)
+	rsrcErr, ok := err.(*resource.ResourceError)
 	if !ok && rsrcErr != nil {
 		code = rsrcErr.Code()
 	}
 	switch code {
-	case storage.ErrInvalidValue:
+	case resource.ErrInvalidValue:
 		return http.StatusBadRequest, defaultErr
-	case storage.ErrNotFound, storage.ErrNotSynced, storage.ErrNothingToReturn, storage.ErrInit:
+	case resource.ErrNotFound, resource.ErrNotSynced, resource.ErrNothingToReturn, resource.ErrInit:
 		return http.StatusNotFound, defaultErr
-	case storage.ErrUnauthorized, storage.ErrInvalidSignature:
+	case resource.ErrUnauthorized, resource.ErrInvalidSignature:
 		return http.StatusUnauthorized, defaultErr
-	case storage.ErrDataOverflow:
+	case resource.ErrDataOverflow:
 		return http.StatusRequestEntityTooLarge, defaultErr
 	}
 

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -98,7 +98,6 @@ func serverFunc(api *api.Api) testutil.TestServer {
 // and raw retrieve of that hash should return the data
 func TestBzzResourceMultihash(t *testing.T) {
 
-	t.Skip("fixed in different branch to be merged after this PR")
 	srv := testutil.NewTestSwarmServer(t, serverFunc)
 	defer srv.Close()
 

--- a/swarm/pss/api.go
+++ b/swarm/pss/api.go
@@ -56,6 +56,7 @@ func (pssapi *API) Receive(ctx context.Context, topic Topic) (*rpc.Subscription,
 	}
 
 	deregf := pssapi.Register(&topic, handler)
+	log.Trace("registered handler for api subscribe", "topic", fmt.Sprintf("%x", topic))
 	go func() {
 		defer deregf()
 		select {

--- a/swarm/pss/handshake.go
+++ b/swarm/pss/handshake.go
@@ -369,7 +369,7 @@ func (self *HandshakeController) sendKey(pubkeyid string, topic *Topic, keycount
 	// generate new keys to send
 	for i := 0; i < len(recvkeyids); i++ {
 		var err error
-		recvkeyids[i], err = self.pss.generateSymmetricKey(*topic, to, true)
+		recvkeyids[i], err = self.pss.GenerateSymmetricKey(*topic, to, true)
 		if err != nil {
 			return []string{}, fmt.Errorf("set receive symkey fail (pubkey %x topic %x): %v", pubkeyid, topic, err)
 		}

--- a/swarm/pss/notify/notify.go
+++ b/swarm/pss/notify/notify.go
@@ -94,8 +94,13 @@ func NewController(ps *pss.Pss) *Controller {
 	return ctrl
 }
 
+func (self *Controller) IsActive(name string) bool {
+	_, ok := self.notifiers[name]
+	return ok
+}
+
 func (self *Controller) NewNotifier(name string, threshold int, contentFunc func(string) ([]byte, error)) error {
-	if _, ok := self.notifiers[name]; ok {
+	if self.IsActive(name) {
 		return fmt.Errorf("%s already exists in controller", name)
 	}
 	self.notifiers[name] = &notifier{

--- a/swarm/pss/notify/notify_test.go
+++ b/swarm/pss/notify/notify_test.go
@@ -1,0 +1,251 @@
+package notify
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/p2p/discover"
+	"github.com/ethereum/go-ethereum/p2p/simulations"
+	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
+	"github.com/ethereum/go-ethereum/swarm/network"
+	"github.com/ethereum/go-ethereum/swarm/pss"
+	"github.com/ethereum/go-ethereum/swarm/state"
+	whisper "github.com/ethereum/go-ethereum/whisper/whisperv5"
+)
+
+var (
+	loglevel = flag.Int("l", 3, "loglevel")
+	psses    []*pss.Pss
+	w        *whisper.Whisper
+	wapi     *whisper.PublicWhisperAPI
+	msgSeq   int
+)
+
+func init() {
+	flag.Parse()
+	hs := log.StreamHandler(os.Stderr, log.TerminalFormat(true))
+	hf := log.LvlFilterHandler(log.Lvl(*loglevel), hs)
+	h := log.CallerFileHandler(hf)
+	log.Root().SetHandler(h)
+
+	w = whisper.New(&whisper.DefaultConfig)
+	wapi = whisper.NewPublicWhisperAPI(w)
+}
+
+func TestMsgSerialize(t *testing.T) {
+	msg := &Msg{
+		Name:    "foo.eth",
+		Payload: []byte("xyzzy"),
+		Code:    MsgCodeNotify,
+	}
+	smsg := msg.Serialize()
+	serialResult := []byte{MsgCodeNotify, 0x7, 0x0, 0x5, 0x0, 0x66, 0x6f, 0x6f, 0x2e, 0x65, 0x74, 0x68, 0x78, 0x79, 0x7a, 0x7a, 0x79}
+	if !bytes.Equal(smsg, serialResult) {
+		t.Fatalf("Serialize error, expected %x, got %x", serialResult, smsg)
+	}
+
+	dmsg, err := deserializeMsg(smsg)
+	if err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(dmsg, msg) {
+		t.Fatal("deserialized message does not equal original")
+	}
+}
+
+func TestStart(t *testing.T) {
+	adapter := adapters.NewSimAdapter(newServices(false))
+	net := simulations.NewNetwork(adapter, &simulations.NetworkConfig{
+		ID:             "0",
+		DefaultService: "bzz",
+	})
+	l_nodeconf := adapters.RandomNodeConfig()
+	l_nodeconf.Services = []string{"bzz", "pss"}
+	l_node, err := net.NewNodeWithConfig(l_nodeconf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = net.Start(l_node.ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r_nodeconf := adapters.RandomNodeConfig()
+	r_nodeconf.Services = []string{"bzz", "pss"}
+	r_node, err := net.NewNodeWithConfig(r_nodeconf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = net.Start(r_node.ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = net.Connect(r_node.ID(), l_node.ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	l_rpc, err := l_node.Client()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r_rpc, err := r_node.Client()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var l_addr string
+	err = l_rpc.Call(&l_addr, "pss_baseAddr")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var r_addr string
+	err = r_rpc.Call(&r_addr, "pss_baseAddr")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var l_pub string
+	err = l_rpc.Call(&l_pub, "pss_getPublicKey")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = r_rpc.Call(nil, "pss_setPeerPublicKey", l_pub, controlTopic, l_addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rsrcName := "foo.eth"
+	rsrcTopic := pss.BytesToTopic([]byte(rsrcName))
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+	rmsgC := make(chan *pss.APIMsg)
+	r_sub, err := r_rpc.Subscribe(ctx, "pss", rmsgC, "receive", controlTopic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r_sub.Unsubscribe()
+	r_sub_update, err := r_rpc.Subscribe(ctx, "pss", rmsgC, "receive", rsrcTopic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r_sub_update.Unsubscribe()
+
+	updateMsg := []byte("xyzzy")
+	ctrl := NewController(psses[0])
+	ctrl.NewNotifier("foo.eth", 2, func(name string) ([]byte, error) {
+		msgSeq++
+		return updateMsg, nil
+	})
+
+	msg := &Msg{
+		Name:    rsrcName,
+		Payload: common.FromHex(r_addr),
+		Code:    MsgCodeStart,
+	}
+
+	err = r_rpc.Call(nil, "pss_sendAsym", l_pub, controlTopic, common.ToHex(msg.Serialize()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var inMsg *pss.APIMsg
+	select {
+	case inMsg = <-rmsgC:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	dMsg, err := deserializeMsg(inMsg.Msg)
+	if err != nil {
+		t.Fatal(err)
+	} else if dMsg.Name != rsrcName {
+		t.Fatalf("expected name %s, got %s", rsrcName, dMsg.Name)
+	} else if !bytes.Equal(dMsg.Payload[:len(updateMsg)], updateMsg) {
+		t.Fatalf("expected payload first %d bytes '%x', got '%x'", len(updateMsg), updateMsg, dMsg.Payload[:len(updateMsg)])
+	} else if len(updateMsg)+symKeyLength != len(dMsg.Payload) {
+		t.Fatalf("expected payload length %d, have %d", len(updateMsg)+symKeyLength, len(dMsg.Payload))
+	}
+
+	l_pssAddr := pss.PssAddress(common.FromHex(l_addr))
+	psses[1].SetSymmetricKey(dMsg.Payload[len(updateMsg):], rsrcTopic, &l_pssAddr, true)
+
+	nextUpdateMsg := []byte("plugh")
+	ctrl.Notify(rsrcName, nextUpdateMsg)
+	select {
+	case inMsg = <-rmsgC:
+	case <-ctx.Done():
+		log.Error("timed out waiting for msg", "topic", fmt.Sprintf("%x", rsrcTopic))
+		t.Fatal(ctx.Err())
+	}
+	dMsg, err = deserializeMsg(inMsg.Msg)
+	if err != nil {
+		t.Fatal(err)
+	} else if dMsg.Name != rsrcName {
+		t.Fatalf("expected name %s, got %s", rsrcName, dMsg.Name)
+	} else if !bytes.Equal(dMsg.Payload, nextUpdateMsg) {
+		t.Fatalf("expected payload '%x', got '%x'", nextUpdateMsg, dMsg.Payload)
+	}
+
+}
+
+func newServices(allowRaw bool) adapters.Services {
+	stateStore := state.NewInmemoryStore()
+	kademlias := make(map[discover.NodeID]*network.Kademlia)
+	kademlia := func(id discover.NodeID) *network.Kademlia {
+		if k, ok := kademlias[id]; ok {
+			return k
+		}
+		addr := network.NewAddrFromNodeID(id)
+		params := network.NewKadParams()
+		params.MinProxBinSize = 2
+		params.MaxBinSize = 3
+		params.MinBinSize = 1
+		params.MaxRetries = 1000
+		params.RetryExponent = 2
+		params.RetryInterval = 1000000
+		kademlias[id] = network.NewKademlia(addr.Over(), params)
+		return kademlias[id]
+	}
+	return adapters.Services{
+		"pss": func(ctx *adapters.ServiceContext) (node.Service, error) {
+			ctxlocal, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			keys, err := wapi.NewKeyPair(ctxlocal)
+			privkey, err := w.GetPrivateKey(keys)
+			pssp := pss.NewPssParams().WithPrivateKey(privkey)
+			pssp.MsgTTL = time.Second * 30
+			pssp.AllowRaw = allowRaw
+			pskad := kademlia(ctx.Config.ID)
+			ps, err := pss.NewPss(pskad, pssp)
+			if err != nil {
+				return nil, err
+			}
+			psses = append(psses, ps)
+			return ps, nil
+		},
+		"bzz": func(ctx *adapters.ServiceContext) (node.Service, error) {
+			addr := network.NewAddrFromNodeID(ctx.Config.ID)
+			hp := network.NewHiveParams()
+			hp.Discovery = false
+			config := &network.BzzConfig{
+				OverlayAddr:  addr.Over(),
+				UnderlayAddr: addr.Under(),
+				HiveParams:   hp,
+			}
+			return network.NewBzz(config, kademlia(ctx.Config.ID), stateStore, nil, nil), nil
+		},
+	}
+}

--- a/swarm/pss/protocol_test.go
+++ b/swarm/pss/protocol_test.go
@@ -37,7 +37,7 @@ func testProtocol(t *testing.T) {
 
 	topic := PingTopic.String()
 
-	clients, err := setupNetwork(2, false)
+	clients, err := SetupNetwork(2, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swarm/pss/protocol_test.go
+++ b/swarm/pss/protocol_test.go
@@ -37,7 +37,7 @@ func testProtocol(t *testing.T) {
 
 	topic := PingTopic.String()
 
-	clients, err := SetupNetwork(2, false)
+	clients, err := setupNetwork(2, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swarm/pss/pss.go
+++ b/swarm/pss/pss.go
@@ -450,7 +450,7 @@ func (self *Pss) SetPeerPublicKey(pubkey *ecdsa.PublicKey, topic Topic, address 
 }
 
 // Automatically generate a new symkey for a topic and address hint
-func (self *Pss) generateSymmetricKey(topic Topic, address *PssAddress, addToCache bool) (string, error) {
+func (self *Pss) GenerateSymmetricKey(topic Topic, address *PssAddress, addToCache bool) (string, error) {
 	keyid, err := self.w.GenerateSymKey()
 	if err != nil {
 		return "", err

--- a/swarm/pss/pss.go
+++ b/swarm/pss/pss.go
@@ -404,7 +404,7 @@ func (self *Pss) executeHandlers(topic Topic, payload []byte, from *PssAddress, 
 	for f := range handlers {
 		err := (*f)(payload, p, asymmetric, keyid)
 		if err != nil {
-			log.Warn("Pss handler %p failed: %v", f, err)
+			log.Warn("Pss handler failed", "handler", fmt.Sprintf("%p", f), "err", err)
 		}
 	}
 }

--- a/swarm/pss/pss.go
+++ b/swarm/pss/pss.go
@@ -334,7 +334,7 @@ func (self *Pss) handlePssMsg(msg interface{}) error {
 		return nil
 	}
 	if self.checkFwdCache(pssmsg) {
-		log.Trace(fmt.Sprintf("pss relay block-cache match (process): FROM %x TO %x", self.Overlay.BaseAddr(), common.ToHex(pssmsg.To)))
+		log.Trace(fmt.Sprintf("pss relay block-cache match (process): FROM %x TO %x", self.Overlay.BaseAddr(), pssmsg.To))
 		return nil
 	}
 	self.addFwdCache(pssmsg)
@@ -350,6 +350,7 @@ func (self *Pss) handlePssMsg(msg interface{}) error {
 		if qerr != nil {
 			return fmt.Errorf("process fail: processerr %v, queueerr: %v", err, qerr)
 		}
+		log.Trace("process msg fail", "err", err)
 	}
 	return nil
 
@@ -790,7 +791,7 @@ func (self *Pss) forward(msg *PssMsg) error {
 			log.Trace(fmt.Sprintf("Pss keep forwarding: Partial address + full partial match"))
 			return true
 		} else if isproxbin {
-			log.Trace(fmt.Sprintf("%x is in proxbin, keep forwarding", common.ToHex(op.Address())))
+			log.Trace(fmt.Sprintf("%x is in proxbin, keep forwarding", op.Address()))
 			return true
 		}
 		// at this point we stop forwarding, and the state is as follows:

--- a/swarm/pss/pss_test.go
+++ b/swarm/pss/pss_test.go
@@ -429,7 +429,7 @@ func TestKeys(t *testing.T) {
 	}
 
 	// make a symmetric key that we will send to peer for encrypting messages to us
-	inkeyid, err := ps.generateSymmetricKey(topicobj, &addr, true)
+	inkeyid, err := ps.GenerateSymmetricKey(topicobj, &addr, true)
 	if err != nil {
 		t.Fatalf("failed to set 'our' incoming symmetric key")
 	}
@@ -1178,7 +1178,7 @@ func benchmarkSymKeySend(b *testing.B) {
 	topic := BytesToTopic([]byte("foo"))
 	to := make(PssAddress, 32)
 	copy(to[:], network.RandomAddr().Over())
-	symkeyid, err := ps.generateSymmetricKey(topic, &to, true)
+	symkeyid, err := ps.GenerateSymmetricKey(topic, &to, true)
 	if err != nil {
 		b.Fatalf("could not generate symkey: %v", err)
 	}
@@ -1271,7 +1271,7 @@ func benchmarkSymkeyBruteforceChangeaddr(b *testing.B) {
 	for i := 0; i < int(keycount); i++ {
 		to := make(PssAddress, 32)
 		copy(to[:], network.RandomAddr().Over())
-		keyid, err = ps.generateSymmetricKey(topic, &to, true)
+		keyid, err = ps.GenerateSymmetricKey(topic, &to, true)
 		if err != nil {
 			b.Fatalf("cant generate symkey #%d: %v", i, err)
 		}
@@ -1353,7 +1353,7 @@ func benchmarkSymkeyBruteforceSameaddr(b *testing.B) {
 	topic := BytesToTopic([]byte("foo"))
 	for i := 0; i < int(keycount); i++ {
 		copy(addr[i], network.RandomAddr().Over())
-		keyid, err = ps.generateSymmetricKey(topic, &addr[i], true)
+		keyid, err = ps.GenerateSymmetricKey(topic, &addr[i], true)
 		if err != nil {
 			b.Fatalf("cant generate symkey #%d: %v", i, err)
 		}

--- a/swarm/pss/pss_test.go
+++ b/swarm/pss/pss_test.go
@@ -3,6 +3,7 @@ package pss
 import (
 	"bytes"
 	"context"
+	"crypto/ecdsa"
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
@@ -22,6 +23,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/ethereum/go-ethereum/p2p/protocols"
@@ -29,6 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/swarm/network"
+	"github.com/ethereum/go-ethereum/swarm/state"
 	whisper "github.com/ethereum/go-ethereum/whisper/whisperv5"
 )
 

--- a/swarm/resource_test.go
+++ b/swarm/resource_test.go
@@ -1,0 +1,162 @@
+package swarm
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/p2p/discover"
+	"github.com/ethereum/go-ethereum/p2p/simulations"
+	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
+	"github.com/ethereum/go-ethereum/swarm/api"
+	"github.com/ethereum/go-ethereum/swarm/storage/resource"
+)
+
+const (
+	resourceName      = "foo.eth"
+	resourceFrequency = 2
+)
+
+func TestResourceNotifyWithSwarm(t *testing.T) {
+	dir, err := ioutil.TempDir("", "swarm-resource-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	swarms := make(map[discover.NodeID]*Swarm)
+	services := map[string]adapters.ServiceFunc{
+		"swarm": func(ctx *adapters.ServiceContext) (node.Service, error) {
+			config := api.NewConfig()
+
+			dir, err := ioutil.TempDir(dir, "node")
+			if err != nil {
+				return nil, err
+			}
+
+			config.Path = dir
+
+			privkey, err := crypto.GenerateKey()
+			if err != nil {
+				return nil, err
+			}
+
+			config.Init(privkey)
+			s, err := NewSwarm(nil, nil, config, nil)
+			if err != nil {
+				return nil, err
+			}
+			log.Info("new swarm", "bzzKey", config.BzzKey, "baseAddr", fmt.Sprintf("%x", s.bzz.BaseAddr()))
+			swarms[ctx.Config.ID] = s
+			return s, nil
+		},
+	}
+
+	a := adapters.NewSimAdapter(services)
+	net := simulations.NewNetwork(a, &simulations.NetworkConfig{
+		ID:             "0",
+		DefaultService: "swarm",
+	})
+	defer net.Shutdown()
+
+	l_nodeconf := adapters.RandomNodeConfig()
+	l_node, err := net.NewNodeWithConfig(l_nodeconf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = net.Start(l_node.ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r_nodeconf := adapters.RandomNodeConfig()
+	r_node, err := net.NewNodeWithConfig(r_nodeconf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = net.Start(r_node.ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = net.Connect(l_node.ID(), r_node.ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	l_rpc, err := l_node.Client()
+	if err != nil {
+		t.Fatal(err)
+	}
+	r_rpc, err := r_node.Client()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create the resource
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err = swarms[l_node.ID()].api.ResourceCreate(ctx, resourceName, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// update the resource
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, lastPeriod, lastVersion, err := swarms[l_node.ID()].api.ResourceUpdate(ctx, resourceName, []byte("bar"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// turn on notifications
+	err = l_rpc.Call(nil, "resource_enableNotifications", resourceName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// get address and pubkey of updater node
+	// and add it to the client node address book
+	var l_addr string
+	err = l_rpc.Call(&l_addr, "pss_baseAddr")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var l_pubkey string
+	err = l_rpc.Call(&l_pubkey, "pss_getPublicKey")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+	nC := make(chan resource.Notification)
+	r_sub_rsrc, err := r_rpc.Subscribe(ctx, "resource", nC, "requestNotification", resourceName, l_pubkey, l_addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r_sub_rsrc.Unsubscribe()
+
+	nsg := <-nC
+
+	time.Sleep(time.Second)
+	// update the resource
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, lastPeriod, lastVersion, err = swarms[l_node.ID()].api.ResourceUpdate(ctx, resourceName, []byte("bar"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nsg = <-nC
+	if nsg.Period != lastPeriod || nsg.Version != lastVersion {
+		t.Fatalf("Expected period/version %d.%d, got %d.%d", lastPeriod, lastVersion, nsg.Period, nsg.Version)
+
+	}
+}

--- a/swarm/storage/chunker.go
+++ b/swarm/storage/chunker.go
@@ -173,7 +173,7 @@ func NewTreeSplitterParams(reader io.Reader, putter Putter, size int64, branches
 	return &TreeSplitterParams{
 		SplitterParams: SplitterParams{
 			ChunkerParams: ChunkerParams{
-				chunkSize: chunkSize,
+				chunkSize: DefaultChunkSize,
 				hashSize:  hashSize,
 			},
 			reader: reader,

--- a/swarm/storage/error.go
+++ b/swarm/storage/error.go
@@ -4,21 +4,6 @@ import (
 	"errors"
 )
 
-const (
-	ErrInit = iota
-	ErrNotFound
-	ErrIO
-	ErrUnauthorized
-	ErrInvalidValue
-	ErrDataOverflow
-	ErrNothingToReturn
-	ErrCorruptData
-	ErrInvalidSignature
-	ErrNotSynced
-	ErrPeriodDepth
-	ErrCnt
-)
-
 var (
 	ErrChunkNotFound    = errors.New("chunk not found")
 	ErrFetching         = errors.New("chunk still fetching")

--- a/swarm/storage/netstore.go
+++ b/swarm/storage/netstore.go
@@ -121,6 +121,11 @@ func (self *NetStore) Get(key Key) (chunk *Chunk, err error) {
 	}
 }
 
+// GetWithTimeout makes a single retrieval attempt for a chunk with a explicit timeout parameter
+func (self *NetStore) GetWithTimeout(key Key, timeout time.Duration) (chunk *Chunk, err error) {
+	return self.get(key, timeout)
+}
+
 func (self *NetStore) get(key Key, timeout time.Duration) (chunk *Chunk, err error) {
 	if timeout == 0 {
 		timeout = searchTimeout
@@ -171,4 +176,6 @@ func (self *NetStore) Put(chunk *Chunk) {
 }
 
 // Close chunk store
-func (self *NetStore) Close() {}
+func (self *NetStore) Close() {
+	self.localStore.Close()
+}

--- a/swarm/storage/resource/api.go
+++ b/swarm/storage/resource/api.go
@@ -1,0 +1,68 @@
+package resource
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/ethereum/go-ethereum/swarm/pss"
+	"github.com/ethereum/go-ethereum/swarm/pss/notify"
+)
+
+type Notification struct {
+	Name    string
+	Period  uint32
+	Version uint32
+}
+
+type API struct {
+	subscribers   map[string]*rpc.Notifier
+	subscriptions map[string]rpc.ID
+	//notifier      *notify.Controller
+	resourceHandler *ResourceHandler
+}
+
+func NewAPI(rh *ResourceHandler) *API {
+	api := &API{
+		subscribers:     make(map[string]*rpc.Notifier),
+		subscriptions:   make(map[string]rpc.ID),
+		resourceHandler: rh,
+	}
+	return api
+}
+
+func (self *API) RequestNotification(ctx context.Context, name string, pubkeyHex hexutil.Bytes, address hexutil.Bytes) (*rpc.Subscription, error) {
+	pubkey := crypto.ToECDSAPub(pubkeyHex)
+	self.resourceHandler.notifier.Request(name, pubkey, pss.PssAddress(address), self.handle)
+	rpcnotifier, supported := rpc.NotifierFromContext(ctx)
+	if !supported {
+		return nil, fmt.Errorf("Subscribe not supported")
+	}
+	sub := rpcnotifier.CreateSubscription()
+	self.subscribers[name] = rpcnotifier
+	self.subscriptions[name] = sub.ID
+	return sub, nil
+}
+
+// EnableNotifications turns on pss notifications for the specified resource
+// The resource has to be loaded
+func (self *API) EnableNotifications(name string) error {
+	if _, ok := self.resourceHandler.resources[name]; !ok {
+		return fmt.Errorf("Unknown resource '%s'", name)
+	}
+	self.resourceHandler.notifier.NewNotifier(name, notify.DefaultAddressLength, self.resourceHandler.CreateNotification)
+	return nil
+}
+
+func (self *API) handle(name string, data []byte) error {
+	period := binary.LittleEndian.Uint32(data[:4])
+	version := binary.LittleEndian.Uint32(data[4:])
+	return self.subscribers[name].Notify(self.subscriptions[name], &Notification{
+		Name:    name,
+		Period:  period,
+		Version: version,
+	})
+}

--- a/swarm/storage/resource/error.go
+++ b/swarm/storage/resource/error.go
@@ -1,0 +1,16 @@
+package resource
+
+const (
+	ErrInit = iota
+	ErrNotFound
+	ErrIO
+	ErrUnauthorized
+	ErrInvalidValue
+	ErrDataOverflow
+	ErrNothingToReturn
+	ErrCorruptData
+	ErrInvalidSignature
+	ErrNotSynced
+	ErrPeriodDepth
+	ErrCnt
+)

--- a/swarm/storage/resource/resource.go
+++ b/swarm/storage/resource/resource.go
@@ -232,7 +232,6 @@ func (self *ResourceHandler) SetStore(store *storage.NetStore) {
 	self.chunkStore = store
 }
 
-//
 func (self *ResourceHandler) notify(rsrc *resource) error {
 	if self.notifier == nil {
 		return errors.New("Notifications not enabled")
@@ -259,7 +258,7 @@ func (self *ResourceHandler) CreateNotification(name string) ([]byte, error) {
 
 func (self *ResourceHandler) createNotification(rsrc *resource) ([]byte, error) {
 	b := bytes.NewBuffer(nil)
-	ib := make([]byte, 8)
+	ib := make([]byte, 4)
 	period, err := self.GetLastPeriod(*rsrc.name)
 	if err != nil {
 		return nil, err
@@ -278,11 +277,11 @@ func (self *ResourceHandler) createNotification(rsrc *resource) ([]byte, error) 
 // HandleNotification parses a resource handler notification data structure to required metadata for the update
 // it returns period and version
 func (self *ResourceHandler) ParseNotification(data []byte) (period uint32, version uint32, err error) {
-	if len(data) != 16 {
-		return 0, 0, fmt.Errorf("Expected data length 16, have %d", len(data))
+	if len(data) != 8 {
+		return 0, 0, fmt.Errorf("Expected data length 8 have %d", len(data))
 	}
 	period = binary.LittleEndian.Uint32(data)
-	version = binary.LittleEndian.Uint32(data[8:])
+	version = binary.LittleEndian.Uint32(data[4:])
 	return period, version, nil
 }
 
@@ -856,6 +855,7 @@ func (self *ResourceHandler) update(ctx context.Context, name string, data []byt
 	rsrc.version = version
 	rsrc.data = make([]byte, len(data))
 	copy(rsrc.data, data)
+	self.notify(rsrc)
 	return key, nil
 }
 

--- a/swarm/storage/resource/resource.go
+++ b/swarm/storage/resource/resource.go
@@ -1,4 +1,4 @@
-package storage
+package resource
 
 import (
 	"bytes"
@@ -19,6 +19,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/swarm/pss/notify"
+	"github.com/ethereum/go-ethereum/swarm/storage"
 )
 
 const (
@@ -28,7 +29,7 @@ const (
 	chunkSize              = 4096 // temporary until we implement DPA in the resourcehandler
 	defaultStoreTimeout    = 4000 * time.Millisecond
 	hasherCount            = 8
-	resourceHash           = SHA3Hash
+	resourceHash           = storage.SHA3Hash
 	defaultRetrieveTimeout = 100 * time.Millisecond
 )
 
@@ -100,7 +101,7 @@ type resource struct {
 	nameHash   common.Hash
 	startBlock uint64
 	lastPeriod uint32
-	lastKey    Key
+	lastKey    storage.Key
 	frequency  uint64
 	version    uint32
 	data       []byte
@@ -172,7 +173,7 @@ type headerGetter interface {
 //
 // TODO: Include modtime in chunk data + signature
 type ResourceHandler struct {
-	chunkStore      *NetStore
+	chunkStore      *storage.NetStore
 	notifier        *notify.Controller
 	HashSize        int
 	signer          ResourceSigner
@@ -209,14 +210,14 @@ func NewResourceHandler(params *ResourceHandlerParams) (*ResourceHandler, error)
 		signer:       params.Signer,
 		hashPool: sync.Pool{
 			New: func() interface{} {
-				return MakeHashFunc(resourceHash)()
+				return storage.MakeHashFunc(resourceHash)()
 			},
 		},
 		queryMaxPeriods: params.QueryMaxPeriods,
 	}
 
 	for i := 0; i < hasherCount; i++ {
-		hashfunc := MakeHashFunc(resourceHash)()
+		hashfunc := storage.MakeHashFunc(resourceHash)()
 		if rh.HashSize == 0 {
 			rh.HashSize = hashfunc.Size()
 		}
@@ -227,21 +228,24 @@ func NewResourceHandler(params *ResourceHandlerParams) (*ResourceHandler, error)
 }
 
 // SetStore sets the store backend for resource updates
-func (self *ResourceHandler) SetStore(store *NetStore) {
+func (self *ResourceHandler) SetStore(store *storage.NetStore) {
 	self.chunkStore = store
 }
 
 //
 func (self *ResourceHandler) notify(rsrc *resource) error {
-	if self.notifiers == nil {
+	if self.notifier == nil {
 		return errors.New("Notifications not enabled")
 	}
-	notifier, ok := self.notifiers[rsrc.name]
-	if ok != nil {
-		return fmt.Errorf("Notifications for %s not enabled", rsrc.name)
+	if !self.notifier.IsActive(*rsrc.name) {
+		return fmt.Errorf("Notifications for %s not enabled", *rsrc.name)
 	}
 	notificationData, err := self.createNotification(rsrc)
-	notifier.Notify(rsrc.Name, notificationData)
+	if err != nil {
+		return err
+	}
+	self.notifier.Notify(*rsrc.name, notificationData)
+	return nil
 }
 
 // CreateNotification creates a new notification data structure to be sent over the notifier
@@ -253,24 +257,32 @@ func (self *ResourceHandler) CreateNotification(name string) ([]byte, error) {
 	return self.createNotification(rsrc)
 }
 
-func (self *ResourceHandler) createNotification(rsrc *resource) []byte {
+func (self *ResourceHandler) createNotification(rsrc *resource) ([]byte, error) {
 	b := bytes.NewBuffer(nil)
 	ib := make([]byte, 8)
-	binary.LittleEndian.PutUint64(ib, self.GetLastPeriod)
+	period, err := self.GetLastPeriod(*rsrc.name)
+	if err != nil {
+		return nil, err
+	}
+	binary.LittleEndian.PutUint32(ib, period)
 	b.Write(ib)
-	binary.LittleEndian.PutUint64(ib, self.GetVersion)
+	version, err := self.GetVersion(*rsrc.name)
+	if err != nil {
+		return nil, err
+	}
+	binary.LittleEndian.PutUint32(ib, version)
 	b.Write(ib)
-	return b
+	return b.Bytes(), nil
 }
 
 // HandleNotification parses a resource handler notification data structure to required metadata for the update
 // it returns period and version
-func (self *ResourceHandler) ParseNotification(data []byte) (period uint64, version uint64, err error) {
+func (self *ResourceHandler) ParseNotification(data []byte) (period uint32, version uint32, err error) {
 	if len(data) != 16 {
 		return 0, 0, fmt.Errorf("Expected data length 16, have %d", len(data))
 	}
-	period = binary.LittleEndian.Uint64(data)
-	version = binary.LittleEndian.Uint64(data[8:])
+	period = binary.LittleEndian.Uint32(data)
+	version = binary.LittleEndian.Uint32(data[8:])
 	return period, version, nil
 }
 
@@ -279,7 +291,7 @@ func (self *ResourceHandler) ParseNotification(data []byte) (period uint64, vers
 // If resource update, owner is checked against ENS record of resource name inferred from chunk data
 // If parsed signature is nil, validates automatically
 // If not resource update, it validates are root chunk if length is indexSize and first two bytes are 0
-func (self *ResourceHandler) Validate(key Key, data []byte) bool {
+func (self *ResourceHandler) Validate(key storage.Key, data []byte) bool {
 	signature, period, version, name, parseddata, _, err := self.parseUpdate(data)
 	if err != nil {
 		if len(data) == indexSize {
@@ -307,8 +319,8 @@ func (self *ResourceHandler) IsValidated() bool {
 }
 
 // Create the resource update digest used in signatures
-func (self *ResourceHandler) keyDataHash(key Key, data []byte) common.Hash {
-	hasher := self.hashPool.Get().(SwarmHash)
+func (self *ResourceHandler) keyDataHash(key storage.Key, data []byte) common.Hash {
+	hasher := self.hashPool.Get().(storage.SwarmHash)
 	defer self.hashPool.Put(hasher)
 	hasher.Reset()
 	hasher.Write(key[:])
@@ -326,7 +338,7 @@ func (self *ResourceHandler) checkAccess(name string, address common.Address) (b
 }
 
 // get data from current resource
-func (self *ResourceHandler) GetContent(name string) (Key, []byte, error) {
+func (self *ResourceHandler) GetContent(name string) (storage.Key, []byte, error) {
 	rsrc := self.getResource(name)
 	if rsrc == nil || !rsrc.isSynced() {
 		return nil, nil, NewResourceError(ErrNotFound, "Resource does not exist or is not synced")
@@ -401,8 +413,8 @@ func (self *ResourceHandler) NewResource(ctx context.Context, name string, frequ
 
 	// chunk with key equal to namehash points to data of first blockheight + update frequency
 	// from this we know from what blockheight we should look for updates, and how often
-	key := Key(nameHash.Bytes())
-	chunk := NewChunk(key, nil)
+	key := storage.Key(nameHash.Bytes())
+	chunk := storage.NewChunk(key, nil)
 	chunk.SData = make([]byte, indexSize)
 
 	// root block has first two bytes both, which distinguishes from update bytes
@@ -556,7 +568,7 @@ func (self *ResourceHandler) lookup(rsrc *resource, period uint32, version uint3
 			return nil, NewResourceError(ErrPeriodDepth, fmt.Sprintf("Lookup exceeded max period hops (%d)", maxLookup.Max))
 		}
 		key := self.resourceHash(period, version, rsrc.nameHash)
-		chunk, err := self.chunkStore.get(key, defaultRetrieveTimeout)
+		chunk, err := self.chunkStore.GetWithTimeout(key, defaultRetrieveTimeout)
 		if err == nil {
 			if specificversion {
 				return self.updateResourceIndex(rsrc, chunk)
@@ -566,7 +578,7 @@ func (self *ResourceHandler) lookup(rsrc *resource, period uint32, version uint3
 			for {
 				newversion := version + 1
 				key := self.resourceHash(period, newversion, rsrc.nameHash)
-				newchunk, err := self.chunkStore.get(key, defaultRetrieveTimeout)
+				newchunk, err := self.chunkStore.GetWithTimeout(key, defaultRetrieveTimeout)
 				if err != nil {
 					return self.updateResourceIndex(rsrc, chunk)
 				}
@@ -602,7 +614,8 @@ func (self *ResourceHandler) loadResource(nameHash common.Hash, name string, ref
 		rsrc.nameHash = nameHash
 
 		// get the root info chunk and update the cached value
-		chunk, err := self.chunkStore.get(Key(rsrc.nameHash[:]), defaultRetrieveTimeout)
+		//chunk, err := self.chunkStore.get(storage.Key(rsrc.nameHash[:]), defaultRetrieveTimeout)
+		chunk, err := self.chunkStore.GetWithTimeout(storage.Key(rsrc.nameHash[:]), defaultRetrieveTimeout)
 		if err != nil {
 			return nil, err
 		}
@@ -623,7 +636,7 @@ func (self *ResourceHandler) loadResource(nameHash common.Hash, name string, ref
 }
 
 // update mutable resource index map with specified content
-func (self *ResourceHandler) updateResourceIndex(rsrc *resource, chunk *Chunk) (*resource, error) {
+func (self *ResourceHandler) updateResourceIndex(rsrc *resource, chunk *storage.Chunk) (*resource, error) {
 
 	// retrieve metadata from chunk data and check that it matches this mutable resource
 	signature, period, version, name, data, multihash, err := self.parseUpdate(chunk.SData)
@@ -742,18 +755,18 @@ func (self *ResourceHandler) parseUpdate(chunkdata []byte) (*Signature, uint32, 
 //
 // A resource update cannot span chunks, and thus has max length 4096
 
-func (self *ResourceHandler) UpdateMultihash(ctx context.Context, name string, data []byte) (Key, error) {
+func (self *ResourceHandler) UpdateMultihash(ctx context.Context, name string, data []byte) (storage.Key, error) {
 	if isMultihash(data) == 0 {
 		return nil, NewResourceError(ErrNothingToReturn, "Invalid multihash")
 	}
 	return self.update(ctx, name, data, true)
 }
 
-func (self *ResourceHandler) Update(ctx context.Context, name string, data []byte) (Key, error) {
+func (self *ResourceHandler) Update(ctx context.Context, name string, data []byte) (storage.Key, error) {
 	return self.update(ctx, name, data, false)
 }
 
-func (self *ResourceHandler) update(ctx context.Context, name string, data []byte, multihash bool) (Key, error) {
+func (self *ResourceHandler) update(ctx context.Context, name string, data []byte, multihash bool) (storage.Key, error) {
 
 	if len(data) == 0 {
 		return nil, NewResourceError(ErrInvalidValue, "I refuse to waste swarm space for updates with empty values, amigo (data length is 0)")
@@ -836,15 +849,6 @@ func (self *ResourceHandler) update(ctx context.Context, name string, data []byt
 
 	// send the chunk
 	self.chunkStore.Put(chunk)
-	timeout := time.NewTimer(self.storeTimeout)
-	select {
-	case <-chunk.dbStoredC:
-		if err := chunk.GetErrored(); err != nil {
-			return nil, NewResourceError(ErrIO, fmt.Sprintf("chunk not stored: %v", err))
-		}
-	case <-timeout.C:
-		return nil, NewResourceError(ErrIO, "chunk store timeout")
-	}
 	log.Trace("resource update", "name", name, "key", key, "currentblock", currentblock, "lastperiod", nextperiod, "version", version, "data", chunk.SData, "multihash", multihash)
 
 	// update our resources map entry and return the new key
@@ -893,9 +897,9 @@ func (self *ResourceHandler) setResource(name string, rsrc *resource) {
 }
 
 // used for chunk keys
-func (self *ResourceHandler) resourceHash(period uint32, version uint32, namehash common.Hash) Key {
+func (self *ResourceHandler) resourceHash(period uint32, version uint32, namehash common.Hash) storage.Key {
 	// format is: hash(period|version|namehash)
-	hasher := self.hashPool.Get().(SwarmHash)
+	hasher := self.hashPool.Get().(storage.SwarmHash)
 	defer self.hashPool.Put(hasher)
 	hasher.Reset()
 	b := make([]byte, 4)
@@ -920,7 +924,7 @@ func getAddressFromDataSig(datahash common.Hash, signature Signature) (common.Ad
 }
 
 // create an update chunk
-func newUpdateChunk(key Key, signature *Signature, period uint32, version uint32, name string, data []byte, datalength int) *Chunk {
+func newUpdateChunk(key storage.Key, signature *Signature, period uint32, version uint32, name string, data []byte, datalength int) *storage.Chunk {
 
 	// no signatures if no validator
 	var signaturelength int
@@ -932,7 +936,7 @@ func newUpdateChunk(key Key, signature *Signature, period uint32, version uint32
 	headerlength := len(name) + 4 + 4
 
 	actualdatalength := len(data)
-	chunk := NewChunk(key, nil)
+	chunk := storage.NewChunk(key, nil)
 	chunk.SData = make([]byte, 4+signaturelength+headerlength+actualdatalength) // initial 4 are uint16 length descriptors for headerlength and datalength
 
 	// data header length does NOT include the header length prefix bytes themselves
@@ -1025,14 +1029,14 @@ func NewTestResourceHandler(datadir string, params *ResourceHandlerParams) (*Res
 	if err != nil {
 		return nil, fmt.Errorf("resource handler create fail: %v", err)
 	}
-	localstoreparams := NewDefaultLocalStoreParams()
+	localstoreparams := storage.NewDefaultLocalStoreParams()
 	localstoreparams.Init(path)
-	localStore, err := NewLocalStore(localstoreparams, nil)
+	localStore, err := storage.NewLocalStore(localstoreparams, nil)
 	if err != nil {
 		return nil, fmt.Errorf("localstore create fail, path %s: %v", path, err)
 	}
 	localStore.Validators = append(localStore.Validators, rh)
-	dpaStore := NewNetStore(localStore, nil)
+	dpaStore := storage.NewNetStore(localStore, nil)
 	rh.SetStore(dpaStore)
 	return rh, nil
 }

--- a/swarm/storage/resource/resource_sign.go
+++ b/swarm/storage/resource/resource_sign.go
@@ -1,4 +1,4 @@
-package storage
+package resource
 
 import (
 	"crypto/ecdsa"

--- a/swarm/storage/resource/resource_test.go
+++ b/swarm/storage/resource/resource_test.go
@@ -1,4 +1,4 @@
-package storage
+package resource
 
 import (
 	"bytes"
@@ -24,10 +24,12 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/swarm/multihash"
+	"github.com/ethereum/go-ethereum/swarm/storage"
 )
 
 var (
-	testHasher        = MakeHashFunc(SHA3Hash)()
+	loglevel          = flag.Int("loglevel", 3, "loglevel")
+	testHasher        = storage.MakeHashFunc(storage.SHA3Hash)()
 	zeroAddr          = common.Address{}
 	startBlock        = uint64(4200)
 	resourceFrequency = uint64(42)
@@ -163,7 +165,8 @@ func TestResourceHandler(t *testing.T) {
 
 	// check that the new resource is stored correctly
 	namehash := ens.EnsNode(safeName)
-	chunk, err := rh.chunkStore.localStore.memStore.Get(Key(namehash[:]))
+	//chunk, err := rh.chunkStore.localStore.memStore.Get(Key(namehash[:]))
+	chunk, err := rh.chunkStore.Get(storage.Key(namehash[:]))
 	if err != nil {
 		t.Fatal(err)
 	} else if len(chunk.SData) < 16 {
@@ -187,7 +190,7 @@ func TestResourceHandler(t *testing.T) {
 	}
 
 	// update halfway to first period
-	resourcekey := make(map[string]Key)
+	resourcekey := make(map[string]storage.Key)
 	fwdBlocks(int(resourceFrequency/2), backend)
 	data := []byte(updates[0])
 	resourcekey[updates[0]], err = rh.Update(ctx, safeName, data)
@@ -233,7 +236,7 @@ func TestResourceHandler(t *testing.T) {
 		EthClient: rh.ethClient,
 	}
 
-	rh.chunkStore.localStore.Close()
+	rh.chunkStore.Close()
 	rh2, err := NewTestResourceHandler(datadir, rhparams)
 	if err != nil {
 		t.Fatal(err)
@@ -450,7 +453,7 @@ func TestResourceMultihash(t *testing.T) {
 		EnsClient: rh.ensClient,
 	}
 	// test with signed data
-	rh.chunkStore.localStore.Close()
+	rh.chunkStore.Close()
 	rh2, err := NewTestResourceHandler(datadir, rhparams)
 	if err != nil {
 		t.Fatal(err)
@@ -638,8 +641,8 @@ func newTestSigner() (*GenericResourceSigner, error) {
 	}, nil
 }
 
-func getUpdateDirect(rh *ResourceHandler, key Key) ([]byte, error) {
-	chunk, err := rh.chunkStore.localStore.memStore.Get(key)
+func getUpdateDirect(rh *ResourceHandler, key storage.Key) ([]byte, error) {
+	chunk, err := rh.chunkStore.Get(key)
 	if err != nil {
 		return nil, err
 	}

--- a/swarm/storage/resource/resource_test.go
+++ b/swarm/storage/resource/resource_test.go
@@ -546,6 +546,57 @@ func TestResourceChunkValidator(t *testing.T) {
 	}
 }
 
+// Tests that notification creation will include latest version
+// and that wire format serializes and parses correctly
+func TestResourceNotify(t *testing.T) {
+
+	// make fake backend, set up rpc and create resourcehandler
+	backend := &fakeBackend{
+		blocknumber: int64(startBlock),
+	}
+	rh, _, teardownTest, err := setupTest(backend, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer teardownTest()
+
+	// create a new resource
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_, err = rh.NewResource(ctx, safeName, resourceFrequency)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// updates
+	resourcekey := make(map[string]storage.Key)
+	fwdBlocks(int(resourceFrequency/2), backend)
+	update := "foo"
+	data := []byte(update)
+	resourcekey[update], err = rh.Update(ctx, safeName, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	update = "bar"
+	data = []byte(update)
+	resourcekey[update], err = rh.Update(ctx, safeName, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check notify parse and result
+	notifyBytes, err := rh.CreateNotification(safeName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	period, version, err := rh.ParseNotification(notifyBytes)
+	if err != nil {
+		t.Fatal(err)
+	} else if period != 1 || version != 2 {
+		t.Fatalf("Expected period/version 1.2 got %d.%d", period, version)
+	}
+}
+
 // fast-forward blockheight
 func fwdBlocks(count int, backend *fakeBackend) {
 	for i := 0; i < count; i++ {

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -50,6 +50,7 @@ import (
 	"github.com/ethereum/go-ethereum/swarm/state"
 	"github.com/ethereum/go-ethereum/swarm/storage"
 	"github.com/ethereum/go-ethereum/swarm/storage/mock"
+	"github.com/ethereum/go-ethereum/swarm/storage/resource"
 )
 
 var (
@@ -189,13 +190,13 @@ func NewSwarm(ctx *node.ServiceContext, backend chequebook.Backend, config *api.
 	// Swarm Hash Merklised Chunking for Arbitrary-length Document/File storage
 	self.dpa = storage.NewDPA(dpaChunkStore, self.config.DPAParams)
 
-	var resourceHandler *storage.ResourceHandler
-	rhparams := &storage.ResourceHandlerParams{
+	var resourceHandler *resource.ResourceHandler
+	rhparams := &resource.ResourceHandlerParams{
 		// TODO: config parameter to set limits
-		QueryMaxPeriods: &storage.ResourceLookupParams{
+		QueryMaxPeriods: &resource.ResourceLookupParams{
 			Limit: false,
 		},
-		Signer: &storage.GenericResourceSigner{
+		Signer: &resource.GenericResourceSigner{
 			PrivKey: self.privateKey,
 		},
 		EthClient: resolver,
@@ -206,9 +207,9 @@ func NewSwarm(ctx *node.ServiceContext, backend chequebook.Backend, config *api.
 	} else {
 		log.Warn("No ETH API specified, resource updates will use block height approximation")
 		// TODO: blockestimator should use saved values derived from last time ethclient was connected
-		rhparams.EthClient = storage.NewBlockEstimator()
+		rhparams.EthClient = resource.NewBlockEstimator()
 	}
-	resourceHandler, err = storage.NewResourceHandler(rhparams)
+	resourceHandler, err = resource.NewResourceHandler(rhparams)
 	if err != nil {
 		return nil, err
 	}

--- a/swarm/testutil/http.go
+++ b/swarm/testutil/http.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/swarm/api"
 	"github.com/ethereum/go-ethereum/swarm/storage"
+	"github.com/ethereum/go-ethereum/swarm/storage/resource"
 )
 
 type TestServer interface {
@@ -67,11 +68,11 @@ func NewTestSwarmServer(t *testing.T, serverFunc func(*api.Api) TestServer) *Tes
 	if err != nil {
 		t.Fatal(err)
 	}
-	rhparams := &storage.ResourceHandlerParams{
-		QueryMaxPeriods: &storage.ResourceLookupParams{},
+	rhparams := &resource.ResourceHandlerParams{
+		QueryMaxPeriods: &resource.ResourceLookupParams{},
 		EthClient:       &fakeBackend{},
 	}
-	rh, err := storage.NewTestResourceHandler(resourceDir, rhparams)
+	rh, err := resource.NewTestResourceHandler(resourceDir, rhparams)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PRs adds a generic notifier mechanism in `pss` and implements it for mutable resource updates.

It also separates mutable resources into a separate package, as accessing the `pss` package from the `storage` package creates a dependency cycle.