### PR TITLE
Add authors and owners file

### DIFF
--- a/swarm/AUTHORS
+++ b/swarm/AUTHORS
@@ -2,7 +2,7 @@
 
 Viktor Trón - @zelig
 Louis Holbrook - @nolash
-Lewis Marshal - @lmars
+Lewis Marshall - @lmars
 Anton Evangelatov - @nonsense
 Janoš Guljaš - @janos
 Balint Gabor - @gbalint

--- a/swarm/AUTHORS
+++ b/swarm/AUTHORS
@@ -1,0 +1,35 @@
+# Core team members
+
+Viktor Trón - @zelig
+Louis Holbrook - @nolash
+Lewis Marshal - @lmars
+Anton Evangelatov - @nonsense
+Janos Gulyas - @janos
+Balint Gabor - @gbalint
+Elad Nachmias - @justelad
+Daniel A. Nagy - @nagydani
+Aron Fischer - @homotopycolimit
+Fabio Barone - @holisticode
+Zahoor Mohamed - @jmozah
+Zsolt Felföldi - @zsfelfoldi
+
+# External contributors
+
+Kiel Barry
+Gary Rong 
+Jared Wasinger 
+Leon Stanko
+Javier Peletier [epiclabs.io]
+Bartek Borkowski [tungsten-labs.com]
+Shane Howley [mainframe.com]
+Doug Leonard [mainframe.com]
+Ivan Daniluk [status.im]
+Felix Lange [EF]
+Martin Holst Swende [EF]
+Guillaume Ballet [EF]
+ligi [EF]
+Christopher Dro [blick-labs.com]
+Sergii Bomko [ledgerleopard.com]
+Domino Valdano 
+Rafael Matias 
+Coogan Brennan

--- a/swarm/AUTHORS
+++ b/swarm/AUTHORS
@@ -4,7 +4,7 @@ Viktor Trón - @zelig
 Louis Holbrook - @nolash
 Lewis Marshal - @lmars
 Anton Evangelatov - @nonsense
-Janos Gulyas - @janos
+Janoš Guljaš - @janos
 Balint Gabor - @gbalint
 Elad Nachmias - @justelad
 Daniel A. Nagy - @nagydani

--- a/swarm/OWNERS
+++ b/swarm/OWNERS
@@ -1,0 +1,26 @@
+# Ownership by go packages
+
+swarm
+├── api ─────────────────── ethersphere
+├── bmt ─────────────────── @zelig
+├── dev ─────────────────── @lmars
+├── fuse ────────────────── @jmozah, @holisticode
+├── grafana_dashboards ──── @nonsense
+├── metrics ─────────────── @nonsense, @holisticode
+├── multihash ───────────── @nolash
+├── network ─────────────── ethersphere
+│   ├── bitvector ───────── @zelig, @janos, @gbalint
+│   ├── priorityqueue ───── @zelig, @janos, @gbalint
+│   ├── simulations ─────── @zelig
+│   └── stream ──────────── @janos, @zelig, @gbalint, @holisticode, @justelad
+│       ├── intervals ───── @janos
+│       └── testing ─────── @zelig
+├── pot ─────────────────── @zelig
+├── pss ─────────────────── @nolash, @zelig, @nonsense
+├── services ────────────── @zelig
+├── state ───────────────── @justelad
+├── storage ─────────────── ethersphere
+│   ├── encryption ──────── @gbalint, @zelig, @nagydani
+│   ├── mock ────────────── @janos
+│   └── mru ─────────────── @nolash
+└── testutil ────────────── @lmars


### PR DESCRIPTION
Because we squash the commits when we merge to `ethereum/master` it would be nice to somehow refer to the people who contributed to the network rewrite project.