### PR TITLE
Pyramid split fix

### DIFF
--- a/swarm/storage/chunker_test.go
+++ b/swarm/storage/chunker_test.go
@@ -238,9 +238,6 @@ func TestDataAppend(t *testing.T) {
 }
 
 func TestRandomData(t *testing.T) {
-	// TODO: fix pyramid split for this cases
-	//sizes := []int{524288 + 4096, 7*524288 + 4096}
-
 	sizes := []int{1, 60, 83, 179, 253, 1024, 4095, 4096, 4097, 8191, 8192, 8193, 12287, 12288, 12289, 123456, 2345678, 524288, 524288 + 1, 524288 + 4097, 7 * 524288, 7*524288 + 1, 7*524288 + 4097}
 	tester := &chunkerTester{t: t}
 

--- a/swarm/storage/chunker_test.go
+++ b/swarm/storage/chunker_test.go
@@ -238,6 +238,8 @@ func TestDataAppend(t *testing.T) {
 }
 
 func TestRandomData(t *testing.T) {
+	// This test can validate files up to a relatively short length, as tree chunker slows down drastically.
+	// Validation of longer files is done by TestLocalStoreAndRetrieve in swarm package.
 	sizes := []int{1, 60, 83, 179, 253, 1024, 4095, 4096, 4097, 8191, 8192, 8193, 12287, 12288, 12289, 123456, 2345678, 524288, 524288 + 1, 524288 + 4097, 7 * 524288, 7*524288 + 1, 7*524288 + 4097}
 	tester := &chunkerTester{t: t}
 

--- a/swarm/storage/chunker_test.go
+++ b/swarm/storage/chunker_test.go
@@ -238,7 +238,10 @@ func TestDataAppend(t *testing.T) {
 }
 
 func TestRandomData(t *testing.T) {
-	sizes := []int{1, 60, 83, 179, 253, 1024, 4095, 4096, 4097, 8191, 8192, 8193, 12287, 12288, 12289, 123456, 2345678}
+	// TODO: fix pyramid split for this cases
+	//sizes := []int{524288 + 4096, 7*524288 + 4096}
+
+	sizes := []int{1, 60, 83, 179, 253, 1024, 4095, 4096, 4097, 8191, 8192, 8193, 12287, 12288, 12289, 123456, 2345678, 524288, 524288 + 1, 524288 + 4097, 7 * 524288, 7*524288 + 1, 7*524288 + 4097}
 	tester := &chunkerTester{t: t}
 
 	for _, s := range sizes {

--- a/swarm/storage/pyramid.go
+++ b/swarm/storage/pyramid.go
@@ -630,7 +630,7 @@ func (self *PyramidChunker) buildTree(isAppend bool, ent *TreeEntry, chunkWG *sy
 		if !isAppend {
 			chunkWG.Wait()
 			if compress {
-				self.chunkLevel[lvl] = nil
+				self.chunkLevel = append(self.chunkLevel[:lvl], append(self.chunkLevel[lvl+1:], nil)...)
 			}
 		}
 	}

--- a/swarm/storage/pyramid.go
+++ b/swarm/storage/pyramid.go
@@ -18,9 +18,7 @@ package storage
 
 import (
 	"encoding/binary"
-	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"sync"
@@ -118,11 +116,6 @@ type TreeEntry struct {
 	key           []byte
 	index         int  // used in append to indicate the index of existing tree entry
 	updatePending bool // indicates if the entry is loaded from existing tree
-}
-
-// TODO: REMOVE. Temporary for debugging.
-func (te *TreeEntry) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf(`"%v, %v, %x: %x"`, te.level, te.branchCount, te.key, te.chunk)), nil
 }
 
 func NewTreeEntry(pyramid *PyramidChunker) *TreeEntry {
@@ -394,12 +387,6 @@ func (self *PyramidChunker) prepareChunks(isAppend bool) {
 	log.Debug("pyramid.chunker: prepareChunks", "isAppend", isAppend)
 	defer self.wg.Done()
 
-	// TODO: REMOVE. Temporary for debugging.
-	defer func() {
-		d, _ := json.MarshalIndent(self.chunkLevel, "", "    ")
-		fmt.Println(string(d))
-	}()
-
 	chunkWG := &sync.WaitGroup{}
 
 	self.incrementWorkerCount()
@@ -458,9 +445,6 @@ func (self *PyramidChunker) prepareChunks(isAppend bool) {
 
 		var res []byte
 		res, err = ioutil.ReadAll(io.LimitReader(self.reader, int64(len(chunkData)-(8+readBytes))))
-
-		// TODO: REMOVE. Temporary for debugging.
-		fmt.Println("res", len(res))
 
 		// hack for ioutil.ReadAll:
 		// a successful call to ioutil.ReadAll returns err == nil, not err == EOF, whereas we

--- a/swarm/storage/pyramid.go
+++ b/swarm/storage/pyramid.go
@@ -475,7 +475,7 @@ func (self *PyramidChunker) prepareChunks(isAppend bool) {
 
 		if err != nil {
 			if err == io.EOF || err == io.ErrUnexpectedEOF {
-				if parent.branchCount == 1 && self.depth() == 0 {
+				if parent.branchCount == 1 && (self.depth() == 0 || isAppend) {
 					// Data is exactly one chunk.. pick the last chunk key as root
 					chunkWG.Wait()
 					lastChunksKey := parent.chunk[8 : 8+self.hashSize]
@@ -506,7 +506,7 @@ func (self *PyramidChunker) prepareChunks(isAppend bool) {
 				if parent.branchCount <= 1 {
 					chunkWG.Wait()
 
-					if self.depth() == 0 {
+					if isAppend || self.depth() == 0 {
 						copy(self.rootKey, pkey)
 					} else {
 						self.buildTree(isAppend, parent, chunkWG, true, pkey)

--- a/swarm/storage/pyramid.go
+++ b/swarm/storage/pyramid.go
@@ -459,6 +459,7 @@ func (self *PyramidChunker) prepareChunks(isAppend bool) {
 
 		if err != nil {
 			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				// Check if we are appending or the chunk is the only one.
 				if parent.branchCount == 1 && (self.depth() == 0 || isAppend) {
 					// Data is exactly one chunk.. pick the last chunk key as root
 					chunkWG.Wait()
@@ -491,8 +492,13 @@ func (self *PyramidChunker) prepareChunks(isAppend bool) {
 					chunkWG.Wait()
 
 					if isAppend || self.depth() == 0 {
+						// No need to build the tree if the depth is 0
+						// or we are appending.
+						// Just use the last key.
 						copy(self.rootKey, pkey)
 					} else {
+						// We need to build the tree and and provide the lonely
+						// chunk key to replace the last tree chunk key.
 						self.buildTree(isAppend, parent, chunkWG, true, pkey)
 					}
 					break
@@ -519,7 +525,7 @@ func (self *PyramidChunker) prepareChunks(isAppend bool) {
 
 }
 
-func (self *PyramidChunker) buildTree(isAppend bool, ent *TreeEntry, chunkWG *sync.WaitGroup, last bool, lonelyKey []byte) {
+func (self *PyramidChunker) buildTree(isAppend bool, ent *TreeEntry, chunkWG *sync.WaitGroup, last bool, lonelyChunkKey []byte) {
 	chunkWG.Wait()
 	self.enqueueTreeChunk(ent, chunkWG, last)
 
@@ -600,9 +606,11 @@ func (self *PyramidChunker) buildTree(isAppend bool, ent *TreeEntry, chunkWG *sy
 					copy(newEntry.chunk[8+(index*self.hashSize):8+((index+1)*self.hashSize)], entry.key[:self.hashSize])
 					index++
 				}
-				if lonelyKey != nil {
+				// Lonely chunk key is the key of the last chunk that is only one on the last branch.
+				// In this case, ignore the its tree chunk key and replace it with the lonely chunk key.
+				if lonelyChunkKey != nil {
 					// Overwrite the last tree chunk key with the lonely data chunk key.
-					copy(newEntry.chunk[int64(len(newEntry.chunk))-self.hashSize:], lonelyKey[:self.hashSize])
+					copy(newEntry.chunk[int64(len(newEntry.chunk))-self.hashSize:], lonelyChunkKey[:self.hashSize])
 				}
 
 				self.enqueueTreeChunk(newEntry, chunkWG, last)
@@ -614,6 +622,9 @@ func (self *PyramidChunker) buildTree(isAppend bool, ent *TreeEntry, chunkWG *sy
 		if !isAppend {
 			chunkWG.Wait()
 			if compress {
+				// Remove the chunk level by cutting chunkLevel slice.
+				// Do not set the chunkLevel to nil, as it breaks tree building
+				// in edge cases.
 				self.chunkLevel = append(self.chunkLevel[:lvl], append(self.chunkLevel[lvl+1:], nil)...)
 			}
 		}
@@ -662,6 +673,9 @@ func (self *PyramidChunker) enqueueDataChunk(chunkData []byte, size uint64, pare
 
 }
 
+// depth returns the number of chunk levels.
+// It is used to detect if there is only one data chunk
+// left for the last branch.
 func (self *PyramidChunker) depth() (d int) {
 	for _, l := range self.chunkLevel {
 		if l == nil {

--- a/swarm/swarm_test.go
+++ b/swarm/swarm_test.go
@@ -18,9 +18,12 @@ package swarm
 
 import (
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"path"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -272,5 +275,84 @@ func TestParseEnsAPIAddress(t *testing.T) {
 				t.Errorf("expected TLD %q, got %q", x.tld, tld)
 			}
 		})
+	}
+}
+
+// TestLocalStoreAndRetrieve runs multiple tests where different size files are uploaded
+// to a single Swarm instance using API Store and checked against the dontent returned
+// by API Retrieve function.
+//
+// This test is intended to validate functionality of chunker store and join functions
+// and their intergartion into Swarm, without comparing results with ones produced by
+// another chunker implementation, as it is done in swarm/storage tests.
+func TestLocalStoreAndRetrieve(t *testing.T) {
+	sizes := []int{1, 60, 83, 179, 253, 1024, 4095, 4096, 4097, 8191, 8192, 8193, 12287, 12288, 12289, 123456, 2345678, 67298391, 524288, 524288 + 1, 524288 + 4096, 524288 + 4097, 7 * 524288, 7*524288 + 1, 7*524288 + 4096, 7*524288 + 4097, 128*524288 + 1, 128*524288 + 4096, 128*524288 + 4097}
+	for _, n := range sizes {
+		testLocalStoreAndRetrieve(t, n, true)
+		testLocalStoreAndRetrieve(t, n, false)
+	}
+}
+
+// testLocalStoreAndRetrieve creates a single Swarm instance, uploads
+// a file of length n with optional random data using API Store function,
+// and checks the output of API Retrieve function on the same instance.
+// This is a regression test for issue
+// https://github.com/ethersphere/go-ethereum/issues/639
+// where pyramid chunker did not split correctly files with lengths that
+// are edge cases for chunk and tree parameters, depending whether there
+// is a tree chunk with only one data chunk and how the compress functionality
+// changed the tree.
+func testLocalStoreAndRetrieve(t *testing.T, n int, randomData bool) {
+	config := api.NewConfig()
+
+	dir, err := ioutil.TempDir("", "node")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	config.Path = dir
+
+	privkey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config.Init(privkey)
+
+	swarm, err := NewSwarm(config, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	slice := make([]byte, n)
+	if randomData {
+		rand.Seed(time.Now().UnixNano())
+		rand.Read(slice)
+	}
+	dataPut := string(slice)
+
+	k, wait, err := swarm.api.Store(strings.NewReader(dataPut), int64(len(dataPut)), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wait != nil {
+		wait()
+	}
+
+	r, _ := swarm.api.Retrieve(k)
+
+	d, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dataGet := string(d)
+
+	if len(dataPut) != len(dataGet) {
+		t.Fatalf("data not matched: length expected %v, got %v", len(dataPut), len(dataGet))
+	} else {
+		if dataPut != dataGet {
+			t.Fatal("data not matched")
+		}
 	}
 }

--- a/swarm/swarm_test.go
+++ b/swarm/swarm_test.go
@@ -279,7 +279,7 @@ func TestParseEnsAPIAddress(t *testing.T) {
 }
 
 // TestLocalStoreAndRetrieve runs multiple tests where different size files are uploaded
-// to a single Swarm instance using API Store and checked against the dontent returned
+// to a single Swarm instance using API Store and checked against the content returned
 // by API Retrieve function.
 //
 // This test is intended to validate functionality of chunker store and join functions

--- a/swarm/swarm_test.go
+++ b/swarm/swarm_test.go
@@ -286,23 +286,6 @@ func TestParseEnsAPIAddress(t *testing.T) {
 // and their intergartion into Swarm, without comparing results with ones produced by
 // another chunker implementation, as it is done in swarm/storage tests.
 func TestLocalStoreAndRetrieve(t *testing.T) {
-	sizes := []int{1, 60, 83, 179, 253, 1024, 4095, 4096, 4097, 8191, 8192, 8193, 12287, 12288, 12289, 123456, 2345678, 67298391, 524288, 524288 + 1, 524288 + 4096, 524288 + 4097, 7 * 524288, 7*524288 + 1, 7*524288 + 4096, 7*524288 + 4097, 128*524288 + 1, 128*524288 + 4096, 128*524288 + 4097}
-	for _, n := range sizes {
-		testLocalStoreAndRetrieve(t, n, true)
-		testLocalStoreAndRetrieve(t, n, false)
-	}
-}
-
-// testLocalStoreAndRetrieve creates a single Swarm instance, uploads
-// a file of length n with optional random data using API Store function,
-// and checks the output of API Retrieve function on the same instance.
-// This is a regression test for issue
-// https://github.com/ethersphere/go-ethereum/issues/639
-// where pyramid chunker did not split correctly files with lengths that
-// are edge cases for chunk and tree parameters, depending whether there
-// is a tree chunk with only one data chunk and how the compress functionality
-// changed the tree.
-func testLocalStoreAndRetrieve(t *testing.T, n int, randomData bool) {
 	config := api.NewConfig()
 
 	dir, err := ioutil.TempDir("", "node")
@@ -325,6 +308,23 @@ func testLocalStoreAndRetrieve(t *testing.T, n int, randomData bool) {
 		t.Fatal(err)
 	}
 
+	sizes := []int{1, 60, 83, 179, 253, 1024, 4095, 4096, 4097, 8191, 8192, 8193, 12287, 12288, 12289, 123456, 2345678, 67298391, 524288, 524288 + 1, 524288 + 4096, 524288 + 4097, 7 * 524288, 7*524288 + 1, 7*524288 + 4096, 7*524288 + 4097, 128*524288 + 1, 128*524288 + 4096, 128*524288 + 4097}
+	for _, n := range sizes {
+		testLocalStoreAndRetrieve(t, swarm, n, true)
+		testLocalStoreAndRetrieve(t, swarm, n, false)
+	}
+}
+
+// testLocalStoreAndRetrieve creates a single Swarm instance, uploads
+// a file of length n with optional random data using API Store function,
+// and checks the output of API Retrieve function on the same instance.
+// This is a regression test for issue
+// https://github.com/ethersphere/go-ethereum/issues/639
+// where pyramid chunker did not split correctly files with lengths that
+// are edge cases for chunk and tree parameters, depending whether there
+// is a tree chunk with only one data chunk and how the compress functionality
+// changed the tree.
+func testLocalStoreAndRetrieve(t *testing.T, swarm *Swarm, n int, randomData bool) {
 	slice := make([]byte, n)
 	if randomData {
 		rand.Seed(time.Now().UnixNano())

--- a/swarm/swarm_test.go
+++ b/swarm/swarm_test.go
@@ -315,7 +315,7 @@ func TestLocalStoreAndRetrieve(t *testing.T) {
 	}
 }
 
-// testLocalStoreAndRetrieve creates a single Swarm instance, uploads
+// testLocalStoreAndRetrieve is using a single Swarm instance, to upload
 // a file of length n with optional random data using API Store function,
 // and checks the output of API Retrieve function on the same instance.
 // This is a regression test for issue


### PR DESCRIPTION
This PR: 

- addresses issue described here https://github.com/ethersphere/go-ethereum/issues/639
- changes pyramid splitting to handle edge cases where there is only one data chunk on the last branch, while preserving append and compress functionalities
- adds more file sizes in TestRandomData storage package test
- adds TestLocalStoreAndRetrieve test in swarm package to check more edge cases and chunk integration with Swarm