### PR TITLE
Fix mingw test issues on windows

### DIFF
--- a/cmd/swarm/fs_test.go
+++ b/cmd/swarm/fs_test.go
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
+// +build linux darwin freebsd
+
 package main
 
 import (

--- a/swarm/storage/ldbstore_test.go
+++ b/swarm/storage/ldbstore_test.go
@@ -59,12 +59,12 @@ func newTestDbStore(mock bool, trusted bool) (*testDbStore, func(), error) {
 	}
 
 	cleanup := func() {
-		if err != nil {
+		if db != nil {
 			db.Close()
 		}
 		err = os.RemoveAll(dir)
 		if err != nil {
-			panic("db cleanup failed")
+			panic(fmt.Sprintf("db cleanup failed: %v", err))
 		}
 	}
 

--- a/swarm/swarm_test.go
+++ b/swarm/swarm_test.go
@@ -17,10 +17,12 @@
 package swarm
 
 import (
+	"encoding/hex"
 	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -41,6 +43,13 @@ func TestNewSwarm(t *testing.T) {
 
 	// a simple rpc endpoint for testing dialing
 	ipcEndpoint := path.Join(dir, "TestSwarm.ipc")
+
+	// windows namedpipes are not on filesystem but on NPFS
+	if runtime.GOOS == "windows" {
+		b := make([]byte, 8)
+		rand.Read(b)
+		ipcEndpoint = `\\.\pipe\TestSwarm-` + hex.EncodeToString(b)
+	}
 
 	_, server, err := rpc.StartIPCEndpoint(ipcEndpoint, nil)
 	if err != nil {


### PR DESCRIPTION
This PR fixes three tests that fail on MinGW:

- TestCLISwarmFs - disabled by build tag as FUSE is not supported on Windows. This test has issues with IPC enpoints, as they need to be in form `\\.\pipe\<endpoint>` within windows named pipe namespace. But as FUSE is not supported on windows, this fix is not needed.
- TestNewSwarm - properly create a windows named pipe for IPC.
- TestFileStorerandom - fix panic on cleanup function. If error is not nil, db.Close() is never called and removing temporary directory fails as there are still open files. Close db only if it is not nil.

https://ci.appveyor.com/project/ethereum/go-ethereum/build/master.6843/job/6avaiuafdyn09uit