### PR TITLE
client-side mru signatures -- step 1/5

### DIFF
--- a/cmd/swarm/clientaccountmanager.go
+++ b/cmd/swarm/clientaccountmanager.go
@@ -1,0 +1,103 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+/*
+//This module implements the bare minimum to allow client commands to access the keystore
+*/
+package main
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/ethereum/go-ethereum/accounts/usbwallet"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/node"
+	cli "gopkg.in/urfave/cli.v1"
+
+	"github.com/ethereum/go-ethereum/cmd/utils"
+)
+
+type ClientAccountManagerProvider struct {
+	manager *accounts.Manager
+}
+
+func (c *ClientAccountManagerProvider) AccountManager() *accounts.Manager {
+	return c.manager
+}
+
+func getClientAccount(ctx *cli.Context) *ecdsa.PrivateKey {
+	bzzconfig, err := buildConfig(ctx)
+	if err != nil {
+		utils.Fatalf("Cannot read configuration: %s", err.Error())
+		return nil
+	}
+	nodeconfig := defaultNodeConfig
+	if _, err := os.Stat(bzzconfig.Path); err == nil {
+		nodeconfig.DataDir = bzzconfig.Path
+	}
+
+	accountManager, _, err := makeAccountManager(&nodeconfig)
+	if err != nil {
+		utils.Fatalf("Cannot create account manager: %s", err.Error())
+		return nil
+	}
+
+	return getAccount(bzzconfig.BzzAccount, ctx, &ClientAccountManagerProvider{
+		manager: accountManager,
+	})
+
+}
+
+func makeAccountManager(conf *node.Config) (*accounts.Manager, string, error) {
+	scryptN, scryptP, keydir, err := conf.AccountConfig()
+	var ephemeral string
+	if keydir == "" {
+		// There is no datadir.
+		keydir, err = ioutil.TempDir("", "go-ethereum-keystore")
+		ephemeral = keydir
+	}
+
+	if err != nil {
+		return nil, "", err
+	}
+	if err := os.MkdirAll(keydir, 0700); err != nil {
+		return nil, "", err
+	}
+	// Assemble the account manager and supported backends
+	backends := []accounts.Backend{
+		keystore.NewKeyStore(keydir, scryptN, scryptP),
+	}
+	if !conf.NoUSB {
+		// Start a USB hub for Ledger hardware wallets
+		if ledgerhub, err := usbwallet.NewLedgerHub(); err != nil {
+			log.Warn(fmt.Sprintf("Failed to start Ledger hub, disabling: %v", err))
+		} else {
+			backends = append(backends, ledgerhub)
+		}
+		// Start a USB hub for Trezor hardware wallets
+		if trezorhub, err := usbwallet.NewTrezorHub(); err != nil {
+			log.Warn(fmt.Sprintf("Failed to start Trezor hub, disabling: %v", err))
+		} else {
+			backends = append(backends, trezorhub)
+		}
+	}
+	return accounts.NewManager(backends...), ephemeral, nil
+}

--- a/cmd/swarm/mru.go
+++ b/cmd/swarm/mru.go
@@ -1,0 +1,117 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of go-ethereum.
+//
+// go-ethereum is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// go-ethereum is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
+
+// Command resource allows the user to create and update signed mutable resource updates
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
+	"github.com/ethereum/go-ethereum/cmd/utils"
+	swarm "github.com/ethereum/go-ethereum/swarm/api/client"
+	"github.com/ethereum/go-ethereum/swarm/storage/mru"
+	"gopkg.in/urfave/cli.v1"
+)
+
+// swarm resource [--raw] create <name> <frequency> <0x Hexdata>
+// swarm resource update <Manifest Address or ENS domain> <0x Hexdata>
+// swarm resource info <Manifest Address or ENS domain>
+
+func resource(ctx *cli.Context) {
+
+	args := ctx.Args()
+	var (
+		bzzapi      = strings.TrimRight(ctx.GlobalString(SwarmApiFlag.Name), "/")
+		client      = swarm.NewClient(bzzapi)
+		rawResource = ctx.Bool(SwarmResourceRawFlag.Name)
+	)
+
+	if len(args) < 1 {
+		utils.Fatalf("Need create, update or info as first argument")
+		return
+	}
+
+	switch args[0] {
+	case "create":
+		if len(args) < 4 {
+			utils.Fatalf("Incorrect number of arguments. Syntax: swarm resource [--raw] create <name> <frequency> <0x Hexdata>")
+			return
+		}
+		signer := mru.NewGenericSigner(getClientAccount(ctx))
+
+		name := args[1]
+		frequency, err := strconv.ParseUint(args[2], 10, 64)
+		if err != nil {
+			utils.Fatalf("Frequency formatting error: %s", err.Error())
+			return
+		}
+
+		data, err := hexutil.Decode(args[3])
+		if err != nil {
+			utils.Fatalf("Error parsing data: %s", err.Error())
+			return
+		}
+		manifestAddress, err := client.CreateResource(name, frequency, 0, data, !rawResource, signer)
+		if err != nil {
+			utils.Fatalf("Error creating resource: %s", err.Error())
+			return
+		}
+		fmt.Println(manifestAddress)
+	case "update":
+		if len(args) < 3 {
+			utils.Fatalf("Incorrect number of arguments. Syntax:swarm resource update <Manifest Address or ENS domain> <0x Hexdata>")
+			return
+		}
+		signer := mru.NewGenericSigner(getClientAccount(ctx))
+		manifestAddressOrDomain := args[1]
+		data, err := hexutil.Decode(args[2])
+		if err != nil {
+			utils.Fatalf("Error parsing data: %s", err.Error())
+			return
+		}
+		err = client.UpdateResource(manifestAddressOrDomain, data, signer)
+		if err != nil {
+			utils.Fatalf("Error updating resource: %s", err.Error())
+			return
+		}
+	case "info":
+		if len(args) < 2 {
+			utils.Fatalf("Incorrect number of arguments. Syntax: swarm resource info <Manifest Address or ENS domain>")
+			return
+		}
+		manifestAddressOrDomain := args[1]
+		metadata, err := client.GetResourceMetadata(manifestAddressOrDomain)
+		if err != nil {
+			utils.Fatalf("Error retrieving resource metadata: %s", err.Error())
+			return
+		}
+		fmt.Printf("Name: %s\n", metadata.Name())
+		fmt.Printf("Update frequency: %d\n", metadata.Frequency())
+		fmt.Printf("Start time: %d\n", metadata.StartTime())
+		fmt.Printf("Owner: %s\n", metadata.OwnerAddr().Hex())
+		fmt.Printf("Raw: %t\n", !metadata.Multihash())
+		fmt.Printf("Next period: %d\n", metadata.Period())
+		fmt.Printf("Next version: %d\n", metadata.Version())
+
+	default:
+		utils.Fatalf("invalid resource operation")
+		return
+	}
+}

--- a/swarm/api/client/client.go
+++ b/swarm/api/client/client.go
@@ -35,6 +35,7 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/swarm/api"
+	"github.com/ethereum/go-ethereum/swarm/storage/mru"
 )
 
 var (
@@ -561,4 +562,112 @@ func (c *Client) MultipartUpload(hash string, uploader Uploader) (string, error)
 		return "", err
 	}
 	return string(data), nil
+}
+
+// CreateResource creates a Mutable Resource with the given name and frequency, initializing it with the provided
+// data. Data is interpreted as multihash or not depending on the multihash parameter.
+// startTime=0 means "now"
+// Returns the resulting Mutable Resource manifest address that you can use to include in an ENS Resolver (setContent)
+// or reference future updates (Client.UpdateResource)
+func (c *Client) CreateResource(name string, frequency, startTime uint64, data []byte, multihash bool, signer mru.Signer) (string, error) {
+	mruRequest, err := mru.NewUpdateRequest(name, frequency, startTime, signer.Address(), data, multihash)
+	if err != nil {
+		return "", err
+	}
+
+	mruRequest.Sign(signer)
+	if err != nil {
+		return "", err
+	}
+
+	responseStream, err := c.updateResource(mruRequest, "")
+	if err != nil {
+		return "", err
+	}
+	defer responseStream.Close()
+
+	body, err := ioutil.ReadAll(responseStream)
+	if err != nil {
+		return "", err
+	}
+
+	var manifestKey string
+	if err = json.Unmarshal(body, &manifestKey); err != nil {
+		return "", err
+	}
+	return manifestKey, nil
+}
+
+// UpdateResource allows you to send a new version of your content
+// manifestAddressOrDomain is the address you obtained in CreateResource or an ENS domain whose Resolver
+// points to that address
+func (c *Client) UpdateResource(manifestAddressOrDomain string, data []byte, signer mru.Signer) error {
+	mruRequest, err := c.GetResourceMetadata(manifestAddressOrDomain)
+	if err != nil {
+		return err
+	}
+	mruRequest.SetData(data)
+	mruRequest.Sign(signer)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.updateResource(mruRequest, manifestAddressOrDomain)
+	return err
+}
+
+func (c *Client) updateResource(mruRequest *mru.UpdateRequest, manifestAddressOrDomain string) (io.ReadCloser, error) {
+	body, err := mru.EncodeMruRequest(mruRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", c.Gateway+"/bzz-resource:/"+manifestAddressOrDomain, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Body, nil
+
+}
+
+// GetResource returns a byte stream with the raw content of the resource
+// manifestAddressOrDomain is the address you obtained in CreateResource or an ENS domain whose Resolver
+// points to that address
+func (c *Client) GetResource(manifestAddressOrDomain string) (io.ReadCloser, error) {
+
+	res, err := http.Get(c.Gateway + "/bzz-resource:/" + manifestAddressOrDomain)
+	if err != nil {
+		return nil, err
+	}
+	return res.Body, nil
+
+}
+
+// GetResourceMetadata returns a structure that describes the Mutable Resource
+// manifestAddressOrDomain is the address you obtained in CreateResource or an ENS domain whose Resolver
+// points to that address
+func (c *Client) GetResourceMetadata(manifestAddressOrDomain string) (*mru.UpdateRequest, error) {
+
+	responseStream, err := c.GetResource(manifestAddressOrDomain + "/meta")
+	if err != nil {
+		return nil, err
+	}
+	defer responseStream.Close()
+
+	body, err := ioutil.ReadAll(responseStream)
+	if err != nil {
+		return nil, err
+	}
+
+	metadata, err := mru.DecodeMruRequest(body)
+	if err != nil {
+		return nil, err
+	}
+	return metadata, nil
 }

--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -39,7 +39,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/swarm/api"
 	"github.com/ethereum/go-ethereum/swarm/log"
@@ -402,22 +401,31 @@ func resourcePostMode(path string) (isRaw bool, frequency uint64, err error) {
 func (s *Server) HandlePostResource(w http.ResponseWriter, r *Request) {
 	log.Debug("handle.post.resource", "ruid", r.ruid)
 	var err error
-	var addr storage.Address
-	var name string
+	var rootAddr storage.Address
 	var outdata []byte
-	isRaw, frequency, err := resourcePostMode(r.uri.Path)
+
+	// Creation and update must send mruRequest JSON structure
+	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		Respond(w, r, err.Error(), http.StatusBadRequest)
+		Respond(w, r, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	mruRequest, err := mru.DecodeMruRequest(body) // decodes request JSON
+	if err != nil {
+		Respond(w, r, err.Error(), http.StatusBadRequest) //TODO: send different status response depending on error
+		return
+	}
+
+	if err = mruRequest.Verify(); err != nil {
+		Respond(w, r, err.Error(), http.StatusForbidden)
 		return
 	}
 
 	// new mutable resource creation will always have a frequency field larger than 0
-	if frequency > 0 {
-
-		name = r.uri.Addr
+	if mruRequest.Frequency() > 0 {
 
 		// the key is the content addressed root chunk holding mutable resource metadata information
-		addr, err = s.api.ResourceCreate(r.Context(), name, frequency)
+		rootAddr, err = s.api.ResourceCreate(r.Context(), mruRequest)
 		if err != nil {
 			code, err2 := s.translateResourceError(w, r, "resource creation fail", err)
 
@@ -428,7 +436,7 @@ func (s *Server) HandlePostResource(w http.ResponseWriter, r *Request) {
 		// we create a manifest so we can retrieve the resource with bzz:// later
 		// this manifest has a special "resource type" manifest, and its hash is the key of the mutable resource
 		// root chunk
-		m, err := s.api.NewResourceManifest(addr.Hex())
+		m, err := s.api.NewResourceManifest(rootAddr.Hex())
 		if err != nil {
 			Respond(w, r, fmt.Sprintf("failed to create resource manifest: %v", err), http.StatusInternalServerError)
 			return
@@ -454,24 +462,22 @@ func (s *Server) HandlePostResource(w http.ResponseWriter, r *Request) {
 				Respond(w, r, fmt.Sprintf("cannot resolve %s: %s", r.uri.Addr, err), http.StatusNotFound)
 				return
 			}
-		} else {
-			w.Header().Set("Cache-Control", "max-age=2147483648")
 		}
 
 		// get the root chunk key from the manifest
-		addr, err = s.api.ResolveResourceManifest(manifestAddr)
+		rootAddr, err = s.api.ResolveResourceManifest(manifestAddr)
 		if err != nil {
 			getFail.Inc(1)
 			Respond(w, r, fmt.Sprintf("error resolving resource root chunk for %s: %s", r.uri.Addr, err), http.StatusNotFound)
 			return
 		}
 
-		log.Debug("handle.post.resource: resolved", "ruid", r.ruid, "manifestkey", manifestAddr, "rootchunkkey", addr)
+		log.Debug("handle.post.resource: resolved", "ruid", r.ruid, "manifestkey", manifestAddr, "rootchunkkey", rootAddr)
 
 		params := &mru.LookupParams{
-			Root: addr,
+			Root: rootAddr,
 		}
-		name, _, err = s.api.ResourceLookup(r.Context(), params)
+		_, _, err = s.api.ResourceLookup(r.Context(), params)
 		if err != nil {
 			Respond(w, r, err.Error(), http.StatusNotFound)
 			return
@@ -479,30 +485,10 @@ func (s *Server) HandlePostResource(w http.ResponseWriter, r *Request) {
 	}
 
 	// Creation and update must send data aswell. This data constitutes the update data itself.
-	data, err := ioutil.ReadAll(r.Body)
+	_, _, _, err = s.api.ResourceUpdate(r.Context(), rootAddr, &mruRequest.SignedResourceUpdate)
 	if err != nil {
 		Respond(w, r, err.Error(), http.StatusInternalServerError)
 		return
-	}
-
-	// Multihash will be passed as hex-encoded data, so we need to parse this to bytes
-	if isRaw {
-		_, _, _, err = s.api.ResourceUpdate(r.Context(), addr, data)
-		if err != nil {
-			Respond(w, r, err.Error(), http.StatusBadRequest)
-			return
-		}
-	} else {
-		bytesdata, err := hexutil.Decode(string(data))
-		if err != nil {
-			Respond(w, r, err.Error(), http.StatusBadRequest)
-			return
-		}
-		_, _, _, err = s.api.ResourceUpdateMultihash(r.Context(), addr, bytesdata)
-		if err != nil {
-			Respond(w, r, err.Error(), http.StatusBadRequest)
-			return
-		}
 	}
 
 	// If we have data to return, write this now
@@ -520,6 +506,7 @@ func (s *Server) HandlePostResource(w http.ResponseWriter, r *Request) {
 // bzz-resource://<id> - get latest update
 // bzz-resource://<id>/<n> - get latest update on period n
 // bzz-resource://<id>/<n>/<m> - get update version m of period n
+// bzz-resource://<id>/meta - get metadata and next version information
 // <id> = ens name or hash
 func (s *Server) HandleGetResource(w http.ResponseWriter, r *Request) {
 	s.handleGetResource(w, r)
@@ -543,26 +530,46 @@ func (s *Server) handleGetResource(w http.ResponseWriter, r *Request) {
 		w.Header().Set("Cache-Control", "max-age=2147483648")
 	}
 
-	// get the root chunk key from the manifest
-	key, err := s.api.ResolveResourceManifest(manifestAddr)
+	// get the root chunk rootAddr from the manifest
+	rootAddr, err := s.api.ResolveResourceManifest(manifestAddr)
 	if err != nil {
 		getFail.Inc(1)
 		Respond(w, r, fmt.Sprintf("error resolving resource root chunk for %s: %s", r.uri.Addr, err), http.StatusNotFound)
 		return
 	}
 
-	log.Debug("handle.get.resource: resolved", "ruid", r.ruid, "manifestkey", manifestAddr, "rootchunk key", key)
+	log.Debug("handle.get.resource: resolved", "ruid", r.ruid, "manifestkey", manifestAddr, "rootchunk addr", rootAddr)
 
-	// determine if the query specifies period and version
+	// determine if the query specifies period and version or it is a metadata query
 	var params []string
 	if len(r.uri.Path) > 0 {
+		if r.uri.Path == "meta" {
+			unsignedMruRequest, err := s.api.ResourceNewRequest(r.Context(), rootAddr)
+			if err != nil {
+				getFail.Inc(1)
+				Respond(w, r, fmt.Sprintf("cannot retrieve resource metadata for rootAddr=%s: %s", rootAddr.Hex(), err), http.StatusNotFound)
+				return
+			}
+			rawResponse, err := mru.EncodeMruRequest(unsignedMruRequest)
+			if err != nil {
+				Respond(w, r, fmt.Sprintf("cannot encode unsigned MruRequest: %v", err), http.StatusInternalServerError)
+				return
+			}
+			w.Header().Add("Content-type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, string(rawResponse))
+			return
+
+		}
+
 		params = strings.Split(r.uri.Path, "/")
+
 	}
 	var name string
 	var data []byte
 	now := time.Now()
 	lookupParams := &mru.LookupParams{
-		Root: key,
+		Root: rootAddr,
 	}
 
 	switch len(params) {

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -30,12 +30,13 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/swarm/api"
 	swarm "github.com/ethereum/go-ethereum/swarm/api/client"
 	"github.com/ethereum/go-ethereum/swarm/multihash"
 	"github.com/ethereum/go-ethereum/swarm/storage"
+	"github.com/ethereum/go-ethereum/swarm/storage/mru"
 	"github.com/ethereum/go-ethereum/swarm/testutil"
 )
 
@@ -90,12 +91,22 @@ func serverFunc(api *api.API) testutil.TestServer {
 	return NewServer(api)
 }
 
+func newTestSigner() (*mru.GenericSigner, error) {
+	privKey, err := crypto.HexToECDSA("deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	if err != nil {
+		return nil, err
+	}
+	return mru.NewGenericSigner(privKey), nil
+}
+
 // test the transparent resolving of multihash resource types with bzz:// scheme
 //
 // first upload data, and store the multihash to the resulting manifest in a resource update
 // retrieving the update with the multihash should return the manifest pointing directly to the data
 // and raw retrieve of that hash should return the data
 func TestBzzResourceMultihash(t *testing.T) {
+
+	signer, _ := newTestSigner()
 
 	srv := testutil.NewTestSwarmServer(t, serverFunc)
 	defer srv.Close()
@@ -119,15 +130,25 @@ func TestBzzResourceMultihash(t *testing.T) {
 	s := common.FromHex(string(b))
 	mh := multihash.ToMultihash(s)
 
-	mhHex := hexutil.Encode(mh)
 	log.Info("added data", "manifest", string(b), "data", common.ToHex(mh))
 
 	// our mutable resource "name"
 	keybytes := "foo.eth"
+	updateRequest, err := mru.NewUpdateRequest(keybytes, 13, srv.GetCurrentTime(), signer.Address(), mh, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updateRequest.Sign(signer)
+	log.Info("added data", "manifest", string(b), "data", common.ToHex(mh))
+
+	body, err := mru.EncodeMruRequest(updateRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// create the multihash update
-	url = fmt.Sprintf("%s/bzz-resource:/%s/13", srv.URL, keybytes)
-	resp, err = http.Post(url, "application/octet-stream", bytes.NewReader([]byte(mhHex)))
+	url = fmt.Sprintf("%s/bzz-resource:/", srv.URL)
+	resp, err = http.Post(url, "application/json", bytes.NewReader(body))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,9 +166,9 @@ func TestBzzResourceMultihash(t *testing.T) {
 		t.Fatalf("data %s could not be unmarshaled: %v", b, err)
 	}
 
-	correctManifestAddrHex := "2a6f57966187ce8d5165c570755e4c4f03c1176ff49ba84e9c654c5fb1ae205e"
+	correctManifestAddrHex := "ff19cd3107675f20800c80bd940b501778c08a6a455ad9786f8fa4f81a65a63d"
 	if rsrcResp.Hex() != correctManifestAddrHex {
-		t.Fatalf("Response resource key mismatch, expected '%s', got '%s'", correctManifestAddrHex, rsrcResp)
+		t.Fatalf("Response resource key mismatch, expected '%s', got '%s'", correctManifestAddrHex, rsrcResp.Hex())
 	}
 
 	// get bzz manifest transparent resource resolve
@@ -172,6 +193,8 @@ func TestBzzResourceMultihash(t *testing.T) {
 // Test resource updates using the raw update methods
 func TestBzzResource(t *testing.T) {
 	srv := testutil.NewTestSwarmServer(t, serverFunc)
+	signer, _ := newTestSigner()
+
 	defer srv.Close()
 
 	// our mutable resource "name"
@@ -184,9 +207,20 @@ func TestBzzResource(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	updateRequest, err := mru.NewUpdateRequest(keybytes, 13, srv.GetCurrentTime(), signer.Address(), databytes, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updateRequest.Sign(signer)
+
+	body, err := mru.EncodeMruRequest(updateRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	// creates resource and sets update 1
-	url := fmt.Sprintf("%s/bzz-resource:/%s/raw/13", srv.URL, []byte(keybytes))
-	resp, err := http.Post(url, "application/octet-stream", bytes.NewReader(databytes))
+	url := fmt.Sprintf("%s/bzz-resource:/", srv.URL)
+	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -204,7 +238,7 @@ func TestBzzResource(t *testing.T) {
 		t.Fatalf("data %s could not be unmarshaled: %v", b, err)
 	}
 
-	correctManifestAddrHex := "2a6f57966187ce8d5165c570755e4c4f03c1176ff49ba84e9c654c5fb1ae205e"
+	correctManifestAddrHex := "ff19cd3107675f20800c80bd940b501778c08a6a455ad9786f8fa4f81a65a63d"
 	if rsrcResp.Hex() != correctManifestAddrHex {
 		t.Fatalf("Response resource key mismatch, expected '%s', got '%s'", correctManifestAddrHex, rsrcResp.Hex())
 	}
@@ -231,7 +265,7 @@ func TestBzzResource(t *testing.T) {
 	if len(manifest.Entries) != 1 {
 		t.Fatalf("Manifest has %d entries", len(manifest.Entries))
 	}
-	correctRootKeyHex := "1117bba54a84a0e85955bd234bae0b84b9f5a629c69a74889f5a93bcc0284dc4"
+	correctRootKeyHex := "0dc8d8ef18f5b84f229e7deadee0073c6e2fc8e903c319df411ec6937ae45f8f"
 	if manifest.Entries[0].Hash != correctRootKeyHex {
 		t.Fatalf("Expected manifest path '%s', got '%s'", correctRootKeyHex, manifest.Entries[0].Hash)
 	}
@@ -257,6 +291,11 @@ func TestBzzResource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatal("Expected get non-existent resource to fail")
+	}
+
 	resp.Body.Close()
 
 	// get latest update (1.1) through resource directly
@@ -280,9 +319,36 @@ func TestBzzResource(t *testing.T) {
 
 	// update 2
 	log.Info("update 2")
-	url = fmt.Sprintf("%s/bzz-resource:/%s/raw", srv.URL, correctManifestAddrHex)
+
+	// 1.- get metadata about this resource
+	url = fmt.Sprintf("%s/bzz-resource:/%s/", srv.URL, correctManifestAddrHex)
+	resp, err = http.Get(url + "meta")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Get resource metadata returned %s", resp.Status)
+	}
+	b, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updateRequest, err = mru.DecodeMruRequest(b)
+	if err != nil {
+		t.Fatalf("Error decoding resource metadata: %s", err)
+	}
 	data := []byte("foo")
-	resp, err = http.Post(url, "application/octet-stream", bytes.NewReader(data))
+	updateRequest.SetData(data)
+	if err = updateRequest.Sign(signer); err != nil {
+		t.Fatal(err)
+	}
+	body, err = mru.EncodeMruRequest(updateRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err = http.Post(url, "application/json", bytes.NewReader(body))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swarm/storage/mru/resource.go
+++ b/swarm/storage/mru/resource.go
@@ -25,11 +25,12 @@ import (
 	"math/big"
 	"sync"
 	"time"
+	"unsafe"
 
 	"golang.org/x/net/idna"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/contracts/ens"
+
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/swarm/log"
@@ -38,12 +39,11 @@ import (
 )
 
 const (
-	signatureLength         = 65
 	metadataChunkOffsetSize = 16 + common.AddressLength
 	chunkSize               = 4096 // temporary until we implement FileStore in the resourcehandler
 	defaultStoreTimeout     = 4000 * time.Millisecond
 	hasherCount             = 8
-	resourceHash            = storage.DefaultHash
+	resourceHashAlgorithm   = storage.SHA3Hash
 	defaultRetrieveTimeout  = 100 * time.Millisecond
 )
 
@@ -108,9 +108,6 @@ func NewError(code int, s string) error {
 	return r
 }
 
-// Signature is an alias for a static byte array with the size of a signature
-type Signature [signatureLength]byte
-
 // LookupParams is used to specify constraints when performing an update lookup
 // Limit defines whether or not the lookup should be limited
 // If Limit is set to true then Max defines the amount of hops that can be performed
@@ -122,21 +119,23 @@ type LookupParams struct {
 	Limit   uint32
 }
 
+type resourceUpdate struct {
+	version   uint32
+	period    uint32
+	multihash bool
+	metaHash  []byte
+	rootAddr  storage.Address
+	data      []byte
+}
+
 // encapsulates an specific resource update. When synced it contains the most recent
 // version of the resource update data.
 type resource struct {
+	resourceUpdate
+	resourceMetadata
 	*bytes.Reader
-	Multihash  bool
-	name       string
-	nameHash   common.Hash
-	startBlock uint64
-	lastPeriod uint32
-	lastKey    storage.Address
-	frequency  uint64
-	version    uint32
-	data       []byte
-	owner      common.Address
-	updated    time.Time
+	lastKey storage.Address
+	updated time.Time
 }
 
 // TODO Expire content after a defined period (to force resync)
@@ -144,8 +143,8 @@ func (r *resource) isSynced() bool {
 	return !r.updated.IsZero()
 }
 
-func (r *resource) NameHash() common.Hash {
-	return r.nameHash
+func (r *resourceUpdate) Multihash() bool {
+	return r.multihash
 }
 
 // implements (which?) interface
@@ -153,83 +152,77 @@ func (r *resource) Size(_ chan bool) (int64, error) {
 	if !r.isSynced() {
 		return 0, NewError(ErrNotSynced, "Not synced")
 	}
-	return int64(len(r.data)), nil
+	return int64(len(r.resourceUpdate.data)), nil
 }
 
 func (r *resource) Name() string {
 	return r.name
 }
 
-func (r *resource) UnmarshalBinary(data []byte) error {
-	r.startBlock = binary.LittleEndian.Uint64(data)
-	r.frequency = binary.LittleEndian.Uint64(data[8:])
-	copy(r.owner[:], data[16:16+common.AddressLength])
-	r.name = string(data[16+common.AddressLength:])
-	return nil
+type timestampProvider interface {
+	GetCurrentTime() uint64
 }
 
-func (r *resource) MarshalBinary() ([]byte, error) {
-	b := make([]byte, 16+len(r.name))
-	binary.LittleEndian.PutUint64(b, r.startBlock)
-	binary.LittleEndian.PutUint64(b[8:], r.frequency)
-	copy(b[16:], r.owner[:])
-	copy(b[16+common.AddressLength:], []byte(r.name))
-	return b, nil
+type DefaultTimestampProvider struct {
 }
 
-type headerGetter interface {
-	HeaderByNumber(context.Context, string, *big.Int) (*types.Header, error)
+func NewDefaultTimestampProvider() *DefaultTimestampProvider {
+	return &DefaultTimestampProvider{}
+}
+
+func (dtp *DefaultTimestampProvider) GetCurrentTime() uint64 {
+	return uint64(time.Now().Unix())
 }
 
 // Handler is the API for Mutable Resources
 // It enables creating, updating, syncing and retrieving resources and their update data
 type Handler struct {
-	chunkStore      *storage.NetStore
-	HashSize        int
-	signer          Signer
-	headerGetter    headerGetter
-	resources       map[string]*resource
-	hashPool        sync.Pool
-	resourceLock    sync.RWMutex
-	storeTimeout    time.Duration
-	queryMaxPeriods uint32
+	chunkStore        *storage.NetStore
+	HashSize          int
+	timestampProvider timestampProvider
+	resources         map[uint64]*resource
+	resourceLock      sync.RWMutex
+	storeTimeout      time.Duration
+	queryMaxPeriods   uint32
 }
 
 // HandlerParams pass parameters to the Handler constructor NewHandler
-// Signer and HeaderGetter are mandatory parameters
+// Signer and TimestampProvider are mandatory parameters
 type HandlerParams struct {
-	QueryMaxPeriods uint32
-	Signer          Signer
-	HeaderGetter    headerGetter
+	QueryMaxPeriods   uint32
+	TimestampProvider timestampProvider
+}
+
+var hashPool sync.Pool
+
+func init() {
+	hashPool = sync.Pool{
+		New: func() interface{} {
+			return storage.MakeHashFunc(resourceHashAlgorithm)()
+		},
+	}
 }
 
 // NewHandler creates a new Mutable Resource API
 func NewHandler(params *HandlerParams) (*Handler, error) {
-	if params.Signer == nil {
-		return nil, NewError(ErrInit, "Signer cannot be nil")
-	}
-	if params.HeaderGetter == nil {
-		return nil, NewError(ErrInit, "HeaderGetter cannot be nil")
-	}
+
 	rh := &Handler{
-		headerGetter: params.HeaderGetter,
-		resources:    make(map[string]*resource),
-		storeTimeout: defaultStoreTimeout,
-		signer:       params.Signer,
-		hashPool: sync.Pool{
-			New: func() interface{} {
-				return storage.MakeHashFunc(resourceHash)()
-			},
-		},
-		queryMaxPeriods: params.QueryMaxPeriods,
+		timestampProvider: params.TimestampProvider,
+		resources:         make(map[uint64]*resource),
+		storeTimeout:      defaultStoreTimeout,
+		queryMaxPeriods:   params.QueryMaxPeriods,
+	}
+
+	if rh.timestampProvider == nil {
+		rh.timestampProvider = NewDefaultTimestampProvider()
 	}
 
 	for i := 0; i < hasherCount; i++ {
-		hashfunc := storage.MakeHashFunc(resourceHash)()
+		hashfunc := storage.MakeHashFunc(resourceHashAlgorithm)()
 		if rh.HashSize == 0 {
 			rh.HashSize = hashfunc.Size()
 		}
-		rh.hashPool.Put(hashfunc)
+		hashPool.Put(hashfunc)
 	}
 
 	return rh, nil
@@ -245,9 +238,19 @@ func (h *Handler) SetStore(store *storage.NetStore) {
 // It implements the storage.ChunkValidator interface
 func (h *Handler) Validate(addr storage.Address, data []byte) bool {
 
+	if data[0] == 0 && data[1] == 0 && len(data) > common.AddressLength {
+		//metadata chunk
+		rootAddr, _ := metadataHash(data)
+		valid := bytes.Equal(addr, rootAddr)
+		if !valid {
+			log.Warn("Invalid root metadata chunk")
+		}
+		return valid
+	}
+
 	// does the chunk data make sense?
 	// This is not 100% safe evaluation, since content addressed data can coincidentally produce data with length header matching content size
-	signature, period, version, name, parseddata, _, err := h.parseUpdate(data)
+	mru, err := parseUpdate(data)
 	if err != nil {
 		log.Warn("Invalid resource chunk")
 		return false
@@ -255,35 +258,35 @@ func (h *Handler) Validate(addr storage.Address, data []byte) bool {
 
 	// Check if signature is valid against the chunk address
 	// Since we force signatures to be used, we can know be sure that this is valid data
-	digest := h.keyDataHash(addr, parseddata)
-	publicKey, err := crypto.SigToPub(digest.Bytes(), signature[:])
+	ownerAddr, err := mru.Verify(addr)
 	if err != nil {
 		log.Warn("Unparseable signature in resource chunk %s", addr)
 		return false
 	}
-	signAddr := crypto.PubkeyToAddress(*publicKey)
-	nameHash := ens.EnsNode(name)
-	checkAddr := h.resourceHash(period, version, nameHash, signAddr)
-	if !bytes.Equal(checkAddr, addr) {
-		log.Warn("Invalid signature on resource chunk")
+
+	// Check if who signed the resource update really owns the resource
+	if !verifyResourceOwnership(ownerAddr, mru.metaHash, mru.rootAddr) {
+		log.Warn("Update signer does not match with resource owner")
 		return false
 	}
+
 	return true
 }
 
 // create the resource update digest used in signatures
-func (h *Handler) keyDataHash(addr storage.Address, data []byte) common.Hash {
-	hasher := h.hashPool.Get().(storage.SwarmHash)
-	defer h.hashPool.Put(hasher)
+func keyDataHash(addr storage.Address, metaHash []byte, data []byte) common.Hash {
+	hasher := hashPool.Get().(storage.SwarmHash)
+	defer hashPool.Put(hasher)
 	hasher.Reset()
-	hasher.Write(addr[:])
+	hasher.Write(addr)
+	hasher.Write(metaHash)
 	hasher.Write(data)
 	return common.BytesToHash(hasher.Sum(nil))
 }
 
 // GetContent retrieves the data payload of the last synced update of the Mutable Resource
 func (h *Handler) GetContent(addr storage.Address) (storage.Address, []byte, error) {
-	rsrc := h.get(addr.Hex())
+	rsrc := h.get(addr)
 	if rsrc == nil || !rsrc.isSynced() {
 		return nil, nil, NewError(ErrNotFound, " does not exist or is not synced")
 	}
@@ -292,18 +295,18 @@ func (h *Handler) GetContent(addr storage.Address) (storage.Address, []byte, err
 
 // GetLastPeriod retrieves the period of the last synced update of the Mutable Resource
 func (h *Handler) GetLastPeriod(addr storage.Address) (uint32, error) {
-	rsrc := h.get(addr.Hex())
+	rsrc := h.get(addr)
 	if rsrc == nil {
 		return 0, NewError(ErrNotFound, " does not exist")
 	} else if !rsrc.isSynced() {
 		return 0, NewError(ErrNotSynced, " is not synced")
 	}
-	return rsrc.lastPeriod, nil
+	return rsrc.period, nil
 }
 
 // GetVersion retrieves the period of the last synced update of the Mutable Resource
 func (h *Handler) GetVersion(addr storage.Address) (uint32, error) {
-	rsrc := h.get(addr.Hex())
+	rsrc := h.get(addr)
 	if rsrc == nil {
 		return 0, NewError(ErrNotFound, " does not exist")
 	} else if !rsrc.isSynced() {
@@ -318,87 +321,119 @@ func (h *Handler) chunkSize() int64 {
 }
 
 // New creates a new metadata chunk for a Mutable Resource identified by `name` with the specified `frequency`.
-// It uses the public key from the Signer registered with the Handler object
 // The start block of the resource update will be the actual current block height of the connected network.
-func (h *Handler) New(ctx context.Context, name string, frequency uint64) (storage.Address, *resource, error) {
-	return h.NewWithAddress(ctx, name, frequency, h.signer.Address())
-}
-
-// NewWithPublicKey performs the same action as New, but enables a custom public key to be used for the Mutable Resource
-func (h *Handler) NewWithAddress(ctx context.Context, name string, frequency uint64, ownerAddr common.Address) (storage.Address, *resource, error) {
+func (h *Handler) New(ctx context.Context, request *UpdateRequest) error {
 
 	// frequency 0 is invalid
-	if frequency == 0 {
-		return nil, nil, NewError(ErrInvalidValue, "frequency cannot be 0")
+	if request.frequency == 0 {
+		return NewError(ErrInvalidValue, "frequency cannot be 0")
 	}
 
 	// make sure name only contains ascii values
-	if !isSafeName(name) {
-		return nil, nil, NewError(ErrInvalidValue, fmt.Sprintf("invalid name: '%s'", name))
+	if !isSafeName(request.name) {
+		return NewError(ErrInvalidValue, fmt.Sprintf("invalid name: '%s'", request.name))
 	}
 
-	// get our blockheight at this time
-	currentblock, err := h.getBlock(ctx, name)
-	if err != nil {
-		return nil, nil, err
+	// make sure owner is set
+	var zeroAddr = common.Address{}
+	if request.ownerAddr == zeroAddr {
+		return NewError(ErrInvalidValue, "ownerAddr must be set to create a new metadata chunk")
 	}
 
+	// get the current time
+	if request.startTime == 0 {
+		request.startTime = h.getCurrentTime(ctx)
+	}
 	// create the meta chunk and store it in swarm
-	chunk := h.newMetaChunk(name, currentblock, frequency, ownerAddr)
+
+	chunk, metaHash := h.newMetaChunk(&request.resourceMetadata)
 	h.chunkStore.Put(chunk)
 
-	nameHash := ens.EnsNode(name)
-	log.Debug("new resource", "name", name, "key", nameHash, "startBlock", currentblock, "frequency", frequency, "owner", ownerAddr)
+	request.metaHash = metaHash
+	request.rootAddr = chunk.Addr
+	request.period = 1
+	request.version = 1
+
+	log.Debug("new resource", "name", request.name, "startBlock", request.startTime, "frequency", request.frequency, "owner", request.ownerAddr)
 
 	// create the internal index for the resource and populate it with the data of the first version
 	rsrc := &resource{
-		startBlock: currentblock,
-		frequency:  frequency,
-		name:       name,
-		nameHash:   nameHash,
-		updated:    time.Now(),
+		resourceUpdate: resourceUpdate{
+			rootAddr: chunk.Addr,
+		},
+		resourceMetadata: resourceMetadata{
+			name:      request.name,
+			startTime: request.startTime,
+			frequency: request.frequency,
+		},
+		updated: time.Now(),
 	}
-	copy(rsrc.owner[:], ownerAddr[:])
-	h.set(chunk.Addr.Hex(), rsrc)
+	copy(rsrc.ownerAddr[:], request.ownerAddr[:])
+	h.set(chunk.Addr, rsrc)
 
-	return chunk.Addr, rsrc, nil
+	return nil
+}
+
+func (h *Handler) NewUpdateRequest(ctx context.Context, rootAddr storage.Address) (*UpdateRequest, error) {
+
+	if rootAddr == nil {
+		return nil, NewError(ErrInvalidValue, "rootAddr cannot be nil")
+	}
+
+	rsrc, err := h.Load(rootAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	currentblock := h.getCurrentTime(ctx)
+
+	mru := new(UpdateRequest)
+	mru.period, err = getNextPeriod(rsrc.startTime, currentblock, rsrc.frequency)
+	if err != nil {
+		return nil, err
+	}
+	if _, err = h.lookup(rsrc, mru.period, 0, 0); err != nil {
+		return nil, err
+	}
+
+	if !rsrc.isSynced() {
+		return nil, NewError(ErrNotSynced, fmt.Sprintf("NewMruRequest: object '%s' not in sync", rootAddr.Hex()))
+	}
+
+	mru.name = rsrc.name
+	mru.multihash = rsrc.multihash
+	mru.rootAddr = rsrc.rootAddr
+	mru.metaHash = rsrc.metaHash
+	mru.resourceMetadata = rsrc.resourceMetadata
+
+	// if we already have an update for this block then increment version
+	// resource object MUST be in sync for version to be correct, but we checked this earlier in the method already
+	if h.hasUpdate(rootAddr, mru.period) {
+		mru.version = rsrc.version + 1
+	} else {
+		mru.version = 1
+	}
+
+	return mru, nil
 }
 
 // creates a metadata chunk
-func (h *Handler) newMetaChunk(name string, startBlock uint64, frequency uint64, ownerAddr common.Address) *storage.Chunk {
+func (h *Handler) newMetaChunk(metadata *resourceMetadata) (chunk *storage.Chunk, metaHash []byte) {
 	// the metadata chunk points to data of first blockheight + update frequency
 	// from this we know from what blockheight we should look for updates, and how often
 	// it also contains the name of the resource, so we know what resource we are working with
-	metadataChunkLength := metadataChunkOffsetSize + len(name)
-	data := make([]byte, metadataChunkLength)
-
-	// root block has first two bytes both set to 0, which distinguishes from update bytes
-	val := make([]byte, 8)
-	binary.LittleEndian.PutUint64(val, startBlock)
-	copy(data[:8], val)
-	binary.LittleEndian.PutUint64(val, frequency)
-	copy(data[8:16], val)
-	copy(data[16:], ownerAddr[:])
-	copy(data[16+common.AddressLength:], []byte(name))
-	binary.LittleEndian.PutUint64(val, uint64(metadataChunkLength))
 
 	// the key of the metadata chunk is content-addressed
 	// if it wasn't we couldn't replace it later
 	// resolving this relationship is left up to external agents (for example ENS)
-	hasher := h.hashPool.Get().(storage.SwarmHash)
-	hasher.ResetWithLength(val)
-	hasher.Write(data)
-	key := hasher.Sum(nil)
-	h.hashPool.Put(hasher)
+	rootAddr, metaHash, chunkData := metadata.hash()
 
 	// make the chunk and send it to swarm
-	chunk := storage.NewChunk(key, nil)
-	chunk.SData = make([]byte, metadataChunkLength+8)
-	copy(chunk.SData[:8], val)
-	copy(chunk.SData[8:], data)
-	//chunk.SData = make([]byte, metadataChunkLength)
-	//copy(chunk.SData[:], data)
-	return chunk
+	chunk = storage.NewChunk(rootAddr, nil)
+	chunk.SData = chunkData
+	chunk.Size = int64(len(chunkData))
+
+	return chunk, metaHash
 }
 
 // LookupLatest retrieves the latest version of the resource update with metadata chunk at params.Root
@@ -407,18 +442,16 @@ func (h *Handler) newMetaChunk(name string, startBlock uint64, frequency uint64,
 // (or startBlock is reached, in which case there are no updates).
 func (h *Handler) Lookup(ctx context.Context, params *LookupParams) (*resource, error) {
 
-	rsrc := h.get(params.Root.Hex())
+	rsrc := h.get(params.Root)
 	if rsrc == nil {
 		return nil, NewError(ErrNothingToReturn, "resource not loaded")
 	}
 	if params.Period == 0 {
 		// get our blockheight at this time and the next block of the update period
-		currentblock, err := h.getBlock(ctx, rsrc.name)
-		if err != nil {
-			return nil, err
-		}
+		currentblock := h.getCurrentTime(ctx)
+
 		var period uint32
-		period, err = getNextPeriod(rsrc.startBlock, currentblock, rsrc.frequency)
+		period, err := getNextPeriod(rsrc.startTime, currentblock, rsrc.frequency)
 		if err != nil {
 			return nil, err
 		}
@@ -432,24 +465,24 @@ func (h *Handler) Lookup(ctx context.Context, params *LookupParams) (*resource, 
 // merely replacing content.
 // Requires a synced resource object
 func (h *Handler) LookupPrevious(ctx context.Context, params *LookupParams) (*resource, error) {
-	rsrc := h.get(params.Root.Hex())
+	rsrc := h.get(params.Root)
 	if rsrc == nil {
 		return nil, NewError(ErrNothingToReturn, "resource not loaded")
 	}
 	if !rsrc.isSynced() {
 		return nil, NewError(ErrNotSynced, "LookupPrevious requires synced resource.")
-	} else if rsrc.lastPeriod == 0 {
+	} else if rsrc.period == 0 {
 		return nil, NewError(ErrNothingToReturn, " not found")
 	}
 	if rsrc.version > 1 {
 		rsrc.version--
-	} else if rsrc.lastPeriod == 1 {
+	} else if rsrc.period == 1 {
 		return nil, NewError(ErrNothingToReturn, "Current update is the oldest")
 	} else {
 		rsrc.version = 0
-		rsrc.lastPeriod--
+		rsrc.period--
 	}
-	return h.lookup(rsrc, rsrc.lastPeriod, rsrc.version, params.Limit)
+	return h.lookup(rsrc, rsrc.period, rsrc.version, params.Limit)
 }
 
 // base code for public lookup methods
@@ -483,7 +516,7 @@ func (h *Handler) lookup(rsrc *resource, period uint32, version uint32, limit ui
 		if limit != 0 && hops > limit {
 			return nil, NewError(ErrPeriodDepth, fmt.Sprintf("Lookup exceeded max period hops (%d)", limit))
 		}
-		key := h.resourceHash(period, version, rsrc.nameHash, rsrc.owner)
+		key := resourceHash(period, version, rsrc.rootAddr)
 		chunk, err := h.chunkStore.GetWithTimeout(key, defaultRetrieveTimeout)
 		if err == nil {
 			if specificversion {
@@ -493,7 +526,7 @@ func (h *Handler) lookup(rsrc *resource, period uint32, version uint32, limit ui
 			log.Trace("rsrc update version 1 found, checking for version updates", "period", period, "key", key)
 			for {
 				newversion := version + 1
-				key := h.resourceHash(period, newversion, rsrc.nameHash, rsrc.owner)
+				key := resourceHash(period, newversion, rsrc.rootAddr)
 				newchunk, err := h.chunkStore.GetWithTimeout(key, defaultRetrieveTimeout)
 				if err != nil {
 					return h.updateIndex(rsrc, chunk)
@@ -512,8 +545,8 @@ func (h *Handler) lookup(rsrc *resource, period uint32, version uint32, limit ui
 
 // Load retrieves the Mutable Resource metadata chunk stored at addr
 // Upon retrieval it creates/updates the index entry for it with metadata corresponding to the chunk contents
-func (h *Handler) Load(addr storage.Address) (*resource, error) {
-	chunk, err := h.chunkStore.GetWithTimeout(addr, defaultRetrieveTimeout)
+func (h *Handler) Load(rootAddr storage.Address) (*resource, error) {
+	chunk, err := h.chunkStore.GetWithTimeout(rootAddr, defaultRetrieveTimeout)
 	if err != nil {
 		return nil, NewError(ErrNotFound, err.Error())
 	}
@@ -525,10 +558,13 @@ func (h *Handler) Load(addr storage.Address) (*resource, error) {
 
 	// create the index entry
 	rsrc := &resource{}
-	rsrc.UnmarshalBinary(chunk.SData[8:])
-	rsrc.nameHash = ens.EnsNode(rsrc.name)
-	h.set(addr.Hex(), rsrc)
-	log.Trace("resource index load", "rootkey", addr, "name", rsrc.name, "namehash", rsrc.nameHash, "startblock", rsrc.startBlock, "frequency", rsrc.frequency)
+	rsrc.UnmarshalBinary(chunk.SData)
+	rsrc.rootAddr, rsrc.metaHash = metadataHash(chunk.SData)
+	if !bytes.Equal(rsrc.rootAddr, rootAddr) {
+		return nil, NewError(ErrCorruptData, "Corrupt metadata chunk")
+	}
+	h.set(rootAddr, rsrc)
+	log.Trace("resource index load", "rootkey", rootAddr, "name", rsrc.name, "startblock", rsrc.startTime, "frequency", rsrc.frequency)
 	return rsrc, nil
 }
 
@@ -536,43 +572,50 @@ func (h *Handler) Load(addr storage.Address) (*resource, error) {
 func (h *Handler) updateIndex(rsrc *resource, chunk *storage.Chunk) (*resource, error) {
 
 	// retrieve metadata from chunk data and check that it matches this mutable resource
-	signature, period, version, name, data, multihash, err := h.parseUpdate(chunk.SData)
-	if rsrc.name != name {
-		return nil, NewError(ErrNothingToReturn, fmt.Sprintf("Update belongs to '%s', but have '%s'", name, rsrc.name))
-	}
-	log.Trace("resource index update", "name", rsrc.name, "namehash", rsrc.nameHash, "updatekey", chunk.Addr, "period", period, "version", version)
+	mru, err := parseUpdate(chunk.SData)
+	log.Trace("resource index update", "name", rsrc.name, "updatekey", chunk.Addr, "period", mru.period, "version", mru.version)
 
-	// check signature (if signer algorithm is present)
 	// \TODO maybe this check is redundant if also checked upon retrieval of chunk
-	if signature != nil {
-		digest := h.keyDataHash(chunk.Addr, data)
-		_, err = getAddressFromDataSig(digest, *signature)
-		if err != nil {
-			return nil, NewError(ErrUnauthorized, fmt.Sprintf("Invalid signature: %v", err))
-		}
+
+	ownerAddr, err := mru.Verify(chunk.Addr)
+	if err != nil {
+		return nil, NewError(ErrUnauthorized, fmt.Sprintf("Invalid signature: %v", err))
+	}
+
+	// Check if who signed the resource update really owns the resource
+	if !verifyResourceOwnership(ownerAddr, mru.metaHash, mru.rootAddr) {
+		return nil, NewError(ErrUnauthorized, fmt.Sprintf("signature is valid but signer does not own the resource: %v", err))
 	}
 
 	// update our rsrcs entry map
 	rsrc.lastKey = chunk.Addr
-	rsrc.lastPeriod = period
-	rsrc.version = version
+	rsrc.period = mru.period
+	rsrc.version = mru.version
 	rsrc.updated = time.Now()
-	rsrc.data = make([]byte, len(data))
-	rsrc.Multihash = multihash
+	rsrc.data = make([]byte, len(mru.data))
+	rsrc.multihash = mru.multihash
 	rsrc.Reader = bytes.NewReader(rsrc.data)
-	copy(rsrc.data, data)
-	log.Debug(" synced", "name", rsrc.name, "key", chunk.Addr, "period", rsrc.lastPeriod, "version", rsrc.version)
-	h.set(chunk.Addr.Hex(), rsrc)
+	copy(rsrc.data, mru.data)
+	log.Debug(" synced", "name", rsrc.name, "key", chunk.Addr, "period", rsrc.period, "version", rsrc.version)
+	h.set(chunk.Addr, rsrc)
 	return rsrc, nil
 }
 
 // retrieve update metadata from chunk data
 // mirrors newUpdateChunk()
-func (h *Handler) parseUpdate(chunkdata []byte) (*Signature, uint32, uint32, string, []byte, bool, error) {
+func parseUpdate(chunkdata []byte) (*SignedResourceUpdate, error) {
 	// absolute minimum an update chunk can contain:
 	// 14 = header + one byte of name + one byte of data
+
+	// 2 bytes header Length
+	// 2 bytes data length
+	// 4 bytes period
+	// 4 bytes version
+	// 32 bytes rootAddr reference
+	// 32 bytes metaHash digest
+
 	if len(chunkdata) < 14 {
-		return nil, 0, 0, "", nil, false, NewError(ErrNothingToReturn, "chunk less than 13 bytes cannot be a resource update chunk")
+		return nil, NewError(ErrNothingToReturn, "chunk less than 13 bytes cannot be a resource update chunk")
 	}
 	cursor := 0
 	headerlength := binary.LittleEndian.Uint16(chunkdata[cursor : cursor+2])
@@ -580,8 +623,8 @@ func (h *Handler) parseUpdate(chunkdata []byte) (*Signature, uint32, uint32, str
 	datalength := binary.LittleEndian.Uint16(chunkdata[cursor : cursor+2])
 	cursor += 2
 
-	if int(headerlength+datalength) > len(chunkdata) {
-		return nil, 0, 0, "", nil, false, NewError(ErrNothingToReturn, "length specified in header is greater than actual chunk size")
+	if datalength != 0 && int(2+2+headerlength+datalength+signatureLength) != len(chunkdata) {
+		return nil, NewError(ErrNothingToReturn, "length specified in header is different than actual chunk size")
 	}
 
 	var exclsignlength int
@@ -594,14 +637,14 @@ func (h *Handler) parseUpdate(chunkdata []byte) (*Signature, uint32, uint32, str
 		if err != nil {
 			errstr := fmt.Sprintf("corrupt multihash, hash id varint could not be read: %v", err)
 			log.Warn(errstr)
-			return nil, 0, 0, "", nil, false, NewError(ErrCorruptData, errstr)
+			return nil, NewError(ErrCorruptData, errstr)
 
 		}
 		r, err = binary.ReadUvarint(uvarintbuf)
 		if err != nil {
 			errstr := fmt.Sprintf("corrupt multihash, hash length field could not be read: %v", err)
 			log.Warn(errstr)
-			return nil, 0, 0, "", nil, false, NewError(ErrCorruptData, errstr)
+			return nil, NewError(ErrCorruptData, errstr)
 
 		}
 		exclsignlength = int(headerlength + uint16(r))
@@ -612,26 +655,27 @@ func (h *Handler) parseUpdate(chunkdata []byte) (*Signature, uint32, uint32, str
 	// the total length excluding signature is headerlength and datalength fields plus the length of the header and the data given in these fields
 	exclsignlength = int(headerlength + datalength + 4)
 	if exclsignlength > len(chunkdata) || exclsignlength < 14 {
-		return nil, 0, 0, "", nil, false, NewError(ErrNothingToReturn, fmt.Sprintf("Reported headerlength %d + datalength %d longer than actual chunk data length %d", headerlength, exclsignlength, len(chunkdata)))
+		return nil, NewError(ErrNothingToReturn, fmt.Sprintf("Reported headerlength %d + datalength %d longer than actual chunk data length %d", headerlength, exclsignlength, len(chunkdata)))
 	} else if exclsignlength < 14 {
-		return nil, 0, 0, "", nil, false, NewError(ErrNothingToReturn, fmt.Sprintf("Reported headerlength %d + datalength %d is smaller than minimum valid resource chunk length %d", headerlength, datalength, 14))
+		return nil, NewError(ErrNothingToReturn, fmt.Sprintf("Reported headerlength %d + datalength %d is smaller than minimum valid resource chunk length %d", headerlength, datalength, 14))
 	}
 
 	// at this point we can be satisfied that the data integrity is ok
 	var period uint32
 	var version uint32
-	var name string
+
 	var data []byte
 	period = binary.LittleEndian.Uint32(chunkdata[cursor : cursor+4])
 	cursor += 4
 	version = binary.LittleEndian.Uint32(chunkdata[cursor : cursor+4])
 	cursor += 4
-	namelength := int(headerlength) - cursor + 4
-	if l := len(chunkdata); l < cursor+namelength {
-		return nil, 0, 0, "", nil, false, NewError(ErrNothingToReturn, fmt.Sprintf("chunk less than %v bytes is too short to read the name", l))
-	}
-	name = string(chunkdata[cursor : cursor+namelength])
-	cursor += namelength
+
+	rootAddr := storage.Address(make([]byte, storage.KeyLength))
+	metaHash := make([]byte, storage.KeyLength)
+	copy(rootAddr, chunkdata[cursor:cursor+storage.KeyLength])
+	cursor += storage.KeyLength
+	copy(metaHash, chunkdata[cursor:cursor+storage.KeyLength])
+	cursor += storage.KeyLength
 
 	// if multihash content is indicated we check the validity of the multihash
 	// \TODO the check above for multihash probably is sufficient also for this case (or can be with a small adjustment) and if so this code should be removed
@@ -643,13 +687,13 @@ func (h *Handler) parseUpdate(chunkdata []byte) (*Signature, uint32, uint32, str
 		intdatalength, intheaderlength, err = multihash.GetMultihashLength(chunkdata[cursor:])
 		if err != nil {
 			log.Error("multihash parse error", "err", err)
-			return nil, 0, 0, "", nil, false, err
+			return nil, err
 		}
 		intdatalength += intheaderlength
 		multihashboundary := cursor + intdatalength
 		if len(chunkdata) != multihashboundary && len(chunkdata) < multihashboundary+signatureLength {
 			log.Debug("multihash error", "chunkdatalen", len(chunkdata), "multihashboundary", multihashboundary)
-			return nil, 0, 0, "", nil, false, errors.New("Corrupt multihash data")
+			return nil, errors.New("Corrupt multihash data")
 		}
 		ismultihash = true
 	} else {
@@ -661,45 +705,38 @@ func (h *Handler) parseUpdate(chunkdata []byte) (*Signature, uint32, uint32, str
 	// omit signatures if we have no validator
 	var signature *Signature
 	cursor += intdatalength
-	if h.signer != nil {
-		sigdata := chunkdata[cursor : cursor+signatureLength]
-		if len(sigdata) > 0 {
-			signature = &Signature{}
-			copy(signature[:], sigdata)
-		}
+	sigdata := chunkdata[cursor : cursor+signatureLength]
+	if len(sigdata) > 0 {
+		signature = &Signature{}
+		copy(signature[:], sigdata)
 	}
 
-	return signature, period, version, name, data, ismultihash, nil
-}
-
-// Adds an actual data update
-//
-// Uses the data currently loaded in the resources map entry.
-// It is the caller's responsibility to make sure that this data is not stale.
-//
-// A resource update cannot span chunks, and thus has max length 4096
-func (h *Handler) UpdateMultihash(ctx context.Context, addr storage.Address, data []byte) (storage.Address, error) {
-	// \TODO perhaps this check should be in newUpdateChunk()
-	if _, _, err := multihash.GetMultihashLength(data); err != nil {
-		return nil, NewError(ErrNothingToReturn, err.Error())
-	}
-	return h.update(ctx, addr, data, true)
+	return &SignedResourceUpdate{
+		signature: signature,
+		resourceUpdate: resourceUpdate{
+			period:    period,
+			version:   version,
+			rootAddr:  rootAddr,
+			metaHash:  metaHash,
+			data:      data,
+			multihash: ismultihash,
+		},
+	}, nil
 }
 
 // Update adds an actual data update
 // Uses the Mutable Resource metadata currently loaded in the resources map entry.
 // It is the caller's responsibility to make sure that this data is not stale.
 // Note that a Mutable Resource update cannot span chunks, and thus has a MAX NET LENGTH 4096, INCLUDING update header data and signature. An error will be returned if the total length of the chunk payload will exceed this limit.
-func (h *Handler) Update(ctx context.Context, addr storage.Address, data []byte) (storage.Address, error) {
-	return h.update(ctx, addr, data, false)
+func (h *Handler) Update(ctx context.Context, rootAddr storage.Address, mru *SignedResourceUpdate) (storage.Address, error) {
+	return h.update(ctx, rootAddr, mru)
 }
 
 // create and commit an update
-func (h *Handler) update(ctx context.Context, addr storage.Address, data []byte, multihash bool) (storage.Address, error) {
+func (h *Handler) update(ctx context.Context, rootAddr storage.Address, mru *SignedResourceUpdate) (storage.Address, error) {
 
-	// zero-length updates are bogus
-	if len(data) == 0 {
-		return nil, NewError(ErrInvalidValue, "I refuse to waste swarm space for updates with empty values, amigo (data length is 0)")
+	if mru.multihash && isMultihash(mru.data) == 0 {
+		return nil, NewError(ErrNothingToReturn, "Invalid multihash")
 	}
 
 	// we can't update anything without a store
@@ -708,8 +745,8 @@ func (h *Handler) update(ctx context.Context, addr storage.Address, data []byte,
 	}
 
 	// get the cached information
-	addrHex := addr.Hex()
-	rsrc := h.get(addrHex)
+
+	rsrc := h.get(rootAddr)
 	if rsrc == nil {
 		return nil, NewError(ErrNotFound, fmt.Sprintf(" object '%s' not in index", rsrc.name))
 	} else if !rsrc.isSynced() {
@@ -719,78 +756,49 @@ func (h *Handler) update(ctx context.Context, addr storage.Address, data []byte,
 	// an update can be only one chunk long; data length less header and signature data
 	// 12 = length of header and data length fields (2xuint16) plus period and frequency value fields (2xuint32)
 	datalimit := h.chunkSize() - int64(signatureLength-len(rsrc.name)-12)
-	if int64(len(data)) > datalimit {
-		return nil, NewError(ErrDataOverflow, fmt.Sprintf("Data overflow: %d / %d bytes", len(data), datalimit))
+	if int64(len(mru.data)) > datalimit {
+		return nil, NewError(ErrDataOverflow, fmt.Sprintf("Data overflow: %d / %d bytes", len(mru.data), datalimit))
 	}
 
-	// get our blockheight at this time and the next block of the update period
-	currentblock, err := h.getBlock(ctx, rsrc.name)
-	if err != nil {
-		return nil, NewError(ErrIO, fmt.Sprintf("Could not get block height: %v", err))
-	}
-	nextperiod, err := getNextPeriod(rsrc.startBlock, currentblock, rsrc.frequency)
-	if err != nil {
-		return nil, err
-	}
-
-	// if we already have an update for this block then increment version
-	// resource object MUST be in sync for version to be correct, but we checked this earlier in the method already
-	var version uint32
-	if h.hasUpdate(addr, nextperiod) {
-		version = rsrc.version
-	}
-	version++
-
-	// calculate the chunk key
-	key := h.resourceHash(nextperiod, version, rsrc.nameHash, rsrc.owner)
-
-	// if we have a signing function, sign the update
-	// \TODO this code should probably be consolidated with corresponding code in New()
-	var signature *Signature
-	if h.signer != nil {
-		// sign the data hash with the key
-		digest := h.keyDataHash(key, data)
-		sig, err := h.signer.Sign(digest)
-		if err != nil {
-			return nil, NewError(ErrInvalidSignature, fmt.Sprintf("Sign fail: %v", err))
+	if rsrc.period == mru.period {
+		if mru.version != rsrc.version+1 {
+			return nil, NewError(ErrInvalidValue, fmt.Sprintf("Invalid version for this period. Expected version=%d", rsrc.version+1))
 		}
-		signature = &sig
-
-		// get the address of the signer (which also checks that it's a valid signature)
-		_, err = getAddressFromDataSig(digest, *signature)
-		if err != nil {
-			return nil, NewError(ErrInvalidSignature, fmt.Sprintf("Invalid data/signature: %v", err))
+	} else {
+		if !(mru.period > rsrc.period && mru.version == 1) {
+			return nil, NewError(ErrInvalidValue, fmt.Sprintf("Invalid version,period. Expected version=1 and period > %d", rsrc.period))
 		}
 	}
 
-	// a datalength field set to 0 means the content is a multihash
-	var datalength int
-	if !multihash {
-		datalength = len(data)
-	}
-	chunk := newUpdateChunk(key, signature, nextperiod, version, rsrc.name, data, datalength)
+	chunk := newUpdateChunk(mru)
 
 	// send the chunk
 	h.chunkStore.Put(chunk)
-	log.Trace("resource update", "name", rsrc.name, "key", key, "currentblock", currentblock, "lastperiod", nextperiod, "version", version, "data", chunk.SData, "multihash", multihash)
+	log.Trace("resource update", "key", mru.key, "lastperiod", mru.period, "version", mru.version, "data", chunk.SData, "multihash", mru.multihash)
 
 	// update our resources map entry and return the new key
-	rsrc.lastPeriod = nextperiod
-	rsrc.version = version
-	rsrc.data = make([]byte, len(data))
-	copy(rsrc.data, data)
-	return key, nil
+	rsrc.period = mru.period
+	rsrc.version = mru.version
+	rsrc.data = make([]byte, len(mru.data))
+	copy(rsrc.data, mru.data)
+	return mru.key, nil
 }
 
 // gets the current block height
-func (h *Handler) getBlock(ctx context.Context, name string) (uint64, error) {
-	blockheader, err := h.headerGetter.HeaderByNumber(ctx, name, nil)
-	if err != nil {
-		return 0, err
-	}
-	return blockheader.Number.Uint64(), nil
+func (h *Handler) getCurrentTime(ctx context.Context) uint64 {
+
+	return h.timestampProvider.GetCurrentTime()
+
+	/*
+		blockheader, err := h.headerGetter.HeaderByNumber(ctx, name, nil)
+		if err != nil {
+			return 0, err
+		}
+		return blockheader.Number.Uint64(), nil
+	*/
 }
 
+/** UNUSED functions
 // BlockToPeriod calculates the period index (aka major version number) from a given block number
 func (h *Handler) BlockToPeriod(name string, blocknumber uint64) (uint32, error) {
 	return getNextPeriod(h.resources[name].startBlock, blocknumber, h.resources[name].frequency)
@@ -800,35 +808,42 @@ func (h *Handler) BlockToPeriod(name string, blocknumber uint64) (uint32, error)
 func (h *Handler) PeriodToBlock(name string, period uint32) uint64 {
 	return h.resources[name].startBlock + (uint64(period) * h.resources[name].frequency)
 }
+**/
 
 // Retrieves the resource index value for the given nameHash
-func (h *Handler) get(nameHash string) *resource {
+func (h *Handler) get(rootAddr storage.Address) *resource {
+	if rootAddr == nil {
+		log.Warn("Handler.get with nil rootAddr")
+		return nil
+	}
+	hashKey := *(*uint64)(unsafe.Pointer(&rootAddr[0]))
 	h.resourceLock.RLock()
 	defer h.resourceLock.RUnlock()
-	rsrc := h.resources[nameHash]
+	rsrc := h.resources[hashKey]
 	return rsrc
 }
 
 // Sets the resource index value for the given nameHash
-func (h *Handler) set(nameHash string, rsrc *resource) {
+func (h *Handler) set(rootAddr storage.Address, rsrc *resource) {
+	hashKey := *(*uint64)(unsafe.Pointer(&rootAddr[0]))
 	h.resourceLock.Lock()
 	defer h.resourceLock.Unlock()
-	h.resources[nameHash] = rsrc
+	h.resources[hashKey] = rsrc
 }
 
 // used for chunk keys
-//func (h *Handler) resourceHash(period uint32, version uint32, nameHash common.Hash, publicKeyBytes [publicKeyLength]byte) storage.Address {
-func (h *Handler) resourceHash(period uint32, version uint32, nameHash common.Hash, ownerAddr common.Address) storage.Address {
-	hasher := h.hashPool.Get().(storage.SwarmHash)
-	defer h.hashPool.Put(hasher)
+func resourceHash(period uint32, version uint32, rootAddr storage.Address) storage.Address {
+	hasher := hashPool.Get().(storage.SwarmHash)
+	defer hashPool.Put(hasher)
 	hasher.Reset()
-	hasher.Write(NewResourceHash(period, version, nameHash, ownerAddr))
+	hasher.Write(NewResourceHash(period, version, rootAddr))
 	return hasher.Sum(nil)
 }
 
 // Checks if we already have an update on this resource, according to the value in the current state of the resource index
-func (h *Handler) hasUpdate(addr storage.Address, period uint32) bool {
-	return h.resources[addr.Hex()].lastPeriod == period
+func (h *Handler) hasUpdate(rootAddr storage.Address, period uint32) bool {
+	rsrc := h.get(rootAddr)
+	return rsrc != nil && rsrc.period == period
 }
 
 func getAddressFromDataSig(datahash common.Hash, signature Signature) (common.Address, error) {
@@ -840,20 +855,24 @@ func getAddressFromDataSig(datahash common.Hash, signature Signature) (common.Ad
 }
 
 // create an update chunk
-func newUpdateChunk(addr storage.Address, signature *Signature, period uint32, version uint32, name string, data []byte, datalength int) *storage.Chunk {
+func newUpdateChunk(mru *SignedResourceUpdate) *storage.Chunk {
 
-	// no signatures if no validator
-	var signaturelength int
-	if signature != nil {
-		signaturelength = signatureLength
+	if mru.rootAddr == nil || mru.metaHash == nil {
+		log.Warn("Call to newUpdateChunk with nil rootAddr or metaHash")
+		return nil
+	}
+	// a datalength field set to 0 means the content is a multihash
+	var datalength int
+	if !mru.multihash {
+		datalength = len(mru.data)
 	}
 
-	// prepend version and period to allow reverse lookups
-	headerlength := len(name) + 4 + 4
+	// prepend version, period, metaHash and rootAddr references
+	headerlength := 4 + 4 + storage.KeyLength + storage.KeyLength
 
-	actualdatalength := len(data)
-	chunk := storage.NewChunk(addr, nil)
-	chunk.SData = make([]byte, 4+signaturelength+headerlength+actualdatalength) // initial 4 are uint16 length descriptors for headerlength and datalength
+	actualdatalength := len(mru.data)
+	chunk := storage.NewChunk(mru.key, nil)
+	chunk.SData = make([]byte, 2+2+signatureLength+headerlength+actualdatalength) // initial 4 are uint16 length descriptors for headerlength and datalength
 
 	// data header length does NOT include the header length prefix bytes themselves
 	cursor := 0
@@ -864,25 +883,25 @@ func newUpdateChunk(addr storage.Address, signature *Signature, period uint32, v
 	binary.LittleEndian.PutUint16(chunk.SData[cursor:], uint16(datalength))
 	cursor += 2
 
-	// header = period + version + name
-	binary.LittleEndian.PutUint32(chunk.SData[cursor:], period)
+	// header = period + version + rootAddr + metaHash
+	binary.LittleEndian.PutUint32(chunk.SData[cursor:], mru.period)
 	cursor += 4
 
-	binary.LittleEndian.PutUint32(chunk.SData[cursor:], version)
+	binary.LittleEndian.PutUint32(chunk.SData[cursor:], mru.version)
 	cursor += 4
 
-	namebytes := []byte(name)
-	copy(chunk.SData[cursor:], namebytes)
-	cursor += len(namebytes)
+	copy(chunk.SData[cursor:], mru.rootAddr[:storage.KeyLength])
+	cursor += storage.KeyLength
+	copy(chunk.SData[cursor:], mru.metaHash[:storage.KeyLength])
+	cursor += storage.KeyLength
 
 	// add the data
-	copy(chunk.SData[cursor:], data)
+	copy(chunk.SData[cursor:], mru.data)
 
-	// if signature is present it's the last item in the chunk data
-	if signature != nil {
-		cursor += actualdatalength
-		copy(chunk.SData[cursor:], signature[:])
-	}
+	// signature is the last item in the chunk data
+
+	cursor += actualdatalength
+	copy(chunk.SData[cursor:], mru.signature[:])
 
 	chunk.Size = int64(len(chunk.SData))
 	return chunk
@@ -916,16 +935,50 @@ func isSafeName(name string) bool {
 	return validname == name
 }
 
+// if first byte is the start of a multihash this function will try to parse it
+// if successful it returns the length of multihash data, 0 otherwise
+func isMultihash(data []byte) int {
+	cursor := 0
+	_, c := binary.Uvarint(data)
+	if c <= 0 {
+		log.Warn("Corrupt multihash data, hashtype is unreadable")
+		return 0
+	}
+	cursor += c
+	hashlength, c := binary.Uvarint(data[cursor:])
+	if c <= 0 {
+		log.Warn("Corrupt multihash data, hashlength is unreadable")
+		return 0
+	}
+	cursor += c
+	// we cheekily assume hashlength < maxint
+	inthashlength := int(hashlength)
+	if len(data[cursor:]) < inthashlength {
+		log.Warn("Corrupt multihash data, hash does not align with data boundary")
+		return 0
+	}
+	return cursor + inthashlength
+}
+
 // NewResourceHash will create a deterministic address from the update metadata
 // format is: hash(period|version|publickey|namehash)
-func NewResourceHash(period uint32, version uint32, namehash common.Hash, ownerAddr common.Address) []byte {
+func NewResourceHash(period uint32, version uint32, rootAddr storage.Address) []byte {
 	buf := bytes.NewBuffer(nil)
 	b := make([]byte, 4)
 	binary.LittleEndian.PutUint32(b, period)
 	buf.Write(b)
 	binary.LittleEndian.PutUint32(b, version)
 	buf.Write(b)
-	buf.Write(ownerAddr[:])
-	buf.Write(namehash[:])
+	buf.Write(rootAddr[:])
 	return buf.Bytes()
+}
+
+func verifyResourceOwnership(ownerAddr common.Address, metaHash []byte, rootAddr storage.Address) bool {
+	hasher := hashPool.Get().(storage.SwarmHash)
+	defer hashPool.Put(hasher)
+	hasher.Reset()
+	hasher.Write(metaHash)
+	hasher.Write(ownerAddr.Bytes())
+	rootAddr2 := hasher.Sum(nil)
+	return bytes.Equal(rootAddr2, rootAddr)
 }

--- a/swarm/storage/mru/resourcemetadata.go
+++ b/swarm/storage/mru/resourcemetadata.go
@@ -1,0 +1,64 @@
+package mru
+
+import (
+	"encoding/binary"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/swarm/storage"
+)
+
+type resourceMetadata struct {
+	startTime uint64
+	frequency uint64
+	name      string
+	ownerAddr common.Address
+}
+
+func (r *resourceMetadata) UnmarshalBinary(chunkData []byte) error {
+	metadataChunkLength := binary.LittleEndian.Uint16(chunkData[2:6])
+	data := chunkData[8:]
+
+	r.startTime = binary.LittleEndian.Uint64(data[:8])
+	r.frequency = binary.LittleEndian.Uint64(data[8:16])
+	r.name = string(data[16 : 16+metadataChunkLength-metadataChunkOffsetSize])
+	copy(r.ownerAddr[:], data[16+metadataChunkLength-metadataChunkOffsetSize:])
+
+	return nil
+}
+
+func (r *resourceMetadata) MarshalBinary() []byte {
+	metadataChunkLength := metadataChunkOffsetSize + len(r.name)
+	chunkData := make([]byte, metadataChunkLength+8)
+	binary.LittleEndian.PutUint16(chunkData[2:6], uint16(metadataChunkLength))
+
+	data := chunkData[8:]
+
+	// root block has first two bytes both set to 0, which distinguishes from update bytes
+	binary.LittleEndian.PutUint64(data[:8], r.startTime)
+	binary.LittleEndian.PutUint64(data[8:16], r.frequency)
+	copy(data[16:16+len(r.name)], []byte(r.name))
+	copy(data[16+len(r.name):], r.ownerAddr[:])
+
+	return chunkData
+}
+
+func (r *resourceMetadata) hash() (rootAddr, metaHash []byte, chunkData []byte) {
+
+	chunkData = r.MarshalBinary()
+	metaHash, rootAddr = metadataHash(chunkData)
+	return metaHash, rootAddr, chunkData
+
+}
+
+func metadataHash(chunkData []byte) (rootAddr, metaHash []byte) {
+	hasher := hashPool.Get().(storage.SwarmHash)
+	defer hashPool.Put(hasher)
+	hasher.Reset()
+	hasher.Write(chunkData[:len(chunkData)-common.AddressLength])
+	metaHash = hasher.Sum(nil)
+	hasher.Reset()
+	hasher.Write(metaHash)
+	hasher.Write(chunkData[len(chunkData)-common.AddressLength:])
+	rootAddr = hasher.Sum(nil)
+	return
+}

--- a/swarm/storage/mru/testutil.go
+++ b/swarm/storage/mru/testutil.go
@@ -48,7 +48,7 @@ func NewTestHandler(datadir string, params *HandlerParams) (*TestHandler, error)
 	if err != nil {
 		return nil, fmt.Errorf("localstore create fail, path %s: %v", path, err)
 	}
-	localStore.Validators = append(localStore.Validators, storage.NewContentAddressValidator(storage.MakeHashFunc(resourceHash)))
+	localStore.Validators = append(localStore.Validators, storage.NewContentAddressValidator(storage.MakeHashFunc(resourceHashAlgorithm)))
 	localStore.Validators = append(localStore.Validators, rh)
 	netStore := storage.NewNetStore(localStore, nil)
 	rh.SetStore(netStore)

--- a/swarm/storage/mru/updaterequest.go
+++ b/swarm/storage/mru/updaterequest.go
@@ -1,0 +1,277 @@
+package mru
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/swarm/storage"
+)
+
+const signatureLength = 65
+
+// Signature is an alias for a static byte array with the size of a signature
+type Signature [signatureLength]byte
+
+type mruRequestJSON struct {
+	Name      string `json:"name"`
+	Frequency uint64 `json:"frequency"`
+	StartTime uint64 `json:"startTime,omitempty"`
+	OwnerAddr string `json:"ownerAddr"`
+	RootAddr  string `json:"rootAddr,omitempty"`
+	MetaHash  string `json:"metaHash,omitempty"`
+	Version   uint32 `json:"version"`
+	Period    uint32 `json:"period"`
+	Data      string `json:"data,omitempty"`
+	Multihash bool   `json:"multiHash"`
+	Signature string `json:"signature,omitempty"`
+}
+
+type SignedResourceUpdate struct {
+	resourceUpdate
+	signature *Signature
+	key       storage.Address
+}
+
+type UpdateRequest struct {
+	SignedResourceUpdate
+	resourceMetadata
+}
+
+func (mj *mruRequestJSON) decode() (smr *UpdateRequest, err error) {
+
+	// make sure name only contains ascii values
+	if !isSafeName(mj.Name) {
+		return nil, NewError(ErrInvalidValue, fmt.Sprintf("Invalid name: '%s'", mj.Name))
+	}
+
+	mr := &UpdateRequest{
+		SignedResourceUpdate: SignedResourceUpdate{
+			resourceUpdate: resourceUpdate{
+				version:   mj.Version,
+				period:    mj.Period,
+				multihash: mj.Multihash,
+			},
+		},
+		resourceMetadata: resourceMetadata{
+			name:      mj.Name,
+			frequency: mj.Frequency,
+			startTime: mj.StartTime,
+		},
+	}
+
+	ownerAddrBytes, err := hexutil.Decode(mj.OwnerAddr)
+	if err != nil || len(ownerAddrBytes) != common.AddressLength {
+		return nil, NewError(ErrInvalidValue, "Cannot decode ownerAddr")
+	}
+	copy(mr.ownerAddr[:], ownerAddrBytes)
+
+	if mj.Data != "" {
+		mr.data, err = hexutil.Decode(mj.Data)
+		if err != nil {
+			return nil, NewError(ErrInvalidValue, "Cannot decode data")
+		}
+	}
+	if mj.RootAddr != "" {
+		mr.rootAddr, err = hexutil.Decode(mj.RootAddr)
+		if err != nil {
+			return nil, NewError(ErrInvalidValue, "Cannot decode rootAddr")
+		}
+	}
+
+	if mj.MetaHash != "" {
+		mr.metaHash, err = hexutil.Decode(mj.MetaHash)
+		if err != nil {
+			return nil, NewError(ErrInvalidValue, "Cannot decode metaHash")
+		}
+	}
+
+	if mj.Signature != "" {
+		sigBytes, err := hexutil.Decode(mj.Signature)
+		if err != nil || len(sigBytes) != signatureLength {
+			return nil, NewError(ErrInvalidSignature, "Cannot decode signature")
+		}
+		mr.signature = new(Signature)
+		copy(mr.signature[:], sigBytes)
+	}
+	return mr, nil
+}
+
+func NewUpdateRequest(name string, frequency, startTime uint64, ownerAddr common.Address, data []byte, multihash bool) (*UpdateRequest, error) {
+	if !isSafeName(name) {
+		return nil, NewError(ErrInvalidValue, fmt.Sprintf("Invalid name: '%s' when creating NewMruRequest", name))
+	}
+
+	if startTime == 0 {
+		startTime = uint64(time.Now().Unix())
+	}
+
+	updateRequest := &UpdateRequest{
+		SignedResourceUpdate: SignedResourceUpdate{
+			resourceUpdate: resourceUpdate{
+				version:   1,
+				period:    1,
+				data:      data,
+				multihash: multihash,
+			},
+		},
+		resourceMetadata: resourceMetadata{
+			name:      name,
+			frequency: frequency,
+			startTime: startTime,
+			ownerAddr: ownerAddr,
+		},
+	}
+
+	updateRequest.rootAddr, updateRequest.metaHash, _ = updateRequest.resourceMetadata.hash()
+
+	return updateRequest, nil
+}
+
+func (mr *UpdateRequest) Verify() error {
+	key := resourceHash(mr.period, mr.version, mr.rootAddr)
+	digest := keyDataHash(key, mr.metaHash, mr.data)
+	// get the address of the signer (which also checks that it's a valid signature)
+	addr, err := getAddressFromDataSig(digest, *mr.signature)
+	if err != nil {
+		return err
+	}
+	if addr != mr.ownerAddr {
+		return NewError(ErrInvalidSignature, "Signature address does not match with ownerAddr")
+	}
+	_, err = mr.SignedResourceUpdate.Verify(key)
+	return err
+}
+
+func (mr *UpdateRequest) Sign(signer Signer) error {
+	if err := mr.SignedResourceUpdate.Sign(signer); err != nil {
+		return err
+	}
+	mr.ownerAddr = signer.Address()
+	return nil
+}
+
+func (mr *UpdateRequest) Frequency() uint64 {
+	return mr.frequency
+}
+
+func (mr *UpdateRequest) Name() string {
+	return mr.name
+}
+
+func (mr *UpdateRequest) Multihash() bool {
+	return mr.multihash
+}
+
+func (mr *UpdateRequest) Version() uint32 {
+	return mr.version
+}
+func (mr *UpdateRequest) Period() uint32 {
+	return mr.period
+}
+func (mr *UpdateRequest) StartTime() uint64 {
+	return mr.startTime
+}
+func (mr *UpdateRequest) OwnerAddr() common.Address {
+	return mr.ownerAddr
+}
+func (mr *UpdateRequest) RootAddr() storage.Address {
+	return mr.rootAddr
+}
+
+func (mu *SignedResourceUpdate) Verify(key storage.Address) (ownerAddr common.Address, err error) {
+	if len(mu.data) == 0 {
+		return ownerAddr, NewError(ErrInvalidValue, "I refuse to waste swarm space for updates with empty values, amigo (data length is 0)")
+	}
+	if mu.signature == nil {
+		return ownerAddr, NewError(ErrInvalidSignature, "Missing signature field")
+	}
+
+	digest := keyDataHash(key, mu.metaHash, mu.data)
+
+	// get the address of the signer (which also checks that it's a valid signature)
+	ownerAddr, err = getAddressFromDataSig(digest, *mu.signature)
+	if err != nil {
+		return ownerAddr, err
+	}
+
+	if !bytes.Equal(key, resourceHash(mu.period, mu.version, mu.rootAddr)) {
+		return ownerAddr, NewError(ErrInvalidSignature, "Signature address does not match with ownerAddr")
+	}
+	/*	if !verifyResourceOwnership(ownerAddr, mu.metaHash, mu.rootAddr) {
+			return NewError(ErrInvalidSignature, "Signature address does not match with ownerAddr")
+		}
+	*/
+	mu.key = key
+	return ownerAddr, nil
+}
+
+func (mu *SignedResourceUpdate) Sign(signer Signer) error {
+
+	key := resourceHash(mu.period, mu.version, mu.rootAddr)
+
+	digest := keyDataHash(key, mu.metaHash, mu.data)
+	signature, err := signer.Sign(digest)
+	if err != nil {
+		return err
+	}
+	ownerAddress, err := getAddressFromDataSig(digest, signature)
+	if err != nil {
+		return NewError(ErrInvalidSignature, "Error verifying signature")
+	}
+	if ownerAddress != signer.Address() {
+		return NewError(ErrInvalidSignature, "Signer address does not match private key")
+	}
+	mu.signature = &signature
+	mu.key = key
+	return nil
+}
+
+func (mr *UpdateRequest) SetData(data []byte) {
+	mr.signature = nil
+	mr.data = data
+	mr.frequency = 0 //mark as update
+}
+
+func DecodeMruRequest(rawData []byte) (*UpdateRequest, error) {
+	var requestJSON mruRequestJSON
+	if err := json.Unmarshal(rawData, &requestJSON); err != nil {
+		return nil, err
+	}
+	return requestJSON.decode()
+}
+
+func EncodeMruRequest(mruRequest *UpdateRequest) (rawData []byte, err error) {
+	var signatureString, dataHashString, rootAddrString, metaHashString string
+	if mruRequest.signature != nil {
+		signatureString = hexutil.Encode(mruRequest.signature[:])
+	}
+	if mruRequest.data != nil {
+		dataHashString = hexutil.Encode(mruRequest.data)
+	}
+	if mruRequest.rootAddr != nil {
+		rootAddrString = hexutil.Encode(mruRequest.rootAddr)
+	}
+	if mruRequest.metaHash != nil {
+		metaHashString = hexutil.Encode(mruRequest.metaHash)
+	}
+
+	requestJSON := &mruRequestJSON{
+		Name:      mruRequest.name,
+		Frequency: mruRequest.frequency,
+		StartTime: mruRequest.startTime,
+		Version:   mruRequest.version,
+		Period:    mruRequest.period,
+		OwnerAddr: hexutil.Encode(mruRequest.ownerAddr[:]),
+		Data:      dataHashString,
+		Multihash: mruRequest.multihash,
+		Signature: signatureString,
+		RootAddr:  rootAddrString,
+		MetaHash:  metaHashString,
+	}
+
+	return json.Marshal(requestJSON)
+}

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -190,17 +190,9 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 	var resourceHandler *mru.Handler
 	rhparams := &mru.HandlerParams{
 		// TODO: config parameter to set limits
-		Signer: mru.NewGenericSigner(self.privateKey),
+
 	}
-	if resolver != nil {
-		resolver.SetNameHash(ens.EnsNode)
-		// Set HeaderGetter to resolver only if it is not nil.
-		rhparams.HeaderGetter = resolver
-	} else {
-		log.Warn("No ETH API specified, resource updates will use block height approximation")
-		// TODO: blockestimator should use saved values derived from last time ethclient was connected
-		rhparams.HeaderGetter = mru.NewBlockEstimator()
-	}
+
 	resourceHandler, err = mru.NewHandler(rhparams)
 	if err != nil {
 		return nil, err

--- a/swarm/testutil/http.go
+++ b/swarm/testutil/http.go
@@ -17,16 +17,15 @@
 package testutil
 
 import (
-	"context"
 	"io/ioutil"
-	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethereum/go-ethereum/metrics/influxdb"
 	"github.com/ethereum/go-ethereum/swarm/api"
 	"github.com/ethereum/go-ethereum/swarm/storage"
 	"github.com/ethereum/go-ethereum/swarm/storage/mru"
@@ -36,16 +35,17 @@ type TestServer interface {
 	ServeHTTP(http.ResponseWriter, *http.Request)
 }
 
-type fakeBackend struct {
-	blocknumber int64
+// simulated timeProvider
+type fakeTimeProvider struct {
+	currentTime uint64
 }
 
-func (f *fakeBackend) HeaderByNumber(context context.Context, _ string, bigblock *big.Int) (*types.Header, error) {
-	f.blocknumber++
-	biggie := big.NewInt(f.blocknumber)
-	return &types.Header{
-		Number: biggie,
-	}, nil
+func (f *fakeTimeProvider) Tick() {
+	f.currentTime++
+}
+
+func (f *fakeTimeProvider) GetCurrentTime() uint64 {
+	return f.currentTime
 }
 
 func NewTestSwarmServer(t *testing.T, serverFunc func(*api.API) TestServer) *TestSwarmServer {
@@ -70,19 +70,12 @@ func NewTestSwarmServer(t *testing.T, serverFunc func(*api.API) TestServer) *Tes
 		t.Fatal(err)
 	}
 
-	// signer
-	privKeyBytes := [32]byte{}
-	privKeyBytes[0] = 0x2a
-	privKey, err := crypto.ToECDSA(privKeyBytes[:])
-	if err != nil {
-		t.Fatal(err)
+	fakeTimeProvider := &fakeTimeProvider{
+		currentTime: 42,
 	}
-	signer := mru.NewGenericSigner(privKey)
+
 	rhparams := &mru.HandlerParams{
-		Signer: signer,
-		HeaderGetter: &fakeBackend{
-			blocknumber: 42,
-		},
+		TimestampProvider: fakeTimeProvider,
 	}
 	rh, err := mru.NewTestHandler(resourceDir, rhparams)
 	if err != nil {
@@ -92,10 +85,11 @@ func NewTestSwarmServer(t *testing.T, serverFunc func(*api.API) TestServer) *Tes
 	a := api.NewAPI(fileStore, nil, rh.Handler)
 	srv := httptest.NewServer(serverFunc(a))
 	return &TestSwarmServer{
-		Server:    srv,
-		FileStore: fileStore,
-		dir:       dir,
-		Hasher:    storage.MakeHashFunc(storage.DefaultHash)(),
+		Server:            srv,
+		FileStore:         fileStore,
+		dir:               dir,
+		Hasher:            storage.MakeHashFunc(storage.DefaultHash)(),
+		timestampProvider: fakeTimeProvider,
 		cleanup: func() {
 			srv.Close()
 			rh.Close()
@@ -107,12 +101,25 @@ func NewTestSwarmServer(t *testing.T, serverFunc func(*api.API) TestServer) *Tes
 
 type TestSwarmServer struct {
 	*httptest.Server
-	Hasher    storage.SwarmHash
-	FileStore *storage.FileStore
-	dir       string
-	cleanup   func()
+	Hasher            storage.SwarmHash
+	FileStore         *storage.FileStore
+	dir               string
+	cleanup           func()
+	timestampProvider *fakeTimeProvider
 }
 
 func (t *TestSwarmServer) Close() {
 	t.cleanup()
+}
+
+func (t *TestSwarmServer) GetCurrentTime() uint64 {
+	return t.timestampProvider.GetCurrentTime()
+}
+
+// EnableMetrics is starting InfluxDB reporter so that we collect stats when running tests locally
+func EnableMetrics() {
+	metrics.Enabled = true
+	go influxdb.InfluxDBWithTags(metrics.DefaultRegistry, 1*time.Second, "http://localhost:8086", "metrics", "admin", "admin", "swarm.", map[string]string{
+		"host": "test",
+	})
 }


### PR DESCRIPTION
As agreed during Tuesday's roundtable review, I am fragmenting PR #704 in incremental steps to make it easier to review. The steps are these:

* **Step 1** : (PR #732) Minimum set of changes for client-side MRU signatures to work + system-time based MRUs. This was the status roughly 8 days ago.
* **Step 2**: (PR #733) Documentation, refactors and new, more concrete unit tests for the new structures
* **Step 3**: (PR #734) Refactor `LookupParams` so that the different combinations are documented. Moved LookupParams to its own file. Reorder code and create separate files for a few structures
* **Step 4** (PR #748): Final refactors. Refactor serialization for extensibility. Refactor Timestamp to a "Timestamp" struct rather than a lone uint64. More comments throughout.
* **Step 5**: (PR #704) Rewrite CLI and simplify client and internal object structure according to comments to decouple resource creation from updating.

Steps 1-4 are created as PRs to `mru-tmp-2` branch (PR #668) so the diff is viewed as incremental from that point, rather than from `swarm-network-rewrite`, which would include @nolash's work too and make it difficult to view what changes this PR exactly brings in.

This code is not fully refactored and "clean" as the one in PR #704. The objective of this PR is to capture the essence of this change and gather comments. Some of the issues you will see may already have been fixed.

For code that has moved, I will comment below where it has gone.

Thank you in advance for your time and patience in reviewing this. I hope you enjoy this feature!