### PR TITLE
swarm/pss: move EnableMetrics away from testutil

### DIFF
--- a/swarm/pss/pss_test.go
+++ b/swarm/pss/pss_test.go
@@ -38,6 +38,8 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethereum/go-ethereum/metrics/influxdb"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/discover"
@@ -951,7 +953,7 @@ func worker(id int, jobs <-chan Job, rpcs map[discover.NodeID]*rpc.Client, pubke
 // nodes/msgs/addrbytes/adaptertype
 // if adaptertype is exec uses execadapter, simadapter otherwise
 func TestNetwork2000(t *testing.T) {
-	//testutil.EnableMetrics()
+	//enableMetrics()
 
 	t.Run("3/2000/4/sock", testNetwork)
 	t.Run("4/2000/4/sock", testNetwork)
@@ -960,7 +962,7 @@ func TestNetwork2000(t *testing.T) {
 }
 
 func TestNetwork5000(t *testing.T) {
-	//testutil.EnableMetrics()
+	//enableMetrics()
 
 	t.Run("3/5000/4/sim", testNetwork)
 	t.Run("4/5000/4/sim", testNetwork)
@@ -969,12 +971,11 @@ func TestNetwork5000(t *testing.T) {
 }
 
 func TestNetwork10000(t *testing.T) {
-	//testutil.EnableMetrics()
+	//enableMetrics()
 
 	t.Run("3/10000/4/sim", testNetwork)
 	t.Run("4/10000/4/sim", testNetwork)
 	t.Run("8/10000/4/sim", testNetwork)
-	t.Run("16/10000/4/sim", testNetwork)
 }
 
 func testNetwork(t *testing.T) {
@@ -1673,4 +1674,12 @@ func (apitest *APITest) SetSymKeys(pubkeyid string, recvsymkey []byte, sendsymke
 
 func (apitest *APITest) Clean() (int, error) {
 	return apitest.Pss.cleanKeys(), nil
+}
+
+// enableMetrics is starting InfluxDB reporter so that we collect stats when running tests locally
+func enableMetrics() {
+	metrics.Enabled = true
+	go influxdb.InfluxDBWithTags(metrics.DefaultRegistry, 1*time.Second, "http://localhost:8086", "metrics", "admin", "admin", "swarm.", map[string]string{
+		"host": "test",
+	})
 }

--- a/swarm/testutil/http.go
+++ b/swarm/testutil/http.go
@@ -24,11 +24,8 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/metrics"
-	"github.com/ethereum/go-ethereum/metrics/influxdb"
 	"github.com/ethereum/go-ethereum/swarm/api"
 	"github.com/ethereum/go-ethereum/swarm/storage"
 	"github.com/ethereum/go-ethereum/swarm/storage/mru"
@@ -108,12 +105,4 @@ type TestSwarmServer struct {
 
 func (t *TestSwarmServer) Close() {
 	t.cleanup()
-}
-
-// EnableMetrics is starting InfluxDB reporter so that we collect stats when running tests locally
-func EnableMetrics() {
-	metrics.Enabled = true
-	go influxdb.InfluxDBWithTags(metrics.DefaultRegistry, 1*time.Second, "http://localhost:8086", "metrics", "admin", "admin", "swarm.", map[string]string{
-		"host": "test",
-	})
 }


### PR DESCRIPTION
This PR is:
1. Removing one of the PSS tests because Travis is slow and it timeouts on it.
2. Moving `EnableMetrics` away from `testutil`, because it creates a circular dependency with the `api` package.