### PR TITLE
swarm/fuse: do not support relative path for fuse mounting

### DIFF
--- a/cmd/swarm/fs.go
+++ b/cmd/swarm/fs.go
@@ -48,7 +48,7 @@ func mount(cliContext *cli.Context) {
 	mf := &fuse.MountInfo{}
 	mountPoint, err := filepath.Abs(filepath.Clean(args[1]))
 	if err != nil {
-		utils.Fatalf("had an error with getting the mount point: %v", err)
+		utils.Fatalf("error expanding path for mount point: %v", err)
 	}
 	err = client.CallContext(ctx, mf, "swarmfs_mount", args[0], mountPoint)
 	if err != nil {

--- a/cmd/swarm/fs.go
+++ b/cmd/swarm/fs.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -45,7 +46,11 @@ func mount(cliContext *cli.Context) {
 	defer cancel()
 
 	mf := &fuse.MountInfo{}
-	err = client.CallContext(ctx, mf, "swarmfs_mount", args[0], args[1])
+	mountPoint, err := filepath.Abs(filepath.Clean(args[1]))
+	if err != nil {
+		utils.Fatalf("had an error with getting the mount point: %v", err)
+	}
+	err = client.CallContext(ctx, mf, "swarmfs_mount", args[0], mountPoint)
 	if err != nil {
 		utils.Fatalf("had an error calling the RPC endpoint while mounting: %v", err)
 	}

--- a/swarm/fuse/swarmfs_unix.go
+++ b/swarm/fuse/swarmfs_unix.go
@@ -35,10 +35,11 @@ import (
 )
 
 var (
-	errEmptyMountPoint = errors.New("need non-empty mount point")
-	errMaxMountCount   = errors.New("max FUSE mount count reached")
-	errMountTimeout    = errors.New("mount timeout")
-	errAlreadyMounted  = errors.New("mount point is already serving")
+	errEmptyMountPoint      = errors.New("need non-empty mount point")
+	errNoRelativeMountPoint = errors.New("relative mount points are not allowed. please specify an absolute path")
+	errMaxMountCount        = errors.New("max FUSE mount count reached")
+	errMountTimeout         = errors.New("mount timeout")
+	errAlreadyMounted       = errors.New("mount point is already serving")
 )
 
 func isFUSEUnsupportedError(err error) bool {
@@ -48,7 +49,7 @@ func isFUSEUnsupportedError(err error) bool {
 	return err == fuse.ErrOSXFUSENotFound
 }
 
-// information about every active mount
+// MountInfo contains information about every active mount
 type MountInfo struct {
 	MountPoint     string
 	StartManifest  string
@@ -77,6 +78,9 @@ func (swarmfs *SwarmFS) Mount(mhash, mountpoint string) (*MountInfo, error) {
 	log.Info("swarmfs", "mounting hash", mhash, "mount point", mountpoint)
 	if mountpoint == "" {
 		return nil, errEmptyMountPoint
+	}
+	if !strings.HasPrefix(mountpoint, "/") {
+		return nil, errNoRelativeMountPoint
 	}
 	cleanedMountPoint, err := filepath.Abs(filepath.Clean(mountpoint))
 	if err != nil {

--- a/swarm/fuse/swarmfs_unix.go
+++ b/swarm/fuse/swarmfs_unix.go
@@ -36,7 +36,7 @@ import (
 
 var (
 	errEmptyMountPoint      = errors.New("need non-empty mount point")
-	errNoRelativeMountPoint = errors.New("relative mount points are not allowed. please specify an absolute path")
+	errNoRelativeMountPoint = errors.New("invalid path for mount point (need absolute path)")
 	errMaxMountCount        = errors.New("max FUSE mount count reached")
 	errMountTimeout         = errors.New("mount timeout")
 	errAlreadyMounted       = errors.New("mount point is already serving")


### PR DESCRIPTION
fixes #553 
tested through CLI+`geth attach`