### PR TITLE
swarm/storage: branches argument is not used, so remove it

### DIFF
--- a/swarm/storage/chunker.go
+++ b/swarm/storage/chunker.go
@@ -135,7 +135,7 @@ func TreeJoin(addr Address, getter Getter, depth int) *LazyChunkReader {
 	New chunks to store are store using the putter which the caller provides.
 */
 func TreeSplit(data io.Reader, size int64, putter Putter) (k Address, wait func(), err error) {
-	return NewTreeSplitter(NewTreeSplitterParams(data, putter, size, DefaultChunkSize)).Split()
+	return NewTreeSplitter(NewTreeSplitterParams(data, putter, size)).Split()
 }
 
 func NewJoinerParams(addr Address, getter Getter, depth int, chunkSize int64) *JoinerParams {
@@ -168,7 +168,7 @@ func NewTreeJoiner(params *JoinerParams) *TreeChunker {
 	return self
 }
 
-func NewTreeSplitterParams(reader io.Reader, putter Putter, size int64, branches int64) *TreeSplitterParams {
+func NewTreeSplitterParams(reader io.Reader, putter Putter, size int64) *TreeSplitterParams {
 	hashSize := putter.RefSize()
 	return &TreeSplitterParams{
 		SplitterParams: SplitterParams{


### PR DESCRIPTION
This PR is removing `NewTreeSplitterParams` and `NewJoinerParams` as they are used only once and introduce only indirection.

Also they are used in slightly different way with respect to initialisation of `DefaultChunkSize`, which is now made consistent.

Also the parent constructors `NewTreeSplitter` and `NewTreeJoiner` now construct their fields with clear arithmetics based only on input arguments, not referring to `self`, which is based on `params` in the middle of the constructor.