### PR TITLE
Log if chunk to deliver is too short

### DIFF
--- a/swarm/network/stream/delivery.go
+++ b/swarm/network/stream/delivery.go
@@ -183,6 +183,9 @@ func (d *Delivery) handleRetrieveRequestMsg(sp *Peer, req *RetrieveRequestMsg) e
 	// TODO: call the retrieve function of the outgoing syncer
 	if req.SkipCheck {
 		log.Trace("deliver", "peer", sp.ID(), "hash", chunk.Addr)
+		if length := len(chunk.SData); length < 9 {
+			log.Error("Chunk.SData to deliver is too short", "len(chunk.SData)", length, "address", chunk.Addr)
+		}
 		return sp.Deliver(chunk, s.priority)
 	}
 	streamer.deliveryC <- chunk.Addr[:]

--- a/swarm/network/stream/messages.go
+++ b/swarm/network/stream/messages.go
@@ -320,6 +320,9 @@ func (p *Peer) handleWantedHashesMsg(req *WantedHashesMsg) error {
 			}
 			chunk := storage.NewChunk(hash, nil)
 			chunk.SData = data
+			if length := len(chunk.SData); length < 9 {
+				log.Error("Chunk.SData to sync is too short", "len(chunk.SData)", length, "address", chunk.Addr)
+			}
 			if err := p.Deliver(chunk, s.priority); err != nil {
 				return err
 			}


### PR DESCRIPTION
We encountered this panic: https://github.com/ethersphere/go-ethereum/issues/682
It seems it can happen that a chunk received in `processReceivedChunks` is too short, less than 8 bytes.
I don't really know how this can happen. So as a first step I would like to log the other side of this scenario: if it happens that a short chunk is delivered, and also to know if it happens during syncing or delivering.
