### PR TITLE
Client-side MRU signing -- step 5/5

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -185,6 +185,14 @@ var (
 		Name:  "rawmru",
 		Usage: "Determines how to interpret data for a resource update. If not present, data will be interpreted as a multihash",
 	}
+	SwarmResourceNameFlag = cli.StringFlag{
+		Name:  "name",
+		Usage: "User-defined name for the new resource",
+	}
+	SwarmResourceDataOnCreateFlag = cli.StringFlag{
+		Name:  "data",
+		Usage: "Initializes the resource with the given hex-encoded data. Data must be prefixed by 0x",
+	}
 )
 
 //declare a few constant error messages, useful for later error check comparisons in test
@@ -245,9 +253,9 @@ func init() {
 					CustomHelpTemplate: helpTemplate,
 					Name:               "create",
 					Usage:              "creates a new Mutable Resource",
-					ArgsUsage:          "<name> <frequency> [--rawmru] <0x Hex data>",
+					ArgsUsage:          "<frequency>",
 					Description:        "creates a new Mutable Resource",
-					Flags:              []cli.Flag{SwarmResourceRawFlag},
+					Flags:              []cli.Flag{SwarmResourceNameFlag, SwarmResourceDataOnCreateFlag, SwarmResourceRawFlag},
 				},
 				{
 					Action:             resourceUpdate,
@@ -256,6 +264,7 @@ func init() {
 					Usage:              "updates the content of an existing Mutable Resource",
 					ArgsUsage:          "<Manifest Address or ENS domain> <0x Hex data>",
 					Description:        "updates the content of an existing Mutable Resource",
+					Flags:              []cli.Flag{SwarmResourceRawFlag},
 				},
 				{
 					Action:             resourceInfo,

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -181,8 +181,8 @@ var (
 		Usage:  "Number of recent chunks cached in memory (default 5000)",
 		EnvVar: SWARM_ENV_STORE_CACHE_CAPACITY,
 	}
-	SwarmResourceRawFlag = cli.BoolFlag{
-		Name:  "rawmru",
+	SwarmResourceMultihashFlag = cli.BoolTFlag{
+		Name:  "multihash",
 		Usage: "Determines how to interpret data for a resource update. If not present, data will be interpreted as a multihash",
 	}
 	SwarmResourceNameFlag = cli.StringFlag{
@@ -255,7 +255,7 @@ func init() {
 					Usage:              "creates a new Mutable Resource",
 					ArgsUsage:          "<frequency>",
 					Description:        "creates a new Mutable Resource",
-					Flags:              []cli.Flag{SwarmResourceNameFlag, SwarmResourceDataOnCreateFlag, SwarmResourceRawFlag},
+					Flags:              []cli.Flag{SwarmResourceNameFlag, SwarmResourceDataOnCreateFlag, SwarmResourceMultihashFlag},
 				},
 				{
 					Action:             resourceUpdate,
@@ -264,7 +264,7 @@ func init() {
 					Usage:              "updates the content of an existing Mutable Resource",
 					ArgsUsage:          "<Manifest Address or ENS domain> <0x Hex data>",
 					Description:        "updates the content of an existing Mutable Resource",
-					Flags:              []cli.Flag{SwarmResourceRawFlag},
+					Flags:              []cli.Flag{SwarmResourceMultihashFlag},
 				},
 				{
 					Action:             resourceInfo,

--- a/cmd/swarm/mru.go
+++ b/cmd/swarm/mru.go
@@ -30,6 +30,10 @@ import (
 	"gopkg.in/urfave/cli.v1"
 )
 
+func NewGenericSigner(ctx *cli.Context) mru.Signer {
+	return mru.NewGenericSigner(getClientAccount(ctx))
+}
+
 // swarm resource create <frequency> [--name <name>] [--data <0x Hexdata> [--multihash=false]]
 // swarm resource update <Manifest Address or ENS domain> <0x Hexdata> [--multihash=false]
 // swarm resource info <Manifest Address or ENS domain>
@@ -50,8 +54,7 @@ func resourceCreate(ctx *cli.Context) {
 		cli.ShowCommandHelpAndExit(ctx, "create", 1)
 		return
 	}
-	signer := mru.NewGenericSigner(getClientAccount(ctx))
-
+	signer := NewGenericSigner(ctx)
 	frequency, err := strconv.ParseUint(args[0], 10, 64)
 	if err != nil {
 		fmt.Printf("Frequency formatting error: %s\n", err.Error())
@@ -106,7 +109,7 @@ func resourceUpdate(ctx *cli.Context) {
 		cli.ShowCommandHelpAndExit(ctx, "update", 1)
 		return
 	}
-	signer := mru.NewGenericSigner(getClientAccount(ctx))
+	signer := NewGenericSigner(ctx)
 	manifestAddressOrDomain := args[0]
 	data, err := hexutil.Decode(args[1])
 	if err != nil {
@@ -153,7 +156,7 @@ func resourceInfo(ctx *cli.Context) {
 		utils.Fatalf("Error retrieving resource metadata: %s", err.Error())
 		return
 	}
-	encodedMetadata, err := mru.EncodeUpdateRequest(metadata)
+	encodedMetadata, err := mru.Marshal(metadata)
 	if err != nil {
 		utils.Fatalf("Error encoding metadata to JSON for display:%s", err)
 	}

--- a/cmd/swarm/mru.go
+++ b/cmd/swarm/mru.go
@@ -156,7 +156,7 @@ func resourceInfo(ctx *cli.Context) {
 		utils.Fatalf("Error retrieving resource metadata: %s", err.Error())
 		return
 	}
-	encodedMetadata, err := mru.Marshal(metadata)
+	encodedMetadata, err := metadata.Marshal()
 	if err != nil {
 		utils.Fatalf("Error encoding metadata to JSON for display:%s", err)
 	}

--- a/cmd/swarm/mru.go
+++ b/cmd/swarm/mru.go
@@ -30,8 +30,8 @@ import (
 	"gopkg.in/urfave/cli.v1"
 )
 
-// swarm resource create <frequency> [--name <name>] [--data <0x Hexdata> [--rawmru]]
-// swarm resource update <Manifest Address or ENS domain> <0x Hexdata> [--rawmru]
+// swarm resource create <frequency> [--name <name>] [--data <0x Hexdata> [--multihash=false]]
+// swarm resource update <Manifest Address or ENS domain> <0x Hexdata> [--multihash=false]
 // swarm resource info <Manifest Address or ENS domain>
 
 func resourceCreate(ctx *cli.Context) {
@@ -40,7 +40,7 @@ func resourceCreate(ctx *cli.Context) {
 	var (
 		bzzapi      = strings.TrimRight(ctx.GlobalString(SwarmApiFlag.Name), "/")
 		client      = swarm.NewClient(bzzapi)
-		rawResource = ctx.Bool(SwarmResourceRawFlag.Name)
+		multihash   = ctx.Bool(SwarmResourceMultihashFlag.Name)
 		initialData = ctx.String(SwarmResourceDataOnCreateFlag.Name)
 		name        = ctx.String(SwarmResourceNameFlag.Name)
 	)
@@ -62,7 +62,7 @@ func resourceCreate(ctx *cli.Context) {
 	newResourceRequest, err := mru.NewCreateRequest(&mru.ResourceMetadata{
 		Name:      name,
 		Frequency: frequency,
-		OwnerAddr: signer.Address(),
+		Owner:     signer.Address(),
 	})
 
 	if err != nil {
@@ -77,7 +77,7 @@ func resourceCreate(ctx *cli.Context) {
 			return
 		}
 
-		newResourceRequest.SetData(initialDataBytes, !rawResource)
+		newResourceRequest.SetData(initialDataBytes, multihash)
 		if err = newResourceRequest.Sign(signer); err != nil {
 			utils.Fatalf("Error signing resource update: %s", err.Error())
 		}
@@ -96,9 +96,9 @@ func resourceUpdate(ctx *cli.Context) {
 	args := ctx.Args()
 
 	var (
-		bzzapi      = strings.TrimRight(ctx.GlobalString(SwarmApiFlag.Name), "/")
-		client      = swarm.NewClient(bzzapi)
-		rawResource = ctx.Bool(SwarmResourceRawFlag.Name)
+		bzzapi    = strings.TrimRight(ctx.GlobalString(SwarmApiFlag.Name), "/")
+		client    = swarm.NewClient(bzzapi)
+		multihash = ctx.Bool(SwarmResourceMultihashFlag.Name)
 	)
 
 	if len(args) < 2 {
@@ -121,7 +121,7 @@ func resourceUpdate(ctx *cli.Context) {
 	}
 
 	// set the new data
-	updateRequest.SetData(data, !rawResource)
+	updateRequest.SetData(data, multihash)
 
 	// sign update
 	if err = updateRequest.Sign(signer); err != nil {

--- a/cmd/swarm/mru.go
+++ b/cmd/swarm/mru.go
@@ -156,7 +156,7 @@ func resourceInfo(ctx *cli.Context) {
 		utils.Fatalf("Error retrieving resource metadata: %s", err.Error())
 		return
 	}
-	encodedMetadata, err := metadata.Marshal()
+	encodedMetadata, err := metadata.MarshalJSON()
 	if err != nil {
 		utils.Fatalf("Error encoding metadata to JSON for display:%s", err)
 	}

--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -676,11 +676,7 @@ func (a *API) ResourceLookup(ctx context.Context, params *mru.LookupParams) (str
 
 // Create Mutable resource
 func (a *API) ResourceCreate(ctx context.Context, request *mru.Request) error {
-	err := a.resource.New(ctx, request)
-	if err != nil {
-		return err
-	}
-	return nil
+	return a.resource.New(ctx, request)
 }
 
 // ResourceNewRequest creates a Request object to update a specific mutable resource

--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -674,30 +674,30 @@ func (a *API) ResourceLookup(ctx context.Context, params *mru.LookupParams) (str
 	return rsrc.Name(), data, nil
 }
 
-func (a *API) ResourceCreate(ctx context.Context, mru *mru.Request) (storage.Address, error) {
-	err := a.resource.New(ctx, mru)
+// Create Mutable resource
+func (a *API) ResourceCreate(ctx context.Context, request *mru.Request) (storage.Address, error) {
+	err := a.resource.New(ctx, request)
 	if err != nil {
 		return nil, err
 	}
-	return mru.RootAddr(), nil
+	return request.RootAddr(), nil
 }
 
-// ResourceUpdateMultihash updates a Mutable Resource and marks the update's content to be of multihash type, which will be recognized upon retrieval.
-// It will fail if the data is not a valid multihash.
+// ResourceNewRequest creates a Request object to update a specific mutable resource
 func (a *API) ResourceNewRequest(ctx context.Context, rootAddr storage.Address) (*mru.Request, error) {
 	return a.resource.NewUpdateRequest(ctx, rootAddr)
 }
 
 // ResourceUpdate updates a Mutable Resource with arbitrary data.
 // Upon retrieval the update will be retrieved verbatim as bytes.
-func (a *API) ResourceUpdate(ctx context.Context, rootAddr storage.Address, mru *mru.SignedResourceUpdate) (storage.Address, uint32, uint32, error) {
-	return a.resourceUpdate(ctx, rootAddr, mru)
+func (a *API) ResourceUpdate(ctx context.Context, rootAddr storage.Address, request *mru.SignedResourceUpdate) (storage.Address, uint32, uint32, error) {
+	return a.resourceUpdate(ctx, rootAddr, request)
 }
 
-func (a *API) resourceUpdate(ctx context.Context, rootAddr storage.Address, mru *mru.SignedResourceUpdate) (storage.Address, uint32, uint32, error) {
+func (a *API) resourceUpdate(ctx context.Context, rootAddr storage.Address, request *mru.SignedResourceUpdate) (storage.Address, uint32, uint32, error) {
 	var updateAddr storage.Address
 	var err error
-	updateAddr, err = a.resource.Update(ctx, rootAddr, mru)
+	updateAddr, err = a.resource.Update(ctx, rootAddr, request)
 	period, _ := a.resource.GetLastPeriod(rootAddr)
 	version, _ := a.resource.GetVersion(rootAddr)
 	return updateAddr, period, version, err

--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -655,7 +655,7 @@ func (a *API) BuildDirectoryTree(ctx context.Context, mhash string, nameresolver
 	return addr, manifestEntryMap, nil
 }
 
-// Look up mutable resource updates at specific periods and versions
+// ResourceLookup finds mutable resource updates at specific periods and versions
 func (a *API) ResourceLookup(ctx context.Context, params *mru.LookupParams) (string, []byte, error) {
 	var err error
 	rsrc, err := a.resource.Load(params.RootAddr())

--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -675,12 +675,12 @@ func (a *API) ResourceLookup(ctx context.Context, params *mru.LookupParams) (str
 }
 
 // Create Mutable resource
-func (a *API) ResourceCreate(ctx context.Context, request *mru.Request) (storage.Address, error) {
+func (a *API) ResourceCreate(ctx context.Context, request *mru.Request) error {
 	err := a.resource.New(ctx, request)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return request.RootAddr(), nil
+	return nil
 }
 
 // ResourceNewRequest creates a Request object to update a specific mutable resource
@@ -690,17 +690,8 @@ func (a *API) ResourceNewRequest(ctx context.Context, rootAddr storage.Address) 
 
 // ResourceUpdate updates a Mutable Resource with arbitrary data.
 // Upon retrieval the update will be retrieved verbatim as bytes.
-func (a *API) ResourceUpdate(ctx context.Context, rootAddr storage.Address, request *mru.SignedResourceUpdate) (storage.Address, uint32, uint32, error) {
-	return a.resourceUpdate(ctx, rootAddr, request)
-}
-
-func (a *API) resourceUpdate(ctx context.Context, rootAddr storage.Address, request *mru.SignedResourceUpdate) (storage.Address, uint32, uint32, error) {
-	var updateAddr storage.Address
-	var err error
-	updateAddr, err = a.resource.Update(ctx, rootAddr, request)
-	period, _ := a.resource.GetLastPeriod(rootAddr)
-	version, _ := a.resource.GetVersion(rootAddr)
-	return updateAddr, period, version, err
+func (a *API) ResourceUpdate(ctx context.Context, request *mru.SignedResourceUpdate) (storage.Address, error) {
+	return a.resource.Update(ctx, request)
 }
 
 // ResourceHashSize returned the size of the digest produced by the Mutable Resource hashing function

--- a/swarm/api/client/client.go
+++ b/swarm/api/client/client.go
@@ -595,7 +595,7 @@ func (c *Client) UpdateResource(request *mru.Request) error {
 }
 
 func (c *Client) updateResource(request *mru.Request) (io.ReadCloser, error) {
-	body, err := request.Marshal()
+	body, err := request.MarshalJSON()
 	if err != nil {
 		return nil, err
 	}
@@ -644,7 +644,7 @@ func (c *Client) GetResourceMetadata(manifestAddressOrDomain string) (*mru.Reque
 	}
 
 	var metadata mru.Request
-	if err := metadata.Unmarshal(body); err != nil {
+	if err := metadata.UnmarshalJSON(body); err != nil {
 		return nil, err
 	}
 	return &metadata, nil

--- a/swarm/api/client/client.go
+++ b/swarm/api/client/client.go
@@ -595,7 +595,7 @@ func (c *Client) UpdateResource(request *mru.Request) error {
 }
 
 func (c *Client) updateResource(request *mru.Request) (io.ReadCloser, error) {
-	body, err := mru.EncodeUpdateRequest(request)
+	body, err := request.Marshal()
 	if err != nil {
 		return nil, err
 	}
@@ -643,9 +643,9 @@ func (c *Client) GetResourceMetadata(manifestAddressOrDomain string) (*mru.Reque
 		return nil, err
 	}
 
-	metadata, err := mru.DecodeUpdateRequest(body)
-	if err != nil {
+	var metadata mru.Request
+	if err := metadata.Unmarshal(body); err != nil {
 		return nil, err
 	}
-	return metadata, nil
+	return &metadata, nil
 }

--- a/swarm/api/client/client.go
+++ b/swarm/api/client/client.go
@@ -569,8 +569,8 @@ func (c *Client) MultipartUpload(hash string, uploader Uploader) (string, error)
 // startTime=0 means "now"
 // Returns the resulting Mutable Resource manifest address that you can use to include in an ENS Resolver (setContent)
 // or reference future updates (Client.UpdateResource)
-func (c *Client) CreateResource(createRequest *mru.Request) (string, error) {
-	responseStream, err := c.updateResource(createRequest)
+func (c *Client) CreateResource(request *mru.Request) (string, error) {
+	responseStream, err := c.updateResource(request)
 	if err != nil {
 		return "", err
 	}
@@ -581,21 +581,21 @@ func (c *Client) CreateResource(createRequest *mru.Request) (string, error) {
 		return "", err
 	}
 
-	var manifestKey string
-	if err = json.Unmarshal(body, &manifestKey); err != nil {
+	var manifestAddress string
+	if err = json.Unmarshal(body, &manifestAddress); err != nil {
 		return "", err
 	}
-	return manifestKey, nil
+	return manifestAddress, nil
 }
 
 // UpdateResource allows you to send a new version of your content
-func (c *Client) UpdateResource(updateRequest *mru.Request) error {
-	_, err := c.updateResource(updateRequest)
+func (c *Client) UpdateResource(request *mru.Request) error {
+	_, err := c.updateResource(request)
 	return err
 }
 
-func (c *Client) updateResource(updateRequest *mru.Request) (io.ReadCloser, error) {
-	body, err := mru.EncodeUpdateRequest(updateRequest)
+func (c *Client) updateResource(request *mru.Request) (io.ReadCloser, error) {
+	body, err := mru.EncodeUpdateRequest(request)
 	if err != nil {
 		return nil, err
 	}

--- a/swarm/api/client/client_test.go
+++ b/swarm/api/client/client_test.go
@@ -414,7 +414,7 @@ func TestClientCreateResourceMultihash(t *testing.T) {
 		t.Fatalf("Error creating resource: %s", err)
 	}
 
-	correctManifestAddrHex := "19e911ba30608cc70af7cad3776501366a7ccf818025f2b3010794d9d66d7eb5"
+	correctManifestAddrHex := "6d3bc4664c97d8b821cb74bcae43f592494fb46d2d9cd31e69f3c7c802bbbd8e"
 	if resourceManifestHash != correctManifestAddrHex {
 		t.Fatalf("Response resource key mismatch, expected '%s', got '%s'", correctManifestAddrHex, resourceManifestHash)
 	}
@@ -465,7 +465,7 @@ func TestClientCreateUpdateResource(t *testing.T) {
 
 	resourceManifestHash, err := client.CreateResource(createRequest)
 
-	correctManifestAddrHex := "a09bdcc9e0e4762e01d3e0a69a00f673fa67e8ac17e647043ce07672424ba014"
+	correctManifestAddrHex := "cc7904c17b49f9679e2d8006fe25e87e3f5c2072c2b49cab50f15e544471b30a"
 	if resourceManifestHash != correctManifestAddrHex {
 		t.Fatalf("Response resource key mismatch, expected '%s', got '%s'", correctManifestAddrHex, resourceManifestHash)
 	}

--- a/swarm/api/client/client_test.go
+++ b/swarm/api/client/client_test.go
@@ -419,6 +419,7 @@ func TestClientCreateResourceMultihash(t *testing.T) {
 
 }
 
+// TestClientCreateUpdateResource will check that mutable resources can be created and updated via the HTTP client.
 func TestClientCreateUpdateResource(t *testing.T) {
 
 	signer, _ := newTestSigner()

--- a/swarm/api/client/client_test.go
+++ b/swarm/api/client/client_test.go
@@ -398,7 +398,7 @@ func TestClientCreateResourceMultihash(t *testing.T) {
 		Name:      resourceName,
 		Frequency: 13,
 		StartTime: srv.GetCurrentTime(),
-		OwnerAddr: signer.Address(),
+		Owner:     signer.Address(),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -453,7 +453,7 @@ func TestClientCreateUpdateResource(t *testing.T) {
 		Name:      resourceName,
 		Frequency: 13,
 		StartTime: srv.GetCurrentTime(),
-		OwnerAddr: signer.Address(),
+		Owner:     signer.Address(),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -408,8 +408,8 @@ func (s *Server) HandlePostResource(ctx context.Context, w http.ResponseWriter, 
 		Respond(w, r, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	updateRequest, err := mru.DecodeUpdateRequest(body) // decodes request JSON
-	if err != nil {
+	var updateRequest mru.Request
+	if err := updateRequest.Unmarshal(body); err != nil { // decodes request JSON
 		Respond(w, r, err.Error(), http.StatusBadRequest) //TODO: send different status response depending on error
 		return
 	}
@@ -425,7 +425,7 @@ func (s *Server) HandlePostResource(ctx context.Context, w http.ResponseWriter, 
 	}
 
 	if updateRequest.IsNew() {
-		err = s.api.ResourceCreate(r.Context(), updateRequest)
+		err = s.api.ResourceCreate(r.Context(), &updateRequest)
 		if err != nil {
 			code, err2 := s.translateResourceError(w, r, "resource creation fail", err)
 			Respond(w, r, err2.Error(), code)
@@ -516,7 +516,7 @@ func (s *Server) handleGetResource(ctx context.Context, w http.ResponseWriter, r
 				Respond(w, r, fmt.Sprintf("cannot retrieve resource metadata for rootAddr=%s: %s", rootAddr.Hex(), err), http.StatusNotFound)
 				return
 			}
-			rawResponse, err := mru.EncodeUpdateRequest(unsignedUpdateRequest)
+			rawResponse, err := unsignedUpdateRequest.Marshal()
 			if err != nil {
 				Respond(w, r, fmt.Sprintf("cannot encode unsigned UpdateRequest: %v", err), http.StatusInternalServerError)
 				return

--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -397,11 +397,10 @@ func resourcePostMode(path string) (isRaw bool, frequency uint64, err error) {
 // the page that the multihash is pointing to, as if it held a normal swarm content manifest
 //
 // The POST request admits a JSON structure as defined in the mru package: `mru.updateRequestJSON`
+// The requests can be to a) create a resource, b) update a resource or c) both a+b: create a resource and set the initial content
 func (s *Server) HandlePostResource(ctx context.Context, w http.ResponseWriter, r *Request) {
 	log.Debug("handle.post.resource", "ruid", r.ruid)
 	var err error
-	var rootAddr storage.Address
-	var outdata []byte
 
 	// Creation and update must send mru.updateRequestJSON JSON structure
 	body, err := ioutil.ReadAll(r.Body)
@@ -415,29 +414,41 @@ func (s *Server) HandlePostResource(ctx context.Context, w http.ResponseWriter, 
 		return
 	}
 
-	// Verify that the signature is intact and that the signer is authorized
-	// to update this resource
-	if err = updateRequest.Verify(); err != nil {
-		Respond(w, r, err.Error(), http.StatusForbidden)
-		return
+	if updateRequest.IsUpdate() {
+		// Verify that the signature is intact and that the signer is authorized
+		// to update this resource
+		// Check this early, to avoid creating a resource and then not being able to set its first update.
+		if err = updateRequest.Verify(); err != nil {
+			Respond(w, r, err.Error(), http.StatusForbidden)
+			return
+		}
 	}
 
-	// new mutable resource creation will always have a frequency field larger than 0
-	if updateRequest.Frequency() > 0 {
-
-		// rootAddr is the content addressed root chunk holding mutable resource metadata information
-		rootAddr, err = s.api.ResourceCreate(r.Context(), updateRequest)
+	if updateRequest.IsNew() {
+		err = s.api.ResourceCreate(r.Context(), updateRequest)
 		if err != nil {
 			code, err2 := s.translateResourceError(w, r, "resource creation fail", err)
-
 			Respond(w, r, err2.Error(), code)
 			return
 		}
+	}
 
+	if updateRequest.IsUpdate() {
+		_, err = s.api.ResourceUpdate(r.Context(), &updateRequest.SignedResourceUpdate)
+		if err != nil {
+			Respond(w, r, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	// at this point both possible operations (create, update or both) were successful
+	// so in case it was a new resource, then create a manifest and send it over.
+
+	if updateRequest.IsNew() {
 		// we create a manifest so we can retrieve the resource with bzz:// later
 		// this manifest has a special "resource type" manifest, and its hash is the key of the mutable resource
 		// metadata chunk (rootAddr)
-		m, err := s.api.NewResourceManifest(ctx, rootAddr.Hex())
+		m, err := s.api.NewResourceManifest(ctx, updateRequest.RootAddr().Hex())
 		if err != nil {
 			Respond(w, r, fmt.Sprintf("failed to create resource manifest: %v", err), http.StatusInternalServerError)
 			return
@@ -447,57 +458,14 @@ func (s *Server) HandlePostResource(ctx context.Context, w http.ResponseWriter, 
 		// the client can access the root chunk key directly through its Hash member
 		// the manifest key should be set as content in the resolver of the ENS name
 		// \TODO update manifest key automatically in ENS
-		outdata, err = json.Marshal(m)
+		outdata, err := json.Marshal(m)
 		if err != nil {
 			Respond(w, r, fmt.Sprintf("failed to create json response: %s", err), http.StatusInternalServerError)
 			return
 		}
-	} else {
-		// to update the resource through http we need to retrieve the key for the mutable resource root chunk
-		// that means that we retrieve the manifest and inspect its Hash member.
-		manifestAddr := r.uri.Address()
-		if manifestAddr == nil {
-			manifestAddr, err = s.api.Resolve(ctx, r.uri)
-			if err != nil {
-				getFail.Inc(1)
-				Respond(w, r, fmt.Sprintf("cannot resolve %s: %s", r.uri.Addr, err), http.StatusNotFound)
-				return
-			}
-		}
-
-		// get the metadata rootAddr from the manifest
-		rootAddr, err = s.api.ResolveResourceManifest(ctx, manifestAddr)
-		if err != nil {
-			getFail.Inc(1)
-			Respond(w, r, fmt.Sprintf("error resolving resource root chunk for %s: %s", r.uri.Addr, err), http.StatusNotFound)
-			return
-		}
-
-		log.Debug("handle.post.resource: resolved", "ruid", r.ruid, "manifestkey", manifestAddr, "rootchunkkey", rootAddr)
-
-		_, _, err = s.api.ResourceLookup(r.Context(), mru.LookupLatest(rootAddr))
-		if err != nil {
-			Respond(w, r, err.Error(), http.StatusNotFound)
-			return
-		}
-	}
-
-	// Creation and update must send data aswell. This data constitutes the update data itself.
-	_, _, _, err = s.api.ResourceUpdate(r.Context(), rootAddr, &updateRequest.SignedResourceUpdate)
-	if err != nil {
-		Respond(w, r, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	// If we have data to return, write this now
-	// \TODO there should always be data to return here
-	if len(outdata) > 0 {
-		w.Header().Add("Content-type", "application/json")
-		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, string(outdata))
-		return
 	}
-	w.WriteHeader(http.StatusOK)
+	w.Header().Add("Content-type", "application/json")
 }
 
 // Retrieve mutable resource updates:

--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -409,7 +409,7 @@ func (s *Server) HandlePostResource(ctx context.Context, w http.ResponseWriter, 
 		return
 	}
 	var updateRequest mru.Request
-	if err := updateRequest.Unmarshal(body); err != nil { // decodes request JSON
+	if err := updateRequest.UnmarshalJSON(body); err != nil { // decodes request JSON
 		Respond(w, r, err.Error(), http.StatusBadRequest) //TODO: send different status response depending on error
 		return
 	}
@@ -516,7 +516,7 @@ func (s *Server) handleGetResource(ctx context.Context, w http.ResponseWriter, r
 				Respond(w, r, fmt.Sprintf("cannot retrieve resource metadata for rootAddr=%s: %s", rootAddr.Hex(), err), http.StatusNotFound)
 				return
 			}
-			rawResponse, err := unsignedUpdateRequest.Marshal()
+			rawResponse, err := unsignedUpdateRequest.MarshalJSON()
 			if err != nil {
 				Respond(w, r, fmt.Sprintf("cannot encode unsigned UpdateRequest: %v", err), http.StatusInternalServerError)
 				return

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -297,7 +297,7 @@ func TestBzzResource(t *testing.T) {
 	}
 
 	if resp.StatusCode != http.StatusNotFound {
-		t.Fatal("Expected get non-existent resource to fail")
+		t.Fatalf("Expected get non-existent resource to fail with StatusNotFound (404), got %d", resp.StatusCode)
 	}
 
 	resp.Body.Close()

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -135,10 +135,19 @@ func TestBzzResourceMultihash(t *testing.T) {
 
 	// our mutable resource "name"
 	keybytes := "foo.eth"
-	updateRequest, err := mru.NewCreateRequest(keybytes, 13, srv.GetCurrentTime().Time, signer.Address(), mh, true)
+
+	updateRequest, err := mru.NewCreateRequest(&mru.ResourceMetadata{
+		Name:      keybytes,
+		Frequency: 13,
+		StartTime: srv.GetCurrentTime(),
+		OwnerAddr: signer.Address(),
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	updateRequest.SetData(mh,true)
+
 	if err := updateRequest.Sign(signer); err != nil {
 		t.Fatal(err)
 	}
@@ -210,13 +219,22 @@ func TestBzzResource(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	updateRequest, err := mru.NewCreateRequest(keybytes, 13, srv.GetCurrentTime().Time, signer.Address(), databytes, false)
+	updateRequest, err := mru.NewCreateRequest(&mru.ResourceMetadata{
+		Name:      keybytes,
+		Frequency: 13,
+		StartTime: srv.GetCurrentTime(),
+		OwnerAddr: signer.Address(),
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	updateRequest.SetData(databytes,false)
+
 	if err := updateRequest.Sign(signer); err != nil {
 		t.Fatal(err)
 	}
+
 	body, err := mru.EncodeUpdateRequest(updateRequest)
 	if err != nil {
 		t.Fatal(err)
@@ -343,7 +361,7 @@ func TestBzzResource(t *testing.T) {
 		t.Fatalf("Error decoding resource metadata: %s", err)
 	}
 	data := []byte("foo")
-	updateRequest.SetData(data)
+	updateRequest.SetData(data,false)
 	if err = updateRequest.Sign(signer); err != nil {
 		t.Fatal(err)
 	}

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -140,13 +140,13 @@ func TestBzzResourceMultihash(t *testing.T) {
 		Name:      keybytes,
 		Frequency: 13,
 		StartTime: srv.GetCurrentTime(),
-		OwnerAddr: signer.Address(),
+		Owner:     signer.Address(),
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	updateRequest.SetData(mh,true)
+	updateRequest.SetData(mh, true)
 
 	if err := updateRequest.Sign(signer); err != nil {
 		t.Fatal(err)
@@ -223,13 +223,13 @@ func TestBzzResource(t *testing.T) {
 		Name:      keybytes,
 		Frequency: 13,
 		StartTime: srv.GetCurrentTime(),
-		OwnerAddr: signer.Address(),
+		Owner:     signer.Address(),
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	updateRequest.SetData(databytes,false)
+	updateRequest.SetData(databytes, false)
 
 	if err := updateRequest.Sign(signer); err != nil {
 		t.Fatal(err)
@@ -361,7 +361,7 @@ func TestBzzResource(t *testing.T) {
 		t.Fatalf("Error decoding resource metadata: %s", err)
 	}
 	data := []byte("foo")
-	updateRequest.SetData(data,false)
+	updateRequest.SetData(data, false)
 	if err = updateRequest.Sign(signer); err != nil {
 		t.Fatal(err)
 	}

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -153,7 +153,7 @@ func TestBzzResourceMultihash(t *testing.T) {
 	}
 	log.Info("added data", "manifest", string(b), "data", common.ToHex(mh))
 
-	body, err := mru.EncodeUpdateRequest(updateRequest)
+	body, err := updateRequest.Marshal()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -235,7 +235,7 @@ func TestBzzResource(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	body, err := mru.EncodeUpdateRequest(updateRequest)
+	body, err := updateRequest.Marshal()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -356,8 +356,8 @@ func TestBzzResource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	updateRequest, err = mru.DecodeUpdateRequest(b)
-	if err != nil {
+	updateRequest = &mru.Request{}
+	if err = updateRequest.Unmarshal(b); err != nil {
 		t.Fatalf("Error decoding resource metadata: %s", err)
 	}
 	data := []byte("foo")
@@ -365,7 +365,7 @@ func TestBzzResource(t *testing.T) {
 	if err = updateRequest.Sign(signer); err != nil {
 		t.Fatal(err)
 	}
-	body, err = mru.EncodeUpdateRequest(updateRequest)
+	body, err = updateRequest.Marshal()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -153,7 +153,7 @@ func TestBzzResourceMultihash(t *testing.T) {
 	}
 	log.Info("added data", "manifest", string(b), "data", common.ToHex(mh))
 
-	body, err := updateRequest.Marshal()
+	body, err := updateRequest.MarshalJSON()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -235,7 +235,7 @@ func TestBzzResource(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	body, err := updateRequest.Marshal()
+	body, err := updateRequest.MarshalJSON()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -357,7 +357,7 @@ func TestBzzResource(t *testing.T) {
 		t.Fatal(err)
 	}
 	updateRequest = &mru.Request{}
-	if err = updateRequest.Unmarshal(b); err != nil {
+	if err = updateRequest.UnmarshalJSON(b); err != nil {
 		t.Fatalf("Error decoding resource metadata: %s", err)
 	}
 	data := []byte("foo")
@@ -365,7 +365,7 @@ func TestBzzResource(t *testing.T) {
 	if err = updateRequest.Sign(signer); err != nil {
 		t.Fatal(err)
 	}
-	body, err = updateRequest.Marshal()
+	body, err = updateRequest.MarshalJSON()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -178,7 +178,7 @@ func TestBzzResourceMultihash(t *testing.T) {
 		t.Fatalf("data %s could not be unmarshaled: %v", b, err)
 	}
 
-	correctManifestAddrHex := "19e911ba30608cc70af7cad3776501366a7ccf818025f2b3010794d9d66d7eb5"
+	correctManifestAddrHex := "6d3bc4664c97d8b821cb74bcae43f592494fb46d2d9cd31e69f3c7c802bbbd8e"
 	if rsrcResp.Hex() != correctManifestAddrHex {
 		t.Fatalf("Response resource key mismatch, expected '%s', got '%s'", correctManifestAddrHex, rsrcResp.Hex())
 	}
@@ -260,7 +260,7 @@ func TestBzzResource(t *testing.T) {
 		t.Fatalf("data %s could not be unmarshaled: %v", b, err)
 	}
 
-	correctManifestAddrHex := "19e911ba30608cc70af7cad3776501366a7ccf818025f2b3010794d9d66d7eb5"
+	correctManifestAddrHex := "6d3bc4664c97d8b821cb74bcae43f592494fb46d2d9cd31e69f3c7c802bbbd8e"
 	if rsrcResp.Hex() != correctManifestAddrHex {
 		t.Fatalf("Response resource key mismatch, expected '%s', got '%s'", correctManifestAddrHex, rsrcResp.Hex())
 	}
@@ -287,7 +287,7 @@ func TestBzzResource(t *testing.T) {
 	if len(manifest.Entries) != 1 {
 		t.Fatalf("Manifest has %d entries", len(manifest.Entries))
 	}
-	correctRootKeyHex := "7d7f6791f7bb0e8ec97a4660a39e8787250690e41b8b9ef0fc63eed86b059655"
+	correctRootKeyHex := "68f7ba07ac8867a4c841a4d4320e3cdc549df23702dc7285fcb6acf65df48562"
 	if manifest.Entries[0].Hash != correctRootKeyHex {
 		t.Fatalf("Expected manifest path '%s', got '%s'", correctRootKeyHex, manifest.Entries[0].Hash)
 	}

--- a/swarm/storage/mru/doc.go
+++ b/swarm/storage/mru/doc.go
@@ -51,10 +51,11 @@
 // A user looking up a resource would only need to know the rootAddr in order to get the versions
 //
 // the resource update data is:
-// resourcedata = headerlength|period|version|metaHash|rootAddr|data
+// resourcedata = headerlength|period|version|rootAddr|flags|metaHash
+// where flags is a 1-byte flags field. Flag 0 is set to 1 to indicate multihash
 //
 // the full update data that goes in the chunk payload is:
 // resourcedata|sign(resourcedata)
 //
-// headerlength is a 16 bit value containing the byte length of period|version|rootAddr|multihash|metaHash
+// headerlength is a 16 bit value containing the byte length of period|version|rootAddr|flags|metaHash
 package mru

--- a/swarm/storage/mru/doc.go
+++ b/swarm/storage/mru/doc.go
@@ -48,7 +48,7 @@
 // If more than one update is made in the same period, incremental
 // version numbers are used successively.
 //
-// A lookup agent need only know the rootAddr in order to get the versions
+// A user looking up a resource would only need to know the rootAddr in order to get the versions
 //
 // the resource update data is:
 // resourcedata = headerlength|period|version|metaHash|rootAddr|data
@@ -56,5 +56,5 @@
 // the full update data that goes in the chunk payload is:
 // resourcedata|sign(resourcedata)
 //
-// headerlength is a 16 bit value containing the byte length of period|version|rootAddr|metaHash
+// headerlength is a 16 bit value containing the byte length of period|version|rootAddr|multihash|metaHash
 package mru

--- a/swarm/storage/mru/handler.go
+++ b/swarm/storage/mru/handler.go
@@ -21,11 +21,11 @@ package mru
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"sync"
 	"time"
 	"unsafe"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/swarm/log"
 	"github.com/ethereum/go-ethereum/swarm/storage"
 )
@@ -49,6 +49,7 @@ type HandlerParams struct {
 
 // hashPool contains a pool of ready hashers
 var hashPool sync.Pool
+var minimumChunkLength int
 
 // init initializes the package and hashPool
 func init() {
@@ -56,6 +57,11 @@ func init() {
 		New: func() interface{} {
 			return storage.MakeHashFunc(resourceHashAlgorithm)()
 		},
+	}
+	if minimumMetadataLength < minimumUpdateDataLength {
+		minimumChunkLength = minimumMetadataLength
+	} else {
+		minimumChunkLength = minimumMetadataLength
 	}
 }
 
@@ -95,17 +101,17 @@ func (h *Handler) SetStore(store *storage.NetStore) {
 func (h *Handler) Validate(chunkAddr storage.Address, data []byte) bool {
 
 	dataLength := len(data)
-	if dataLength < 2 {
+	if dataLength < minimumChunkLength {
 		return false
 	}
 
 	//metadata chunks have the first two bytes set to zero
-	if data[0] == 0 && data[1] == 0 && dataLength > common.AddressLength {
+	if data[0] == 0 && data[1] == 0 && dataLength >= minimumMetadataLength {
 		//metadata chunk
 		rootAddr, _ := metadataHash(data)
 		valid := bytes.Equal(chunkAddr, rootAddr)
 		if !valid {
-			log.Warn("Invalid root metadata chunk")
+			log.Warn(fmt.Sprintf("Invalid root metadata chunk with address: %s", chunkAddr.Hex()))
 		}
 		return valid
 	}
@@ -116,7 +122,7 @@ func (h *Handler) Validate(chunkAddr storage.Address, data []byte) bool {
 
 	var r SignedResourceUpdate
 	if err := r.parseUpdateChunk(chunkAddr, data); err != nil {
-		log.Warn("Invalid resource chunk: " + err.Error())
+		log.Warn(fmt.Sprintf("Invalid resource chunk with address %s: %s ", chunkAddr.Hex(), err.Error()))
 		return false
 	}
 
@@ -274,6 +280,31 @@ func (h *Handler) Lookup(ctx context.Context, params *LookupParams) (*resource, 
 	return h.lookup(rsrc, params)
 }
 
+// LookupPrevious returns the resource before the one currently loaded in the resource index
+// This is useful where resource updates are used incrementally in contrast to
+// merely replacing content.
+// Requires a synced resource object
+func (h *Handler) LookupPrevious(ctx context.Context, params *LookupParams) (*resource, error) {
+	rsrc := h.get(params.rootAddr)
+	if rsrc == nil {
+		return nil, NewError(ErrNothingToReturn, "resource not loaded")
+	}
+	if !rsrc.isSynced() {
+		return nil, NewError(ErrNotSynced, "LookupPrevious requires synced resource.")
+	} else if rsrc.period == 0 {
+		return nil, NewError(ErrNothingToReturn, " not found")
+	}
+	if rsrc.version > 1 {
+		rsrc.version--
+	} else if rsrc.period == 1 {
+		return nil, NewError(ErrNothingToReturn, "Current update is the oldest")
+	} else {
+		rsrc.version = 0
+		rsrc.period--
+	}
+	return h.lookup(rsrc, NewLookupParams(rsrc.rootAddr, rsrc.period, rsrc.version, params.Limit))
+}
+
 // base code for public lookup methods
 func (h *Handler) lookup(rsrc *resource, params *LookupParams) (*resource, error) {
 
@@ -306,7 +337,7 @@ func (h *Handler) lookup(rsrc *resource, params *LookupParams) (*resource, error
 		if lp.Limit != 0 && hops > lp.Limit {
 			return nil, NewErrorf(ErrPeriodDepth, "Lookup exceeded max period hops (%d)", lp.Limit)
 		}
-		updateAddr := lp.GetUpdateAddr()
+		updateAddr := lp.Addr()
 		chunk, err := h.chunkStore.GetWithTimeout(updateAddr, defaultRetrieveTimeout)
 		if err == nil {
 			if specificversion {
@@ -316,7 +347,7 @@ func (h *Handler) lookup(rsrc *resource, params *LookupParams) (*resource, error
 			log.Trace("rsrc update version 1 found, checking for version updates", "period", lp.period, "updateAddr", updateAddr)
 			for {
 				newversion := lp.version + 1
-				updateAddr := lp.GetUpdateAddr()
+				updateAddr := lp.Addr()
 				newchunk, err := h.chunkStore.GetWithTimeout(updateAddr, defaultRetrieveTimeout)
 				if err != nil {
 					return h.updateIndex(rsrc, chunk)
@@ -363,7 +394,7 @@ func (h *Handler) updateIndex(rsrc *resource, chunk *storage.Chunk) (*resource, 
 	// retrieve metadata from chunk data and check that it matches this mutable resource
 	var r SignedResourceUpdate
 	if err := r.parseUpdateChunk(chunk.Addr, chunk.SData); err != nil {
-		return nil, NewErrorf(ErrInvalidSignature, "Invalid resource chunk: %s", err)
+		return nil, err
 	}
 	log.Trace("resource index update", "name", rsrc.ResourceMetadata.Name, "updatekey", chunk.Addr, "period", r.period, "version", r.version)
 

--- a/swarm/storage/mru/handler.go
+++ b/swarm/storage/mru/handler.go
@@ -61,7 +61,7 @@ func init() {
 	if minimumMetadataLength < minimumUpdateDataLength {
 		minimumChunkLength = minimumMetadataLength
 	} else {
-		minimumChunkLength = minimumMetadataLength
+		minimumChunkLength = minimumUpdateDataLength
 	}
 }
 
@@ -111,7 +111,7 @@ func (h *Handler) Validate(chunkAddr storage.Address, data []byte) bool {
 		rootAddr, _ := metadataHash(data)
 		valid := bytes.Equal(chunkAddr, rootAddr)
 		if !valid {
-			log.Warn(fmt.Sprintf("Invalid root metadata chunk with address: %s", chunkAddr.Hex()))
+			log.Debug(fmt.Sprintf("Invalid root metadata chunk with address: %s", chunkAddr.Hex()))
 		}
 		return valid
 	}
@@ -122,7 +122,7 @@ func (h *Handler) Validate(chunkAddr storage.Address, data []byte) bool {
 
 	var r SignedResourceUpdate
 	if err := r.fromChunk(chunkAddr, data); err != nil {
-		log.Warn(fmt.Sprintf("Invalid resource chunk with address %s: %s ", chunkAddr.Hex(), err.Error()))
+		log.Debug(fmt.Sprintf("Invalid resource chunk with address %s: %s ", chunkAddr.Hex(), err.Error()))
 		return false
 	}
 
@@ -407,7 +407,7 @@ func (h *Handler) updateIndex(rsrc *resource, chunk *storage.Chunk) (*resource, 
 	rsrc.multihash = r.multihash
 	copy(rsrc.data, r.data)
 	rsrc.Reader = bytes.NewReader(rsrc.data)
-	log.Debug(" synced", "name", rsrc.ResourceMetadata.Name, "updateAddr", chunk.Addr, "period", rsrc.period, "version", rsrc.version)
+	log.Debug("resource synced", "name", rsrc.ResourceMetadata.Name, "updateAddr", chunk.Addr, "period", rsrc.period, "version", rsrc.version)
 	h.set(chunk.Addr, rsrc)
 	return rsrc, nil
 }

--- a/swarm/storage/mru/handler.go
+++ b/swarm/storage/mru/handler.go
@@ -163,18 +163,17 @@ func (h *Handler) chunkSize() int64 {
 func (h *Handler) New(ctx context.Context, request *Request) error {
 
 	// frequency 0 is invalid
-	if request.frequency == 0 {
+	if request.metadata.Frequency == 0 {
 		return NewError(ErrInvalidValue, "frequency cannot be 0 when creating a resource")
 	}
 
 	// make sure owner is set to something
-	var zeroAddr = common.Address{}
-	if request.ownerAddr == zeroAddr {
+	if request.metadata.OwnerAddr == zeroAddr {
 		return NewError(ErrInvalidValue, "ownerAddr must be set to create a new metadata chunk")
 	}
 
 	// create the meta chunk and store it in swarm
-	chunk, metaHash, err := request.resourceMetadata.newChunk()
+	chunk, metaHash, err := request.metadata.newChunk()
 	if err != nil {
 		return err
 	}
@@ -187,7 +186,7 @@ func (h *Handler) New(ctx context.Context, request *Request) error {
 	request.rootAddr = chunk.Addr
 
 	h.chunkStore.Put(chunk)
-	log.Debug("new resource", "name", request.name, "startTime", request.startTime, "frequency", request.frequency, "owner", request.ownerAddr)
+	log.Debug("new resource", "name", request.metadata.Name, "startTime", request.metadata.StartTime, "frequency", request.metadata.Frequency, "owner", request.metadata.OwnerAddr)
 
 	// create the internal index for the resource and populate it with the data of the first version
 	rsrc := &resource{
@@ -198,14 +197,9 @@ func (h *Handler) New(ctx context.Context, request *Request) error {
 				},
 			},
 		},
-		resourceMetadata: resourceMetadata{
-			name:      request.name,
-			startTime: request.startTime,
-			frequency: request.frequency,
-		},
-		updated: time.Now(),
+		ResourceMetadata: request.metadata,
+		updated:          time.Now(),
 	}
-	copy(rsrc.ownerAddr[:], request.ownerAddr[:])
 	h.set(chunk.Addr, rsrc)
 
 	return nil
@@ -229,7 +223,7 @@ func (h *Handler) NewUpdateRequest(ctx context.Context, rootAddr storage.Address
 	now := h.getCurrentTime(ctx)
 
 	updateRequest := new(Request)
-	updateRequest.period, err = getNextPeriod(rsrc.startTime.Time, now.Time, rsrc.frequency)
+	updateRequest.period, err = getNextPeriod(rsrc.StartTime.Time, now.Time, rsrc.Frequency)
 	if err != nil {
 		return nil, err
 	}
@@ -240,7 +234,7 @@ func (h *Handler) NewUpdateRequest(ctx context.Context, rootAddr storage.Address
 	updateRequest.multihash = rsrc.multihash
 	updateRequest.rootAddr = rsrc.rootAddr
 	updateRequest.metaHash = rsrc.metaHash
-	updateRequest.resourceMetadata = rsrc.resourceMetadata
+	updateRequest.metadata = rsrc.ResourceMetadata
 
 	// if we already have an update for this period then increment version
 	// resource object MUST be in sync for version to be correct, but we checked this earlier in the method already
@@ -268,7 +262,7 @@ func (h *Handler) Lookup(ctx context.Context, params *LookupParams) (*resource, 
 		now := h.getCurrentTime(ctx)
 
 		var period uint32
-		period, err := getNextPeriod(rsrc.startTime.Time, now.Time, rsrc.frequency)
+		period, err := getNextPeriod(rsrc.StartTime.Time, now.Time, rsrc.Frequency)
 		if err != nil {
 			return nil, err
 		}
@@ -372,7 +366,7 @@ func (h *Handler) Load(rootAddr storage.Address) (*resource, error) {
 	// create the index entry
 	rsrc := &resource{}
 
-	if err := rsrc.resourceMetadata.binaryGet(chunk.SData); err != nil { // Will fail if this is not really a metadata chunk
+	if err := rsrc.ResourceMetadata.binaryGet(chunk.SData); err != nil { // Will fail if this is not really a metadata chunk
 		return nil, err
 	}
 
@@ -381,7 +375,7 @@ func (h *Handler) Load(rootAddr storage.Address) (*resource, error) {
 		return nil, NewError(ErrCorruptData, "Corrupt metadata chunk")
 	}
 	h.set(rootAddr, rsrc)
-	log.Trace("resource index load", "rootkey", rootAddr, "name", rsrc.name, "starttime", rsrc.startTime, "frequency", rsrc.frequency)
+	log.Trace("resource index load", "rootkey", rootAddr, "name", rsrc.ResourceMetadata.Name, "starttime", rsrc.ResourceMetadata.StartTime, "frequency", rsrc.ResourceMetadata.Frequency)
 	return rsrc, nil
 }
 
@@ -393,7 +387,7 @@ func (h *Handler) updateIndex(rsrc *resource, chunk *storage.Chunk) (*resource, 
 	if err := r.parseUpdateChunk(chunk.Addr, chunk.SData); err != nil {
 		return nil, NewErrorf(ErrInvalidSignature, "Invalid resource chunk: %s", err)
 	}
-	log.Trace("resource index update", "name", rsrc.name, "updatekey", chunk.Addr, "period", r.period, "version", r.version)
+	log.Trace("resource index update", "name", rsrc.ResourceMetadata.Name, "updatekey", chunk.Addr, "period", r.period, "version", r.version)
 
 	// update our rsrcs entry map
 	rsrc.lastKey = chunk.Addr
@@ -404,7 +398,7 @@ func (h *Handler) updateIndex(rsrc *resource, chunk *storage.Chunk) (*resource, 
 	rsrc.multihash = r.multihash
 	rsrc.Reader = bytes.NewReader(rsrc.data)
 	copy(rsrc.data, r.data)
-	log.Debug(" synced", "name", rsrc.name, "updateAddr", chunk.Addr, "period", rsrc.period, "version", rsrc.version)
+	log.Debug(" synced", "name", rsrc.ResourceMetadata.Name, "updateAddr", chunk.Addr, "period", rsrc.period, "version", rsrc.version)
 	h.set(chunk.Addr, rsrc)
 	return rsrc, nil
 }
@@ -413,12 +407,12 @@ func (h *Handler) updateIndex(rsrc *resource, chunk *storage.Chunk) (*resource, 
 // Uses the Mutable Resource metadata currently loaded in the resources map entry.
 // It is the caller's responsibility to make sure that this data is not stale.
 // Note that a Mutable Resource update cannot span chunks, and thus has a MAX NET LENGTH 4096, INCLUDING update header data and signature. An error will be returned if the total length of the chunk payload will exceed this limit.
-func (h *Handler) Update(ctx context.Context, rootAddr storage.Address, r *SignedResourceUpdate) (storage.Address, error) {
-	return h.update(ctx, rootAddr, r)
+func (h *Handler) Update(ctx context.Context, r *SignedResourceUpdate) (storage.Address, error) {
+	return h.update(ctx, r)
 }
 
 // create and commit an update
-func (h *Handler) update(ctx context.Context, rootAddr storage.Address, r *SignedResourceUpdate) (storage.Address, error) {
+func (h *Handler) update(ctx context.Context, r *SignedResourceUpdate) (storage.Address, error) {
 
 	// we can't update anything without a store
 	if h.chunkStore == nil {
@@ -427,9 +421,9 @@ func (h *Handler) update(ctx context.Context, rootAddr storage.Address, r *Signe
 
 	// get the cached information
 
-	rsrc := h.get(rootAddr)
+	rsrc := h.get(r.rootAddr)
 	if rsrc == nil {
-		return nil, NewErrorf(ErrNotFound, " object '%s' not in index", rsrc.name)
+		return nil, NewErrorf(ErrNotFound, " object '%s' not in index", rsrc.ResourceMetadata.Name)
 	} else if !rsrc.isSynced() {
 		return nil, NewError(ErrNotSynced, " object not in sync")
 	}

--- a/swarm/storage/mru/handler.go
+++ b/swarm/storage/mru/handler.go
@@ -121,7 +121,7 @@ func (h *Handler) Validate(chunkAddr storage.Address, data []byte) bool {
 	// to update
 
 	var r SignedResourceUpdate
-	if err := r.parseUpdateChunk(chunkAddr, data); err != nil {
+	if err := r.fromChunk(chunkAddr, data); err != nil {
 		log.Warn(fmt.Sprintf("Invalid resource chunk with address %s: %s ", chunkAddr.Hex(), err.Error()))
 		return false
 	}
@@ -174,7 +174,7 @@ func (h *Handler) New(ctx context.Context, request *Request) error {
 	}
 
 	// make sure owner is set to something
-	if request.metadata.OwnerAddr == zeroAddr {
+	if request.metadata.Owner == zeroAddr {
 		return NewError(ErrInvalidValue, "ownerAddr must be set to create a new metadata chunk")
 	}
 
@@ -192,7 +192,7 @@ func (h *Handler) New(ctx context.Context, request *Request) error {
 	request.rootAddr = chunk.Addr
 
 	h.chunkStore.Put(chunk)
-	log.Debug("new resource", "name", request.metadata.Name, "startTime", request.metadata.StartTime, "frequency", request.metadata.Frequency, "owner", request.metadata.OwnerAddr)
+	log.Debug("new resource", "name", request.metadata.Name, "startTime", request.metadata.StartTime, "frequency", request.metadata.Frequency, "owner", request.metadata.Owner)
 
 	// create the internal index for the resource and populate it with the data of the first version
 	rsrc := &resource{
@@ -226,7 +226,7 @@ func (h *Handler) NewUpdateRequest(ctx context.Context, rootAddr storage.Address
 		return nil, err
 	}
 
-	now := h.getCurrentTime(ctx)
+	now := h.Now(ctx)
 
 	updateRequest = new(Request)
 	updateRequest.period, err = getNextPeriod(rsrc.StartTime.Time, now.Time, rsrc.Frequency)
@@ -268,7 +268,7 @@ func (h *Handler) Lookup(ctx context.Context, params *LookupParams) (*resource, 
 	}
 	if params.period == 0 {
 		// get the current time and the next period
-		now := h.getCurrentTime(ctx)
+		now := h.Now(ctx)
 
 		var period uint32
 		period, err := getNextPeriod(rsrc.StartTime.Time, now.Time, rsrc.Frequency)
@@ -337,7 +337,7 @@ func (h *Handler) lookup(rsrc *resource, params *LookupParams) (*resource, error
 		if lp.Limit != 0 && hops > lp.Limit {
 			return nil, NewErrorf(ErrPeriodDepth, "Lookup exceeded max period hops (%d)", lp.Limit)
 		}
-		updateAddr := lp.Addr()
+		updateAddr := lp.UpdateAddr()
 		chunk, err := h.chunkStore.GetWithTimeout(updateAddr, defaultRetrieveTimeout)
 		if err == nil {
 			if specificversion {
@@ -347,7 +347,7 @@ func (h *Handler) lookup(rsrc *resource, params *LookupParams) (*resource, error
 			log.Trace("rsrc update version 1 found, checking for version updates", "period", lp.period, "updateAddr", updateAddr)
 			for {
 				newversion := lp.version + 1
-				updateAddr := lp.Addr()
+				updateAddr := lp.UpdateAddr()
 				newchunk, err := h.chunkStore.GetWithTimeout(updateAddr, defaultRetrieveTimeout)
 				if err != nil {
 					return h.updateIndex(rsrc, chunk)
@@ -393,7 +393,7 @@ func (h *Handler) updateIndex(rsrc *resource, chunk *storage.Chunk) (*resource, 
 
 	// retrieve metadata from chunk data and check that it matches this mutable resource
 	var r SignedResourceUpdate
-	if err := r.parseUpdateChunk(chunk.Addr, chunk.SData); err != nil {
+	if err := r.fromChunk(chunk.Addr, chunk.SData); err != nil {
 		return nil, err
 	}
 	log.Trace("resource index update", "name", rsrc.ResourceMetadata.Name, "updatekey", chunk.Addr, "period", r.period, "version", r.version)
@@ -441,7 +441,7 @@ func (h *Handler) update(ctx context.Context, r *SignedResourceUpdate) (updateAd
 		}
 	}
 
-	chunk, err := r.newUpdateChunk() // Serialize the update into a chunk. Fails if data is too big
+	chunk, err := r.toChunk() // Serialize the update into a chunk. Fails if data is too big
 	if err != nil {
 		return nil, err
 	}
@@ -466,8 +466,8 @@ func (h *Handler) update(ctx context.Context, r *SignedResourceUpdate) (updateAd
 }
 
 // gets the current time
-func (h *Handler) getCurrentTime(ctx context.Context) Timestamp {
-	return h.timestampProvider.GetCurrentTimestamp()
+func (h *Handler) Now(ctx context.Context) Timestamp {
+	return h.timestampProvider.Now()
 }
 
 // Retrieves the resource index value for the given nameHash

--- a/swarm/storage/mru/lookup.go
+++ b/swarm/storage/mru/lookup.go
@@ -76,8 +76,8 @@ type UpdateLookup struct {
 // storage.Keylength for rootAddr
 const updateLookupLength = 4 + 4 + storage.KeyLength
 
-// Addr calculates the resource update chunk address corresponding to this lookup key
-func (u *UpdateLookup) Addr() (updateAddr storage.Address) {
+// UpdateAddr calculates the resource update chunk address corresponding to this lookup key
+func (u *UpdateLookup) UpdateAddr() (updateAddr storage.Address) {
 	serializedData := make([]byte, updateLookupLength)
 	u.binaryPut(serializedData)
 	hasher := hashPool.Get().(hash.Hash)

--- a/swarm/storage/mru/lookup.go
+++ b/swarm/storage/mru/lookup.go
@@ -76,8 +76,8 @@ type UpdateLookup struct {
 // storage.Keylength for rootAddr
 const updateLookupLength = 4 + 4 + storage.KeyLength
 
-// resourceUpdateChunkAddr calculates the resource update chunk address (formerly known as resourceHash)
-func (u *UpdateLookup) GetUpdateAddr() (updateAddr storage.Address) {
+// Addr calculates the resource update chunk address corresponding to this lookup key
+func (u *UpdateLookup) Addr() (updateAddr storage.Address) {
 	serializedData := make([]byte, updateLookupLength)
 	u.binaryPut(serializedData)
 	hasher := hashPool.Get().(hash.Hash)

--- a/swarm/storage/mru/lookup.go
+++ b/swarm/storage/mru/lookup.go
@@ -20,7 +20,6 @@ import (
 	"encoding/binary"
 	"hash"
 
-	"github.com/ethereum/go-ethereum/swarm/log"
 	"github.com/ethereum/go-ethereum/swarm/storage"
 )
 
@@ -93,7 +92,6 @@ func (u *UpdateLookup) binaryPut(serializedData []byte) error {
 		return NewErrorf(ErrInvalidValue, "Incorrect slice size to serialize UpdateLookup. Expected %d, got %d", updateLookupLength, len(serializedData))
 	}
 	if len(u.rootAddr) != storage.KeyLength {
-		log.Warn("Call to UpdateLookup.binaryPut with incorrect rootAddr")
 		return NewError(ErrInvalidValue, "UpdateLookup.binaryPut called without rootAddr set")
 	}
 	binary.LittleEndian.PutUint32(serializedData[:4], u.period)

--- a/swarm/storage/mru/metadata.go
+++ b/swarm/storage/mru/metadata.go
@@ -30,7 +30,7 @@ type ResourceMetadata struct {
 	StartTime Timestamp      // time at which the resource starts to be valid
 	Frequency uint64         // expected update frequency for the resource
 	Name      string         // name of the resource, for the reference of the user
-	OwnerAddr common.Address // public address of the resource owner
+	Owner     common.Address // public address of the resource owner
 }
 
 // Resource metadata chunk layout:
@@ -77,7 +77,7 @@ func (r *ResourceMetadata) binaryGet(serializedData []byte) error {
 	r.Name = string(serializedData[cursor : cursor+nameLength])
 	cursor += nameLength
 
-	copy(r.OwnerAddr[:], serializedData[cursor:])
+	copy(r.Owner[:], serializedData[cursor:])
 	return nil
 }
 
@@ -111,7 +111,7 @@ func (r *ResourceMetadata) binaryPut(serializedData []byte) error {
 	copy(serializedData[cursor:cursor+nameLength], []byte(r.Name[:nameLength]))
 	cursor += nameLength
 
-	copy(serializedData[cursor:cursor+common.AddressLength], r.OwnerAddr[:])
+	copy(serializedData[cursor:cursor+common.AddressLength], r.Owner[:])
 	cursor += common.AddressLength
 
 	return nil

--- a/swarm/storage/mru/metadata.go
+++ b/swarm/storage/mru/metadata.go
@@ -34,15 +34,16 @@ type ResourceMetadata struct {
 }
 
 const frequencyLength = 8 // sizeof(uint64)
+const nameLengthLength = 1
 
 // Resource metadata chunk layout:
-// 4 prefix bytes (prefixLength). The first two set to zero. The second two indicate the length
+// 4 prefix bytes (chunkPrefixLength). The first two set to zero. The second two indicate the length
 // Timestamp: timestampLength bytes
-// frequency: 8 bytes
-// 1 byte name length
-// name (variable length, can be empty, up to 256 bytes)
+// frequency: frequencyLength bytes
+// name length: nameLengthLength bytes
+// name (variable length, can be empty, up to 255 bytes)
 // ownerAddr: common.AddressLength
-const minimumMetadataLength = chunkPrefixLength + timestampLength + frequencyLength + 1 + common.AddressLength
+const minimumMetadataLength = chunkPrefixLength + timestampLength + frequencyLength + nameLengthLength + common.AddressLength
 
 // binaryGet populates the resource metadata from a byte array
 func (r *ResourceMetadata) binaryGet(serializedData []byte) error {

--- a/swarm/storage/mru/metadata.go
+++ b/swarm/storage/mru/metadata.go
@@ -121,9 +121,9 @@ func (r *ResourceMetadata) binaryLength() int {
 	return minimumMetadataLength + len(r.Name)
 }
 
-// hashAndSerialize returns the root chunk addr and metadata hash that help identify and ascertain ownership of this resource
+// serializeAndHash returns the root chunk addr and metadata hash that help identify and ascertain ownership of this resource
 // returns the serialized metadata as a byproduct of having to hash it.
-func (r *ResourceMetadata) hashAndSerialize() (rootAddr, metaHash []byte, chunkData []byte, err error) {
+func (r *ResourceMetadata) serializeAndHash() (rootAddr, metaHash []byte, chunkData []byte, err error) {
 
 	chunkData = make([]byte, r.binaryLength())
 	if err := r.binaryPut(chunkData); err != nil {
@@ -144,7 +144,7 @@ func (metadata *ResourceMetadata) newChunk() (chunk *storage.Chunk, metaHash []b
 	// the key (rootAddr) of the metadata chunk is content-addressed
 	// if it wasn't we couldn't replace it later
 	// resolving this relationship is left up to external agents (for example ENS)
-	rootAddr, metaHash, chunkData, err := metadata.hashAndSerialize()
+	rootAddr, metaHash, chunkData, err := metadata.serializeAndHash()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/swarm/storage/mru/metadata_test.go
+++ b/swarm/storage/mru/metadata_test.go
@@ -35,7 +35,7 @@ func TestMarshallingAndUnmarshalling(t *testing.T) {
 			Time: 1528880400,
 		},
 		Frequency: 3600,
-		OwnerAddr: ownerAddr,
+		Owner:     ownerAddr,
 	}
 
 	rootAddr, metaHash, chunkData, err := metadata.hashAndSerialize() // creates hashes and marshals, in one go

--- a/swarm/storage/mru/metadata_test.go
+++ b/swarm/storage/mru/metadata_test.go
@@ -29,13 +29,13 @@ func compareByteSliceToExpectedHex(t *testing.T, variableName string, actualValu
 
 func TestMarshallingAndUnmarshalling(t *testing.T) {
 	ownerAddr := newCharlieSigner().Address()
-	metadata := resourceMetadata{
-		name: "world news report, every hour, on the hour",
-		startTime: Timestamp{
+	metadata := ResourceMetadata{
+		Name: "world news report, every hour, on the hour",
+		StartTime: Timestamp{
 			Time: 1528880400,
 		},
-		frequency: 3600,
-		ownerAddr: ownerAddr,
+		Frequency: 3600,
+		OwnerAddr: ownerAddr,
 	}
 
 	rootAddr, metaHash, chunkData, err := metadata.hashAndSerialize() // creates hashes and marshals, in one go
@@ -50,7 +50,7 @@ func TestMarshallingAndUnmarshalling(t *testing.T) {
 	compareByteSliceToExpectedHex(t, "metaHash", metaHash, expectedMetaHash)
 	compareByteSliceToExpectedHex(t, "chunkData", chunkData, expectedChunkData)
 
-	recoveredMetadata := resourceMetadata{}
+	recoveredMetadata := ResourceMetadata{}
 	recoveredMetadata.binaryGet(chunkData)
 
 	if recoveredMetadata != metadata {

--- a/swarm/storage/mru/metadata_test.go
+++ b/swarm/storage/mru/metadata_test.go
@@ -38,7 +38,7 @@ func TestMarshallingAndUnmarshalling(t *testing.T) {
 		Owner:     ownerAddr,
 	}
 
-	rootAddr, metaHash, chunkData, err := metadata.hashAndSerialize() // creates hashes and marshals, in one go
+	rootAddr, metaHash, chunkData, err := metadata.serializeAndHash() // creates hashes and marshals, in one go
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swarm/storage/mru/metadata_test.go
+++ b/swarm/storage/mru/metadata_test.go
@@ -42,9 +42,9 @@ func TestMarshallingAndUnmarshalling(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	const expectedRootAddr = "0xed0d5141d039eb69a3cc7d6c60ce101f6f80371074df02aedd804fca88ee21b4"
-	const expectedMetaHash = "0x1f1cf772ee37263f90af030ad37a75b08eb750a1915e428f43382192e554111a"
-	const expectedChunkData = "0x00006f0010dd205b000000000000000000000000000000000000000000000000000000000000000000000000100e0000000000002a776f726c64206e657773207265706f72742c20657665727920686f75722c206f6e2074686520686f7572876a8936a7cd0b79ef0735ad0896c1afe278781c"
+	const expectedRootAddr = "0xfb0ed7efa696bdb0b54cd75554cc3117ffc891454317df7dd6fefad978e2f2fb"
+	const expectedMetaHash = "0xf74a10ce8f26ffc8bfaa07c3031a34b2c61f517955e7deb1592daccf96c69cf0"
+	const expectedChunkData = "0x00004f0010dd205b00000000100e0000000000002a776f726c64206e657773207265706f72742c20657665727920686f75722c206f6e2074686520686f7572876a8936a7cd0b79ef0735ad0896c1afe278781c"
 
 	compareByteSliceToExpectedHex(t, "rootAddr", rootAddr, expectedRootAddr)
 	compareByteSliceToExpectedHex(t, "metaHash", metaHash, expectedMetaHash)

--- a/swarm/storage/mru/request.go
+++ b/swarm/storage/mru/request.go
@@ -84,7 +84,7 @@ func NewCreateRequest(metadata *ResourceMetadata) (*Request, error) {
 	return request, nil
 }
 
-// Frequency Returns the resource expected update frequency
+// Frequency returns the resource's expected update frequency
 func (r *Request) Frequency() uint64 {
 	return r.metadata.Frequency
 }
@@ -240,7 +240,7 @@ func (j *updateRequestJSON) decode() (*Request, error) {
 			return nil, NewError(ErrInvalidSignature, "Cannot decode signature")
 		}
 		r.signature = new(Signature)
-		r.updateAddr = r.GetUpdateAddr()
+		r.updateAddr = r.Addr()
 		copy(r.signature[:], sigBytes)
 	}
 	return r, nil

--- a/swarm/storage/mru/request.go
+++ b/swarm/storage/mru/request.go
@@ -243,8 +243,9 @@ func decodeHexSlice(src string, expectedLength int, name string) (bytes []byte, 
 	return bytes, nil
 }
 
-// Unmarshal takes a JSON structure stored in a byte array and populates the Request object
-func (r *Request) Unmarshal(rawData []byte) error {
+// UnmarshalJSON takes a JSON structure stored in a byte array and populates the Request object
+// Implements json.Unmarshaler interface
+func (r *Request) UnmarshalJSON(rawData []byte) error {
 	var requestJSON updateRequestJSON
 	if err := json.Unmarshal(rawData, &requestJSON); err != nil {
 		return err
@@ -252,8 +253,9 @@ func (r *Request) Unmarshal(rawData []byte) error {
 	return r.fromJSON(&requestJSON)
 }
 
-// Marshal takes an update request and encodes it as a JSON structure into a byte array
-func (r *Request) Marshal() (rawData []byte, err error) {
+// MarshalJSON takes an update request and encodes it as a JSON structure into a byte array
+// Implements json.Marshaler interface
+func (r *Request) MarshalJSON() (rawData []byte, err error) {
 	var signatureString, dataHashString, rootAddrString, metaHashString string
 	if r.signature != nil {
 		signatureString = hexutil.Encode(r.signature[:])

--- a/swarm/storage/mru/request.go
+++ b/swarm/storage/mru/request.go
@@ -140,10 +140,6 @@ func (r *Request) Sign(signer Signer) error {
 func (r *Request) SetData(data []byte, multihash bool) {
 	r.data = data
 	r.multihash = multihash
-	r.dirty()
-}
-
-func (r *Request) dirty() {
 	r.signature = nil
 	if r.period != 1 || r.version != 1 {
 		r.metadata.Frequency = 0 // mark as update if this is not the first request
@@ -158,7 +154,7 @@ func (r *Request) IsUpdate() bool {
 	return r.signature != nil
 }
 
-// decode takes an update request JSON and populates an UpdateRequest
+// fromJSON takes an update request JSON and populates an UpdateRequest
 func (r *Request) fromJSON(j *updateRequestJSON) error {
 
 	r.version = j.Version

--- a/swarm/storage/mru/request.go
+++ b/swarm/storage/mru/request.go
@@ -169,11 +169,11 @@ func (r *Request) fromJSON(j *updateRequestJSON) error {
 	r.metadata.Frequency = j.Frequency
 	r.metadata.StartTime.Time = j.StartTime
 
-	if err := decodeHexArray(r.metadata.StartTime.Proof[:], j.StartTimeProof, common.HashLength, "startTimeProof"); err != nil {
+	if err := decodeHexArray(r.metadata.StartTime.Proof[:], j.StartTimeProof, "startTimeProof"); err != nil {
 		return err
 	}
 
-	if err := decodeHexArray(r.metadata.Owner[:], j.Owner, common.AddressLength, "ownerAddr"); err != nil {
+	if err := decodeHexArray(r.metadata.Owner[:], j.Owner, "ownerAddr"); err != nil {
 		return err
 	}
 
@@ -231,8 +231,8 @@ func (r *Request) fromJSON(j *updateRequestJSON) error {
 	return nil
 }
 
-func decodeHexArray(dst []byte, src string, expectedLength int, name string) error {
-	bytes, err := decodeHexSlice(src, expectedLength, name)
+func decodeHexArray(dst []byte, src, name string) error {
+	bytes, err := decodeHexSlice(src, len(dst), name)
 	if err != nil {
 		return err
 	}

--- a/swarm/storage/mru/request.go
+++ b/swarm/storage/mru/request.go
@@ -28,18 +28,17 @@ import (
 
 // updateRequestJSON represents a JSON-serialized UpdateRequest
 type updateRequestJSON struct {
-	Name           string `json:"name,omitempty"`
-	Frequency      uint64 `json:"frequency,omitempty"`
-	StartTime      uint64 `json:"startTime,omitempty"`
-	StartTimeProof string `json:"startTimeProof,omitempty"`
-	Owner          string `json:"ownerAddr,omitempty"`
-	RootAddr       string `json:"rootAddr,omitempty"`
-	MetaHash       string `json:"metaHash,omitempty"`
-	Version        uint32 `json:"version"`
-	Period         uint32 `json:"period"`
-	Data           string `json:"data,omitempty"`
-	Multihash      bool   `json:"multiHash"`
-	Signature      string `json:"signature,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Frequency uint64 `json:"frequency,omitempty"`
+	StartTime uint64 `json:"startTime,omitempty"`
+	Owner     string `json:"ownerAddr,omitempty"`
+	RootAddr  string `json:"rootAddr,omitempty"`
+	MetaHash  string `json:"metaHash,omitempty"`
+	Version   uint32 `json:"version"`
+	Period    uint32 `json:"period"`
+	Data      string `json:"data,omitempty"`
+	Multihash bool   `json:"multiHash"`
+	Signature string `json:"signature,omitempty"`
 }
 
 // Request represents an update and/or resource create message
@@ -169,10 +168,6 @@ func (r *Request) fromJSON(j *updateRequestJSON) error {
 	r.metadata.Frequency = j.Frequency
 	r.metadata.StartTime.Time = j.StartTime
 
-	if err := decodeHexArray(r.metadata.StartTime.Proof[:], j.StartTimeProof, "startTimeProof"); err != nil {
-		return err
-	}
-
 	if err := decodeHexArray(r.metadata.Owner[:], j.Owner, "ownerAddr"); err != nil {
 		return err
 	}
@@ -282,26 +277,19 @@ func (r *Request) Marshal() (rawData []byte, err error) {
 	} else {
 		ownerAddrString = hexutil.Encode(r.metadata.Owner[:])
 	}
-	var startTimeProofString string
-	if r.metadata.StartTime.Time == 0 {
-		startTimeProofString = ""
-	} else {
-		startTimeProofString = hexutil.Encode(r.metadata.StartTime.Proof[:])
-	}
 
 	requestJSON := &updateRequestJSON{
-		Name:           r.metadata.Name,
-		Frequency:      r.metadata.Frequency,
-		StartTime:      r.metadata.StartTime.Time,
-		StartTimeProof: startTimeProofString,
-		Version:        r.version,
-		Period:         r.period,
-		Owner:          ownerAddrString,
-		Data:           dataHashString,
-		Multihash:      r.multihash,
-		Signature:      signatureString,
-		RootAddr:       rootAddrString,
-		MetaHash:       metaHashString,
+		Name:      r.metadata.Name,
+		Frequency: r.metadata.Frequency,
+		StartTime: r.metadata.StartTime.Time,
+		Version:   r.version,
+		Period:    r.period,
+		Owner:     ownerAddrString,
+		Data:      dataHashString,
+		Multihash: r.multihash,
+		Signature: signatureString,
+		RootAddr:  rootAddrString,
+		MetaHash:  metaHashString,
 	}
 
 	return json.Marshal(requestJSON)

--- a/swarm/storage/mru/request_test.go
+++ b/swarm/storage/mru/request_test.go
@@ -45,14 +45,14 @@ func TestEncodingDecodingUpdateRequests(t *testing.T) {
 	}
 
 	// We now encode the create message to simulate we send it over the wire
-	messageRawData, err := EncodeUpdateRequest(createRequest)
+	messageRawData, err := createRequest.Marshal()
 	if err != nil {
 		t.Fatalf("Error encoding create resource request: %s", err)
 	}
 
 	// ... the message arrives and is decoded...
-	recoveredCreateRequest, err := DecodeUpdateRequest(messageRawData)
-	if err != nil {
+	var recoveredCreateRequest Request
+	if err := recoveredCreateRequest.Unmarshal(messageRawData); err != nil {
 		t.Fatalf("Error decoding create resource request: %s", err)
 	}
 
@@ -89,7 +89,7 @@ func TestEncodingDecodingUpdateRequests(t *testing.T) {
 		},
 	}
 
-	messageRawData, err = EncodeUpdateRequest(request)
+	messageRawData, err = request.Marshal()
 	if err != nil {
 		t.Fatalf("Error encoding update request: %s", err)
 	}
@@ -105,8 +105,8 @@ func TestEncodingDecodingUpdateRequests(t *testing.T) {
 	// now the encoded message messageRawData is sent over the wire and arrives to the signer
 
 	//Attempt to extract an UpdateRequest out of the encoded message
-	recoveredRequest, err := DecodeUpdateRequest(messageRawData)
-	if err != nil {
+	var recoveredRequest Request
+	if err := recoveredRequest.Unmarshal(messageRawData); err != nil {
 		t.Fatalf("Error decoding update request: %s", err)
 	}
 
@@ -125,8 +125,8 @@ func TestEncodingDecodingUpdateRequests(t *testing.T) {
 	}
 	j.Signature = "Certainly not a signature"
 	corruptMessage, _ := json.Marshal(j) // encode the message with the bad signature
-	_, err = DecodeUpdateRequest(corruptMessage)
-	if err == nil {
+	var corruptRequest Request
+	if err = corruptRequest.Unmarshal(corruptMessage); err == nil {
 		t.Fatal("Expected DecodeUpdateRequest to fail when trying to interpret a corrupt message with an invalid signature")
 	}
 
@@ -137,14 +137,14 @@ func TestEncodingDecodingUpdateRequests(t *testing.T) {
 	}
 
 	// Now Bob encodes the message to send it over the wire...
-	messageRawData, err = EncodeUpdateRequest(request)
+	messageRawData, err = request.Marshal()
 	if err != nil {
 		t.Fatalf("Error encoding message:%s", err)
 	}
 
 	// ... the message arrives to our Swarm node and it is decoded.
-	recoveredRequest, err = DecodeUpdateRequest(messageRawData)
-	if err != nil {
+	recoveredRequest = Request{}
+	if err := recoveredRequest.Unmarshal(messageRawData); err != nil {
 		t.Fatalf("Error decoding message:%s", err)
 	}
 

--- a/swarm/storage/mru/request_test.go
+++ b/swarm/storage/mru/request_test.go
@@ -44,14 +44,14 @@ func TestEncodingDecodingUpdateRequests(t *testing.T) {
 	}
 
 	// We now encode the create message to simulate we send it over the wire
-	messageRawData, err := createRequest.Marshal()
+	messageRawData, err := createRequest.MarshalJSON()
 	if err != nil {
 		t.Fatalf("Error encoding create resource request: %s", err)
 	}
 
 	// ... the message arrives and is decoded...
 	var recoveredCreateRequest Request
-	if err := recoveredCreateRequest.Unmarshal(messageRawData); err != nil {
+	if err := recoveredCreateRequest.UnmarshalJSON(messageRawData); err != nil {
 		t.Fatalf("Error decoding create resource request: %s", err)
 	}
 
@@ -88,7 +88,7 @@ func TestEncodingDecodingUpdateRequests(t *testing.T) {
 		},
 	}
 
-	messageRawData, err = request.Marshal()
+	messageRawData, err = request.MarshalJSON()
 	if err != nil {
 		t.Fatalf("Error encoding update request: %s", err)
 	}
@@ -105,7 +105,7 @@ func TestEncodingDecodingUpdateRequests(t *testing.T) {
 
 	//Attempt to extract an UpdateRequest out of the encoded message
 	var recoveredRequest Request
-	if err := recoveredRequest.Unmarshal(messageRawData); err != nil {
+	if err := recoveredRequest.UnmarshalJSON(messageRawData); err != nil {
 		t.Fatalf("Error decoding update request: %s", err)
 	}
 
@@ -125,7 +125,7 @@ func TestEncodingDecodingUpdateRequests(t *testing.T) {
 	j.Signature = "Certainly not a signature"
 	corruptMessage, _ := json.Marshal(j) // encode the message with the bad signature
 	var corruptRequest Request
-	if err = corruptRequest.Unmarshal(corruptMessage); err == nil {
+	if err = corruptRequest.UnmarshalJSON(corruptMessage); err == nil {
 		t.Fatal("Expected DecodeUpdateRequest to fail when trying to interpret a corrupt message with an invalid signature")
 	}
 
@@ -136,14 +136,14 @@ func TestEncodingDecodingUpdateRequests(t *testing.T) {
 	}
 
 	// Now Bob encodes the message to send it over the wire...
-	messageRawData, err = request.Marshal()
+	messageRawData, err = request.MarshalJSON()
 	if err != nil {
 		t.Fatalf("Error encoding message:%s", err)
 	}
 
 	// ... the message arrives to our Swarm node and it is decoded.
 	recoveredRequest = Request{}
-	if err := recoveredRequest.Unmarshal(messageRawData); err != nil {
+	if err := recoveredRequest.UnmarshalJSON(messageRawData); err != nil {
 		t.Fatalf("Error decoding message:%s", err)
 	}
 

--- a/swarm/storage/mru/request_test.go
+++ b/swarm/storage/mru/request_test.go
@@ -38,7 +38,7 @@ func TestEncodingDecodingUpdateRequests(t *testing.T) {
 		Name:      "a good resource name",
 		Frequency: 300,
 		StartTime: Timestamp{Time: 1528900000},
-		OwnerAddr: signer.Address()})
+		Owner:     signer.Address()})
 
 	if err != nil {
 		t.Fatalf("Error creating resource name: %s", err)

--- a/swarm/storage/mru/request_test.go
+++ b/swarm/storage/mru/request_test.go
@@ -13,8 +13,7 @@ func areEqualJSON(s1, s2 string) (bool, error) {
 	var o1 interface{}
 	var o2 interface{}
 
-	var err error
-	err = json.Unmarshal([]byte(s1), &o1)
+	err := json.Unmarshal([]byte(s1), &o1)
 	if err != nil {
 		return false, fmt.Errorf("Error mashalling string 1 :: %s", err.Error())
 	}

--- a/swarm/storage/mru/request_test.go
+++ b/swarm/storage/mru/request_test.go
@@ -34,8 +34,12 @@ func TestEncodingDecodingUpdateRequests(t *testing.T) {
 	falseSigner := newBobSigner() //Bob will play the bad guy again
 
 	// Create a resource to our good guy Charlie's name
-	createRequest, err := NewCreateRequest("a good resource name",
-		300, 1528900000, signer.Address(), nil, false)
+	createRequest, err := NewCreateRequest(&ResourceMetadata{
+		Name:      "a good resource name",
+		Frequency: 300,
+		StartTime: Timestamp{Time: 1528900000},
+		OwnerAddr: signer.Address()})
+
 	if err != nil {
 		t.Fatalf("Error creating resource name: %s", err)
 	}

--- a/swarm/storage/mru/request_test.go
+++ b/swarm/storage/mru/request_test.go
@@ -66,8 +66,8 @@ func TestEncodingDecodingUpdateRequests(t *testing.T) {
 
 	metaHash := createRequest.metaHash
 	rootAddr := createRequest.rootAddr
-	const expectedSignature = "0x2bd4aa556c1350e0e49d001f6096ad8b767ad943b11976887a36bc992fcced527c32ddbe033d2dc88f988954a2a1593aefd237dcb4994b52b8cc30563d04984800"
-	const expectedJSON = `{"rootAddr":"0xea7c952ee78f8852b1596211e8801f81de1aa6b39b46b103a272a5acb46f89f9","metaHash":"0xd87c91c88ab9b4d23ac1b1b1ce59c4ed714594c304f677db8367e0726e117b9c","version":1,"period":7,"data":"0x5468697320686f75722773207570646174653a20537761726d2039392e3020686173206265656e2072656c656173656421","multiHash":false}`
+	const expectedSignature = "0x89315e442c2b5620517ab00d7f3e358207d5d8792d544303093b22b7ff92fb2c36dfe0d53e2f3adf7d17ba0aa2299d2b1e40b86c4d0ad19e4c2729bfc57043e101"
+	const expectedJSON = `{"rootAddr":"0x6e744a730f7ea0881528576f0354b6268b98e35a6981ef703153ff1b8d32bbef","metaHash":"0x0c0d5c18b89da503af92302a1a64fab6acb60f78e288eb9c3d541655cd359b60","version":1,"period":7,"data":"0x5468697320686f75722773207570646174653a20537761726d2039392e3020686173206265656e2072656c656173656421","multiHash":false}`
 
 	//Put together an unsigned update request that we will serialize to send it to the signer.
 	data := []byte("This hour's update: Swarm 99.0 has been released!")

--- a/swarm/storage/mru/resource.go
+++ b/swarm/storage/mru/resource.go
@@ -35,7 +35,7 @@ const (
 // version of the resource data and the metadata of its root chunk.
 type resource struct {
 	resourceUpdate
-	resourceMetadata
+	ResourceMetadata
 	*bytes.Reader
 	lastKey storage.Address
 	updated time.Time
@@ -61,7 +61,7 @@ func (r *resource) Size(_ chan bool) (int64, error) {
 
 //returns the resource's human-readable name
 func (r *resource) Name() string {
-	return r.name
+	return r.ResourceMetadata.Name
 }
 
 // Helper function to calculate the next update period number from the current time, start time and frequency

--- a/swarm/storage/mru/resource.go
+++ b/swarm/storage/mru/resource.go
@@ -51,7 +51,7 @@ func (r *resourceUpdate) Multihash() bool {
 	return r.multihash
 }
 
-// implements (which?) interface
+// implements storage.LazySectionReader
 func (r *resource) Size(_ chan bool) (int64, error) {
 	if !r.isSynced() {
 		return 0, NewError(ErrNotSynced, "Not synced")

--- a/swarm/storage/mru/resource_sign.go
+++ b/swarm/storage/mru/resource_sign.go
@@ -23,9 +23,9 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-// Signature is an alias for a static byte array with the size of a signature
 const signatureLength = 65
 
+// Signature is an alias for a static byte array with the size of a signature
 type Signature [signatureLength]byte
 
 // Signer signs Mutable Resource update payloads

--- a/swarm/storage/mru/resource_test.go
+++ b/swarm/storage/mru/resource_test.go
@@ -183,7 +183,7 @@ func TestReverse(t *testing.T) {
 		},
 	}
 	// generate a hash for t=4200 version 1
-	key := update.GetUpdateAddr()
+	key := update.Addr()
 
 	if err = update.Sign(signer); err != nil {
 		t.Fatal(err)
@@ -441,6 +441,25 @@ func TestResourceHandler(t *testing.T) {
 		t.Fatalf("resource data (historical) was %v, expected %v", string(rsrc2.data), updates[2])
 	}
 	log.Debug("Specific version lookup", "period", rsrc2.period, "version", rsrc2.version, "data", rsrc2.data)
+
+	// we are now at third update
+	// check backwards stepping to the first
+	for i := 1; i >= 0; i-- {
+		rsrc, err := rh2.LookupPrevious(ctx, lookupParams)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(rsrc.data, []byte(updates[i])) {
+			t.Fatalf("resource data (previous) was %v, expected %v", rsrc.data, updates[i])
+
+		}
+	}
+
+	// beyond the first should yield an error
+	rsrc, err = rh2.LookupPrevious(ctx, lookupParams)
+	if err == nil {
+		t.Fatalf("expected previous to fail, returned period %d version %d data %v", rsrc.period, rsrc.version, rsrc.data)
+	}
 
 }
 
@@ -801,7 +820,7 @@ func TestValidatorInStore(t *testing.T) {
 		rootAddr: rootChunk.Addr,
 	}
 
-	updateAddr := updateLookup.GetUpdateAddr()
+	updateAddr := updateLookup.Addr()
 	data := []byte("bar")
 
 	r := SignedResourceUpdate{

--- a/swarm/storage/mru/resource_test.go
+++ b/swarm/storage/mru/resource_test.go
@@ -319,16 +319,7 @@ func TestResourceHandler(t *testing.T) {
 		t.Fatal("Suggested period should be 1 and version should be 2")
 	}
 
-	request.version = 1 // force version 1 instead of 2 to make it fail
 	data = []byte(updates[1])
-	request.SetData(data, false)
-	if err := request.Sign(signer); err != nil {
-		t.Fatal(err)
-	}
-	resourcekey[updates[1]], err = rh.Update(ctx, &request.SignedResourceUpdate)
-	if err == nil {
-		t.Fatal("Expected update to fail since this version already exists")
-	}
 
 	// update on second period with version = 1, correct. period=2, version=1
 	fwdClock(int(resourceFrequency/2), timeProvider)

--- a/swarm/storage/mru/resource_test.go
+++ b/swarm/storage/mru/resource_test.go
@@ -155,7 +155,7 @@ func TestReverse(t *testing.T) {
 		Owner:     signer.Address(),
 	}
 
-	rootAddr, metaHash, _, err := metadata.hashAndSerialize()
+	rootAddr, metaHash, _, err := metadata.serializeAndHash()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swarm/storage/mru/resource_test.go
+++ b/swarm/storage/mru/resource_test.go
@@ -87,7 +87,7 @@ func TestUpdateChunkSerializationErrorChecking(t *testing.T) {
 			updateHeader: updateHeader{
 				UpdateLookup: UpdateLookup{
 
-					rootAddr: make([]byte, 79),
+					rootAddr: make([]byte, 79), // put the wrong length, should be storage.KeyLength
 				},
 				metaHash:  nil,
 				multihash: false,
@@ -104,7 +104,7 @@ func TestUpdateChunkSerializationErrorChecking(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected newUpdateChunk to fail when there is no data")
 	}
-	r.data = make([]byte, 79)
+	r.data = make([]byte, 79) // put some arbitrary length data
 	_, err = r.toChunk()
 	if err == nil {
 		t.Fatal("expected newUpdateChunk to fail when there is no signature", err)
@@ -121,7 +121,7 @@ func TestUpdateChunkSerializationErrorChecking(t *testing.T) {
 	}
 
 	r.multihash = true
-	r.data[1] = 79
+	r.data[1] = 79 // mess with the multihash, corrupting one byte of it.
 	if err := r.Sign(alice); err == nil {
 		t.Fatal("expected Sign() to fail when an invalid multihash is in data and multihash=true", err)
 	}

--- a/swarm/storage/mru/signedupdate.go
+++ b/swarm/storage/mru/signedupdate.go
@@ -25,7 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/swarm/storage"
 )
 
-// SignedResourceUpdate contains signature information about a resource update
+// SignedResourceUpdate represents a resource update with all the necessary information to prove ownership of the resource
 type SignedResourceUpdate struct {
 	resourceUpdate // actual content that will be put on the chunk, less signature
 	signature      *Signature
@@ -53,7 +53,7 @@ func (r *SignedResourceUpdate) Verify() (err error) {
 		return err
 	}
 
-	if !bytes.Equal(r.updateAddr, r.GetUpdateAddr()) {
+	if !bytes.Equal(r.updateAddr, r.Addr()) {
 		return NewError(ErrInvalidSignature, "Signature address does not match with ownerAddr")
 	}
 
@@ -68,7 +68,7 @@ func (r *SignedResourceUpdate) Verify() (err error) {
 // Sign executes the signature to validate the resource
 func (r *SignedResourceUpdate) Sign(signer Signer) error {
 
-	updateAddr := r.GetUpdateAddr()
+	updateAddr := r.Addr()
 
 	r.binaryData = nil                     //invalidate serialized data
 	digest, err := r.getDigest(updateAddr) // computes digest and serializes into .binaryData
@@ -139,7 +139,7 @@ func (r *SignedResourceUpdate) parseUpdateChunk(updateAddr storage.Address, chun
 	// check that the lookup information contained in the chunk matches the updateAddr (chunk search key)
 	// that was used to retrieve this chunk
 	// if this validation fails, someone forged a chunk.
-	if !bytes.Equal(updateAddr, r.updateHeader.GetUpdateAddr()) {
+	if !bytes.Equal(updateAddr, r.updateHeader.Addr()) {
 		return NewError(ErrInvalidSignature, "period,version,rootAddr contained in update chunk do not match updateAddr")
 	}
 

--- a/swarm/storage/mru/signedupdate.go
+++ b/swarm/storage/mru/signedupdate.go
@@ -89,7 +89,7 @@ func (r *SignedResourceUpdate) Sign(signer Signer) error {
 	}
 
 	if ownerAddress != signer.Address() { // sanity check to make sure the Signer is declaring the same address used to sign!
-		return NewError(ErrInvalidSignature, "Signer address does not match private key")
+		return NewError(ErrInvalidSignature, "Signer address does not match ownerAddr")
 	}
 
 	r.signature = &signature

--- a/swarm/storage/mru/timestampprovider.go
+++ b/swarm/storage/mru/timestampprovider.go
@@ -19,20 +19,15 @@ package mru
 import (
 	"encoding/binary"
 	"time"
-
-	"github.com/ethereum/go-ethereum/common"
 )
 
-// Encodes a point in time as a Unix epoch and provides
-// space for proof the timestamp was not created prior to its time
+// Encodes a point in time as a Unix epoch
 type Timestamp struct {
-	Time  uint64      // Unix epoch timestamp, in seconds
-	Proof common.Hash // space to hold proof of the timestamp, e.g., a block hash
+	Time uint64 // Unix epoch timestamp, in seconds
 }
 
-// 8 bytes Time
-// 32 bytes hash length
-const timestampLength = 8 + common.HashLength
+// 8 bytes uint64 Time
+const timestampLength = 8
 
 // timestampProvider interface describes a source of timestamp information
 type timestampProvider interface {
@@ -45,7 +40,6 @@ func (t *Timestamp) binaryGet(data []byte) error {
 		return NewError(ErrCorruptData, "timestamp data has the wrong size")
 	}
 	t.Time = binary.LittleEndian.Uint64(data[:8])
-	copy(t.Proof[:], data[8:])
 	return nil
 }
 
@@ -55,7 +49,6 @@ func (t *Timestamp) binaryPut(data []byte) error {
 		return NewError(ErrCorruptData, "timestamp data has the wrong size")
 	}
 	binary.LittleEndian.PutUint64(data, t.Time)
-	copy(data[8:], t.Proof[:])
 	return nil
 }
 
@@ -70,7 +63,6 @@ func NewDefaultTimestampProvider() *DefaultTimestampProvider {
 // Now returns the current time according to this provider
 func (dtp *DefaultTimestampProvider) Now() Timestamp {
 	return Timestamp{
-		Time:  uint64(time.Now().Unix()),
-		Proof: common.Hash{},
+		Time: uint64(time.Now().Unix()),
 	}
 }

--- a/swarm/storage/mru/timestampprovider.go
+++ b/swarm/storage/mru/timestampprovider.go
@@ -32,7 +32,7 @@ type Timestamp struct {
 
 // 8 bytes Time
 // 32 bytes hash length
-const timestampLength = 8 + 32
+const timestampLength = 8 + common.HashLength
 
 // timestampProvider interface describes a source of timestamp information
 type timestampProvider interface {

--- a/swarm/storage/mru/timestampprovider.go
+++ b/swarm/storage/mru/timestampprovider.go
@@ -36,7 +36,7 @@ const timestampLength = 8 + 32
 
 // timestampProvider interface describes a source of timestamp information
 type timestampProvider interface {
-	GetCurrentTimestamp() Timestamp // returns the current timestamp information
+	Now() Timestamp // returns the current timestamp information
 }
 
 // binaryGet populates the timestamp structure from the given byte slice
@@ -67,8 +67,8 @@ func NewDefaultTimestampProvider() *DefaultTimestampProvider {
 	return &DefaultTimestampProvider{}
 }
 
-// GetCurrentTimestamp returns the current time according to this provider
-func (dtp *DefaultTimestampProvider) GetCurrentTimestamp() Timestamp {
+// Now returns the current time according to this provider
+func (dtp *DefaultTimestampProvider) Now() Timestamp {
 	return Timestamp{
 		Time:  uint64(time.Now().Unix()),
 		Proof: common.Hash{},

--- a/swarm/testutil/http.go
+++ b/swarm/testutil/http.go
@@ -44,7 +44,7 @@ func (f *fakeTimeProvider) Tick() {
 	f.currentTime++
 }
 
-func (f *fakeTimeProvider) GetCurrentTimestamp() mru.Timestamp {
+func (f *fakeTimeProvider) Now() mru.Timestamp {
 	return mru.Timestamp{Time: f.currentTime}
 }
 
@@ -113,7 +113,7 @@ func (t *TestSwarmServer) Close() {
 }
 
 func (t *TestSwarmServer) GetCurrentTime() mru.Timestamp {
-	return t.timestampProvider.GetCurrentTimestamp()
+	return t.timestampProvider.Now()
 }
 
 // EnableMetrics is starting InfluxDB reporter so that we collect stats when running tests locally


### PR DESCRIPTION
## Note:
This PR is being reviewed in several steps. In this PR you can view the entire change. For a step by step process, please look at the following:

* **Step 1** : (PR #732) Minimum set of changes for client-side MRU signatures to work + system-time based MRUs. This was the status roughly 8 days ago.
* **Step 2**: (PR #733) Documentation, refactors and new, more concrete unit tests for the new structures
* **Step 3**: (PR #734) Refactor `LookupParams` so that the different combinations are documented. Moved LookupParams to its own file. Reorder code and create separate files for a few structures
* **Step 4** (PR #748): Final refactors. Refactor serialization for extensibility. Refactor Timestamp to a "Timestamp" struct rather than a lone uint64. More comments throughout.
* **Step 5**: (PR #704) Rewrite CLI and simplify client and internal object structure according to comments to decouple resource creation from updating.

## Abstract
The current implementation of MRU uses the running node's private key to sign all MRUs that are requested to that node. This is a limitation for environments in which a node is shared among different users (for example, a company-wide node) and also does not allow people using public nodes to test MRUs, Swarm's Power of the Dark Side!

This PR moves MRU signatures to the client, so anyone can create and update resources with their private/public key through any node, including support for Web3 browsers such as Mist and plug-ins like Metamask. Indeed, **this would allow to update content directly from your browser**!

This PR's continues @nolash's work that detaches ENS for authorization. **WARNING**: merging this PR will automatically merge @nolash's #743 !!

### Additionally, this PR adds the following:
* Fully removes ENS dependencies, such as having to name resources after domain names. The resource name is now a completely independent convenience user field.
* Command-line tool (`swarm resource`) to manage creating, updating resources and reading their metadata easily
* Code clean-up and refactoring. Segregated the metadata from updates in easily upgradeable structures
* Refactored chunk serialization/deserialization for extensibility
* Strong verification that the user updating a resource indeed owns the private key associated to it via a 2-step hash algorithm. There was a bug in the current implementation that allowed anyone to update your resource!!
* Removed blockchain dependency for timing. Update frequencies are expressed in seconds. This was implemented as an abstraction with a `timestampProvider` interface, so really any source of timing can be used, or time can be "frozen" for testing.
* Added support for MRUs in the client (`client.go`), so MRUs can be used from other golang applications, including Swarm's cli.
* Allow the user to set a start time in the future. This allows to publish a resource that won't resolve until the clock hits that time.
* Documentation update

Support for **_automatically_** signing MRUs by the node's `bzzaccount` private key has been removed from the server side. However, the API easily allows the node itself to use MRUs with its own private key. The `swarm` command line tool (client)  can pick your local account from the same place, so regular users wouldn't notice where signing is actually taking place.

## Code refactoring and terminology standarization
Throughout the package, the code has been refactored with the following reusable and extensible structures. To avoid confusion, the use of ambiguous terms such as `addr`or `key` has been removed.
### Main structures:
* `resourceUpdate`: encapsulates the information sent as part of a resource update: period, version, multihash flag, the data payload and a reference to the Mutable Resource's metadata chunk.
* `resourceMetadata`: carries the immutable information about a mutable resource: start time, frequency, name and owner.
* `resource`: `resourceUpdate` + `resourceMetadata`. Caches resource data. When synced it contains the most recent version of the resource data and the metadata of its root chunk
* `SignedResourceUpdate`: `resourceUpdate` + signature
* `UpdateRequest` message: `SignedResourceUpdate` + `resourceMetadata`. Serializable structure used to issue Mutable Resource creation and update messages.
### Terms:
* `ownerAddr`: Address of the resource owner. Type: `storage.Address`
* `metaHash` is the SHA3 hash of the encoded `resourceMetadata`, excluding `ownerAddr`
* `rootAddr`: this is the key of the chunk that contains the Mutable Resource metadata. Calculated as the SHA3 hash of `ownerAddr` and `metaHash`. Type: `storage.Address`
* `updateAddr`: this is the key of the chunk that contains the Mutable Resource update. Calculated as the SHA3 hash of `period`, `version` and `rootAddr`. Type: `storage.Address`
### Chunk Validator refactor
The chunk validator (`Validate` method) has been rewritten to:
* Validate medatata chunks, whose key is content-addressed not as a direct Swarm hash of the content, but rather as `SHA3(ownerAddr, metaHash)` where `metaHash = SHA3(resource name, frequency, startTime)`.
* Validate update chunks verifying signatures and proof of ownership of the resource to be updated without having to lookup/download the referenced metadata chunk.
	* Ownership is proven if the following holds true `rootAddr == SHA3(signature_address, metaHash)`, where `signature_address` is the recovered address from the signature of the update chunk digest; `digest = SHA3(updateAddr, metaHash, data)`, where `updateAddr` is the update chunk address, `updateAddr = SHA3(period, version, rootAddr)`.

## HTTP API
The HTTP API for resources (`/bzz-resource:/`) now works as follows:
#### Resource creation:
 `POST /bzz-resource:/` with the following JSON as payload: 
```
{
  "name": string,
  "frequency": number,
  "startTime": number,
  "rootAddr" : hex string,
  "data": hex string,
  "multihash": boolean,
  "period": number,
  "version": number,
  "signature": hex string
}
```
where:
* `name` Resource name. This is a user field. You can use any name
* `frequency` Time interval the resource is expected to update at, in seconds.
* `startTime` Time the resource is valid from, in Unix time (seconds).
* `ownerAddr` is the address derived from your public key. Hex encoded.
* `multihash` is a flag indicating whether the `data` field should be interpreted as raw data or a multihash
* `data` contains hex-encoded raw data or a multihash of the content the mutable resource will be initialized with
* `period` indicates for what period we are signing. Set to 1 for creation.
* `version` indicates what resource version of the period we are signing. Must be set to 1 for creation.
* `signature` Signature of the digest calculated as follows `digest = H(H(period, version, rootAddr), metaHash, data)`. Hex encoded.

Returns: **MRU Manifest Key**, as a quoted string. As before, this key can be put in an ENS Resolver contract with `setContent`.
The MRU Manifest Key resolves to a manifest that points to the metadata root chunk (`rootAddr`)

### To update a resource:
#### Step 1:
either
    `GET /bzz-resource:/<MRU_MANIFEST_KEY>/meta`
-or-
    `GET /bzz-resource:/<DOMAIN THAT POINTS TO MRU_MANIFEST_KEY>/meta`

This produces a response like this:
```
{
  "name": "myresource",
  "frequency": 300,
  "startTime": 1528722352,
  "ownerAddr": "0x7a2e393025c567ec4089d34f393ae6b5c234536a",
  "rootAddr": "0x0c5acf8e3176900bc5b7b732261b5ebafc05a56da3b01c044214408e841f4ded",
  "metaHash": "0x0d6968416844245d605b5e4205858e9a4779936fc3a279dce2d38415de91d79f",
  "version": 1,
  "period": 8,
  "multiHash": true
}
```
where:
* **Metadata Fields**
	* `name`: filled with the original value used to create the resource
	* `frequency`: filled with the original value used to create the resource
	* `startTime`: filled with the original value used to create the resource
	* `ownerAddr`: filled with the original value used to create the resource
	* `metaHash` Metadata hash, calculated as `metaHash=H(len(metadata), startTime, frequency,name)`. Hex encoded
	* `rootAddr` Metadata Root Chunk Address, calculated as `rootAddr = H(metaHash, ownerAddr)`. This scheme effectively locks the root chunk so that only the owner of the private key that `ownerAddr` was derived from can sign updates.
* **Information about current update**
	*  `version`: filled with the version number of the MRU that must be used for the next update to be  successful. 
	* `period`: filled with the period number of the MRU that must be used for the next update to be successful
	* `multihash`: whether the current data pointed to by the resource is multihash

#### Step 2:
To update the resource, create a new flat JSON with the following fields:
* `data`: new data you want to set
* `multihash`: whether the new data should be considered a multihash
* `period`: use the suggested period from Step 1.
* `version`: use the suggested version from Step 1.
* `signature`, calculated in the same way as explained for resource creation.

Then, POST the resulting JSON to:
 `POST /bzz-resource:/`

**do not change version/period values**, since this will cause your update to be rejected. 

Phew! That looks like a lot of stuff! But don't worry, we got you covered with API and tools. See below.

### Reading a resource
This is unchanged, you can still use as before:
* `GET /bzz-resource:/<MRU_MANIFEST_KEY>/` 
* `GET /bzz-resource://<MRU_MANIFEST_KEY>` - get latest update
* `GET /bzz-resource://<MRU_MANIFEST_KEY>/<n>` - get latest update on period n
* `GET /bzz-resource://<MRU_MANIFEST_KEY>/<n>/<m>` - get update version m of period n

## Go API
Swarm client (package `swarm/api/client`) has been updated with the following new methods:
* `CreateResource(name string, frequency, startTime uint64, data []byte, multihash bool, signer mru.Signer)`
	* `CreateResource` creates a Mutable Resource with the given name and frequency, initializing it with the provided data. Data is interpreted as multihash or not depending on the multihash parameter.
		* `name`: human-readable name for your resource.
		* `startTime`: when the resource starts to be valid. 0 means "now". Unix time in seconds.
		* `data`: initial data the resource will contain.
		* `multihash`: whether to interpret data as multihash
		* `signer`: Signer object containing the `Sign` callback function
		* Returns the resulting Mutable Resource manifest address that you can use to include in an ENS Resolver (`setContent`) or reference future updates (`Client.UpdateResource`)
* `UpdateResource(manifestAddressOrDomain string, data []byte, signer mru.Signer)`
	* `UpdateResource` allows you to send a new version of your content
		* `manifestAddressOrDomain` is the address you obtained in `CreateResource` or an ENS domain whose Resolver points to that address.
		* `data`: new data to update the resource to.
		* `signer`: Signer object containing the `Sign` callback function
* `GetResource(manifestAddressOrDomain string) (io.ReadCloser, error)`
	* Returns the latest data currently contained in the resource as an octect stream. TODO: allow to get specific period/version 
* `GetResourceMetadata(manifestAddressOrDomain string) (*mru.UpdateRequest, error)`
	* Returns an UpdateRequest object that describes the resource and can be used to construct an update.

## Command line tools:
In this first version, the `swarm` cli interface has been updated with a new (advanced) command `resource` to manage resources, with this syntax:

#### Create:
`swarm --bzzaccount="<account>" resource create [--raw] <name> <frequency> <0x hex data>`
If successful, this command will output a Manifest Address that can be used in ENS's `setContent` or directly in your browser via http://localhost:8500/bzz:/<returned value>
#### Update:
`swarm --bzzaccount="<account>" resource [--raw] update <Manifest Address or ENS domain> <0x Hexdata>` 

the `--raw` flag sets `multihash` to false. This means that by default the data is considered to be a multihash. If you want to use the output of `swarm up`, prefix it with `0x1b20` to indicate a keccak256 hash.

## Quick and dirty test:
```
$ MH=$(swarm up file.jpg) && swarm --bzzaccount "your public key" resource create myresource 300 0x1b20${MH}
```
This uploads `file.jpg` and creates a resource that is expected to update every 5 minutes.
## Final notes:
Please let me know your feedback, questions and test issues while I document and clean up the code. I hope you like this feature. I am available on Gitter (@jpeletier). Enjoy!!

### PR Review guide:
[Client-side MRU signing.pdf](https://github.com/ethersphere/go-ethereum/files/2118843/Client-side.MRU.signing.pdf)
