### PR TITLE
Fix lint warning in Validate function

### DIFF
--- a/swarm/storage/types.go
+++ b/swarm/storage/types.go
@@ -344,8 +344,5 @@ func (v *ContentAddressValidator) Validate(addr Address, data []byte) bool {
 	hasher.Write(data[8:])
 	hash := hasher.Sum(nil)
 
-	if !bytes.Equal(hash, addr[:]) {
-		return false
-	}
-	return true
+	return bytes.Equal(hash, addr[:])
 }


### PR DESCRIPTION
Fixes:

```
swarm/storage/types.go:347:2:warning: should use 'return <expr>' instead of 'if <expr> { return <bool> }; return <bool>' (S1008) (gosimple)
```