### PR TITLE
Fix panic: do not set nil resolver for interface types

### DIFF
--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -195,11 +195,12 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 		Signer: &storage.GenericResourceSigner{
 			PrivKey: self.privateKey,
 		},
-		HeaderGetter:   resolver,
-		OwnerValidator: resolver,
 	}
 	if resolver != nil {
 		resolver.SetNameHash(ens.EnsNode)
+		// Set HeaderGetter and OwnerValidator interfaces to resolver only if it is not nil.
+		rhparams.HeaderGetter = resolver
+		rhparams.OwnerValidator = resolver
 	} else {
 		log.Warn("No ETH API specified, resource updates will use block height approximation")
 		// TODO: blockestimator should use saved values derived from last time ethclient was connected


### PR DESCRIPTION
This PR fixes this panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x46cabc6]

goroutine 86 [running]:
github.com/ethereum/go-ethereum/swarm/api.(*MultiResolver).getResolveValidator(0x0, 0xc421f340d0, 0xd, 0x0, 0xc4242561e0, 0x20, 0x20, 0x0)
	/Users/janos/go/src/github.com/ethereum/go-ethereum/swarm/api/api.go:191 +0x26
github.com/ethereum/go-ethereum/swarm/api.(*MultiResolver).ValidateOwner(0x0, 0xc421f340d0, 0xd, 0x44ba8f5f39bab270, 0xa76e7955eb363426, 0xeb3634267d2b245c, 0x7d2b245ca76e7955, 0xc424256160, 0xc4245aa190)
	/Users/janos/go/src/github.com/ethereum/go-ethereum/swarm/api/api.go:159 +0x5a
github.com/ethereum/go-ethereum/swarm/storage.(*ResourceHandler).checkAccess(0xc420232240, 0xc421f340d0, 0xd, 0x44ba8f5f39bab270, 0xa76e7955eb363426, 0xdb04ae037d2b245c, 0xab41b0fc886ce013, 0x3e311bf4fbe1d796, 0x5b1b6f6777f31a4f)
	/Users/janos/go/src/github.com/ethereum/go-ethereum/swarm/storage/resource.go:313 +0x65
github.com/ethereum/go-ethereum/swarm/storage.(*ResourceHandler).Validate(0xc420232240, 0xc421f7ab20, 0x20, 0x4e0, 0xc4200ebb80, 0x7c, 0x7c, 0x0)
	/Users/janos/go/src/github.com/ethereum/go-ethereum/swarm/storage/resource.go:289 +0x30e
github.com/ethereum/go-ethereum/swarm/storage.(*LocalStore).Put(0xc420c99c20, 0xc421f78d00)
	/Users/janos/go/src/github.com/ethereum/go-ethereum/swarm/storage/localstore.go:102 +0xd4
github.com/ethereum/go-ethereum/swarm/storage.(*DBAPI).Put(0xc420ca4010, 0xc421f78d00)
	/Users/janos/go/src/github.com/ethereum/go-ethereum/swarm/storage/dbapi.go:51 +0x39
github.com/ethereum/go-ethereum/swarm/network/stream.(*Delivery).processReceivedChunks(0xc420c99c50)
	/Users/janos/go/src/github.com/ethereum/go-ethereum/swarm/network/stream/delivery.go:224 +0x19c
created by github.com/ethereum/go-ethereum/swarm/network/stream.NewDelivery
	/Users/janos/go/src/github.com/ethereum/go-ethereum/swarm/network/stream/delivery.go:59 +0xbe
```

ResourceHandlerParams interface fields HeaderGetter and OwnerValidator are set to resolver value even if ti is nil. Type for resolver is a concrete one *api.MultiResolver and by setting a nil concrete type to an interface value (in this case a struct field), the interface value is not nil, but the concrete type is. This results in a panic as check at ResourceHandler.checkAccess function for ResourceHandler.ownerValidator is not nil, but the *api.MultiResolver is nil at swarm/api/api.go:191.

This was a mistake in this PR by me https://github.com/ethersphere/go-ethereum/pull/558.