### PR TITLE
swarm, swarm/storage: use MultiResolver for resource ownerValidator

### DIFF
--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -153,7 +153,6 @@ func NewSwarm(ctx *node.ServiceContext, backend chequebook.Backend, config *api.
 	// set up high level api
 	//transactOpts := bind.NewKeyedTransactor(self.privateKey)
 	var resolver *api.MultiResolver
-	var ensresolver *ens.ENS
 	if len(config.EnsAPIs) > 0 {
 		opts := []api.MultiResolverOption{}
 		for _, c := range config.EnsAPIs {
@@ -162,7 +161,6 @@ func NewSwarm(ctx *node.ServiceContext, backend chequebook.Backend, config *api.
 			if err != nil {
 				return nil, err
 			}
-			ensresolver = r.ENS
 			opts = append(opts, api.MultiResolverOptionWithResolver(r, tld))
 
 		}
@@ -199,15 +197,15 @@ func NewSwarm(ctx *node.ServiceContext, backend chequebook.Backend, config *api.
 		Signer: &storage.GenericResourceSigner{
 			PrivKey: self.privateKey,
 		},
-		EthClient: resolver,
-		EnsClient: ensresolver,
+		HeaderGetter:   resolver,
+		OwnerValidator: resolver,
 	}
 	if resolver != nil {
 		resolver.SetNameHash(ens.EnsNode)
 	} else {
 		log.Warn("No ETH API specified, resource updates will use block height approximation")
 		// TODO: blockestimator should use saved values derived from last time ethclient was connected
-		rhparams.EthClient = storage.NewBlockEstimator()
+		rhparams.HeaderGetter = storage.NewBlockEstimator()
 	}
 	resourceHandler, err = storage.NewResourceHandler(rhparams)
 	if err != nil {

--- a/swarm/testutil/http.go
+++ b/swarm/testutil/http.go
@@ -69,7 +69,7 @@ func NewTestSwarmServer(t *testing.T, serverFunc func(*api.Api) TestServer) *Tes
 	}
 	rhparams := &storage.ResourceHandlerParams{
 		QueryMaxPeriods: &storage.ResourceLookupParams{},
-		EthClient:       &fakeBackend{},
+		HeaderGetter:    &fakeBackend{},
 	}
 	rh, err := storage.NewTestResourceHandler(resourceDir, rhparams)
 	if err != nil {


### PR DESCRIPTION
This PR:

- replaces ensClient and ethClient resourcehandler fields with headerGetter and ownerValidator interfaces
- uses MultiResolver for both headerGetter and ownerValidator fields to fix https://github.com/ethersphere/go-ethereum/issues/556
- updates tests to reflect this changes