### PR TITLE
swarm/api: update log.Output to report meaningful log line

### DIFF
--- a/swarm/api/http/error.go
+++ b/swarm/api/http/error.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/swarm/api"
+	l "github.com/ethereum/go-ethereum/swarm/log"
 )
 
 //templateMap holds a mapping of an HTTP error code to a template
@@ -145,9 +146,9 @@ func Respond(w http.ResponseWriter, req *Request, msg string, code int) {
 	additionalMessage := ValidateCaseErrors(req)
 	switch code {
 	case http.StatusInternalServerError:
-		log.Output(msg, log.LvlError, 3, "ruid", req.ruid, "code", code)
+		log.Output(msg, log.LvlError, l.CallDepth, "ruid", req.ruid, "code", code)
 	default:
-		log.Output(msg, log.LvlDebug, 3, "ruid", req.ruid, "code", code)
+		log.Output(msg, log.LvlDebug, l.CallDepth, "ruid", req.ruid, "code", code)
 	}
 
 	if code >= 400 {

--- a/swarm/log/log.go
+++ b/swarm/log/log.go
@@ -5,38 +5,44 @@ import (
 	"github.com/ethereum/go-ethereum/metrics"
 )
 
+const (
+	// CallDepth is set to 1 in order to influence to reported line number of
+	// the log message with 1 skipped stack frame of calling l.Output()
+	CallDepth = 1
+)
+
 // Warn is a convenient alias for log.Warn with stats
 func Warn(msg string, ctx ...interface{}) {
 	metrics.GetOrRegisterCounter("warn", nil).Inc(1)
-	l.Output(msg, l.LvlWarn, 3, ctx...)
+	l.Output(msg, l.LvlWarn, CallDepth, ctx...)
 }
 
 // Error is a convenient alias for log.Error with stats
 func Error(msg string, ctx ...interface{}) {
 	metrics.GetOrRegisterCounter("error", nil).Inc(1)
-	l.Output(msg, l.LvlError, 3, ctx...)
+	l.Output(msg, l.LvlError, CallDepth, ctx...)
 }
 
 // Crit is a convenient alias for log.Crit with stats
 func Crit(msg string, ctx ...interface{}) {
 	metrics.GetOrRegisterCounter("crit", nil).Inc(1)
-	l.Output(msg, l.LvlCrit, 3, ctx...)
+	l.Output(msg, l.LvlCrit, CallDepth, ctx...)
 }
 
 // Info is a convenient alias for log.Info with stats
 func Info(msg string, ctx ...interface{}) {
 	metrics.GetOrRegisterCounter("info", nil).Inc(1)
-	l.Output(msg, l.LvlInfo, 3, ctx...)
+	l.Output(msg, l.LvlInfo, CallDepth, ctx...)
 }
 
 // Debug is a convenient alias for log.Debug with stats
 func Debug(msg string, ctx ...interface{}) {
 	metrics.GetOrRegisterCounter("debug", nil).Inc(1)
-	l.Output(msg, l.LvlDebug, 3, ctx...)
+	l.Output(msg, l.LvlDebug, CallDepth, ctx...)
 }
 
 // Trace is a convenient alias for log.Trace with stats
 func Trace(msg string, ctx ...interface{}) {
 	metrics.GetOrRegisterCounter("trace", nil).Inc(1)
-	l.Output(msg, l.LvlTrace, 3, ctx...)
+	l.Output(msg, l.LvlTrace, CallDepth, ctx...)
 }


### PR DESCRIPTION
You are probably wondering why the change from 3 to 1 - because we refactored this code as part of https://github.com/ethereum/go-ethereum/pull/16898 and log.Output is automatically adding 2 to the skip level.

After merging master back to swarm-network-rewrite, we didn't modify the log.Output on Swarm side.