### PR TITLE
swarm/api: copy reader to writer with a 64mb buffer

### DIFF
--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -982,7 +982,8 @@ func (s *Server) HandleGetFile(w http.ResponseWriter, r *Request) {
 	buf := make([]byte, 64000000)
 	written, err := io.CopyBuffer(writer, reader, buf)
 	if err != nil {
-		panic(err)
+		log.Error("handle.get.file: written", "ruid", r.ruid, "written", written)
+		Respond(w, r, fmt.Sprintf("file not fully loaded %s: %s", r.uri, err), http.StatusNotFound)
 	}
 	log.Debug("handle.get.file: written", "ruid", r.ruid, "written", written)
 	http.ServeContent(w, &r.Request, "", time.Now(), reader)

--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -21,6 +21,7 @@ package http
 
 import (
 	"archive/tar"
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"errors"
@@ -975,6 +976,15 @@ func (s *Server) HandleGetFile(w http.ResponseWriter, r *Request) {
 	}
 
 	w.Header().Set("Content-Type", contentType)
+	var mybuf bytes.Buffer
+	writer := bufio.NewWriter(&mybuf)
+
+	buf := make([]byte, 64000000)
+	written, err := io.CopyBuffer(writer, reader, buf)
+	if err != nil {
+		panic(err)
+	}
+	log.Debug("handle.get.file: written", "ruid", r.ruid, "written", written)
 	http.ServeContent(w, &r.Request, "", time.Now(), reader)
 }
 


### PR DESCRIPTION
This is an experiment to increase the number of go-routines requesting chunks from 8 to 128.