### PR TITLE
p2p, swarm: measure number of p2p.Send calls and time them

### DIFF
--- a/p2p/protocols/protocol.go
+++ b/p2p/protocols/protocol.go
@@ -33,7 +33,9 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+	"time"
 
+	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p"
 )
 
@@ -217,6 +219,8 @@ func (p *Peer) Drop(err error) {
 // this low level call will be wrapped by libraries providing routed or broadcast sends
 // but often just used to forward and push messages to directly connected peers
 func (p *Peer) Send(msg interface{}) error {
+	defer metrics.GetOrRegisterResettingTimer("peer.send", nil).UpdateSince(time.Now())
+	metrics.GetOrRegisterCounter("peer.send", nil).Inc(1)
 	code, found := p.spec.GetCode(msg)
 	if !found {
 		return errorf(ErrInvalidMsgType, "%v", code)

--- a/swarm/network/stream/peer.go
+++ b/swarm/network/stream/peer.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p/protocols"
 	pq "github.com/ethereum/go-ethereum/swarm/network/priorityqueue"
 	"github.com/ethereum/go-ethereum/swarm/network/stream/intervals"
@@ -92,6 +93,8 @@ func (p *Peer) Deliver(chunk *storage.Chunk, priority uint8) error {
 
 // SendPriority sends message to the peer using the outgoing priority queue
 func (p *Peer) SendPriority(msg interface{}, priority uint8) error {
+	defer metrics.GetOrRegisterResettingTimer(fmt.Sprintf("peer.sendpriority.%d", priority), nil).UpdateSince(time.Now())
+	metrics.GetOrRegisterCounter(fmt.Sprintf("peer.sendpriority.%d", priority), nil).Inc(1)
 	ctx, cancel := context.WithTimeout(context.Background(), sendTimeout)
 	defer cancel()
 	return p.pq.Push(ctx, msg, int(priority))

--- a/swarm/network/stream/stream.go
+++ b/swarm/network/stream/stream.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/ethereum/go-ethereum/p2p/protocols"
@@ -348,12 +349,14 @@ func (r *Registry) getPeer(peerId discover.NodeID) *Peer {
 func (r *Registry) setPeer(peer *Peer) {
 	r.peersMu.Lock()
 	r.peers[peer.ID()] = peer
+	metrics.GetOrRegisterGauge("registry.peers", nil).Update(int64(len(r.peers)))
 	r.peersMu.Unlock()
 }
 
 func (r *Registry) deletePeer(peer *Peer) {
 	r.peersMu.Lock()
 	delete(r.peers, peer.ID())
+	metrics.GetOrRegisterGauge("registry.peers", nil).Update(int64(len(r.peers)))
 	r.peersMu.Unlock()
 }
 


### PR DESCRIPTION
This PR is adding for:
1. Counters and timers for `p2p.Send` and `p2p.SendPriority` calls, so that we have better intuition on how many messages we send to our peers and how long it takes for the call to return.

2. Counters for `registry`'s number of peers, so that we have an average of number of messages per peer.