### PR TITLE
p2p, swarm: use different names for counter and timer

### DIFF
--- a/p2p/protocols/protocol.go
+++ b/p2p/protocols/protocol.go
@@ -219,7 +219,7 @@ func (p *Peer) Drop(err error) {
 // this low level call will be wrapped by libraries providing routed or broadcast sends
 // but often just used to forward and push messages to directly connected peers
 func (p *Peer) Send(msg interface{}) error {
-	defer metrics.GetOrRegisterResettingTimer("peer.send", nil).UpdateSince(time.Now())
+	defer metrics.GetOrRegisterResettingTimer("peer.send_t", nil).UpdateSince(time.Now())
 	metrics.GetOrRegisterCounter("peer.send", nil).Inc(1)
 	code, found := p.spec.GetCode(msg)
 	if !found {

--- a/swarm/network/stream/peer.go
+++ b/swarm/network/stream/peer.go
@@ -93,7 +93,7 @@ func (p *Peer) Deliver(chunk *storage.Chunk, priority uint8) error {
 
 // SendPriority sends message to the peer using the outgoing priority queue
 func (p *Peer) SendPriority(msg interface{}, priority uint8) error {
-	defer metrics.GetOrRegisterResettingTimer(fmt.Sprintf("peer.sendpriority.%d", priority), nil).UpdateSince(time.Now())
+	defer metrics.GetOrRegisterResettingTimer(fmt.Sprintf("peer.sendpriority_t.%d", priority), nil).UpdateSince(time.Now())
 	metrics.GetOrRegisterCounter(fmt.Sprintf("peer.sendpriority.%d", priority), nil).Inc(1)
 	ctx, cancel := context.WithTimeout(context.Background(), sendTimeout)
 	defer cancel()


### PR DESCRIPTION
Fixes regression introduced in https://github.com/ethersphere/go-ethereum/pull/590

I thought we add `.count` and `.timer` to metrics, but apparently this happens later.

So we cannot have metrics with the same name.