### PR TITLE
Add ldbstore quit channel to terminate running loops

### DIFF
--- a/swarm/storage/ldbstore.go
+++ b/swarm/storage/ldbstore.go
@@ -583,6 +583,7 @@ mainLoop:
 				e = s.entryCnt
 				select {
 				case <-s.quit:
+					s.lock.Unlock()
 					break mainLoop
 				case <-done:
 				}


### PR DESCRIPTION
This PR tries to prevent Swarm stop blocking by terminating running loops, one of which may be a garbageCollect inside writeBatches.

Related issue: https://github.com/ethersphere/go-ethereum/issues/678.