### PR TITLE
BMT hasher rewrite

### DIFF
--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -145,7 +145,7 @@ func TestBzzResourceMultihash(t *testing.T) {
 		t.Fatalf("data %s could not be unmarshaled: %v", b, err)
 	}
 
-	correctManifestAddrHex := "b606e1c22cae0b5173caf2c7b2bd429acd925285133b66a50d2999c388c1d48b"
+	correctManifestAddrHex := "d689648fb9e00ddc7ebcf474112d5881c5bf7dbc6e394681b1d224b11b59b5e0"
 	if rsrcResp.Hex() != correctManifestAddrHex {
 		t.Fatalf("Response resource key mismatch, expected '%s', got '%s'", correctManifestAddrHex, rsrcResp)
 	}
@@ -204,7 +204,7 @@ func TestBzzResource(t *testing.T) {
 		t.Fatalf("data %s could not be unmarshaled: %v", b, err)
 	}
 
-	correctManifestAddrHex := "b606e1c22cae0b5173caf2c7b2bd429acd925285133b66a50d2999c388c1d48b"
+	correctManifestAddrHex := "d689648fb9e00ddc7ebcf474112d5881c5bf7dbc6e394681b1d224b11b59b5e0"
 	if rsrcResp.Hex() != correctManifestAddrHex {
 		t.Fatalf("Response resource key mismatch, expected '%s', got '%s'", correctManifestAddrHex, rsrcResp.Hex())
 	}

--- a/swarm/bmt/bmt_r.go
+++ b/swarm/bmt/bmt_r.go
@@ -37,7 +37,7 @@ type RefHasher struct {
 }
 
 // NewRefHasher returns a new RefHasher
-func NewRefHasher(hasher BaseHasher, count int) *RefHasher {
+func NewRefHasher(hasher BaseHasherFunc, count int) *RefHasher {
 	h := hasher()
 	hashsize := h.Size()
 	c := 2

--- a/swarm/bmt/bmt_test.go
+++ b/swarm/bmt/bmt_test.go
@@ -136,7 +136,7 @@ func TestHasherCorrectness(t *testing.T) {
 	}
 }
 
-func testHasher(f func(BaseHasher, []byte, int, int) error) error {
+func testHasher(f func(BaseHasherFunc, []byte, int, int) error) error {
 	data := newData(BufferSize)
 	hasher := sha3.NewKeccak256
 	size := hasher().Size()
@@ -216,7 +216,7 @@ LOOP:
 }
 
 // helper function that creates  a tree pool
-func testBaseHasher(hasher BaseHasher, d []byte, n, count int) error {
+func testBaseHasher(hasher BaseHasherFunc, d []byte, n, count int) error {
 	pool := NewTreePool(hasher, count, 1)
 	defer pool.Drain(0)
 	bmt := New(pool)
@@ -225,7 +225,7 @@ func testBaseHasher(hasher BaseHasher, d []byte, n, count int) error {
 
 // helper function that compares reference and optimised implementations on
 // correctness
-func testHasherCorrectness(bmt *Hasher, hasher BaseHasher, d []byte, n, count int) (err error) {
+func testHasherCorrectness(bmt *Hasher, hasher BaseHasherFunc, d []byte, n, count int) (err error) {
 	span := make([]byte, 8)
 	if len(d) < n {
 		n = len(d)

--- a/swarm/storage/types.go
+++ b/swarm/storage/types.go
@@ -114,7 +114,7 @@ func MakeHashFunc(hash string) SwarmHasher {
 	case "BMT":
 		return func() SwarmHash {
 			hasher := sha3.NewKeccak256
-			pool := bmt.NewTreePool(hasher, bmt.DefaultSegmentCount, bmt.DefaultPoolSize)
+			pool := bmt.NewTreePool(hasher, bmt.SegmentCount, bmt.PoolSize)
 			return bmt.New(pool)
 		}
 	}


### PR DESCRIPTION
fixes #539 
fixes #536 

The main purpose of this PR is to change the BMT hash to a someone simpler algorithm, that hashes shorter chunks as if they were padding with zeros.

The PR brings a major overhaul of the bmt hasher
 - bookkeeping is pushed from the hasher to the reused tree structure
 - racy code is fixed and the optimised verion is simplified
 - tests are cleaned up and changed
 - plenty of comments and documentation