### PR TITLE
Set ETag header with correct syntax

### DIFF
--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -683,7 +683,7 @@ func (s *Server) HandleGet(w http.ResponseWriter, r *Request) {
 	}
 	etag := common.Bytes2Hex(addr)
 	noneMatchEtag := r.Header.Get("If-None-Match")
-	w.Header().Set("ETag", etag) // set etag to manifest key or raw entry key.
+	w.Header().Set("ETag", fmt.Sprintf("%q", etag)) // set etag to manifest key or raw entry key.
 	if noneMatchEtag != "" {
 		if bytes.Equal(storage.Address(common.Hex2Bytes(noneMatchEtag)), addr) {
 			Respond(w, r, "Not Modified", http.StatusNotModified)
@@ -931,7 +931,7 @@ func (s *Server) HandleGetFile(w http.ResponseWriter, r *Request) {
 
 	etag := common.Bytes2Hex(contentKey)
 	noneMatchEtag := r.Header.Get("If-None-Match")
-	w.Header().Set("ETag", etag) // set etag to actual content key.
+	w.Header().Set("ETag", fmt.Sprintf("%q", etag)) // set etag to actual content key.
 	if noneMatchEtag != "" {
 		if bytes.Equal(storage.Address(common.Hex2Bytes(noneMatchEtag)), contentKey) {
 			Respond(w, r, "Not Modified", http.StatusNotModified)


### PR DESCRIPTION
This PR sets the ETag header with the right syntax (under double quotes) in order to stdlib's http.scanETag parse it correctly when it is provided as the value of If-Range http request header.

If If-Range http header is provided in request and the http.Request has ETag header (what is the case in HandleGet and HandleGetFile functions), http.ServeContent will try to match their values in order to validate the request's Range header. If values from request If-Range and response Etag are not matched, Request header value is discarded and the server wil serve the full content with response status code 200. This is currently happening when Chrome video player makes requests. It provides the ETag value from the previous request as the value for If-Range request header. Unfortunately, that value is required to be under double quotes to stdlib's http.scanETag parse it correctly. If it is not parsed correctly, it is considered as a no match forcing the full response, instead the partial one.

This change significantly improves the performance of video playback in Chrome.