### PR TITLE
client-side mru signatures -- step 2/5

### DIFF
--- a/swarm/storage/mru/resource.go
+++ b/swarm/storage/mru/resource.go
@@ -306,11 +306,6 @@ func (h *Handler) New(ctx context.Context, request *UpdateRequest) error {
 		return NewError(ErrInvalidValue, "ownerAddr must be set to create a new metadata chunk")
 	}
 
-	// get the current time
-	if request.startTime == 0 {
-		request.startTime = h.getCurrentTime(ctx)
-	}
-
 	// create the meta chunk and store it in swarm
 	chunk, metaHash := h.newMetaChunk(&request.resourceMetadata)
 	if request.metaHash != nil && !bytes.Equal(request.metaHash, metaHash) ||

--- a/swarm/storage/mru/updaterequest.go
+++ b/swarm/storage/mru/updaterequest.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -84,6 +85,11 @@ type UpdateRequest struct {
 func NewCreateRequest(name string, frequency, startTime uint64, ownerAddr common.Address, data []byte, multihash bool) (*UpdateRequest, error) {
 	if !isSafeName(name) {
 		return nil, NewError(ErrInvalidValue, fmt.Sprintf("Invalid name: '%s' when creating a new UpdateRequest", name))
+	}
+
+	// get the current time
+	if startTime == 0 {
+		startTime = uint64(time.Now().Unix())
 	}
 
 	updateRequest := &UpdateRequest{


### PR DESCRIPTION
As agreed during Tuesday's roundtable review, I am fragmenting PR #704 in incremental steps to make it easier to review. The steps are these:

* **Step 1** : (PR #732) Minimum set of changes for client-side MRU signatures to work + system-time based MRUs. This was the status roughly 8 days ago.
* **Step 2**: (PR #733) Documentation, refactors and new, more concrete unit tests for the new structures
* **Step 3**: (PR #734) Refactor `LookupParams` so that the different combinations are documented. Moved LookupParams to its own file. Reorder code and create separate files for a few structures
* **Step 4** (PR #748): Final refactors. Refactor serialization for extensibility. Refactor Timestamp to a "Timestamp" struct rather than a lone uint64. More comments throughout.
* **Step 5**: (PR #704) Rewrite CLI and simplify client and internal object structure according to comments to decouple resource creation from updating.
