### PR TITLE
Fix panic in p2psim

### DIFF
--- a/p2p/simulations/network.go
+++ b/p2p/simulations/network.go
@@ -206,9 +206,13 @@ func (net *Network) watchPeerEvents(id discover.NodeID, events chan *p2p.PeerEve
 
 		// assume the node is now down
 		net.lock.Lock()
+		defer net.lock.Unlock()
 		node := net.getNode(id)
+		if node == nil {
+			log.Error("Can not find node for id", "id", id)
+			return
+		}
 		node.Up = false
-		net.lock.Unlock()
 		net.events.Send(NewEvent(node))
 	}()
 	for {


### PR DESCRIPTION
See this issue: https://github.com/ethersphere/go-ethereum/issues/586
Instead of panic let's log the event. We can fix it later if we see it in the logs, but I don't know how to reproduce it now.