### PR TITLE
Log unexpected db error in processReceivedChunks

### DIFF
--- a/swarm/network/stream/delivery.go
+++ b/swarm/network/stream/delivery.go
@@ -18,7 +18,6 @@ package stream
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -213,7 +212,7 @@ R:
 		}
 		if err != storage.ErrFetching {
 			log.Error("processReceivedChunks db error", "addr", req.Addr, "err", err, "chunk", chunk)
-			panic(fmt.Sprintf("not in db? addr %v chunk %v", req.Addr, chunk))
+			continue R
 		}
 		select {
 		case <-chunk.ReqC:

--- a/swarm/network/stream/delivery.go
+++ b/swarm/network/stream/delivery.go
@@ -212,6 +212,7 @@ R:
 			continue R
 		}
 		if err != storage.ErrFetching {
+			log.Error("processReceivedChunks db error", "addr", req.Addr, "err", err, "chunk", chunk)
 			panic(fmt.Sprintf("not in db? addr %v chunk %v", req.Addr, chunk))
 		}
 		select {


### PR DESCRIPTION
We saw "not in db" panics, see issue: https://github.com/ethersphere/go-ethereum/issues/681

However, the panic message doesn't include the actual error itself, so it is hard to see what happened. Maybe it is an ErrChunkNotFound, but it is also possible that a lower level leveldb error. Let's log it to have more information about the issue.