### PR TITLE
Fix storage benchmark tests

### DIFF
--- a/swarm/storage/common_test.go
+++ b/swarm/storage/common_test.go
@@ -181,9 +181,6 @@ func testStoreCorrect(m ChunkStore, processors int, n int, chunksize int64, t *t
 }
 
 func benchmarkStorePut(store ChunkStore, processors int, n int, chunksize int64, b *testing.B) {
-	b.ReportAllocs()
-	b.ResetTimer()
-
 	chunks := make([]*Chunk, n)
 	i := 0
 	f := func(dataSize int64) *Chunk {
@@ -200,6 +197,9 @@ func benchmarkStorePut(store ChunkStore, processors int, n int, chunksize int64,
 		i++
 		return chunk
 	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
 
 	for j := 0; j < b.N; j++ {
 		i = 0

--- a/swarm/storage/filestore.go
+++ b/swarm/storage/filestore.go
@@ -34,7 +34,7 @@ implementation for storage or retrieval.
 
 const (
 	defaultLDBCapacity                = 5000000 // capacity for LevelDB, by default 5*10^6*4096 bytes == 20GB
-	defaultCacheCapacity              = 500     // capacity for in-memory chunks' cache
+	defaultCacheCapacity              = 10000   // capacity for in-memory chunks' cache
 	defaultChunkRequestsCacheCapacity = 5000000 // capacity for container holding outgoing requests for chunks. should be set to LevelDB capacity
 )
 

--- a/swarm/storage/filestore_test.go
+++ b/swarm/storage/filestore_test.go
@@ -32,11 +32,11 @@ func TestFileStorerandom(t *testing.T) {
 }
 
 func testFileStoreRandom(toEncrypt bool, t *testing.T) {
-	tdb, err := newTestDbStore(false, false)
+	tdb, cleanup, err := newTestDbStore(false, false)
+	defer cleanup()
 	if err != nil {
 		t.Fatalf("init dbStore failed: %v", err)
 	}
-	defer tdb.close()
 	db := tdb.LDBStore
 	db.setCapacity(50000)
 	memStore := NewMemStore(NewDefaultStoreParams(), db)
@@ -91,17 +91,17 @@ func testFileStoreRandom(toEncrypt bool, t *testing.T) {
 	}
 }
 
-func TestDPA_capacity(t *testing.T) {
-	testDPA_capacity(false, t)
-	testDPA_capacity(true, t)
+func TestFileStoreCapacity(t *testing.T) {
+	testFileStoreCapacity(false, t)
+	testFileStoreCapacity(true, t)
 }
 
-func testDPA_capacity(toEncrypt bool, t *testing.T) {
-	tdb, err := newTestDbStore(false, false)
+func testFileStoreCapacity(toEncrypt bool, t *testing.T) {
+	tdb, cleanup, err := newTestDbStore(false, false)
+	defer cleanup()
 	if err != nil {
 		t.Fatalf("init dbStore failed: %v", err)
 	}
-	defer tdb.close()
 	db := tdb.LDBStore
 	memStore := NewMemStore(NewDefaultStoreParams(), db)
 	localStore := &LocalStore{

--- a/swarm/storage/memstore_test.go
+++ b/swarm/storage/memstore_test.go
@@ -52,20 +52,20 @@ func TestMemStoreCorrect_1(t *testing.T) {
 	testMemStoreCorrect(1, 1, 4104, t)
 }
 
-func TestMemStoreRandom_1_10k(t *testing.T) {
-	testMemStoreRandom(1, 5000, 0, t)
+func TestMemStoreRandom_1_1k(t *testing.T) {
+	testMemStoreRandom(1, 1000, 0, t)
 }
 
-func TestMemStoreCorrect_1_10k(t *testing.T) {
-	testMemStoreCorrect(1, 5000, 4096, t)
+func TestMemStoreCorrect_1_1k(t *testing.T) {
+	testMemStoreCorrect(1, 100, 4096, t)
 }
 
-func TestMemStoreRandom_8_10k(t *testing.T) {
-	testMemStoreRandom(8, 5000, 0, t)
+func TestMemStoreRandom_8_1k(t *testing.T) {
+	testMemStoreRandom(8, 1000, 0, t)
 }
 
-func TestMemStoreCorrect_8_10k(t *testing.T) {
-	testMemStoreCorrect(8, 5000, 4096, t)
+func TestMemStoreCorrect_8_1k(t *testing.T) {
+	testMemStoreCorrect(8, 1000, 4096, t)
 }
 
 func TestMemStoreNotFound(t *testing.T) {
@@ -90,20 +90,20 @@ func benchmarkMemStoreGet(n int, processors int, chunksize int64, b *testing.B) 
 	benchmarkStoreGet(m, processors, n, chunksize, b)
 }
 
-func BenchmarkMemStorePut_1_5k(b *testing.B) {
-	benchmarkMemStorePut(5000, 1, 4096, b)
+func BenchmarkMemStorePut_1_500(b *testing.B) {
+	benchmarkMemStorePut(500, 1, 4096, b)
 }
 
-func BenchmarkMemStorePut_8_5k(b *testing.B) {
-	benchmarkMemStorePut(5000, 8, 4096, b)
+func BenchmarkMemStorePut_8_500(b *testing.B) {
+	benchmarkMemStorePut(500, 8, 4096, b)
 }
 
-func BenchmarkMemStoreGet_1_5k(b *testing.B) {
-	benchmarkMemStoreGet(5000, 1, 4096, b)
+func BenchmarkMemStoreGet_1_500(b *testing.B) {
+	benchmarkMemStoreGet(500, 1, 4096, b)
 }
 
-func BenchmarkMemStoreGet_8_5k(b *testing.B) {
-	benchmarkMemStoreGet(5000, 8, 4096, b)
+func BenchmarkMemStoreGet_8_500(b *testing.B) {
+	benchmarkMemStoreGet(500, 8, 4096, b)
 }
 
 func newLDBStore(t *testing.T) (*LDBStore, func()) {


### PR DESCRIPTION
Several issues with storage benchmark tests are fixed:

- test dbstore was not cleaned up in several tests, which caused batch write errors
- memstore size was really low 500(!), increased it to 10000, this affects production code too, not just tests, but that is good, 2MB memstore was really small. This caused benchmarks to fail, because they inserted more chunks than the full capacity.
- Put benchmark tests were not correct, because the dbstore used contained more and more items as the test loop ran. So the later insertions happened in a bigger db, which is not a correct comparison for performance test. As a fix now we always insert the same set of chunks, so they are just overwritten, and the db size is not growing.

fixes https://github.com/ethersphere/go-ethereum/issues/703