### PR TITLE
swarm/pss: Generic notifications package

### DIFF
--- a/swarm/pss/handshake.go
+++ b/swarm/pss/handshake.go
@@ -369,7 +369,7 @@ func (ctl *HandshakeController) sendKey(pubkeyid string, topic *Topic, keycount 
 	// generate new keys to send
 	for i := 0; i < len(recvkeyids); i++ {
 		var err error
-		recvkeyids[i], err = ctl.pss.generateSymmetricKey(*topic, to, true)
+		recvkeyids[i], err = ctl.pss.GenerateSymmetricKey(*topic, to, true)
 		if err != nil {
 			return []string{}, fmt.Errorf("set receive symkey fail (pubkey %x topic %x): %v", pubkeyid, topic, err)
 		}

--- a/swarm/pss/notify/notify.go
+++ b/swarm/pss/notify/notify.go
@@ -57,8 +57,8 @@ func NewMsg(code byte, name string, payload []byte) *Msg {
 	}
 }
 
-func (self *Msg) GetName() string {
-	return string(self.Name)
+func (c *Msg) GetName() string {
+	return string(c.Name)
 }
 
 // a notifier has one sendmux entry for each address space it sends messages to
@@ -100,14 +100,14 @@ func NewController(ps *pss.Pss) *Controller {
 
 // IsActive is used to check if a notification service exists for a specified id string
 // Returns true if exists, false if not
-func (self *Controller) IsActive(name string) bool {
-	self.mu.Lock()
-	defer self.mu.Unlock()
-	return self.isActive(name)
+func (c *Controller) IsActive(name string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.isActive(name)
 }
 
-func (self *Controller) isActive(name string) bool {
-	_, ok := self.notifiers[name]
+func (c *Controller) isActive(name string) bool {
+	_, ok := c.notifiers[name]
 	return ok
 }
 
@@ -115,30 +115,30 @@ func (self *Controller) isActive(name string) bool {
 // It will create a MsgCodeStart message and send asymmetrically to the provider using its public key and routing address
 // The handler function is a callback that will be called when notifications are recieved
 // Fails if the request pss cannot be sent or if the update message could not be serialized
-func (self *Controller) Request(name string, pubkey *ecdsa.PublicKey, address pss.PssAddress, handler func(string, []byte) error) error {
-	self.mu.Lock()
-	defer self.mu.Unlock()
-	msg := NewMsg(MsgCodeStart, name, self.pss.BaseAddr())
-	self.handlers[name] = handler
-	self.pss.SetPeerPublicKey(pubkey, controlTopic, &address)
+func (c *Controller) Request(name string, pubkey *ecdsa.PublicKey, address pss.PssAddress, handler func(string, []byte) error) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	msg := NewMsg(MsgCodeStart, name, c.pss.BaseAddr())
+	c.handlers[name] = handler
+	c.pss.SetPeerPublicKey(pubkey, controlTopic, &address)
 	pubkeyid := common.ToHex(crypto.FromECDSAPub(pubkey))
 	smsg, err := rlp.EncodeToBytes(msg)
 	if err != nil {
 		return fmt.Errorf("message could not be serialized: %v", err)
 	}
-	return self.pss.SendAsym(pubkeyid, controlTopic, smsg)
+	return c.pss.SendAsym(pubkeyid, controlTopic, smsg)
 }
 
 // NewNotifier is used by a notification service provider to create a new notification service
 // It takes a name as identifier for the resource, a threshold indicating the granularity of the subscription address bin, and a callback for getting the latest update
 // Fails if a notifier already is registered on the name
-func (self *Controller) NewNotifier(name string, threshold int, contentFunc func(string) ([]byte, error)) error {
-	self.mu.Lock()
-	defer self.mu.Unlock()
-	if self.isActive(name) {
+func (c *Controller) NewNotifier(name string, threshold int, contentFunc func(string) ([]byte, error)) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.isActive(name) {
 		return fmt.Errorf("Notification service %s already exists in controller", name)
 	}
-	self.notifiers[name] = &notifier{
+	c.notifiers[name] = &notifier{
 		topic:       pss.BytesToTopic([]byte(name)),
 		threshold:   threshold,
 		contentFunc: contentFunc,
@@ -150,20 +150,20 @@ func (self *Controller) NewNotifier(name string, threshold int, contentFunc func
 // It takes the name of the notification service the data to be sent.
 // It fails if a notifier with this name does not exist or if data could not be serialized
 // Note that it does NOT fail on failure to send a message
-func (self *Controller) Notify(name string, data []byte) error {
-	self.mu.Lock()
-	defer self.mu.Unlock()
-	if !self.isActive(name) {
+func (c *Controller) Notify(name string, data []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.isActive(name) {
 		return fmt.Errorf("Notification service %s doesn't exist", name)
 	}
 	msg := NewMsg(MsgCodeNotify, name, data)
-	for _, m := range self.notifiers[name].bins {
-		log.Debug("sending pss notify", "name", name, "addr", fmt.Sprintf("%x", m.address), "topic", fmt.Sprintf("%x", self.notifiers[name].topic), "data", data)
+	for _, m := range c.notifiers[name].bins {
+		log.Debug("sending pss notify", "name", name, "addr", fmt.Sprintf("%x", m.address), "topic", fmt.Sprintf("%x", c.notifiers[name].topic), "data", data)
 		smsg, err := rlp.EncodeToBytes(msg)
 		if err != nil {
 			return fmt.Errorf("Failed to serialize message: %v", err)
 		}
-		err = self.pss.SendSym(m.symKeyId, self.notifiers[name].topic, smsg)
+		err = c.pss.SendSym(m.symKeyId, c.notifiers[name].topic, smsg)
 		if err != nil {
 			log.Warn("Failed to send notify to addr %x: %v", m.address, err)
 		}
@@ -173,8 +173,8 @@ func (self *Controller) Notify(name string, data []byte) error {
 
 // adds an client address to the corresponding address bin in the notifier service
 // this method is not concurrency safe
-func (self *Controller) addToNotifier(name string, address pss.PssAddress) (string, error) {
-	notifier, ok := self.notifiers[name]
+func (c *Controller) addToNotifier(name string, address pss.PssAddress) (string, error) {
+	notifier, ok := c.notifiers[name]
 	if !ok {
 		return "", fmt.Errorf("Unknown notifier %s", name)
 	}
@@ -184,7 +184,7 @@ func (self *Controller) addToNotifier(name string, address pss.PssAddress) (stri
 			return m.symKeyId, nil
 		}
 	}
-	symKeyId, err := self.pss.GenerateSymmetricKey(notifier.topic, &address, false)
+	symKeyId, err := c.pss.GenerateSymmetricKey(notifier.topic, &address, false)
 	if err != nil {
 		return "", fmt.Errorf("Generate symkey fail: %v", err)
 	}
@@ -198,9 +198,9 @@ func (self *Controller) addToNotifier(name string, address pss.PssAddress) (stri
 
 // Handler is the pss topic handler to be used to process notification service messages
 // It should be registered in the pss of both to any notification service provides and clients using the service
-func (self *Controller) Handler(smsg []byte, p *p2p.Peer, asymmetric bool, keyid string) error {
-	self.mu.Lock()
-	defer self.mu.Unlock()
+func (c *Controller) Handler(smsg []byte, p *p2p.Peer, asymmetric bool, keyid string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	log.Debug("notify controller handler", "keyid", keyid)
 
 	// see if the message is valid
@@ -215,35 +215,35 @@ func (self *Controller) Handler(smsg []byte, p *p2p.Peer, asymmetric bool, keyid
 		pubkey := crypto.ToECDSAPub(common.FromHex(keyid))
 
 		// if name is not registered for notifications we will not react
-		if _, ok := self.notifiers[msg.GetName()]; !ok {
+		if _, ok := c.notifiers[msg.GetName()]; !ok {
 			return fmt.Errorf("Subscribe attempted on unknown resource %s", msg.GetName())
 		}
 
 		// parse the address from the message and truncate if longer than our mux threshold
 		address := msg.Payload
-		if len(msg.Payload) > self.notifiers[msg.GetName()].threshold {
-			address = address[:self.notifiers[msg.GetName()].threshold]
+		if len(msg.Payload) > c.notifiers[msg.GetName()].threshold {
+			address = address[:c.notifiers[msg.GetName()].threshold]
 		}
 
 		// add the address to the notification list
-		symKeyId, err := self.addToNotifier(msg.GetName(), address)
+		symKeyId, err := c.addToNotifier(msg.GetName(), address)
 		if err != nil {
 			return fmt.Errorf("add address to notifier fail: %v", err)
 		}
-		symkey, err := self.pss.GetSymmetricKey(symKeyId)
+		symkey, err := c.pss.GetSymmetricKey(symKeyId)
 		if err != nil {
 			return fmt.Errorf("retrieve symkey fail: %v", err)
 		}
 
 		// add to address book for send initial notify
 		pssaddr := pss.PssAddress(address)
-		err = self.pss.SetPeerPublicKey(pubkey, controlTopic, &pssaddr)
+		err = c.pss.SetPeerPublicKey(pubkey, controlTopic, &pssaddr)
 		if err != nil {
 			return fmt.Errorf("add pss peer for reply fail: %v", err)
 		}
 
 		// send initial notify, will contain symkey to use for consecutive messages
-		notify, err := self.notifiers[msg.GetName()].contentFunc(msg.GetName())
+		notify, err := c.notifiers[msg.GetName()].contentFunc(msg.GetName())
 		if err != nil {
 			return fmt.Errorf("retrieve current update from source fail: %v", err)
 		}
@@ -254,7 +254,7 @@ func (self *Controller) Handler(smsg []byte, p *p2p.Peer, asymmetric bool, keyid
 		if err != nil {
 			return fmt.Errorf("reply message could not be serialized: %v", err)
 		}
-		err = self.pss.SendAsym(keyid, controlTopic, sReplyMsg)
+		err = c.pss.SendAsym(keyid, controlTopic, sReplyMsg)
 		if err != nil {
 			return fmt.Errorf("send start reply fail: %v", err)
 		}
@@ -263,11 +263,11 @@ func (self *Controller) Handler(smsg []byte, p *p2p.Peer, asymmetric bool, keyid
 		topic := pss.BytesToTopic(msg.Name)
 		// \TODO keep track of and add actual address
 		updaterAddr := pss.PssAddress([]byte{})
-		self.pss.SetSymmetricKey(symkey, topic, &updaterAddr, true)
-		self.pss.Register(&topic, self.Handler)
-		return self.handlers[msg.GetName()](msg.GetName(), msg.Payload)
+		c.pss.SetSymmetricKey(symkey, topic, &updaterAddr, true)
+		c.pss.Register(&topic, c.Handler)
+		return c.handlers[msg.GetName()](msg.GetName(), msg.Payload)
 	case MsgCodeNotify:
-		return self.handlers[msg.GetName()](msg.GetName(), msg.Payload)
+		return c.handlers[msg.GetName()](msg.GetName(), msg.Payload)
 	default:
 		return fmt.Errorf("Invalid message code: %d", msg.Code)
 	}

--- a/swarm/pss/notify/notify.go
+++ b/swarm/pss/notify/notify.go
@@ -1,0 +1,244 @@
+package notify
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/swarm/pss"
+)
+
+const (
+	MsgCodeStart = iota
+	MsgCodeNotifyWithKey
+	MsgCodeNotify
+	MsgCodeStop
+	MsgCodeMax
+)
+
+const (
+	DefaultAddressLength = 1
+	minimumAddressLength = 1
+	symKeyLength         = 32 // this should be gotten from source
+)
+
+var (
+	controlTopic = pss.Topic{0x00, 0x00, 0x00, 0x01}
+)
+
+// when code is MsgCodeStart, Payload is address
+// when code is MsgCodeNotify, Payload is symkey. If len = 0, keep old key
+// when code is MsgCodeStop, Payload is address
+type Msg struct {
+	Name    string
+	Payload []byte
+	Code    byte
+}
+
+func (self *Msg) Serialize() []byte {
+	b := bytes.NewBuffer(nil)
+	b.Write([]byte{self.Code})
+	ib := make([]byte, 2)
+	binary.LittleEndian.PutUint16(ib, uint16(len(self.Name)))
+	b.Write(ib)
+	binary.LittleEndian.PutUint16(ib, uint16(len(self.Payload)))
+	b.Write(ib)
+	b.Write([]byte(self.Name))
+	b.Write(self.Payload)
+	return b.Bytes()
+}
+
+func deserializeMsg(msgbytes []byte) (*Msg, error) {
+	msg := &Msg{
+		Code: msgbytes[0],
+	}
+	nameLen := binary.LittleEndian.Uint16(msgbytes[1:3])
+	dataLen := binary.LittleEndian.Uint16(msgbytes[3:5])
+	if int(nameLen+dataLen)+5 != len(msgbytes) {
+		return nil, errors.New("corrupt message")
+	}
+	msg.Name = string(msgbytes[5 : 5+nameLen])
+	msg.Payload = msgbytes[5+nameLen:]
+	return msg, nil
+}
+
+// a notifier has one sendmux entry for each address space it sends messages to
+type sendMux struct {
+	address  pss.PssAddress
+	symKeyId string
+	count    int
+}
+
+type notifier struct {
+	muxes       []*sendMux
+	topic       pss.Topic
+	threshold   int
+	contentFunc func(string) ([]byte, error)
+	updateFunc  func(string, []byte)
+	mu          sync.Mutex
+}
+
+type Controller struct {
+	pss       *pss.Pss
+	notifiers map[string]*notifier
+	handlers  map[string]func(string, []byte) error
+}
+
+func NewController(ps *pss.Pss) *Controller {
+	ctrl := &Controller{
+		pss:       ps,
+		notifiers: make(map[string]*notifier),
+		handlers:  make(map[string]func(string, []byte) error),
+	}
+	ctrl.pss.Register(&controlTopic, ctrl.Handler)
+	return ctrl
+}
+
+func (self *Controller) IsActive(name string) bool {
+	_, ok := self.notifiers[name]
+	return ok
+}
+
+func (self *Controller) Request(name string, pubkey *ecdsa.PublicKey, address pss.PssAddress, handler func(string, []byte) error) error {
+	msg := &Msg{
+		Name:    name,
+		Payload: self.pss.BaseAddr(),
+		Code:    MsgCodeStart,
+	}
+	self.handlers[name] = handler
+	self.pss.SetPeerPublicKey(pubkey, controlTopic, &address)
+	pubkeyid := common.ToHex(crypto.FromECDSAPub(pubkey))
+	return self.pss.SendAsym(pubkeyid, controlTopic, msg.Serialize())
+}
+
+func (self *Controller) NewNotifier(name string, threshold int, contentFunc func(string) ([]byte, error)) error {
+	if self.IsActive(name) {
+		return fmt.Errorf("%s already exists in controller", name)
+	}
+	self.notifiers[name] = &notifier{
+		topic:       pss.BytesToTopic([]byte(name)),
+		threshold:   threshold,
+		contentFunc: contentFunc,
+	}
+	return nil
+}
+
+func (self *Controller) Notify(name string, data []byte) error {
+	msg := &Msg{
+		Name:    name,
+		Payload: data,
+		Code:    MsgCodeNotify,
+	}
+	for _, m := range self.notifiers[name].muxes {
+		log.Debug("sending pss notify", "name", name, "addr", fmt.Sprintf("%x", m.address), "topic", fmt.Sprintf("%x", self.notifiers[name].topic), "data", data)
+		err := self.pss.SendSym(m.symKeyId, self.notifiers[name].topic, msg.Serialize())
+		if err != nil {
+			log.Warn("Failed to send notify to addr %x: %v", m.address, err)
+		}
+	}
+	return nil
+}
+
+func (self *Controller) addToNotifier(name string, address pss.PssAddress) (string, error) {
+	notifier, ok := self.notifiers[name]
+	if !ok {
+		return "", fmt.Errorf("Unknown notifier %s", name)
+	}
+	for _, m := range notifier.muxes {
+		if bytes.Equal(address, m.address) {
+			m.count++
+			return m.symKeyId, nil
+		}
+	}
+	symKeyId, err := self.pss.GenerateSymmetricKey(notifier.topic, &address, false)
+	if err != nil {
+		return "", fmt.Errorf("Generate symkey fail: %v", err)
+	}
+	notifier.muxes = append(notifier.muxes, &sendMux{
+		address:  address,
+		symKeyId: symKeyId,
+		count:    1,
+	})
+	return symKeyId, nil
+}
+
+func (self *Controller) Handler(smsg []byte, p *p2p.Peer, asymmetric bool, keyid string) error {
+	log.Debug("notify controller handler", "keyid", keyid)
+
+	// see if the message is valid
+	msg, err := deserializeMsg(smsg)
+	if err != nil {
+		return fmt.Errorf("Invalid message: %v", err)
+	}
+
+	switch msg.Code {
+	case MsgCodeStart:
+		pubkey := crypto.ToECDSAPub(common.FromHex(keyid))
+
+		// if name is not registered for notifications we will not react
+		if _, ok := self.notifiers[msg.Name]; !ok {
+			return fmt.Errorf("Subscribe attempted on unknown resource %s", msg.Name)
+		}
+
+		// parse the address from the message and truncate if longer than our mux threshold
+		address := msg.Payload
+		if len(msg.Payload) > self.notifiers[msg.Name].threshold {
+			address = address[:self.notifiers[msg.Name].threshold]
+		}
+
+		// add the address to the notification list
+		symKeyId, err := self.addToNotifier(msg.Name, address)
+		if err != nil {
+			return fmt.Errorf("add address to notifier fail: %v", err)
+		}
+		symkey, err := self.pss.GetSymmetricKey(symKeyId)
+		if err != nil {
+			return fmt.Errorf("retrieve symkey fail: %v", err)
+		}
+
+		// add to address book for send initial notify
+		pssaddr := pss.PssAddress(address)
+		err = self.pss.SetPeerPublicKey(pubkey, controlTopic, &pssaddr)
+		if err != nil {
+			return fmt.Errorf("add pss peer for reply fail: %v", err)
+		}
+
+		// send initial notify, will contain symkey to use for consecutive messages
+		notify, err := self.notifiers[msg.Name].contentFunc(msg.Name)
+		if err != nil {
+			return fmt.Errorf("retrieve current update from source fail: %v", err)
+		}
+		replyMsg := &Msg{
+			Name:    msg.Name,
+			Payload: make([]byte, len(notify)+symKeyLength),
+			Code:    MsgCodeNotifyWithKey,
+		}
+		copy(replyMsg.Payload, notify)
+		copy(replyMsg.Payload[len(notify):], symkey)
+		err = self.pss.SendAsym(keyid, controlTopic, replyMsg.Serialize())
+		if err != nil {
+			return fmt.Errorf("send start reply fail: %v", err)
+		}
+	case MsgCodeNotifyWithKey:
+		symkey := msg.Payload[len(msg.Payload)-symKeyLength:]
+		topic := pss.BytesToTopic([]byte(msg.Name))
+		// \TODO keep track of and add actual address
+		updaterAddr := pss.PssAddress([]byte{})
+		self.pss.SetSymmetricKey(symkey, topic, &updaterAddr, true)
+		self.pss.Register(&topic, self.Handler)
+		return self.handlers[msg.Name](msg.Name, msg.Payload)
+	case MsgCodeNotify:
+		return self.handlers[msg.Name](msg.Name, msg.Payload)
+	default:
+		return fmt.Errorf("Invalid message code: %d", msg.Code)
+	}
+
+	return nil
+}

--- a/swarm/pss/notify/notify.go
+++ b/swarm/pss/notify/notify.go
@@ -16,9 +16,16 @@ import (
 )
 
 const (
+	// sent from requester to updater to request start of notifications
 	MsgCodeStart = iota
+
+	// sent from updater to requester, contains a notification plus a new symkey to replace the old
 	MsgCodeNotifyWithKey
+
+	// sent from updater to requester, contains a notification
 	MsgCodeNotify
+
+	// sent from requester to updater to request stop of notifications (currently unused)
 	MsgCodeStop
 	MsgCodeMax
 )
@@ -30,11 +37,13 @@ const (
 )
 
 var (
+	// control topic is used before symmetric key issuance completes
 	controlTopic = pss.Topic{0x00, 0x00, 0x00, 0x01}
 )
 
 // when code is MsgCodeStart, Payload is address
-// when code is MsgCodeNotify, Payload is symkey. If len = 0, keep old key
+// when code is MsgCodeNotifyWithKey, Payload is notification | symkey
+// when code is MsgCodeNotify, Payload is notification
 // when code is MsgCodeStop, Payload is address
 type Msg struct {
 	Name    string
@@ -42,6 +51,7 @@ type Msg struct {
 	Code    byte
 }
 
+// Serialize create a message byte string ready to send through pss
 func (self *Msg) Serialize() []byte {
 	b := bytes.NewBuffer(nil)
 	b.Write([]byte{self.Code})
@@ -55,6 +65,7 @@ func (self *Msg) Serialize() []byte {
 	return b.Bytes()
 }
 
+// reverses Serialize
 func deserializeMsg(msgbytes []byte) (*Msg, error) {
 	msg := &Msg{
 		Code: msgbytes[0],
@@ -70,27 +81,32 @@ func deserializeMsg(msgbytes []byte) (*Msg, error) {
 }
 
 // a notifier has one sendmux entry for each address space it sends messages to
-type sendMux struct {
+type sendBin struct {
 	address  pss.PssAddress
 	symKeyId string
 	count    int
 }
 
+// represents a single notification service
+// only subscription address bins that match the address of a notification client have entries. The threshold sets the amount of bytes each address bin uses.
+// every notification has a topic used for pss transfer of symmetrically encrypted notifications
+// contentFunc is the callback to get initial update data from the notifications service provider
 type notifier struct {
-	muxes       []*sendMux
+	bins        []*sendBin
 	topic       pss.Topic
 	threshold   int
 	contentFunc func(string) ([]byte, error)
-	updateFunc  func(string, []byte)
 	mu          sync.Mutex
 }
 
+// Controller is the interface to control, add and remove notification services
 type Controller struct {
 	pss       *pss.Pss
 	notifiers map[string]*notifier
 	handlers  map[string]func(string, []byte) error
 }
 
+// NewController creates a new Controller object
 func NewController(ps *pss.Pss) *Controller {
 	ctrl := &Controller{
 		pss:       ps,
@@ -101,11 +117,17 @@ func NewController(ps *pss.Pss) *Controller {
 	return ctrl
 }
 
+// IsActive is used to check if a notification service exists for a specified id string
+// Returns true if exists, false if not
 func (self *Controller) IsActive(name string) bool {
 	_, ok := self.notifiers[name]
 	return ok
 }
 
+// Request is used by a client to request notifications from a notification service provider
+// It will create a MsgCodeStart message and send asymmetrically to the provider using its public key and routing address
+// The handler function is a callback that will be called when notifications are recieved
+// Fails if the request pss cannot be sent
 func (self *Controller) Request(name string, pubkey *ecdsa.PublicKey, address pss.PssAddress, handler func(string, []byte) error) error {
 	msg := &Msg{
 		Name:    name,
@@ -118,9 +140,12 @@ func (self *Controller) Request(name string, pubkey *ecdsa.PublicKey, address ps
 	return self.pss.SendAsym(pubkeyid, controlTopic, msg.Serialize())
 }
 
+// NewNotifier is used by a notification service provider to create a new notification service
+// It takes a name as identifier for the resource, a threshold indicating the granularity of the subscription address bin, and a callback for getting the latest update
+// Fails if a notifier already is registered on the name
 func (self *Controller) NewNotifier(name string, threshold int, contentFunc func(string) ([]byte, error)) error {
 	if self.IsActive(name) {
-		return fmt.Errorf("%s already exists in controller", name)
+		return fmt.Errorf("Notification service %s already exists in controller", name)
 	}
 	self.notifiers[name] = &notifier{
 		topic:       pss.BytesToTopic([]byte(name)),
@@ -130,13 +155,20 @@ func (self *Controller) NewNotifier(name string, threshold int, contentFunc func
 	return nil
 }
 
+// Notify is called by a notification service provider to issue a new notification
+// It takes the name of the notification service the data to be sent.
+// It fails if a notifier with this name does not exist.
+// Note that it does NOT fail on failure to send a message
 func (self *Controller) Notify(name string, data []byte) error {
+	if !self.IsActive(name) {
+		return fmt.Errorf("Notification service %s doesn't exist", name)
+	}
 	msg := &Msg{
 		Name:    name,
 		Payload: data,
 		Code:    MsgCodeNotify,
 	}
-	for _, m := range self.notifiers[name].muxes {
+	for _, m := range self.notifiers[name].bins {
 		log.Debug("sending pss notify", "name", name, "addr", fmt.Sprintf("%x", m.address), "topic", fmt.Sprintf("%x", self.notifiers[name].topic), "data", data)
 		err := self.pss.SendSym(m.symKeyId, self.notifiers[name].topic, msg.Serialize())
 		if err != nil {
@@ -146,12 +178,13 @@ func (self *Controller) Notify(name string, data []byte) error {
 	return nil
 }
 
+// adds an client address to the corresponding address bin in the notifier service
 func (self *Controller) addToNotifier(name string, address pss.PssAddress) (string, error) {
 	notifier, ok := self.notifiers[name]
 	if !ok {
 		return "", fmt.Errorf("Unknown notifier %s", name)
 	}
-	for _, m := range notifier.muxes {
+	for _, m := range notifier.bins {
 		if bytes.Equal(address, m.address) {
 			m.count++
 			return m.symKeyId, nil
@@ -161,7 +194,7 @@ func (self *Controller) addToNotifier(name string, address pss.PssAddress) (stri
 	if err != nil {
 		return "", fmt.Errorf("Generate symkey fail: %v", err)
 	}
-	notifier.muxes = append(notifier.muxes, &sendMux{
+	notifier.bins = append(notifier.bins, &sendBin{
 		address:  address,
 		symKeyId: symKeyId,
 		count:    1,
@@ -169,6 +202,8 @@ func (self *Controller) addToNotifier(name string, address pss.PssAddress) (stri
 	return symKeyId, nil
 }
 
+// Handler is the pss topic handler to be used to process notification service messages
+// It should be registered in the pss of both to any notification service provides and clients using the service
 func (self *Controller) Handler(smsg []byte, p *p2p.Peer, asymmetric bool, keyid string) error {
 	log.Debug("notify controller handler", "keyid", keyid)
 

--- a/swarm/pss/notify/notify.go
+++ b/swarm/pss/notify/notify.go
@@ -337,7 +337,7 @@ func (c *Controller) Handler(smsg []byte, p *p2p.Peer, asymmetric bool, keyid st
 			return fmt.Errorf("Unsubscribe attempted on unknown resource '%s'", msg.namestring)
 		}
 
-		// parse the address from the message and truncate if longer than our mux threshold
+		// parse the address from the message and truncate if longer than our bins' address length threshold
 		address := msg.Payload
 		if len(msg.Payload) > c.notifiers[msg.namestring].threshold {
 			address = address[:c.notifiers[msg.namestring].threshold]

--- a/swarm/pss/notify/notify_test.go
+++ b/swarm/pss/notify/notify_test.go
@@ -41,6 +41,10 @@ func init() {
 	wapi = whisper.NewPublicWhisperAPI(w)
 }
 
+// Creates a client node and notifier node
+// Client sends pss notifications requests
+// notifier sends initial notification with symmetric key, and
+// second notifiaction symmetrically encrypted
 func TestStart(t *testing.T) {
 	adapter := adapters.NewSimAdapter(newServices(false))
 	net := simulations.NewNetwork(adapter, &simulations.NetworkConfig{

--- a/swarm/pss/notify/notify_test.go
+++ b/swarm/pss/notify/notify_test.go
@@ -1,0 +1,251 @@
+package notify
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/p2p/discover"
+	"github.com/ethereum/go-ethereum/p2p/simulations"
+	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
+	"github.com/ethereum/go-ethereum/swarm/network"
+	"github.com/ethereum/go-ethereum/swarm/pss"
+	"github.com/ethereum/go-ethereum/swarm/state"
+	whisper "github.com/ethereum/go-ethereum/whisper/whisperv5"
+)
+
+var (
+	loglevel = flag.Int("l", 3, "loglevel")
+	psses    []*pss.Pss
+	w        *whisper.Whisper
+	wapi     *whisper.PublicWhisperAPI
+	msgSeq   int
+)
+
+func init() {
+	flag.Parse()
+	hs := log.StreamHandler(os.Stderr, log.TerminalFormat(true))
+	hf := log.LvlFilterHandler(log.Lvl(*loglevel), hs)
+	h := log.CallerFileHandler(hf)
+	log.Root().SetHandler(h)
+
+	w = whisper.New(&whisper.DefaultConfig)
+	wapi = whisper.NewPublicWhisperAPI(w)
+}
+
+func TestMsgSerialize(t *testing.T) {
+	msg := &Msg{
+		Name:    "foo.eth",
+		Payload: []byte("xyzzy"),
+		Code:    MsgCodeNotify,
+	}
+	smsg := msg.Serialize()
+	serialResult := []byte{MsgCodeNotify, 0x7, 0x0, 0x5, 0x0, 0x66, 0x6f, 0x6f, 0x2e, 0x65, 0x74, 0x68, 0x78, 0x79, 0x7a, 0x7a, 0x79}
+	if !bytes.Equal(smsg, serialResult) {
+		t.Fatalf("Serialize error, expected %x, got %x", serialResult, smsg)
+	}
+
+	dmsg, err := deserializeMsg(smsg)
+	if err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(dmsg, msg) {
+		t.Fatal("deserialized message does not equal original")
+	}
+}
+
+func TestStart(t *testing.T) {
+	adapter := adapters.NewSimAdapter(newServices(false))
+	net := simulations.NewNetwork(adapter, &simulations.NetworkConfig{
+		ID:             "0",
+		DefaultService: "bzz",
+	})
+	l_nodeconf := adapters.RandomNodeConfig()
+	l_nodeconf.Services = []string{"bzz", "pss"}
+	l_node, err := net.NewNodeWithConfig(l_nodeconf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = net.Start(l_node.ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r_nodeconf := adapters.RandomNodeConfig()
+	r_nodeconf.Services = []string{"bzz", "pss"}
+	r_node, err := net.NewNodeWithConfig(r_nodeconf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = net.Start(r_node.ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = net.Connect(r_node.ID(), l_node.ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	l_rpc, err := l_node.Client()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r_rpc, err := r_node.Client()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var l_addr string
+	err = l_rpc.Call(&l_addr, "pss_baseAddr")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var r_addr string
+	err = r_rpc.Call(&r_addr, "pss_baseAddr")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var l_pub string
+	err = l_rpc.Call(&l_pub, "pss_getPublicKey")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = r_rpc.Call(nil, "pss_setPeerPublicKey", l_pub, controlTopic, l_addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rsrcName := "foo.eth"
+	rsrcTopic := pss.BytesToTopic([]byte(rsrcName))
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+	rmsgC := make(chan *pss.APIMsg)
+	r_sub, err := r_rpc.Subscribe(ctx, "pss", rmsgC, "receive", controlTopic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r_sub.Unsubscribe()
+	r_sub_update, err := r_rpc.Subscribe(ctx, "pss", rmsgC, "receive", rsrcTopic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r_sub_update.Unsubscribe()
+
+	updateMsg := []byte("xyzzy")
+	ctrl := NewController(psses[0])
+	ctrl.NewNotifier("foo.eth", 2, func(name string) ([]byte, error) {
+		msgSeq++
+		return updateMsg, nil
+	})
+
+	msg := &Msg{
+		Name:    rsrcName,
+		Payload: common.FromHex(r_addr),
+		Code:    MsgCodeStart,
+	}
+
+	err = r_rpc.Call(nil, "pss_sendAsym", l_pub, controlTopic, common.ToHex(msg.Serialize()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var inMsg *pss.APIMsg
+	select {
+	case inMsg = <-rmsgC:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	dMsg, err := deserializeMsg(inMsg.Msg)
+	if err != nil {
+		t.Fatal(err)
+	} else if dMsg.Name != rsrcName {
+		t.Fatalf("expected name %s, got %s", rsrcName, dMsg.Name)
+	} else if !bytes.Equal(dMsg.Payload[:len(updateMsg)], updateMsg) {
+		t.Fatalf("expected payload first %d bytes '%x', got '%x'", len(updateMsg), updateMsg, dMsg.Payload[:len(updateMsg)])
+	} else if len(updateMsg)+symKeyLength != len(dMsg.Payload) {
+		t.Fatalf("expected payload length %d, have %d", len(updateMsg)+symKeyLength, len(dMsg.Payload))
+	}
+
+	l_pssAddr := pss.PssAddress(common.FromHex(l_addr))
+	psses[1].SetSymmetricKey(dMsg.Payload[len(updateMsg):], rsrcTopic, &l_pssAddr, true)
+
+	nextUpdateMsg := []byte("plugh")
+	ctrl.Notify(rsrcName, nextUpdateMsg)
+	select {
+	case inMsg = <-rmsgC:
+	case <-ctx.Done():
+		log.Error("timed out waiting for msg", "topic", fmt.Sprintf("%x", rsrcTopic))
+		t.Fatal(ctx.Err())
+	}
+	dMsg, err = deserializeMsg(inMsg.Msg)
+	if err != nil {
+		t.Fatal(err)
+	} else if dMsg.Name != rsrcName {
+		t.Fatalf("expected name %s, got %s", rsrcName, dMsg.Name)
+	} else if !bytes.Equal(dMsg.Payload, nextUpdateMsg) {
+		t.Fatalf("expected payload '%x', got '%x'", nextUpdateMsg, dMsg.Payload)
+	}
+
+}
+
+func newServices(allowRaw bool) adapters.Services {
+	stateStore := state.NewInmemoryStore()
+	kademlias := make(map[discover.NodeID]*network.Kademlia)
+	kademlia := func(id discover.NodeID) *network.Kademlia {
+		if k, ok := kademlias[id]; ok {
+			return k
+		}
+		addr := network.NewAddrFromNodeID(id)
+		params := network.NewKadParams()
+		params.MinProxBinSize = 2
+		params.MaxBinSize = 3
+		params.MinBinSize = 1
+		params.MaxRetries = 1000
+		params.RetryExponent = 2
+		params.RetryInterval = 1000000
+		kademlias[id] = network.NewKademlia(addr.Over(), params)
+		return kademlias[id]
+	}
+	return adapters.Services{
+		"pss": func(ctx *adapters.ServiceContext) (node.Service, error) {
+			ctxlocal, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			keys, err := wapi.NewKeyPair(ctxlocal)
+			privkey, err := w.GetPrivateKey(keys)
+			pssp := pss.NewPssParams().WithPrivateKey(privkey)
+			pssp.MsgTTL = time.Second * 30
+			pssp.AllowRaw = allowRaw
+			pskad := kademlia(ctx.Config.ID)
+			ps, err := pss.NewPss(pskad, pssp)
+			if err != nil {
+				return nil, err
+			}
+			psses = append(psses, ps)
+			return ps, nil
+		},
+		"bzz": func(ctx *adapters.ServiceContext) (node.Service, error) {
+			addr := network.NewAddrFromNodeID(ctx.Config.ID)
+			hp := network.NewHiveParams()
+			hp.Discovery = false
+			config := &network.BzzConfig{
+				OverlayAddr:  addr.Over(),
+				UnderlayAddr: addr.Under(),
+				HiveParams:   hp,
+			}
+			return network.NewBzz(config, kademlia(ctx.Config.ID), stateStore, nil, nil), nil
+		},
+	}
+}

--- a/swarm/pss/pss.go
+++ b/swarm/pss/pss.go
@@ -330,11 +330,11 @@ func (p *Pss) handlePssMsg(msg interface{}) error {
 		return fmt.Errorf("invalid message type. Expected *PssMsg, got %T ", msg)
 	}
 	if int64(pssmsg.Expire) < time.Now().Unix() {
-		log.Trace(fmt.Sprintf("pss filtered expired message FROM %x TO %x", p.Overlay.BaseAddr(), common.ToHex(pssmsg.To)))
+		log.Trace(fmt.Sprintf("pss filtered expired message FROM %s TO %s", common.ToHex(p.Overlay.BaseAddr()), common.ToHex(pssmsg.To)))
 		return nil
 	}
 	if p.checkFwdCache(pssmsg) {
-		log.Trace(fmt.Sprintf("pss relay block-cache match (process): FROM %x TO %x", p.Overlay.BaseAddr(), common.ToHex(pssmsg.To)))
+		log.Trace(fmt.Sprintf("pss relay block-cache match (process): FROM %s TO %s", common.ToHex(p.Overlay.BaseAddr()), common.ToHex(pssmsg.To)))
 		return nil
 	}
 	p.addFwdCache(pssmsg)

--- a/swarm/pss/pss.go
+++ b/swarm/pss/pss.go
@@ -407,7 +407,7 @@ func (p *Pss) executeHandlers(topic Topic, payload []byte, from *PssAddress, asy
 	for f := range handlers {
 		err := (*f)(payload, peer, asymmetric, keyid)
 		if err != nil {
-			log.Warn("Pss handler %p failed: %v", f, err)
+			log.Warn("Pss handler failed", "handler", fmt.Sprintf("%p", f), "err", err)
 		}
 	}
 }

--- a/swarm/pss/pss.go
+++ b/swarm/pss/pss.go
@@ -454,8 +454,8 @@ func (p *Pss) SetPeerPublicKey(pubkey *ecdsa.PublicKey, topic Topic, address *Ps
 }
 
 // Automatically generate a new symkey for a topic and address hint
-func (p *Pss) generateSymmetricKey(topic Topic, address *PssAddress, addToCache bool) (string, error) {
-	keyid, err := p.w.GenerateSymKey()
+func (p *Pss) GenerateSymmetricKey(topic Topic, address *PssAddress, addToCache bool) (string, error) {
+	keyid, err := self.w.GenerateSymKey()
 	if err != nil {
 		return "", err
 	}

--- a/swarm/pss/pss.go
+++ b/swarm/pss/pss.go
@@ -455,7 +455,7 @@ func (p *Pss) SetPeerPublicKey(pubkey *ecdsa.PublicKey, topic Topic, address *Ps
 
 // Automatically generate a new symkey for a topic and address hint
 func (p *Pss) GenerateSymmetricKey(topic Topic, address *PssAddress, addToCache bool) (string, error) {
-	keyid, err := self.w.GenerateSymKey()
+	keyid, err := p.w.GenerateSymKey()
 	if err != nil {
 		return "", err
 	}

--- a/swarm/pss/pss.go
+++ b/swarm/pss/pss.go
@@ -821,7 +821,7 @@ func (p *Pss) forward(msg *PssMsg) error {
 			log.Trace(fmt.Sprintf("Pss keep forwarding: Partial address + full partial match"))
 			return true
 		} else if isproxbin {
-			log.Trace(fmt.Sprintf("%x is in proxbin, keep forwarding", common.ToHex(op.Address())))
+			log.Trace(fmt.Sprintf("%s is in proxbin, keep forwarding", common.ToHex(op.Address())))
 			return true
 		}
 		// at this point we stop forwarding, and the state is as follows:

--- a/swarm/pss/pss_test.go
+++ b/swarm/pss/pss_test.go
@@ -452,7 +452,7 @@ func TestKeys(t *testing.T) {
 	}
 
 	// make a symmetric key that we will send to peer for encrypting messages to us
-	inkeyid, err := ps.generateSymmetricKey(topicobj, &addr, true)
+	inkeyid, err := ps.GenerateSymmetricKey(topicobj, &addr, true)
 	if err != nil {
 		t.Fatalf("failed to set 'our' incoming symmetric key")
 	}
@@ -1259,7 +1259,7 @@ func benchmarkSymKeySend(b *testing.B) {
 	topic := BytesToTopic([]byte("foo"))
 	to := make(PssAddress, 32)
 	copy(to[:], network.RandomAddr().Over())
-	symkeyid, err := ps.generateSymmetricKey(topic, &to, true)
+	symkeyid, err := ps.GenerateSymmetricKey(topic, &to, true)
 	if err != nil {
 		b.Fatalf("could not generate symkey: %v", err)
 	}
@@ -1352,7 +1352,7 @@ func benchmarkSymkeyBruteforceChangeaddr(b *testing.B) {
 	for i := 0; i < int(keycount); i++ {
 		to := make(PssAddress, 32)
 		copy(to[:], network.RandomAddr().Over())
-		keyid, err = ps.generateSymmetricKey(topic, &to, true)
+		keyid, err = ps.GenerateSymmetricKey(topic, &to, true)
 		if err != nil {
 			b.Fatalf("cant generate symkey #%d: %v", i, err)
 		}
@@ -1434,7 +1434,7 @@ func benchmarkSymkeyBruteforceSameaddr(b *testing.B) {
 	topic := BytesToTopic([]byte("foo"))
 	for i := 0; i < int(keycount); i++ {
 		copy(addr[i], network.RandomAddr().Over())
-		keyid, err = ps.generateSymmetricKey(topic, &addr[i], true)
+		keyid, err = ps.GenerateSymmetricKey(topic, &addr[i], true)
 		if err != nil {
 			b.Fatalf("cant generate symkey #%d: %v", i, err)
 		}


### PR DESCRIPTION
This PR adds a notifications package to pss. It enables separate notifications objects to be constructed for each notification service.

The primary use case are resource update subscriptions.

A notification subscription is added to an address bin, and all addresses within that bin share a symmetric key. Thus, for every notification sent out, there is a guarantee that not more sends will be performed than the number of address bins.

For example, if the address _threshold_ is one byte, then a maximum of 256 sends will be performed for that notification. Empty bins will not be sent to.

Next steps should probably be to:

* Implement key rotation.
* Refactor pss to allow bit-level instead of byte-level addressing.