### PR TITLE
swarm/pss: Pssmsg flags

### DIFF
--- a/swarm/pss/pss.go
+++ b/swarm/pss/pss.go
@@ -376,10 +376,10 @@ func (p *Pss) process(pssmsg *PssMsg) error {
 		payload = pssmsg.Payload.Data
 	} else {
 		if pssmsg.isSym() {
-			keyFunc = self.processSym
+			keyFunc = p.processSym
 		} else {
 			asymmetric = true
-			keyFunc = self.processAsym
+			keyFunc = p.processAsym
 		}
 
 		recvmsg, keyid, from, err = keyFunc(envelope)
@@ -394,7 +394,7 @@ func (p *Pss) process(pssmsg *PssMsg) error {
 			return err
 		}
 	}
-	p.executeHandlers(psstopic, recvmsg.Payload, from, asymmetric, keyid)
+	p.executeHandlers(psstopic, payload, from, asymmetric, keyid)
 
 	return nil
 
@@ -608,7 +608,6 @@ func (p *Pss) cleanKeys() (count int) {
 	for keyid, peertopics := range p.symKeyPool {
 		var expiredtopics []Topic
 		for topic, psp := range peertopics {
-			//log.Trace("check topic", "topic", topic, "id", keyid, "protect", psp.protected, "p", fmt.Sprintf("%p", self.symKeyPool[keyid][topic]))
 			if psp.protected {
 				continue
 			}
@@ -616,7 +615,6 @@ func (p *Pss) cleanKeys() (count int) {
 			var match bool
 			for i := p.symKeyDecryptCacheCursor; i > p.symKeyDecryptCacheCursor-cap(p.symKeyDecryptCache) && i > 0; i-- {
 				cacheid := p.symKeyDecryptCache[i%cap(p.symKeyDecryptCache)]
-				//log.Trace("check cache", "idx", i, "id", *cacheid)
 				if *cacheid == keyid {
 					match = true
 				}
@@ -668,7 +666,7 @@ func (p *Pss) SendRaw(address PssAddress, topic Topic, msg []byte) error {
 	pssMsg.To = address
 	pssMsg.Expire = uint32(time.Now().Add(p.msgTTL).Unix())
 	pssMsg.Payload = payload
-	self.addFwdCache(pssMsg)
+	p.addFwdCache(pssMsg)
 	return p.enqueue(pssMsg)
 }
 

--- a/swarm/pss/pss_test.go
+++ b/swarm/pss/pss_test.go
@@ -612,7 +612,7 @@ func testSendRaw(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	topic := "0x00000000"
+	topic := "0xdeadbeef"
 
 	var loaddrhex string
 	err = clients[0].Call(&loaddrhex, "pss_baseAddr")
@@ -646,7 +646,7 @@ func testSendRaw(t *testing.T) {
 
 	// send and verify delivery
 	lmsg := []byte("plugh")
-	err = clients[1].Call(nil, "pss_sendRaw", lmsg, loaddrhex)
+	err = clients[1].Call(nil, "pss_sendRaw", loaddrhex, topic, lmsg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -659,7 +659,7 @@ func testSendRaw(t *testing.T) {
 		t.Fatalf("test message (left) timed out: %v", cerr)
 	}
 	rmsg := []byte("xyzzy")
-	err = clients[0].Call(nil, "pss_sendRaw", rmsg, roaddrhex)
+	err = clients[0].Call(nil, "pss_sendRaw", roaddrhex, topic, rmsg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swarm/pss/pss_test.go
+++ b/swarm/pss/pss_test.go
@@ -121,6 +121,29 @@ func TestTopic(t *testing.T) {
 	}
 }
 
+// test bit packing of message control flags
+func TestMsgParams(t *testing.T) {
+	var ctrl byte
+	ctrl |= pssControlRaw
+	p := newMsgParamsFromBytes([]byte{ctrl})
+	m := newPssMsg(p)
+	if !m.isRaw() || m.isSym() {
+		t.Fatal("expected raw=true and sym=false")
+	}
+	ctrl |= pssControlSym
+	p = newMsgParamsFromBytes([]byte{ctrl})
+	m = newPssMsg(p)
+	if !m.isRaw() || !m.isSym() {
+		t.Fatal("expected raw=true and sym=true")
+	}
+	ctrl &= 0xff &^ pssControlRaw
+	p = newMsgParamsFromBytes([]byte{ctrl})
+	m = newPssMsg(p)
+	if m.isRaw() || !m.isSym() {
+		t.Fatal("expected raw=false and sym=true")
+	}
+}
+
 // test if we can insert into cache, match items with cache and cache expiry
 func TestCache(t *testing.T) {
 	var err error

--- a/swarm/pss/types.go
+++ b/swarm/pss/types.go
@@ -17,6 +17,11 @@ const (
 	defaultWhisperTTL = 6000
 )
 
+const (
+	pssControlSym = 1
+	pssControlRaw = 1 << 1
+)
+
 var (
 	topicHashMutex = sync.Mutex{}
 	topicHashFunc  = storage.MakeHashFunc("SHA256")()
@@ -70,6 +75,7 @@ type pssDigest [digestLength]byte
 // Encapsulates messages transported over pss.
 type PssMsg struct {
 	To      []byte
+	Control []byte
 	Expire  uint32
 	Payload *whisper.Envelope
 }


### PR DESCRIPTION
https://github.com/ethersphere/go-ethereum/issues/593

Unused bits reserved for future use.

(and may be a prerequisite to introduce filtering https://github.com/ethersphere/go-ethereum/issues/565 - although bloom filters aren't very likely candidate)