### PR TITLE
swarm/storage/mru: (UPDATE) Add embedded publickey and remove ENS dependency

### DIFF
--- a/cmd/swarm/fs_test.go
+++ b/cmd/swarm/fs_test.go
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with go-ethereum. If not, see <http://www.gnu.org/licenses/>.
 
+// +build linux darwin freebsd
+
 package main
 
 import (

--- a/cmd/swarm/hash.go
+++ b/cmd/swarm/hash.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -39,7 +40,7 @@ func hash(ctx *cli.Context) {
 
 	stat, _ := f.Stat()
 	fileStore := storage.NewFileStore(storage.NewMapChunkStore(), storage.NewFileStoreParams())
-	addr, _, err := fileStore.Store(f, stat.Size(), false)
+	addr, _, err := fileStore.Store(context.TODO(), f, stat.Size(), false)
 	if err != nil {
 		utils.Fatalf("%v\n", err)
 	} else {

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -155,7 +155,7 @@ var (
 	}
 	SwarmUploadMimeType = cli.StringFlag{
 		Name:  "mime",
-		Usage: "force mime type on upload",
+		Usage: "Manually specify MIME type",
 	}
 	SwarmEncryptedFlag = cli.BoolFlag{
 		Name:  "encrypt",

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -143,7 +143,7 @@ var (
 	}
 	SwarmWantManifestFlag = cli.BoolTFlag{
 		Name:  "manifest",
-		Usage: "Automatic manifest upload",
+		Usage: "Automatic manifest upload (default true)",
 	}
 	SwarmUploadDefaultPath = cli.StringFlag{
 		Name:  "defaultpath",
@@ -155,7 +155,7 @@ var (
 	}
 	SwarmUploadMimeType = cli.StringFlag{
 		Name:  "mime",
-		Usage: "force mime type",
+		Usage: "force mime type on upload",
 	}
 	SwarmEncryptedFlag = cli.BoolFlag{
 		Name:  "encrypt",

--- a/cmd/swarm/swarm-smoke/upload_and_sync.go
+++ b/cmd/swarm/swarm-smoke/upload_and_sync.go
@@ -38,13 +38,13 @@ import (
 
 func generateEndpoints(scheme string, cluster string, from int, to int) {
 	if cluster == "prod" {
-		for port := from; port <= to; port++ {
-			endpoints = append(endpoints, fmt.Sprintf("%s://%v.swarm-gateways.net", scheme, port))
-		}
+		cluster = ""
 	} else {
-		for port := from; port <= to; port++ {
-			endpoints = append(endpoints, fmt.Sprintf("%s://%v.%s.swarm-gateways.net", scheme, port, cluster))
-		}
+		cluster = cluster + "."
+	}
+
+	for port := from; port <= to; port++ {
+		endpoints = append(endpoints, fmt.Sprintf("%s://%v.%sswarm-gateways.net", scheme, port, cluster))
 	}
 
 	if includeLocalhost {

--- a/cmd/swarm/swarm-smoke/upload_and_sync.go
+++ b/cmd/swarm/swarm-smoke/upload_and_sync.go
@@ -37,8 +37,14 @@ import (
 )
 
 func generateEndpoints(scheme string, cluster string, from int, to int) {
-	for port := from; port <= to; port++ {
-		endpoints = append(endpoints, fmt.Sprintf("%s://%v.%s.swarm-gateways.net", scheme, port, cluster))
+	if cluster == "prod" {
+		for port := from; port <= to; port++ {
+			endpoints = append(endpoints, fmt.Sprintf("%s://%v.swarm-gateways.net", scheme, port))
+		}
+	} else {
+		for port := from; port <= to; port++ {
+			endpoints = append(endpoints, fmt.Sprintf("%s://%v.%s.swarm-gateways.net", scheme, port, cluster))
+		}
 	}
 
 	if includeLocalhost {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -58,11 +58,14 @@ func CollectProcessMetrics(refresh time.Duration) {
 	memPauses := GetOrRegisterMeter("system/memory/pauses", DefaultRegistry)
 
 	var diskReads, diskReadBytes, diskWrites, diskWriteBytes Meter
+	var diskReadBytesCounter, diskWriteBytesCounter Counter
 	if err := ReadDiskStats(diskstats[0]); err == nil {
 		diskReads = GetOrRegisterMeter("system/disk/readcount", DefaultRegistry)
 		diskReadBytes = GetOrRegisterMeter("system/disk/readdata", DefaultRegistry)
+		diskReadBytesCounter = GetOrRegisterCounter("system/disk/readbytes", DefaultRegistry)
 		diskWrites = GetOrRegisterMeter("system/disk/writecount", DefaultRegistry)
 		diskWriteBytes = GetOrRegisterMeter("system/disk/writedata", DefaultRegistry)
+		diskWriteBytesCounter = GetOrRegisterCounter("system/disk/writebytes", DefaultRegistry)
 	} else {
 		log.Debug("Failed to read disk metrics", "err", err)
 	}
@@ -82,6 +85,9 @@ func CollectProcessMetrics(refresh time.Duration) {
 			diskReadBytes.Mark(diskstats[location1].ReadBytes - diskstats[location2].ReadBytes)
 			diskWrites.Mark(diskstats[location1].WriteCount - diskstats[location2].WriteCount)
 			diskWriteBytes.Mark(diskstats[location1].WriteBytes - diskstats[location2].WriteBytes)
+
+			diskReadBytesCounter.Inc(diskstats[location1].ReadBytes - diskstats[location2].ReadBytes)
+			diskWriteBytesCounter.Inc(diskstats[location1].WriteBytes - diskstats[location2].WriteBytes)
 		}
 		time.Sleep(refresh)
 	}

--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -227,28 +227,28 @@ func NewAPI(fileStore *storage.FileStore, dns Resolver, resourceHandler *mru.Han
 }
 
 // Upload to be used only in TEST
-func (a *API) Upload(uploadDir, index string, toEncrypt bool) (hash string, err error) {
+func (a *API) Upload(ctx context.Context, uploadDir, index string, toEncrypt bool) (hash string, err error) {
 	fs := NewFileSystem(a)
 	hash, err = fs.Upload(uploadDir, index, toEncrypt)
 	return hash, err
 }
 
 // Retrieve FileStore reader API
-func (a *API) Retrieve(addr storage.Address) (reader storage.LazySectionReader, isEncrypted bool) {
-	return a.fileStore.Retrieve(addr)
+func (a *API) Retrieve(ctx context.Context, addr storage.Address) (reader storage.LazySectionReader, isEncrypted bool) {
+	return a.fileStore.Retrieve(ctx, addr)
 }
 
 // Store wraps the Store API call of the embedded FileStore
-func (a *API) Store(data io.Reader, size int64, toEncrypt bool) (addr storage.Address, wait func(), err error) {
+func (a *API) Store(ctx context.Context, data io.Reader, size int64, toEncrypt bool) (addr storage.Address, wait func(), err error) {
 	log.Debug("api.store", "size", size)
-	return a.fileStore.Store(data, size, toEncrypt)
+	return a.fileStore.Store(ctx, data, size, toEncrypt)
 }
 
 // ErrResolve is returned when an URI cannot be resolved from ENS.
 type ErrResolve error
 
 // Resolve resolves a URI to an Address using the MultiResolver.
-func (a *API) Resolve(uri *URI) (storage.Address, error) {
+func (a *API) Resolve(ctx context.Context, uri *URI) (storage.Address, error) {
 	apiResolveCount.Inc(1)
 	log.Trace("resolving", "uri", uri.Addr)
 
@@ -286,17 +286,17 @@ func (a *API) Resolve(uri *URI) (storage.Address, error) {
 }
 
 // Put provides singleton manifest creation on top of FileStore store
-func (a *API) Put(content, contentType string, toEncrypt bool) (k storage.Address, wait func(), err error) {
+func (a *API) Put(ctx context.Context, content string, contentType string, toEncrypt bool) (k storage.Address, wait func(), err error) {
 	apiPutCount.Inc(1)
 	r := strings.NewReader(content)
-	key, waitContent, err := a.fileStore.Store(r, int64(len(content)), toEncrypt)
+	key, waitContent, err := a.fileStore.Store(ctx, r, int64(len(content)), toEncrypt)
 	if err != nil {
 		apiPutFail.Inc(1)
 		return nil, nil, err
 	}
 	manifest := fmt.Sprintf(`{"entries":[{"hash":"%v","contentType":"%s"}]}`, key, contentType)
 	r = strings.NewReader(manifest)
-	key, waitManifest, err := a.fileStore.Store(r, int64(len(manifest)), toEncrypt)
+	key, waitManifest, err := a.fileStore.Store(ctx, r, int64(len(manifest)), toEncrypt)
 	if err != nil {
 		apiPutFail.Inc(1)
 		return nil, nil, err
@@ -310,10 +310,10 @@ func (a *API) Put(content, contentType string, toEncrypt bool) (k storage.Addres
 // Get uses iterative manifest retrieval and prefix matching
 // to resolve basePath to content using FileStore retrieve
 // it returns a section reader, mimeType, status, the key of the actual content and an error
-func (a *API) Get(manifestAddr storage.Address, path string) (reader storage.LazySectionReader, mimeType string, status int, contentAddr storage.Address, err error) {
+func (a *API) Get(ctx context.Context, manifestAddr storage.Address, path string) (reader storage.LazySectionReader, mimeType string, status int, contentAddr storage.Address, err error) {
 	log.Debug("api.get", "key", manifestAddr, "path", path)
 	apiGetCount.Inc(1)
-	trie, err := loadManifest(a.fileStore, manifestAddr, nil)
+	trie, err := loadManifest(ctx, a.fileStore, manifestAddr, nil)
 	if err != nil {
 		apiGetNotFound.Inc(1)
 		status = http.StatusNotFound
@@ -375,7 +375,7 @@ func (a *API) Get(manifestAddr storage.Address, path string) (reader storage.Laz
 				log.Trace("resource is multihash", "key", manifestAddr)
 
 				// get the manifest the multihash digest points to
-				trie, err := loadManifest(a.fileStore, manifestAddr, nil)
+				trie, err := loadManifest(ctx, a.fileStore, manifestAddr, nil)
 				if err != nil {
 					apiGetNotFound.Inc(1)
 					status = http.StatusNotFound
@@ -410,7 +410,7 @@ func (a *API) Get(manifestAddr storage.Address, path string) (reader storage.Laz
 		}
 		mimeType = entry.ContentType
 		log.Debug("content lookup key", "key", contentAddr, "mimetype", mimeType)
-		reader, _ = a.fileStore.Retrieve(contentAddr)
+		reader, _ = a.fileStore.Retrieve(ctx, contentAddr)
 	} else {
 		// no entry found
 		status = http.StatusNotFound
@@ -422,10 +422,10 @@ func (a *API) Get(manifestAddr storage.Address, path string) (reader storage.Laz
 }
 
 // Modify loads manifest and checks the content hash before recalculating and storing the manifest.
-func (a *API) Modify(addr storage.Address, path, contentHash, contentType string) (storage.Address, error) {
+func (a *API) Modify(ctx context.Context, addr storage.Address, path, contentHash, contentType string) (storage.Address, error) {
 	apiModifyCount.Inc(1)
 	quitC := make(chan bool)
-	trie, err := loadManifest(a.fileStore, addr, quitC)
+	trie, err := loadManifest(ctx, a.fileStore, addr, quitC)
 	if err != nil {
 		apiModifyFail.Inc(1)
 		return nil, err
@@ -449,7 +449,7 @@ func (a *API) Modify(addr storage.Address, path, contentHash, contentType string
 }
 
 // AddFile creates a new manifest entry, adds it to swarm, then adds a file to swarm.
-func (a *API) AddFile(mhash, path, fname string, content []byte, nameresolver bool) (storage.Address, string, error) {
+func (a *API) AddFile(ctx context.Context, mhash, path, fname string, content []byte, nameresolver bool) (storage.Address, string, error) {
 	apiAddFileCount.Inc(1)
 
 	uri, err := Parse("bzz:/" + mhash)
@@ -457,7 +457,7 @@ func (a *API) AddFile(mhash, path, fname string, content []byte, nameresolver bo
 		apiAddFileFail.Inc(1)
 		return nil, "", err
 	}
-	mkey, err := a.Resolve(uri)
+	mkey, err := a.Resolve(ctx, uri)
 	if err != nil {
 		apiAddFileFail.Inc(1)
 		return nil, "", err
@@ -476,13 +476,13 @@ func (a *API) AddFile(mhash, path, fname string, content []byte, nameresolver bo
 		ModTime:     time.Now(),
 	}
 
-	mw, err := a.NewManifestWriter(mkey, nil)
+	mw, err := a.NewManifestWriter(ctx, mkey, nil)
 	if err != nil {
 		apiAddFileFail.Inc(1)
 		return nil, "", err
 	}
 
-	fkey, err := mw.AddEntry(bytes.NewReader(content), entry)
+	fkey, err := mw.AddEntry(ctx, bytes.NewReader(content), entry)
 	if err != nil {
 		apiAddFileFail.Inc(1)
 		return nil, "", err
@@ -496,11 +496,10 @@ func (a *API) AddFile(mhash, path, fname string, content []byte, nameresolver bo
 	}
 
 	return fkey, newMkey.String(), nil
-
 }
 
 // RemoveFile removes a file entry in a manifest.
-func (a *API) RemoveFile(mhash, path, fname string, nameresolver bool) (string, error) {
+func (a *API) RemoveFile(ctx context.Context, mhash string, path string, fname string, nameresolver bool) (string, error) {
 	apiRmFileCount.Inc(1)
 
 	uri, err := Parse("bzz:/" + mhash)
@@ -508,7 +507,7 @@ func (a *API) RemoveFile(mhash, path, fname string, nameresolver bool) (string, 
 		apiRmFileFail.Inc(1)
 		return "", err
 	}
-	mkey, err := a.Resolve(uri)
+	mkey, err := a.Resolve(ctx, uri)
 	if err != nil {
 		apiRmFileFail.Inc(1)
 		return "", err
@@ -519,7 +518,7 @@ func (a *API) RemoveFile(mhash, path, fname string, nameresolver bool) (string, 
 		path = path[1:]
 	}
 
-	mw, err := a.NewManifestWriter(mkey, nil)
+	mw, err := a.NewManifestWriter(ctx, mkey, nil)
 	if err != nil {
 		apiRmFileFail.Inc(1)
 		return "", err
@@ -542,7 +541,7 @@ func (a *API) RemoveFile(mhash, path, fname string, nameresolver bool) (string, 
 }
 
 // AppendFile removes old manifest, appends file entry to new manifest and adds it to Swarm.
-func (a *API) AppendFile(mhash, path, fname string, existingSize int64, content []byte, oldAddr storage.Address, offset int64, addSize int64, nameresolver bool) (storage.Address, string, error) {
+func (a *API) AppendFile(ctx context.Context, mhash, path, fname string, existingSize int64, content []byte, oldAddr storage.Address, offset int64, addSize int64, nameresolver bool) (storage.Address, string, error) {
 	apiAppendFileCount.Inc(1)
 
 	buffSize := offset + addSize
@@ -552,7 +551,7 @@ func (a *API) AppendFile(mhash, path, fname string, existingSize int64, content 
 
 	buf := make([]byte, buffSize)
 
-	oldReader, _ := a.Retrieve(oldAddr)
+	oldReader, _ := a.Retrieve(ctx, oldAddr)
 	io.ReadAtLeast(oldReader, buf, int(offset))
 
 	newReader := bytes.NewReader(content)
@@ -575,7 +574,7 @@ func (a *API) AppendFile(mhash, path, fname string, existingSize int64, content 
 		apiAppendFileFail.Inc(1)
 		return nil, "", err
 	}
-	mkey, err := a.Resolve(uri)
+	mkey, err := a.Resolve(ctx, uri)
 	if err != nil {
 		apiAppendFileFail.Inc(1)
 		return nil, "", err
@@ -586,7 +585,7 @@ func (a *API) AppendFile(mhash, path, fname string, existingSize int64, content 
 		path = path[1:]
 	}
 
-	mw, err := a.NewManifestWriter(mkey, nil)
+	mw, err := a.NewManifestWriter(ctx, mkey, nil)
 	if err != nil {
 		apiAppendFileFail.Inc(1)
 		return nil, "", err
@@ -606,7 +605,7 @@ func (a *API) AppendFile(mhash, path, fname string, existingSize int64, content 
 		ModTime:     time.Now(),
 	}
 
-	fkey, err := mw.AddEntry(io.Reader(combinedReader), entry)
+	fkey, err := mw.AddEntry(ctx, io.Reader(combinedReader), entry)
 	if err != nil {
 		apiAppendFileFail.Inc(1)
 		return nil, "", err
@@ -620,23 +619,22 @@ func (a *API) AppendFile(mhash, path, fname string, existingSize int64, content 
 	}
 
 	return fkey, newMkey.String(), nil
-
 }
 
 // BuildDirectoryTree used by swarmfs_unix
-func (a *API) BuildDirectoryTree(mhash string, nameresolver bool) (addr storage.Address, manifestEntryMap map[string]*manifestTrieEntry, err error) {
+func (a *API) BuildDirectoryTree(ctx context.Context, mhash string, nameresolver bool) (addr storage.Address, manifestEntryMap map[string]*manifestTrieEntry, err error) {
 
 	uri, err := Parse("bzz:/" + mhash)
 	if err != nil {
 		return nil, nil, err
 	}
-	addr, err = a.Resolve(uri)
+	addr, err = a.Resolve(ctx, uri)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	quitC := make(chan bool)
-	rootTrie, err := loadManifest(a.fileStore, addr, quitC)
+	rootTrie, err := loadManifest(ctx, a.fileStore, addr, quitC)
 	if err != nil {
 		return nil, nil, fmt.Errorf("can't load manifest %v: %v", addr.String(), err)
 	}
@@ -725,8 +723,8 @@ func (a *API) ResourceIsValidated() bool {
 }
 
 // ResolveResourceManifest retrieves the Mutable Resource manifest for the given address, and returns the address of the metadata chunk.
-func (a *API) ResolveResourceManifest(addr storage.Address) (storage.Address, error) {
-	trie, err := loadManifest(a.fileStore, addr, nil)
+func (a *API) ResolveResourceManifest(ctx context.Context, addr storage.Address) (storage.Address, error) {
+	trie, err := loadManifest(ctx, a.fileStore, addr, nil)
 	if err != nil {
 		return nil, fmt.Errorf("cannot load resource manifest: %v", err)
 	}

--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -720,11 +720,6 @@ func (a *API) ResourceHashSize() int {
 	return a.resource.HashSize
 }
 
-// ResourceIsValidated checks if the Mutable Resource has an active content validator.
-func (a *API) ResourceIsValidated() bool {
-	return a.resource.IsValidated()
-}
-
 // ResolveResourceManifest retrieves the Mutable Resource manifest for the given address, and returns the address of the metadata chunk.
 func (a *API) ResolveResourceManifest(ctx context.Context, addr storage.Address) (storage.Address, error) {
 	trie, err := loadManifest(ctx, a.fileStore, addr, nil)

--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -660,7 +660,7 @@ func (a *API) BuildDirectoryTree(ctx context.Context, mhash string, nameresolver
 }
 
 // Look up mutable resource updates at specific periods and versions
-func (a *Api) ResourceLookup(ctx context.Context, params *mru.LookupParams) (string, []byte, error) {
+func (a *API) ResourceLookup(ctx context.Context, params *mru.LookupParams) (string, []byte, error) {
 	var err error
 	rsrc, err := a.resource.Load(params.Root)
 	if err != nil {
@@ -689,17 +689,17 @@ func (a *API) ResourceCreate(ctx context.Context, name string, frequency uint64)
 
 // ResourceUpdateMultihash updates a Mutable Resource and marks the update's content to be of multihash type, which will be recognized upon retrieval.
 // It will fail if the data is not a valid multihash.
-func (a *Api) ResourceUpdateMultihash(ctx context.Context, addr storage.Address, data []byte) (storage.Address, uint32, uint32, error) {
+func (a *API) ResourceUpdateMultihash(ctx context.Context, addr storage.Address, data []byte) (storage.Address, uint32, uint32, error) {
 	return a.resourceUpdate(ctx, addr, data, true)
 }
 
 // ResourceUpdate updates a Mutable Resource with arbitrary data.
 // Upon retrieval the update will be retrieved verbatim as bytes.
-func (a *Api) ResourceUpdate(ctx context.Context, addr storage.Address, data []byte) (storage.Address, uint32, uint32, error) {
+func (a *API) ResourceUpdate(ctx context.Context, addr storage.Address, data []byte) (storage.Address, uint32, uint32, error) {
 	return a.resourceUpdate(ctx, addr, data, false)
 }
 
-func (a *Api) resourceUpdate(ctx context.Context, rootAddr storage.Address, data []byte, multihash bool) (storage.Address, uint32, uint32, error) {
+func (a *API) resourceUpdate(ctx context.Context, rootAddr storage.Address, data []byte, multihash bool) (storage.Address, uint32, uint32, error) {
 	var updateAddr storage.Address
 	var err error
 	if multihash {

--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -336,7 +336,8 @@ func (a *API) Get(ctx context.Context, manifestAddr storage.Address, path string
 			log.Trace("resource type", "key", manifestAddr, "hash", entry.Hash)
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			rsrc, err := a.resource.Load(storage.Address(common.FromHex(entry.Hash)))
+			metadataChunkKey := storage.Address(common.FromHex(entry.Hash))
+			rsrc, err := a.resource.Load(metadataChunkKey)
 			if err != nil {
 				apiGetNotFound.Inc(1)
 				status = http.StatusNotFound
@@ -345,7 +346,11 @@ func (a *API) Get(ctx context.Context, manifestAddr storage.Address, path string
 			}
 
 			// use this key to retrieve the latest update
-			rsrc, err = a.resource.LookupLatest(ctx, rsrc.NameHash(), true, &mru.LookupParams{})
+			params := &mru.LookupParams{
+				Root: metadataChunkKey,
+			}
+			//rsrc, err = self.resource.LookupLatest(ctx, rsrc.NameHash(), true, &mru.LookupParams{})
+			rsrc, err = a.resource.Lookup(ctx, params)
 			if err != nil {
 				apiGetNotFound.Inc(1)
 				status = http.StatusNotFound
@@ -358,7 +363,8 @@ func (a *API) Get(ctx context.Context, manifestAddr storage.Address, path string
 			if rsrc.Multihash {
 
 				// get the data of the update
-				_, rsrcData, err := a.resource.GetContent(rsrc.NameHash().Hex())
+				//_, rsrcData, err := self.resource.GetContent(rsrc.NameHash().Hex())
+				_, rsrcData, err := a.resource.GetContent(metadataChunkKey)
 				if err != nil {
 					apiGetNotFound.Inc(1)
 					status = http.StatusNotFound
@@ -653,28 +659,30 @@ func (a *API) BuildDirectoryTree(ctx context.Context, mhash string, nameresolver
 	return addr, manifestEntryMap, nil
 }
 
-// ResourceLookup Looks up mutable resource updates at specific periods and versions
-func (a *API) ResourceLookup(ctx context.Context, addr storage.Address, period uint32, version uint32, maxLookup *mru.LookupParams) (string, []byte, error) {
+// Look up mutable resource updates at specific periods and versions
+func (a *Api) ResourceLookup(ctx context.Context, params *mru.LookupParams) (string, []byte, error) {
 	var err error
-	rsrc, err := a.resource.Load(addr)
+	rsrc, err := a.resource.Load(params.Root)
 	if err != nil {
 		return "", nil, err
 	}
-	if version != 0 {
-		if period == 0 {
-			return "", nil, mru.NewError(mru.ErrInvalidValue, "Period can't be 0")
-		}
-		_, err = a.resource.LookupVersion(ctx, rsrc.NameHash(), period, version, true, maxLookup)
-	} else if period != 0 {
-		_, err = a.resource.LookupHistorical(ctx, rsrc.NameHash(), period, true, maxLookup)
-	} else {
-		_, err = a.resource.LookupLatest(ctx, rsrc.NameHash(), true, maxLookup)
-	}
+	//	if version != 0 {
+	//		if period == 0 {
+	//			return "", nil, mru.NewError(mru.ErrInvalidValue, "Period can't be 0")
+	//		}
+	//		_, err = self.resource.LookupVersion(ctx, rsrc.NameHash(), period, version, true, maxLookup)
+	//	} else if period != 0 {
+	//		_, err = self.resource.LookupHistorical(ctx, rsrc.NameHash(), period, true, maxLookup)
+	//	} else {
+	//		_, err = self.resource.LookupLatest(ctx, rsrc.NameHash(), true, maxLookup)
+	//	}
+	_, err = a.resource.Lookup(ctx, params)
 	if err != nil {
 		return "", nil, err
 	}
 	var data []byte
-	_, data, err = a.resource.GetContent(rsrc.NameHash().Hex())
+	//_, data, err = self.resource.GetContent(rsrc.NameHash().Hex())
+	_, data, err = a.resource.GetContent(params.Root)
 	if err != nil {
 		return "", nil, err
 	}
@@ -692,27 +700,27 @@ func (a *API) ResourceCreate(ctx context.Context, name string, frequency uint64)
 
 // ResourceUpdateMultihash updates a Mutable Resource and marks the update's content to be of multihash type, which will be recognized upon retrieval.
 // It will fail if the data is not a valid multihash.
-func (a *API) ResourceUpdateMultihash(ctx context.Context, name string, data []byte) (storage.Address, uint32, uint32, error) {
-	return a.resourceUpdate(ctx, name, data, true)
+func (a *Api) ResourceUpdateMultihash(ctx context.Context, addr storage.Address, data []byte) (storage.Address, uint32, uint32, error) {
+	return a.resourceUpdate(ctx, addr, data, true)
 }
 
 // ResourceUpdate updates a Mutable Resource with arbitrary data.
 // Upon retrieval the update will be retrieved verbatim as bytes.
-func (a *API) ResourceUpdate(ctx context.Context, name string, data []byte) (storage.Address, uint32, uint32, error) {
-	return a.resourceUpdate(ctx, name, data, false)
+func (a *Api) ResourceUpdate(ctx context.Context, addr storage.Address, data []byte) (storage.Address, uint32, uint32, error) {
+	return a.resourceUpdate(ctx, addr, data, false)
 }
 
-func (a *API) resourceUpdate(ctx context.Context, name string, data []byte, multihash bool) (storage.Address, uint32, uint32, error) {
-	var addr storage.Address
+func (a *Api) resourceUpdate(ctx context.Context, rootAddr storage.Address, data []byte, multihash bool) (storage.Address, uint32, uint32, error) {
+	var updateAddr storage.Address
 	var err error
 	if multihash {
-		addr, err = a.resource.UpdateMultihash(ctx, name, data)
+		updateAddr, err = a.resource.UpdateMultihash(ctx, rootAddr, data)
 	} else {
-		addr, err = a.resource.Update(ctx, name, data)
+		updateAddr, err = a.resource.Update(ctx, rootAddr, data)
 	}
-	period, _ := a.resource.GetLastPeriod(name)
-	version, _ := a.resource.GetVersion(name)
-	return addr, period, version, err
+	period, _ := a.resource.GetLastPeriod(rootAddr)
+	version, _ := a.resource.GetVersion(rootAddr)
+	return updateAddr, period, version, err
 }
 
 // ResourceHashSize returned the size of the digest produced by the Mutable Resource hashing function

--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -666,22 +666,11 @@ func (a *Api) ResourceLookup(ctx context.Context, params *mru.LookupParams) (str
 	if err != nil {
 		return "", nil, err
 	}
-	//	if version != 0 {
-	//		if period == 0 {
-	//			return "", nil, mru.NewError(mru.ErrInvalidValue, "Period can't be 0")
-	//		}
-	//		_, err = self.resource.LookupVersion(ctx, rsrc.NameHash(), period, version, true, maxLookup)
-	//	} else if period != 0 {
-	//		_, err = self.resource.LookupHistorical(ctx, rsrc.NameHash(), period, true, maxLookup)
-	//	} else {
-	//		_, err = self.resource.LookupLatest(ctx, rsrc.NameHash(), true, maxLookup)
-	//	}
 	_, err = a.resource.Lookup(ctx, params)
 	if err != nil {
 		return "", nil, err
 	}
 	var data []byte
-	//_, data, err = self.resource.GetContent(rsrc.NameHash().Hex())
 	_, data, err = a.resource.GetContent(params.Root)
 	if err != nil {
 		return "", nil, err

--- a/swarm/api/api_test.go
+++ b/swarm/api/api_test.go
@@ -109,11 +109,15 @@ func TestApiPut(t *testing.T) {
 	testAPI(t, func(api *API, toEncrypt bool) {
 		content := "hello"
 		exp := expResponse(content, "text/plain", 0)
-		addr, wait, err := api.Put(context.TODO(), content, exp.MimeType, toEncrypt)
+		ctx := context.TODO()
+		addr, wait, err := api.Put(ctx, content, exp.MimeType, toEncrypt)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		wait()
+		err = wait(ctx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		resp := testGet(t, api, addr.Hex(), "")
 		checkResponse(t, resp, exp)
 	})

--- a/swarm/api/api_test.go
+++ b/swarm/api/api_test.go
@@ -85,7 +85,7 @@ func expResponse(content string, mimeType string, status int) *Response {
 
 func testGet(t *testing.T, api *API, bzzhash, path string) *testResponse {
 	addr := storage.Address(common.Hex2Bytes(bzzhash))
-	reader, mimeType, status, _, err := api.Get(addr, path)
+	reader, mimeType, status, _, err := api.Get(context.TODO(), addr, path)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -109,8 +109,7 @@ func TestApiPut(t *testing.T) {
 	testAPI(t, func(api *API, toEncrypt bool) {
 		content := "hello"
 		exp := expResponse(content, "text/plain", 0)
-		// exp := expResponse([]byte(content), "text/plain", 0)
-		addr, wait, err := api.Put(content, exp.MimeType, toEncrypt)
+		addr, wait, err := api.Put(context.TODO(), content, exp.MimeType, toEncrypt)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -226,7 +225,7 @@ func TestAPIResolve(t *testing.T) {
 			if x.immutable {
 				uri.Scheme = "bzz-immutable"
 			}
-			res, err := api.Resolve(uri)
+			res, err := api.Resolve(context.TODO(), uri)
 			if err == nil {
 				if x.expectErr != nil {
 					t.Fatalf("expected error %q, got result %q", x.expectErr, res)

--- a/swarm/api/filesystem.go
+++ b/swarm/api/filesystem.go
@@ -114,12 +114,13 @@ func (fs *FileSystem) Upload(lpath, index string, toEncrypt bool) (string, error
 			if err == nil {
 				stat, _ := f.Stat()
 				var hash storage.Address
-				var wait func()
-				hash, wait, err = fs.api.fileStore.Store(context.TODO(), f, stat.Size(), toEncrypt)
+				var wait func(context.Context) error
+				ctx := context.TODO()
+				hash, wait, err = fs.api.fileStore.Store(ctx, f, stat.Size(), toEncrypt)
 				if hash != nil {
 					list[i].Hash = hash.Hex()
 				}
-				wait()
+				err = wait(ctx)
 				awg.Done()
 				if err == nil {
 					first512 := make([]byte, 512)

--- a/swarm/api/filesystem.go
+++ b/swarm/api/filesystem.go
@@ -18,6 +18,7 @@ package api
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -114,7 +115,7 @@ func (fs *FileSystem) Upload(lpath, index string, toEncrypt bool) (string, error
 				stat, _ := f.Stat()
 				var hash storage.Address
 				var wait func()
-				hash, wait, err = fs.api.fileStore.Store(f, stat.Size(), toEncrypt)
+				hash, wait, err = fs.api.fileStore.Store(context.TODO(), f, stat.Size(), toEncrypt)
 				if hash != nil {
 					list[i].Hash = hash.Hex()
 				}
@@ -189,7 +190,7 @@ func (fs *FileSystem) Download(bzzpath, localpath string) error {
 	if err != nil {
 		return err
 	}
-	addr, err := fs.api.Resolve(uri)
+	addr, err := fs.api.Resolve(context.TODO(), uri)
 	if err != nil {
 		return err
 	}
@@ -200,7 +201,7 @@ func (fs *FileSystem) Download(bzzpath, localpath string) error {
 	}
 
 	quitC := make(chan bool)
-	trie, err := loadManifest(fs.api.fileStore, addr, quitC)
+	trie, err := loadManifest(context.TODO(), fs.api.fileStore, addr, quitC)
 	if err != nil {
 		log.Warn(fmt.Sprintf("fs.Download: loadManifestTrie error: %v", err))
 		return err
@@ -273,7 +274,7 @@ func retrieveToFile(quitC chan bool, fileStore *storage.FileStore, addr storage.
 	if err != nil {
 		return err
 	}
-	reader, _ := fileStore.Retrieve(addr)
+	reader, _ := fileStore.Retrieve(context.TODO(), addr)
 	writer := bufio.NewWriter(f)
 	size, err := reader.Size(quitC)
 	if err != nil {

--- a/swarm/api/filesystem_test.go
+++ b/swarm/api/filesystem_test.go
@@ -18,6 +18,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -63,7 +64,7 @@ func TestApiDirUpload0(t *testing.T) {
 		checkResponse(t, resp, exp)
 
 		addr := storage.Address(common.Hex2Bytes(bzzhash))
-		_, _, _, _, err = api.Get(addr, "")
+		_, _, _, _, err = api.Get(context.TODO(), addr, "")
 		if err == nil {
 			t.Fatalf("expected error: %v", err)
 		}
@@ -95,7 +96,7 @@ func TestApiDirUploadModify(t *testing.T) {
 		}
 
 		addr := storage.Address(common.Hex2Bytes(bzzhash))
-		addr, err = api.Modify(addr, "index.html", "", "")
+		addr, err = api.Modify(context.TODO(), addr, "index.html", "", "")
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 			return
@@ -105,18 +106,18 @@ func TestApiDirUploadModify(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 			return
 		}
-		hash, wait, err := api.Store(bytes.NewReader(index), int64(len(index)), toEncrypt)
+		hash, wait, err := api.Store(context.TODO(), bytes.NewReader(index), int64(len(index)), toEncrypt)
 		wait()
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 			return
 		}
-		addr, err = api.Modify(addr, "index2.html", hash.Hex(), "text/html; charset=utf-8")
+		addr, err = api.Modify(context.TODO(), addr, "index2.html", hash.Hex(), "text/html; charset=utf-8")
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 			return
 		}
-		addr, err = api.Modify(addr, "img/logo.png", hash.Hex(), "text/html; charset=utf-8")
+		addr, err = api.Modify(context.TODO(), addr, "img/logo.png", hash.Hex(), "text/html; charset=utf-8")
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 			return
@@ -137,7 +138,7 @@ func TestApiDirUploadModify(t *testing.T) {
 		exp = expResponse(content, "text/css", 0)
 		checkResponse(t, resp, exp)
 
-		_, _, _, _, err = api.Get(addr, "")
+		_, _, _, _, err = api.Get(context.TODO(), addr, "")
 		if err == nil {
 			t.Errorf("expected error: %v", err)
 		}

--- a/swarm/api/filesystem_test.go
+++ b/swarm/api/filesystem_test.go
@@ -106,8 +106,13 @@ func TestApiDirUploadModify(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 			return
 		}
-		hash, wait, err := api.Store(context.TODO(), bytes.NewReader(index), int64(len(index)), toEncrypt)
-		wait()
+		ctx := context.TODO()
+		hash, wait, err := api.Store(ctx, bytes.NewReader(index), int64(len(index)), toEncrypt)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			return
+		}
+		err = wait(ctx)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 			return

--- a/swarm/api/http/error.go
+++ b/swarm/api/http/error.go
@@ -147,6 +147,14 @@ func Respond(w http.ResponseWriter, req *Request, msg string, code int) {
 	switch code {
 	case http.StatusInternalServerError:
 		log.Output(msg, log.LvlError, l.CallDepth, "ruid", req.ruid, "code", code)
+	case http.StatusMultipleChoices:
+		log.Output(msg, log.LvlDebug, l.CallDepth, "ruid", req.ruid, "code", code)
+		listURI := api.URI{
+			Scheme: "bzz-list",
+			Addr:   req.uri.Addr,
+			Path:   req.uri.Path,
+		}
+		additionalMessage = fmt.Sprintf(`<a href="/%s">multiple choices</a>`, listURI.String())
 	default:
 		log.Output(msg, log.LvlDebug, l.CallDepth, "ruid", req.ruid, "code", code)
 	}

--- a/swarm/api/http/error_templates.go
+++ b/swarm/api/http/error_templates.go
@@ -38,6 +38,26 @@ func GetGenericErrorPage() string {
     <meta name="description" content="Ethereum/Swarm error page">
 		<link rel="shortcut icon" type="image/x-icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHsAAAB5CAYAAAAZD150AAAAAXNSR0IArs4c6QAAAAlwSFlzAAALEwAACxMBAJqcGAAAAVlpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDUuNC4wIj4KICAgPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICAgICAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIKICAgICAgICAgICAgeG1sbnM6dGlmZj0iaHR0cDovL25zLmFkb2JlLmNvbS90aWZmLzEuMC8iPgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPgogICAgICA8L3JkZjpEZXNjcmlwdGlvbj4KICAgPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KTMInWQAAFzFJREFUeAHtnXuwJFV9x7vnzrKwIC95w/ImYFkxlZgiGswCIiCGxPhHCEIwmIemUqYwJkYrJmXlUZRa+IpAWYYEk4qJD4gJGAmoiBIxMQFRQCkXdhdCeL+fYdk7nc+ne87dvnPn0TPTPdNzmd/W2X6fc76/7/n9zjm/PrcniuYy18BcA3MNzDUw18BcA3MNzDUw18BcA3MNrGYNLERroyMAeNQ0QcbTLPxFUfaOOx4Wbd12ThRHp0TJ4s5RFF8RtVoXg/2BSeOfk12lxtc0fjva1jibItZEDf4li3u3i3sqipOPRIvRp6ssvjPvhc4Tq/y4Ab71pEXS1oqw7hw1mz8XJc2LoiQ6iTJaaTkxth0l69jXwNayOZ10AvubSQ+RrFOl8mKy7EOiRuN3UfjrUfItUaN1SbQt+lqp2m02T4payS9HSfxK8k1IGdEWkln2Xuzldd7keBunrsO1f4r9b5Mqk3zBlRUy9Ywb0TtQ6O9Tjx1JkvA8SSXfiJK5Fj1MGkf2jBYWzo9a8Y+TiQRaxnLpTnb+HuvzDerzLk4+mb9Q1v5qduPrUPvxURx/DiWeicK2W1lKdCT2Q7n+VqzuOei5m+Nnh1TsPtGahbOiaOFCrHn/vs8ud+PdbrWLOZr6vIX6PEF97uH4uW43jnpudVp2Mzo1ajV+AwPbgGJUYr4/1Or+jxSwu90R5f6QQdPnaBK603zD4LCLNJsnkusfcUXXrKfoL4MtOzxvfXegPrdGjeRjlHEVx4PrE57us11tlr0b/fKlKIq+OTqsjXulS80sO5Dtbdugfnf4Py5qxGenxEeppbez6LJpte6LFuIWlvhT3J/Pq8vNnBps2eE562t97A608G+xnZMdtMN2H+z3LSj+n9g3cNGN4Nzt9tddCZK0ncnnrChuHBElySaOH8k/mNtf5Pr3onWtL0WthfWUuA/XGGX3KHsw2ZYtqc9Rs4dIW2m4mxjwXd8+z2Y8mXXLXoDk38Eaz4c7+2VJzLvsXtrpRXa43+svh/TTIf1QSP0Rx0+Ei8u2L0RPM6i6hn77e9SFhsJzGWnLG9wgshvpeOEJnn+6nX+D8u+ck51p43hIvhyS38DhHiQJKiqDyDYfG42WeiAk3oO93uLJ3tK6P0pa1zK/vj5aSI6FtF15Zjvhvcle5F69xzMkywxdAk+US7aDgVmSbMTaaFwM0VdS8QNIQTll4TA/SdKd3kvS0oqWgRveeku0uO2NjM4v5TmDJda52/MSqyXfy3YrqXJxEDArcjB92Dvh4RdIjoC1hLJFUp6BAPMOBHQjalC5SdR6wfj3FVFjDV1Bcg698S7ka172y0+3y5DwiRncxAoC1OjSiN6LJTNQSd5MJruQnDqVLbrTB0mPkXEgetwy7oH0T2LppzOrv4bMnif/B0hPsS/pozSkketUZ8s2KPIq3OH5ONWjQVgFwSpO69KajVpVpfzHom3b3hctNHajwR5OOUbyLGt7n85B1VJPspvRydFi/Hba/gYUoFLKJlqPpmXx9ikdBRcZsHH7WLIjZT1F472TXHaFZ6dqO5Gsx0SkbmTvS7/8caYbG1CMJGt1Vciz5O5UKuRflUV31t1yJPdx2jDlp2MPw6wTsfA6ke1U47Pg1mVXqfwXyP1Bypg2dgiOXcDwKJgPZPsSknGPyoiv0wAtZlz6CERsAXB4v1tV/apsTFS/sIgP7xLfTdrMPhbfc6pWONNeN1alzF7lDTqfuTkHS3F0FzcbbHixCG/cUtLvAHBZs4Fluqsb2fnK+XpBS6fVp4Mo+7q6WGS+nmXvE8SJf0imDxKGlfTS3Pq0+61BipJc+9j7gOzI1bCoS3tKUwB51U3st9cwar+Kgeq/sR8GkWPXs+5kbwcYpy/yXWQg2U5brPtqI905yEPRttbfgm0jqVSZHbID7CyUeRc078kpo2lrSFWSbt6lWRd5dYreizdcLI1K4m9F2xa/zHEleGaP7Kzftj933ZgDuZcwc9W9q7QylWRevLeKd+d/lgMnt3I84M0XdwwnNlQCRvHVkOwiBaZh1ckskh20kfXnCQpKI1Opa9fFlxWRWsvSpoPIex1pbxIWxyvVVuv9lGFAZlxp0ohc8PgZMqpkgWFnBWeZ7DwWB3H/g/IMTGjlvoceRbDmBuu/kj2waBf0x9o2/ysvYN1n8ELmtbzFugDHrrsddlWqgy/z3Bw1WeGyNbrNjCclFl4XIagSn0Fl7IdHEQc3W0nh9aQvG2zMna7dt1sheBHK8R5IiPdlcwBbYtc5iZdWwNh3MyuITyFtIN7F0qTCrp0GGB8TLbQuixaTf+HJ+3MlTGQ3a7MTKWpgIQ0W8H2Bu1B4KaIFaeW7k/I4bRBbOBcauv0yHiE+iPvDOS7nJE7oV00rRFd8O57gPK78YMXV5Sesg3GNKgd7y0vsOKpzUKWjqkMfZoM43Xu20CGz3nw2TuOSxqGQfVhPovP3r9x3FejReKSv8gLnQ1w+ZuUtS2csf2pEW4vuLXmpfhPdGdeNd6us1sRy33RlyHPs69bXsIjwWQjGktN+WXff6eo5lZPMjfda4xZI/Ele5JxK3jSc5Cae7uYJcplOfjfv3iZf+vISy3bjy3PffkQ/2zgaeosP4nq78e25bt9Tp48S/TqZba1i+6tlNL5d1Sv3Mut23VcUP8hlRu4t57YOxPbhWNL7W/bKPHud0fpd9eJfiNSui1ztZKtw5rCxUyTduKTuQMK1J3eRHoBwR+Au8ldGIT00JgM8z5KH/XIt9VrLSqn1EgSlx/eQj4v7guS7LfdZAJjcDcf3YYjHQLVTrmEJd9WLixTDc/kyQrm12K42slU0wQ8jXLELIIq+FtW138zgah8oO5DkXN+8AoHsLhPPO4WzITkQqy3B+VqvFrKDsiE4NmDie2DPhfN5zL32mZm0HuaJx0l7ECo9hBs7FwSanyQb3rRfLtqYuHX6slrIJmoW/y/qDNOjYUjOs+Bz9rkP82UG30IdSjogd4MNgYHekoxazlIGk9yZdbIZdMX2l1pz+YqPkzvo0/kbrnivNskzZcmdDWkWyXaEjZtOp1H2mVpi+URnmlI//M1XYhRuDclpmttefTmX6iuzSDZz5XTwFbRaFdGd+dtFmCTbvrzqcimiXJkFslWq1mu/bFDEgdE0Fe1oX9K1cufs06wLxReXupPdLShSB+Xqxp1yOeqX8MHxdW6attSZbIMi9pX2y4HgsJ223kL5DtgC6evYr9OLpVDHpW3dyNaS80ERLahuBC8pL7cj6TZKrVz3rl5rV+86kU28Or6Tce56FOUaL5VVO4VRp15iXXXriqtlbLS1knq5nVZyDV8KJDqVuAhAK69CxGw4tIrpkx+9uZFlR39A/s7/ayV1tZyXQvovwcdPoC0XEYbIWBnKY+qU8KYrDXWWkZ+NR690G/H1L2DP3ykj0yryqCvZAavfUTkNZ34cJ3SRZVhjmWQzKIs3QvKlNMfvUj8Ha7WVupMdFHdU1Gy8DapdQDgu4WWRjbdJ/oEIwGXUyThA7aUOfbarPwdZhMt8voJr541T+rUCnxmV9HH6bAe0z7DG7N9x3H9BDXTZReqxJ/e5eGKqMk2y/bq+X0F6P256X1T2X2iiv4W0WndA+k2QzouP5Cjux0oLKTuv5FHIdrC4EyRfB8kfpcR/5dgR9yDxC4zvaWPcv42xzPHHoPKXXZ+OG1+ITuNN0gXUZD+SS3lcAcr3OpN30/ddx3ERa/GjtOfy3CvS5/mvoIzgxvkcxkLrI4wa/HuvYpJ+GTn+MDeLUc/lHyeI8b1g/BrHRTByW3kyabJfA0HvAOepQHDAZTDClm7SehzwXM3fP13E/rdJReRl5MmH5ZbWbJtnPylCtnrBZcd3UcVroOlyjgflG8rky8bpLxbkMeqxnHdnHiJinXmrdSHHN4SHJrGdFNmHo4A/h+RXA8p1XvmAQyA74NXNYu3xDSiEZ9Lf0AjXem13IHZ1DKtLzsBeDuYmX5b0kkFk2zXwfPIZSP4q+w/3yqjjvBj/lOd+lvNiFFeQQHY4Dhj/A4x/xslN4UKV26rJXktbfifEkbA9NNEFTCfZ+Vt4JrkYm9LSi/SRMf35aTxzOvdLWjfpRzZ/MpT8J+V9nAcZFxSSHcB4HvB+j7u13G4YO8nOZyzGT1LmJzhZBGP+2aH2bWFVyDpeCZxJoOFvUMIbKSBvyZ3l6R5NPST268M/jxr96sIWbgohye73J8lGCLsBK/Odc7d14WLehRRI8djI1818uf9CrPmzHA+aHXALXc5C9Cs8dwkY38RxP4yW1Q/jBjCeXhijpY8g5Vv2QgS58btR5eHUR0X2AZnWuJ9lB0iZxSTRj/i884dxkFeHCwO2B0H6L+JT7D7CGCFv2by4iLew3uxTUHUL9xQhWVR4jvgPwXgkzxTB2M+yA4SAcSMYLxgCY3h+4LYssq3oelr5BSj2BPbz/dWgShQhO58HFht/k77uPZzcQgoWmr+nc//HCMqcy517cWEtj2jxkJ98Hkv+R/YHNUjzU1fraTwf4rmT2B8GYxGyLSMIf3AYXY+HEuNmUpH6hWd7bssg24HJuSjgNynFl/j9BkfdKjIs2eZhf4wVJn+HGiRroycHyAI/rgZJrdfQUB7jub/nfteWF5FD2xh/i5vtHobFOCzZ1mkUjD7XU8YjuxH9CQ3+zeSuxdj6ilhZZ2VGIds8rPsC/7P6M+HzF9EHOS5S/s7cZzSrmLU0/IUffiQm4lMbo2MchWyKW4bxi9T4A+06eG1oGYXsHZiBnsgPlv0lpRkGHMaddavgqGTn86LvxUobvFrcFn2dfZU7jqwB4/FgdIRsQx4X46hk5zEEjAaeruXC0BiHI7tJf9xqvB0Dej2FhQFPvkKj7JdBtuU6bqA/jr/CgOuvUch1nhxaMoxvA+NpPFsWxjLIFop8OWbhj//Tn5e0YReWomTzoyiNC1CAo1qiXMO3qj41KovsUISjY+ar8U30zX/M/uZwYcB2PzAS3kyDIrr6oS2nT/5lkR2KCBhvBuP7OLkpXOi39aF+sgv28i5G2Q6C1pO8v0i/2C/Pzmv2ncX6z84nux9bP0KdRNLi+NexhRY1vpXjXvNgMZ7HvZ9Pn8meLRuj+VWB0RnQW8Ho92O+3wcjlzK3kO50+Y8fMIk/TTYncc3RZ9kKCEWWbdkhX7d6Lqcx32EQ5yDrCU/mZB3WfAnQ3sA559hVYSzbsnMQUoy8keObaklyJheezF/M79vP9ZImLd7R7kZueJrU795eeUzzvET7c02bqLnTGLufTmlynegZwZpsdeisYtycctUd4xJm3V0vCa7HD8r5VWBbjNOPfs/0ymvS531l+hiFOsWSdLH0slrdqxiZwqXLgWcHo/H77GsPASNQektR4uwVGPTwNipJvyvmWx2nAr0U2LvE6q4I2H7ZLyG4htu6ea6orHqMRclWYZnisq8D8is26apP56BKHUgPrTwMhIYhOkOxyjEOQ3ZQiFtXXegmn4TmfdkaQhxFuTw2tvglhEfJpcypkpUSo685/Vnj/djOPMZRyVYZkmvfeC/KcF66G8ntJKzcsh09+xkqlzVV2dD8UmLAuDtlBdKrxlk6xnHIBncq9nUq3PfNKsI3SuZbhTJUgJ+Q1OLCdLBKoikmlU6MDuIc4c8UxjLIztQh8Iz0zewZM9cKypzK2BdryT3nkaEiFW4Dxi2ziLFMsoOOtQL70KdRiIS7KmTUyJtWK8mOsJ3rG6suswGR3UiSx2j35Z8olYXRGUUl3qoKstWelXXu+hDbxyH9pWzzS4E4HCiSGn5G0SibUgeis5psx/gwJxzE6c2ckobZQLiv39YGorcyshcwVkK0laiKbPMOEoIyRrBCfx6u9do6ElaJDsIqA9+r8BHOZ0GZjHRnJ0X0OnGMRSo1AvYVj4QBzl1YgG7PxOvIZVaQeYOspRvA0UJmgWiqmYp1NTxbW4yTIlttZMRlLsv+XLduUCYQ6odeJTnMl8N5Ts2MDML4BBiduUwF4yTJzjOmC7OfykjPwpsqYBYJzuPK79cO4zTIDoQyuuZ7ZrEx9sRRu7H2adQnT1BZ+3mMfg+VgVjiAG6qGCetXJXA9Cm+n63ujBFo4opUpxuORh2dGpgZdRrDo1OXLhjTvysXo8lgjJgnjnGSZBttYoTd8+uEXpdw31ipDK0gWAi7MyEOKokx9MQoiED6xDFWTbZk2RfTP6df8y8aFPE9tEqRcFOdRYySTAg3foStYdwi8QAxqg9nJRPBWCXZAlYBD7KVOKWIErwvNJKgEK2gqli05Y0q4rEhP8B2FIw2koAxkF5FvD3FVxXZAI/vowRDnOO6Yj2D+Ui2/XnRBsOtlUrZGJ12aumVYSyTbEnVhT0Gv8bGbaHjEk0WqZiP/bmkB9c+8QEOZecxgrPUwE/A6JglWHmpGMsgOxCKu05J1jUp4Xx2VM7/NiAblBYg6br3SYhYLFuMklx1UKQSjOOSrQKcL+uy7bOqIJhsV4jlGje3zNCfr7ippBPTxhhcu93YWDIK2YFQ3E1qyaFfDufHqtAQD1ueXsT5ujh0fWUO4sy/DhhtbPbnYhsL47BkqwBaWmrJKtmKTJpkilwh9ue6Vvu4cQc44nHwdS/bumC0TmNjHIZslZkPGNSBZKq0JDa8cYMyAaOvV+vSkJcAtus0MsZBZDvN0VWGEbb9R91IpkorJMxdHcTp+vqJeCTWhuwsImCsO85hMKb4B5Ad21c4FXB0qNRdAVkts3raSB3EBfLCtc4trjrexMlZxzgw/mAf10ue5w/FbuWP+w6EYt89D8ysV0YDztvHjj3S7FKGDRPC+XBdI/kAe3d2uUeMt08AY4iDd6nCWKfaXim+u43xjn65FbHUBmPdV/FH+K+D9CPITEspS3Cf6as/CS9LxMQSqJiG2voivfjXOdbK+0nAeBIYj+TGkjG68DJxTX1ZEjD6jfOA0fFGXylCdsiAT080j4uS1tmc0CMMzDw82GdbNtl6H9aD8aG87MsLuvFhxE+IvJofU/9VHioRY6lki5HGyIfyFtOGXBjjMGQHpe3EVwTPobBXcEKLHGQ14blu27LIVgH8kUJyI7W5kH1XwYwjYoTwFCNeYlyMpZAdMPJFiRQjL5mGk1HIDiUchUJORCHHcsJ8RiF9XLJVwAIkX4tFXkl7vy1UrqTtkW2MP0N+Y2Aci2wxNtsYrxgH4zhkq09d3SHtr/zvx77hy2FkHLKZVjH4Wmx9kAI3kcroVrrVXYwHtzHuz/4IGEcmm2ljvKWNcTNlO8ceWcYle3vBzeapGPfJzFgZjKQCkQNlWLLb9XWRQOufoffygSWUeUOzeQrlngLG3cjWuhTEOBTZASNz/hTjZWVBKI/srEZ74PY2MEA6ETW4wC7MXXvVdxiytWQV8CVIvpoMeQM1Fdm9jfG1xTEWJpspqG/VUozXgO6BMhGWTbZ1M8/dUMibaPgb2O/neoqQbX7+ZMNVjAr+in0HJkUsitsqE+u0axvj8ewPwDiQbPPjQz/Jl8F4Cfu+Ri0do4VUKUfT151Fte3P7fs6AXDcc57twIT+Me2XL2L/dlIdxV8mOruN0YhkF4w9yZ4oxqrJlhy/VXRstNg4GZs/hmNjukEh3ci2TmuJat2KO7sCm/kmx8MOinhkohIwGngSo3PfHMYVZOcxXtnGWGYgpyv4SZAdCjZg8dPtgIUvJ5yqdZJtS+drDsknUMA32LdhzJKI8ZVgJA6RvoBpY1xGthiZORD4yYIiE8M4SbIDaX5o7lws4GWcIGacunEDF3yJKflvqP4o+1rGLMtOYPw1ML4cEASeEkfvvl8Qo4Gfj6X7/DdJmQbZAZ9BmRNQxOsIwX4XBVzBhR+Ei6tkG4IyjNxb38fqxwqKzLpOHLTtRRrwqnWmYYpx71WOcaYJmld+roG5BuYamGtgroG5BuYamJoG/h/ff6XOIB4wOAAAAABJRU5ErkJggg=="/>
     <style>
+      html, body {
+        margin: 0;
+        padding 0;
+        height: 100%;
+      }
+      body {
+        display: flex;
+        flex-direction: column;
+      }
+      content {
+        flex: 1 0 auto;
+        background-color: #FCEFD3;
+      }
+      footer {
+        flex-shrink: 0;
+        background-color: #ffa500;
+        font-size: 1em;
+        text-align: center;
+        padding: 20px;
+      }
 
       body, div, header, footer {
         margin: 0;
@@ -217,20 +237,25 @@ func GetNotFoundErrorPage() string {
     <meta name="description" content="Ethereum/Swarm error page">
 		<link rel="shortcut icon" type="image/x-icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHsAAAB5CAYAAAAZD150AAAAAXNSR0IArs4c6QAAAAlwSFlzAAALEwAACxMBAJqcGAAAAVlpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDUuNC4wIj4KICAgPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICAgICAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIKICAgICAgICAgICAgeG1sbnM6dGlmZj0iaHR0cDovL25zLmFkb2JlLmNvbS90aWZmLzEuMC8iPgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPgogICAgICA8L3JkZjpEZXNjcmlwdGlvbj4KICAgPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KTMInWQAAFzFJREFUeAHtnXuwJFV9x7vnzrKwIC95w/ImYFkxlZgiGswCIiCGxPhHCEIwmIemUqYwJkYrJmXlUZRa+IpAWYYEk4qJD4gJGAmoiBIxMQFRQCkXdhdCeL+fYdk7nc+ne87dvnPn0TPTPdNzmd/W2X6fc76/7/n9zjm/PrcniuYy18BcA3MNzDUw18BcA3MNzDUw18BcA3MNrGYNLERroyMAeNQ0QcbTLPxFUfaOOx4Wbd12ThRHp0TJ4s5RFF8RtVoXg/2BSeOfk12lxtc0fjva1jibItZEDf4li3u3i3sqipOPRIvRp6ssvjPvhc4Tq/y4Ab71pEXS1oqw7hw1mz8XJc2LoiQ6iTJaaTkxth0l69jXwNayOZ10AvubSQ+RrFOl8mKy7EOiRuN3UfjrUfItUaN1SbQt+lqp2m02T4payS9HSfxK8k1IGdEWkln2Xuzldd7keBunrsO1f4r9b5Mqk3zBlRUy9Ywb0TtQ6O9Tjx1JkvA8SSXfiJK5Fj1MGkf2jBYWzo9a8Y+TiQRaxnLpTnb+HuvzDerzLk4+mb9Q1v5qduPrUPvxURx/DiWeicK2W1lKdCT2Q7n+VqzuOei5m+Nnh1TsPtGahbOiaOFCrHn/vs8ud+PdbrWLOZr6vIX6PEF97uH4uW43jnpudVp2Mzo1ajV+AwPbgGJUYr4/1Or+jxSwu90R5f6QQdPnaBK603zD4LCLNJsnkusfcUXXrKfoL4MtOzxvfXegPrdGjeRjlHEVx4PrE57us11tlr0b/fKlKIq+OTqsjXulS80sO5Dtbdugfnf4Py5qxGenxEeppbez6LJpte6LFuIWlvhT3J/Pq8vNnBps2eE562t97A608G+xnZMdtMN2H+z3LSj+n9g3cNGN4Nzt9tddCZK0ncnnrChuHBElySaOH8k/mNtf5Pr3onWtL0WthfWUuA/XGGX3KHsw2ZYtqc9Rs4dIW2m4mxjwXd8+z2Y8mXXLXoDk38Eaz4c7+2VJzLvsXtrpRXa43+svh/TTIf1QSP0Rx0+Ei8u2L0RPM6i6hn77e9SFhsJzGWnLG9wgshvpeOEJnn+6nX+D8u+ck51p43hIvhyS38DhHiQJKiqDyDYfG42WeiAk3oO93uLJ3tK6P0pa1zK/vj5aSI6FtF15Zjvhvcle5F69xzMkywxdAk+US7aDgVmSbMTaaFwM0VdS8QNIQTll4TA/SdKd3kvS0oqWgRveeku0uO2NjM4v5TmDJda52/MSqyXfy3YrqXJxEDArcjB92Dvh4RdIjoC1hLJFUp6BAPMOBHQjalC5SdR6wfj3FVFjDV1Bcg698S7ka172y0+3y5DwiRncxAoC1OjSiN6LJTNQSd5MJruQnDqVLbrTB0mPkXEgetwy7oH0T2LppzOrv4bMnif/B0hPsS/pozSkketUZ8s2KPIq3OH5ONWjQVgFwSpO69KajVpVpfzHom3b3hctNHajwR5OOUbyLGt7n85B1VJPspvRydFi/Hba/gYUoFLKJlqPpmXx9ikdBRcZsHH7WLIjZT1F472TXHaFZ6dqO5Gsx0SkbmTvS7/8caYbG1CMJGt1Vciz5O5UKuRflUV31t1yJPdx2jDlp2MPw6wTsfA6ke1U47Pg1mVXqfwXyP1Bypg2dgiOXcDwKJgPZPsSknGPyoiv0wAtZlz6CERsAXB4v1tV/apsTFS/sIgP7xLfTdrMPhbfc6pWONNeN1alzF7lDTqfuTkHS3F0FzcbbHixCG/cUtLvAHBZs4Fluqsb2fnK+XpBS6fVp4Mo+7q6WGS+nmXvE8SJf0imDxKGlfTS3Pq0+61BipJc+9j7gOzI1bCoS3tKUwB51U3st9cwar+Kgeq/sR8GkWPXs+5kbwcYpy/yXWQg2U5brPtqI905yEPRttbfgm0jqVSZHbID7CyUeRc078kpo2lrSFWSbt6lWRd5dYreizdcLI1K4m9F2xa/zHEleGaP7Kzftj933ZgDuZcwc9W9q7QylWRevLeKd+d/lgMnt3I84M0XdwwnNlQCRvHVkOwiBaZh1ckskh20kfXnCQpKI1Opa9fFlxWRWsvSpoPIex1pbxIWxyvVVuv9lGFAZlxp0ohc8PgZMqpkgWFnBWeZ7DwWB3H/g/IMTGjlvoceRbDmBuu/kj2waBf0x9o2/ysvYN1n8ELmtbzFugDHrrsddlWqgy/z3Bw1WeGyNbrNjCclFl4XIagSn0Fl7IdHEQc3W0nh9aQvG2zMna7dt1sheBHK8R5IiPdlcwBbYtc5iZdWwNh3MyuITyFtIN7F0qTCrp0GGB8TLbQuixaTf+HJ+3MlTGQ3a7MTKWpgIQ0W8H2Bu1B4KaIFaeW7k/I4bRBbOBcauv0yHiE+iPvDOS7nJE7oV00rRFd8O57gPK78YMXV5Sesg3GNKgd7y0vsOKpzUKWjqkMfZoM43Xu20CGz3nw2TuOSxqGQfVhPovP3r9x3FejReKSv8gLnQ1w+ZuUtS2csf2pEW4vuLXmpfhPdGdeNd6us1sRy33RlyHPs69bXsIjwWQjGktN+WXff6eo5lZPMjfda4xZI/Ele5JxK3jSc5Cae7uYJcplOfjfv3iZf+vISy3bjy3PffkQ/2zgaeosP4nq78e25bt9Tp48S/TqZba1i+6tlNL5d1Sv3Mut23VcUP8hlRu4t57YOxPbhWNL7W/bKPHud0fpd9eJfiNSui1ztZKtw5rCxUyTduKTuQMK1J3eRHoBwR+Au8ldGIT00JgM8z5KH/XIt9VrLSqn1EgSlx/eQj4v7guS7LfdZAJjcDcf3YYjHQLVTrmEJd9WLixTDc/kyQrm12K42slU0wQ8jXLELIIq+FtW138zgah8oO5DkXN+8AoHsLhPPO4WzITkQqy3B+VqvFrKDsiE4NmDie2DPhfN5zL32mZm0HuaJx0l7ECo9hBs7FwSanyQb3rRfLtqYuHX6slrIJmoW/y/qDNOjYUjOs+Bz9rkP82UG30IdSjogd4MNgYHekoxazlIGk9yZdbIZdMX2l1pz+YqPkzvo0/kbrnivNskzZcmdDWkWyXaEjZtOp1H2mVpi+URnmlI//M1XYhRuDclpmttefTmX6iuzSDZz5XTwFbRaFdGd+dtFmCTbvrzqcimiXJkFslWq1mu/bFDEgdE0Fe1oX9K1cufs06wLxReXupPdLShSB+Xqxp1yOeqX8MHxdW6attSZbIMi9pX2y4HgsJ223kL5DtgC6evYr9OLpVDHpW3dyNaS80ERLahuBC8pL7cj6TZKrVz3rl5rV+86kU28Or6Tce56FOUaL5VVO4VRp15iXXXriqtlbLS1knq5nVZyDV8KJDqVuAhAK69CxGw4tIrpkx+9uZFlR39A/s7/ayV1tZyXQvovwcdPoC0XEYbIWBnKY+qU8KYrDXWWkZ+NR690G/H1L2DP3ykj0yryqCvZAavfUTkNZ34cJ3SRZVhjmWQzKIs3QvKlNMfvUj8Ha7WVupMdFHdU1Gy8DapdQDgu4WWRjbdJ/oEIwGXUyThA7aUOfbarPwdZhMt8voJr541T+rUCnxmV9HH6bAe0z7DG7N9x3H9BDXTZReqxJ/e5eGKqMk2y/bq+X0F6P256X1T2X2iiv4W0WndA+k2QzouP5Cjux0oLKTuv5FHIdrC4EyRfB8kfpcR/5dgR9yDxC4zvaWPcv42xzPHHoPKXXZ+OG1+ITuNN0gXUZD+SS3lcAcr3OpN30/ddx3ERa/GjtOfy3CvS5/mvoIzgxvkcxkLrI4wa/HuvYpJ+GTn+MDeLUc/lHyeI8b1g/BrHRTByW3kyabJfA0HvAOepQHDAZTDClm7SehzwXM3fP13E/rdJReRl5MmH5ZbWbJtnPylCtnrBZcd3UcVroOlyjgflG8rky8bpLxbkMeqxnHdnHiJinXmrdSHHN4SHJrGdFNmHo4A/h+RXA8p1XvmAQyA74NXNYu3xDSiEZ9Lf0AjXem13IHZ1DKtLzsBeDuYmX5b0kkFk2zXwfPIZSP4q+w/3yqjjvBj/lOd+lvNiFFeQQHY4Dhj/A4x/xslN4UKV26rJXktbfifEkbA9NNEFTCfZ+Vt4JrkYm9LSi/SRMf35aTxzOvdLWjfpRzZ/MpT8J+V9nAcZFxSSHcB4HvB+j7u13G4YO8nOZyzGT1LmJzhZBGP+2aH2bWFVyDpeCZxJoOFvUMIbKSBvyZ3l6R5NPST268M/jxr96sIWbgohye73J8lGCLsBK/Odc7d14WLehRRI8djI1818uf9CrPmzHA+aHXALXc5C9Cs8dwkY38RxP4yW1Q/jBjCeXhijpY8g5Vv2QgS58btR5eHUR0X2AZnWuJ9lB0iZxSTRj/i884dxkFeHCwO2B0H6L+JT7D7CGCFv2by4iLew3uxTUHUL9xQhWVR4jvgPwXgkzxTB2M+yA4SAcSMYLxgCY3h+4LYssq3oelr5BSj2BPbz/dWgShQhO58HFht/k77uPZzcQgoWmr+nc//HCMqcy517cWEtj2jxkJ98Hkv+R/YHNUjzU1fraTwf4rmT2B8GYxGyLSMIf3AYXY+HEuNmUpH6hWd7bssg24HJuSjgNynFl/j9BkfdKjIs2eZhf4wVJn+HGiRroycHyAI/rgZJrdfQUB7jub/nfteWF5FD2xh/i5vtHobFOCzZ1mkUjD7XU8YjuxH9CQ3+zeSuxdj6ilhZZ2VGIds8rPsC/7P6M+HzF9EHOS5S/s7cZzSrmLU0/IUffiQm4lMbo2MchWyKW4bxi9T4A+06eG1oGYXsHZiBnsgPlv0lpRkGHMaddavgqGTn86LvxUobvFrcFn2dfZU7jqwB4/FgdIRsQx4X46hk5zEEjAaeruXC0BiHI7tJf9xqvB0Dej2FhQFPvkKj7JdBtuU6bqA/jr/CgOuvUch1nhxaMoxvA+NpPFsWxjLIFop8OWbhj//Tn5e0YReWomTzoyiNC1CAo1qiXMO3qj41KovsUISjY+ar8U30zX/M/uZwYcB2PzAS3kyDIrr6oS2nT/5lkR2KCBhvBuP7OLkpXOi39aF+sgv28i5G2Q6C1pO8v0i/2C/Pzmv2ncX6z84nux9bP0KdRNLi+NexhRY1vpXjXvNgMZ7HvZ9Pn8meLRuj+VWB0RnQW8Ho92O+3wcjlzK3kO50+Y8fMIk/TTYncc3RZ9kKCEWWbdkhX7d6Lqcx32EQ5yDrCU/mZB3WfAnQ3sA559hVYSzbsnMQUoy8keObaklyJheezF/M79vP9ZImLd7R7kZueJrU795eeUzzvET7c02bqLnTGLufTmlynegZwZpsdeisYtycctUd4xJm3V0vCa7HD8r5VWBbjNOPfs/0ymvS531l+hiFOsWSdLH0slrdqxiZwqXLgWcHo/H77GsPASNQektR4uwVGPTwNipJvyvmWx2nAr0U2LvE6q4I2H7ZLyG4htu6ea6orHqMRclWYZnisq8D8is26apP56BKHUgPrTwMhIYhOkOxyjEOQ3ZQiFtXXegmn4TmfdkaQhxFuTw2tvglhEfJpcypkpUSo685/Vnj/djOPMZRyVYZkmvfeC/KcF66G8ntJKzcsh09+xkqlzVV2dD8UmLAuDtlBdKrxlk6xnHIBncq9nUq3PfNKsI3SuZbhTJUgJ+Q1OLCdLBKoikmlU6MDuIc4c8UxjLIztQh8Iz0zewZM9cKypzK2BdryT3nkaEiFW4Dxi2ziLFMsoOOtQL70KdRiIS7KmTUyJtWK8mOsJ3rG6suswGR3UiSx2j35Z8olYXRGUUl3qoKstWelXXu+hDbxyH9pWzzS4E4HCiSGn5G0SibUgeis5psx/gwJxzE6c2ckobZQLiv39YGorcyshcwVkK0laiKbPMOEoIyRrBCfx6u9do6ElaJDsIqA9+r8BHOZ0GZjHRnJ0X0OnGMRSo1AvYVj4QBzl1YgG7PxOvIZVaQeYOspRvA0UJmgWiqmYp1NTxbW4yTIlttZMRlLsv+XLduUCYQ6odeJTnMl8N5Ts2MDML4BBiduUwF4yTJzjOmC7OfykjPwpsqYBYJzuPK79cO4zTIDoQyuuZ7ZrEx9sRRu7H2adQnT1BZ+3mMfg+VgVjiAG6qGCetXJXA9Cm+n63ujBFo4opUpxuORh2dGpgZdRrDo1OXLhjTvysXo8lgjJgnjnGSZBttYoTd8+uEXpdw31ipDK0gWAi7MyEOKokx9MQoiED6xDFWTbZk2RfTP6df8y8aFPE9tEqRcFOdRYySTAg3foStYdwi8QAxqg9nJRPBWCXZAlYBD7KVOKWIErwvNJKgEK2gqli05Y0q4rEhP8B2FIw2koAxkF5FvD3FVxXZAI/vowRDnOO6Yj2D+Ui2/XnRBsOtlUrZGJ12aumVYSyTbEnVhT0Gv8bGbaHjEk0WqZiP/bmkB9c+8QEOZecxgrPUwE/A6JglWHmpGMsgOxCKu05J1jUp4Xx2VM7/NiAblBYg6br3SYhYLFuMklx1UKQSjOOSrQKcL+uy7bOqIJhsV4jlGje3zNCfr7ippBPTxhhcu93YWDIK2YFQ3E1qyaFfDufHqtAQD1ueXsT5ujh0fWUO4sy/DhhtbPbnYhsL47BkqwBaWmrJKtmKTJpkilwh9ue6Vvu4cQc44nHwdS/bumC0TmNjHIZslZkPGNSBZKq0JDa8cYMyAaOvV+vSkJcAtus0MsZBZDvN0VWGEbb9R91IpkorJMxdHcTp+vqJeCTWhuwsImCsO85hMKb4B5Ad21c4FXB0qNRdAVkts3raSB3EBfLCtc4trjrexMlZxzgw/mAf10ue5w/FbuWP+w6EYt89D8ysV0YDztvHjj3S7FKGDRPC+XBdI/kAe3d2uUeMt08AY4iDd6nCWKfaXim+u43xjn65FbHUBmPdV/FH+K+D9CPITEspS3Cf6as/CS9LxMQSqJiG2voivfjXOdbK+0nAeBIYj+TGkjG68DJxTX1ZEjD6jfOA0fFGXylCdsiAT080j4uS1tmc0CMMzDw82GdbNtl6H9aD8aG87MsLuvFhxE+IvJofU/9VHioRY6lki5HGyIfyFtOGXBjjMGQHpe3EVwTPobBXcEKLHGQ14blu27LIVgH8kUJyI7W5kH1XwYwjYoTwFCNeYlyMpZAdMPJFiRQjL5mGk1HIDiUchUJORCHHcsJ8RiF9XLJVwAIkX4tFXkl7vy1UrqTtkW2MP0N+Y2Aci2wxNtsYrxgH4zhkq09d3SHtr/zvx77hy2FkHLKZVjH4Wmx9kAI3kcroVrrVXYwHtzHuz/4IGEcmm2ljvKWNcTNlO8ceWcYle3vBzeapGPfJzFgZjKQCkQNlWLLb9XWRQOufoffygSWUeUOzeQrlngLG3cjWuhTEOBTZASNz/hTjZWVBKI/srEZ74PY2MEA6ETW4wC7MXXvVdxiytWQV8CVIvpoMeQM1Fdm9jfG1xTEWJpspqG/VUozXgO6BMhGWTbZ1M8/dUMibaPgb2O/neoqQbX7+ZMNVjAr+in0HJkUsitsqE+u0axvj8ewPwDiQbPPjQz/Jl8F4Cfu+Ri0do4VUKUfT151Fte3P7fs6AXDcc57twIT+Me2XL2L/dlIdxV8mOruN0YhkF4w9yZ4oxqrJlhy/VXRstNg4GZs/hmNjukEh3ci2TmuJat2KO7sCm/kmx8MOinhkohIwGngSo3PfHMYVZOcxXtnGWGYgpyv4SZAdCjZg8dPtgIUvJ5yqdZJtS+drDsknUMA32LdhzJKI8ZVgJA6RvoBpY1xGthiZORD4yYIiE8M4SbIDaX5o7lws4GWcIGacunEDF3yJKflvqP4o+1rGLMtOYPw1ML4cEASeEkfvvl8Qo4Gfj6X7/DdJmQbZAZ9BmRNQxOsIwX4XBVzBhR+Ei6tkG4IyjNxb38fqxwqKzLpOHLTtRRrwqnWmYYpx71WOcaYJmld+roG5BuYamGtgroG5BuYamJoG/h/ff6XOIB4wOAAAAABJRU5ErkJggg=="/>
     <style>
-
-      body, div, header, footer {
+      html, body {
         margin: 0;
-        padding: 0;
+        padding 0;
+        height: 100%;
       }
-
       body {
-        overflow: hidden;
+        display: flex;
+        flex-direction: column;
       }
-
-      .container {
-        min-width: 100%;
-        min-height: 100%;
-        max-height: 100%;
+      content {
+        flex: 1 0 auto;
+        background-color: #FCEFD3;
+      }
+      footer {
+        flex-shrink: 0;
+        background-color: #ffa500;
+        font-size: 1em;
+        text-align: center;
+        padding: 20px;
       }
 
       header {
@@ -266,12 +291,7 @@ func GetNotFoundErrorPage() string {
       content-body {
         display: block;
         margin: 0 auto;
-        /* width: 50%; */
-        min-height: 60vh;
-        max-height: 60vh;
         padding: 50px 20px;
-        opacity: 0.6;
-        background-color: #FCEFD3;
       }
 
       table {
@@ -299,7 +319,6 @@ func GetNotFoundErrorPage() string {
       }
 
       footer {
-        height: 20vh;
         background-color: #ffa500;
         font-size: 1em;
         text-align: center;
@@ -313,7 +332,7 @@ func GetNotFoundErrorPage() string {
 
 
   <body>
-    <div class="container">
+    <content>
 
       <header>
         <div class="header-left">
@@ -336,10 +355,6 @@ func GetNotFoundErrorPage() string {
               </td>
             </thead>
             <tbody>
-              <tr>
-                <td class="key">
-                </td>
-              </tr>
               <tr>
                 <td class="value">
                   {{.Msg}}
@@ -367,16 +382,14 @@ func GetNotFoundErrorPage() string {
           </table>
         </section>
       </content-body>
+    </content>
 
-      <footer>
-        <p>
-          Swarm: Serverless Hosting Incentivised Peer-To-Peer Storage And Content Distribution<br/>
-          <a href="/bzz:/theswarm.eth">Swarm</a>
-        </p>
-      </footer>
+    <footer>
+      <p>
+        <a href="/bzz:/theswarm.eth">Swarm</a>: Serverless Hosting Incentivised peer-to-peer Storage and Content Distribution
+      </p>
+    </footer>
 
-
-    </div>
   </body>
 
 </html>
@@ -398,20 +411,25 @@ func GetMultipleChoicesErrorPage() string {
     <meta name="description" content="Ethereum/Swarm multiple options page">
 		<link rel="shortcut icon" type="image/x-icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHsAAAB5CAYAAAAZD150AAAAAXNSR0IArs4c6QAAAAlwSFlzAAALEwAACxMBAJqcGAAAAVlpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDUuNC4wIj4KICAgPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICAgICAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIKICAgICAgICAgICAgeG1sbnM6dGlmZj0iaHR0cDovL25zLmFkb2JlLmNvbS90aWZmLzEuMC8iPgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPgogICAgICA8L3JkZjpEZXNjcmlwdGlvbj4KICAgPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KTMInWQAAFzFJREFUeAHtnXuwJFV9x7vnzrKwIC95w/ImYFkxlZgiGswCIiCGxPhHCEIwmIemUqYwJkYrJmXlUZRa+IpAWYYEk4qJD4gJGAmoiBIxMQFRQCkXdhdCeL+fYdk7nc+ne87dvnPn0TPTPdNzmd/W2X6fc76/7/n9zjm/PrcniuYy18BcA3MNzDUw18BcA3MNzDUw18BcA3MNrGYNLERroyMAeNQ0QcbTLPxFUfaOOx4Wbd12ThRHp0TJ4s5RFF8RtVoXg/2BSeOfk12lxtc0fjva1jibItZEDf4li3u3i3sqipOPRIvRp6ssvjPvhc4Tq/y4Ab71pEXS1oqw7hw1mz8XJc2LoiQ6iTJaaTkxth0l69jXwNayOZ10AvubSQ+RrFOl8mKy7EOiRuN3UfjrUfItUaN1SbQt+lqp2m02T4payS9HSfxK8k1IGdEWkln2Xuzldd7keBunrsO1f4r9b5Mqk3zBlRUy9Ywb0TtQ6O9Tjx1JkvA8SSXfiJK5Fj1MGkf2jBYWzo9a8Y+TiQRaxnLpTnb+HuvzDerzLk4+mb9Q1v5qduPrUPvxURx/DiWeicK2W1lKdCT2Q7n+VqzuOei5m+Nnh1TsPtGahbOiaOFCrHn/vs8ud+PdbrWLOZr6vIX6PEF97uH4uW43jnpudVp2Mzo1ajV+AwPbgGJUYr4/1Or+jxSwu90R5f6QQdPnaBK603zD4LCLNJsnkusfcUXXrKfoL4MtOzxvfXegPrdGjeRjlHEVx4PrE57us11tlr0b/fKlKIq+OTqsjXulS80sO5Dtbdugfnf4Py5qxGenxEeppbez6LJpte6LFuIWlvhT3J/Pq8vNnBps2eE562t97A608G+xnZMdtMN2H+z3LSj+n9g3cNGN4Nzt9tddCZK0ncnnrChuHBElySaOH8k/mNtf5Pr3onWtL0WthfWUuA/XGGX3KHsw2ZYtqc9Rs4dIW2m4mxjwXd8+z2Y8mXXLXoDk38Eaz4c7+2VJzLvsXtrpRXa43+svh/TTIf1QSP0Rx0+Ei8u2L0RPM6i6hn77e9SFhsJzGWnLG9wgshvpeOEJnn+6nX+D8u+ck51p43hIvhyS38DhHiQJKiqDyDYfG42WeiAk3oO93uLJ3tK6P0pa1zK/vj5aSI6FtF15Zjvhvcle5F69xzMkywxdAk+US7aDgVmSbMTaaFwM0VdS8QNIQTll4TA/SdKd3kvS0oqWgRveeku0uO2NjM4v5TmDJda52/MSqyXfy3YrqXJxEDArcjB92Dvh4RdIjoC1hLJFUp6BAPMOBHQjalC5SdR6wfj3FVFjDV1Bcg698S7ka172y0+3y5DwiRncxAoC1OjSiN6LJTNQSd5MJruQnDqVLbrTB0mPkXEgetwy7oH0T2LppzOrv4bMnif/B0hPsS/pozSkketUZ8s2KPIq3OH5ONWjQVgFwSpO69KajVpVpfzHom3b3hctNHajwR5OOUbyLGt7n85B1VJPspvRydFi/Hba/gYUoFLKJlqPpmXx9ikdBRcZsHH7WLIjZT1F472TXHaFZ6dqO5Gsx0SkbmTvS7/8caYbG1CMJGt1Vciz5O5UKuRflUV31t1yJPdx2jDlp2MPw6wTsfA6ke1U47Pg1mVXqfwXyP1Bypg2dgiOXcDwKJgPZPsSknGPyoiv0wAtZlz6CERsAXB4v1tV/apsTFS/sIgP7xLfTdrMPhbfc6pWONNeN1alzF7lDTqfuTkHS3F0FzcbbHixCG/cUtLvAHBZs4Fluqsb2fnK+XpBS6fVp4Mo+7q6WGS+nmXvE8SJf0imDxKGlfTS3Pq0+61BipJc+9j7gOzI1bCoS3tKUwB51U3st9cwar+Kgeq/sR8GkWPXs+5kbwcYpy/yXWQg2U5brPtqI905yEPRttbfgm0jqVSZHbID7CyUeRc078kpo2lrSFWSbt6lWRd5dYreizdcLI1K4m9F2xa/zHEleGaP7Kzftj933ZgDuZcwc9W9q7QylWRevLeKd+d/lgMnt3I84M0XdwwnNlQCRvHVkOwiBaZh1ckskh20kfXnCQpKI1Opa9fFlxWRWsvSpoPIex1pbxIWxyvVVuv9lGFAZlxp0ohc8PgZMqpkgWFnBWeZ7DwWB3H/g/IMTGjlvoceRbDmBuu/kj2waBf0x9o2/ysvYN1n8ELmtbzFugDHrrsddlWqgy/z3Bw1WeGyNbrNjCclFl4XIagSn0Fl7IdHEQc3W0nh9aQvG2zMna7dt1sheBHK8R5IiPdlcwBbYtc5iZdWwNh3MyuITyFtIN7F0qTCrp0GGB8TLbQuixaTf+HJ+3MlTGQ3a7MTKWpgIQ0W8H2Bu1B4KaIFaeW7k/I4bRBbOBcauv0yHiE+iPvDOS7nJE7oV00rRFd8O57gPK78YMXV5Sesg3GNKgd7y0vsOKpzUKWjqkMfZoM43Xu20CGz3nw2TuOSxqGQfVhPovP3r9x3FejReKSv8gLnQ1w+ZuUtS2csf2pEW4vuLXmpfhPdGdeNd6us1sRy33RlyHPs69bXsIjwWQjGktN+WXff6eo5lZPMjfda4xZI/Ele5JxK3jSc5Cae7uYJcplOfjfv3iZf+vISy3bjy3PffkQ/2zgaeosP4nq78e25bt9Tp48S/TqZba1i+6tlNL5d1Sv3Mut23VcUP8hlRu4t57YOxPbhWNL7W/bKPHud0fpd9eJfiNSui1ztZKtw5rCxUyTduKTuQMK1J3eRHoBwR+Au8ldGIT00JgM8z5KH/XIt9VrLSqn1EgSlx/eQj4v7guS7LfdZAJjcDcf3YYjHQLVTrmEJd9WLixTDc/kyQrm12K42slU0wQ8jXLELIIq+FtW138zgah8oO5DkXN+8AoHsLhPPO4WzITkQqy3B+VqvFrKDsiE4NmDie2DPhfN5zL32mZm0HuaJx0l7ECo9hBs7FwSanyQb3rRfLtqYuHX6slrIJmoW/y/qDNOjYUjOs+Bz9rkP82UG30IdSjogd4MNgYHekoxazlIGk9yZdbIZdMX2l1pz+YqPkzvo0/kbrnivNskzZcmdDWkWyXaEjZtOp1H2mVpi+URnmlI//M1XYhRuDclpmttefTmX6iuzSDZz5XTwFbRaFdGd+dtFmCTbvrzqcimiXJkFslWq1mu/bFDEgdE0Fe1oX9K1cufs06wLxReXupPdLShSB+Xqxp1yOeqX8MHxdW6attSZbIMi9pX2y4HgsJ223kL5DtgC6evYr9OLpVDHpW3dyNaS80ERLahuBC8pL7cj6TZKrVz3rl5rV+86kU28Or6Tce56FOUaL5VVO4VRp15iXXXriqtlbLS1knq5nVZyDV8KJDqVuAhAK69CxGw4tIrpkx+9uZFlR39A/s7/ayV1tZyXQvovwcdPoC0XEYbIWBnKY+qU8KYrDXWWkZ+NR690G/H1L2DP3ykj0yryqCvZAavfUTkNZ34cJ3SRZVhjmWQzKIs3QvKlNMfvUj8Ha7WVupMdFHdU1Gy8DapdQDgu4WWRjbdJ/oEIwGXUyThA7aUOfbarPwdZhMt8voJr541T+rUCnxmV9HH6bAe0z7DG7N9x3H9BDXTZReqxJ/e5eGKqMk2y/bq+X0F6P256X1T2X2iiv4W0WndA+k2QzouP5Cjux0oLKTuv5FHIdrC4EyRfB8kfpcR/5dgR9yDxC4zvaWPcv42xzPHHoPKXXZ+OG1+ITuNN0gXUZD+SS3lcAcr3OpN30/ddx3ERa/GjtOfy3CvS5/mvoIzgxvkcxkLrI4wa/HuvYpJ+GTn+MDeLUc/lHyeI8b1g/BrHRTByW3kyabJfA0HvAOepQHDAZTDClm7SehzwXM3fP13E/rdJReRl5MmH5ZbWbJtnPylCtnrBZcd3UcVroOlyjgflG8rky8bpLxbkMeqxnHdnHiJinXmrdSHHN4SHJrGdFNmHo4A/h+RXA8p1XvmAQyA74NXNYu3xDSiEZ9Lf0AjXem13IHZ1DKtLzsBeDuYmX5b0kkFk2zXwfPIZSP4q+w/3yqjjvBj/lOd+lvNiFFeQQHY4Dhj/A4x/xslN4UKV26rJXktbfifEkbA9NNEFTCfZ+Vt4JrkYm9LSi/SRMf35aTxzOvdLWjfpRzZ/MpT8J+V9nAcZFxSSHcB4HvB+j7u13G4YO8nOZyzGT1LmJzhZBGP+2aH2bWFVyDpeCZxJoOFvUMIbKSBvyZ3l6R5NPST268M/jxr96sIWbgohye73J8lGCLsBK/Odc7d14WLehRRI8djI1818uf9CrPmzHA+aHXALXc5C9Cs8dwkY38RxP4yW1Q/jBjCeXhijpY8g5Vv2QgS58btR5eHUR0X2AZnWuJ9lB0iZxSTRj/i884dxkFeHCwO2B0H6L+JT7D7CGCFv2by4iLew3uxTUHUL9xQhWVR4jvgPwXgkzxTB2M+yA4SAcSMYLxgCY3h+4LYssq3oelr5BSj2BPbz/dWgShQhO58HFht/k77uPZzcQgoWmr+nc//HCMqcy517cWEtj2jxkJ98Hkv+R/YHNUjzU1fraTwf4rmT2B8GYxGyLSMIf3AYXY+HEuNmUpH6hWd7bssg24HJuSjgNynFl/j9BkfdKjIs2eZhf4wVJn+HGiRroycHyAI/rgZJrdfQUB7jub/nfteWF5FD2xh/i5vtHobFOCzZ1mkUjD7XU8YjuxH9CQ3+zeSuxdj6ilhZZ2VGIds8rPsC/7P6M+HzF9EHOS5S/s7cZzSrmLU0/IUffiQm4lMbo2MchWyKW4bxi9T4A+06eG1oGYXsHZiBnsgPlv0lpRkGHMaddavgqGTn86LvxUobvFrcFn2dfZU7jqwB4/FgdIRsQx4X46hk5zEEjAaeruXC0BiHI7tJf9xqvB0Dej2FhQFPvkKj7JdBtuU6bqA/jr/CgOuvUch1nhxaMoxvA+NpPFsWxjLIFop8OWbhj//Tn5e0YReWomTzoyiNC1CAo1qiXMO3qj41KovsUISjY+ar8U30zX/M/uZwYcB2PzAS3kyDIrr6oS2nT/5lkR2KCBhvBuP7OLkpXOi39aF+sgv28i5G2Q6C1pO8v0i/2C/Pzmv2ncX6z84nux9bP0KdRNLi+NexhRY1vpXjXvNgMZ7HvZ9Pn8meLRuj+VWB0RnQW8Ho92O+3wcjlzK3kO50+Y8fMIk/TTYncc3RZ9kKCEWWbdkhX7d6Lqcx32EQ5yDrCU/mZB3WfAnQ3sA559hVYSzbsnMQUoy8keObaklyJheezF/M79vP9ZImLd7R7kZueJrU795eeUzzvET7c02bqLnTGLufTmlynegZwZpsdeisYtycctUd4xJm3V0vCa7HD8r5VWBbjNOPfs/0ymvS531l+hiFOsWSdLH0slrdqxiZwqXLgWcHo/H77GsPASNQektR4uwVGPTwNipJvyvmWx2nAr0U2LvE6q4I2H7ZLyG4htu6ea6orHqMRclWYZnisq8D8is26apP56BKHUgPrTwMhIYhOkOxyjEOQ3ZQiFtXXegmn4TmfdkaQhxFuTw2tvglhEfJpcypkpUSo685/Vnj/djOPMZRyVYZkmvfeC/KcF66G8ntJKzcsh09+xkqlzVV2dD8UmLAuDtlBdKrxlk6xnHIBncq9nUq3PfNKsI3SuZbhTJUgJ+Q1OLCdLBKoikmlU6MDuIc4c8UxjLIztQh8Iz0zewZM9cKypzK2BdryT3nkaEiFW4Dxi2ziLFMsoOOtQL70KdRiIS7KmTUyJtWK8mOsJ3rG6suswGR3UiSx2j35Z8olYXRGUUl3qoKstWelXXu+hDbxyH9pWzzS4E4HCiSGn5G0SibUgeis5psx/gwJxzE6c2ckobZQLiv39YGorcyshcwVkK0laiKbPMOEoIyRrBCfx6u9do6ElaJDsIqA9+r8BHOZ0GZjHRnJ0X0OnGMRSo1AvYVj4QBzl1YgG7PxOvIZVaQeYOspRvA0UJmgWiqmYp1NTxbW4yTIlttZMRlLsv+XLduUCYQ6odeJTnMl8N5Ts2MDML4BBiduUwF4yTJzjOmC7OfykjPwpsqYBYJzuPK79cO4zTIDoQyuuZ7ZrEx9sRRu7H2adQnT1BZ+3mMfg+VgVjiAG6qGCetXJXA9Cm+n63ujBFo4opUpxuORh2dGpgZdRrDo1OXLhjTvysXo8lgjJgnjnGSZBttYoTd8+uEXpdw31ipDK0gWAi7MyEOKokx9MQoiED6xDFWTbZk2RfTP6df8y8aFPE9tEqRcFOdRYySTAg3foStYdwi8QAxqg9nJRPBWCXZAlYBD7KVOKWIErwvNJKgEK2gqli05Y0q4rEhP8B2FIw2koAxkF5FvD3FVxXZAI/vowRDnOO6Yj2D+Ui2/XnRBsOtlUrZGJ12aumVYSyTbEnVhT0Gv8bGbaHjEk0WqZiP/bmkB9c+8QEOZecxgrPUwE/A6JglWHmpGMsgOxCKu05J1jUp4Xx2VM7/NiAblBYg6br3SYhYLFuMklx1UKQSjOOSrQKcL+uy7bOqIJhsV4jlGje3zNCfr7ippBPTxhhcu93YWDIK2YFQ3E1qyaFfDufHqtAQD1ueXsT5ujh0fWUO4sy/DhhtbPbnYhsL47BkqwBaWmrJKtmKTJpkilwh9ue6Vvu4cQc44nHwdS/bumC0TmNjHIZslZkPGNSBZKq0JDa8cYMyAaOvV+vSkJcAtus0MsZBZDvN0VWGEbb9R91IpkorJMxdHcTp+vqJeCTWhuwsImCsO85hMKb4B5Ad21c4FXB0qNRdAVkts3raSB3EBfLCtc4trjrexMlZxzgw/mAf10ue5w/FbuWP+w6EYt89D8ysV0YDztvHjj3S7FKGDRPC+XBdI/kAe3d2uUeMt08AY4iDd6nCWKfaXim+u43xjn65FbHUBmPdV/FH+K+D9CPITEspS3Cf6as/CS9LxMQSqJiG2voivfjXOdbK+0nAeBIYj+TGkjG68DJxTX1ZEjD6jfOA0fFGXylCdsiAT080j4uS1tmc0CMMzDw82GdbNtl6H9aD8aG87MsLuvFhxE+IvJofU/9VHioRY6lki5HGyIfyFtOGXBjjMGQHpe3EVwTPobBXcEKLHGQ14blu27LIVgH8kUJyI7W5kH1XwYwjYoTwFCNeYlyMpZAdMPJFiRQjL5mGk1HIDiUchUJORCHHcsJ8RiF9XLJVwAIkX4tFXkl7vy1UrqTtkW2MP0N+Y2Aci2wxNtsYrxgH4zhkq09d3SHtr/zvx77hy2FkHLKZVjH4Wmx9kAI3kcroVrrVXYwHtzHuz/4IGEcmm2ljvKWNcTNlO8ceWcYle3vBzeapGPfJzFgZjKQCkQNlWLLb9XWRQOufoffygSWUeUOzeQrlngLG3cjWuhTEOBTZASNz/hTjZWVBKI/srEZ74PY2MEA6ETW4wC7MXXvVdxiytWQV8CVIvpoMeQM1Fdm9jfG1xTEWJpspqG/VUozXgO6BMhGWTbZ1M8/dUMibaPgb2O/neoqQbX7+ZMNVjAr+in0HJkUsitsqE+u0axvj8ewPwDiQbPPjQz/Jl8F4Cfu+Ri0do4VUKUfT151Fte3P7fs6AXDcc57twIT+Me2XL2L/dlIdxV8mOruN0YhkF4w9yZ4oxqrJlhy/VXRstNg4GZs/hmNjukEh3ci2TmuJat2KO7sCm/kmx8MOinhkohIwGngSo3PfHMYVZOcxXtnGWGYgpyv4SZAdCjZg8dPtgIUvJ5yqdZJtS+drDsknUMA32LdhzJKI8ZVgJA6RvoBpY1xGthiZORD4yYIiE8M4SbIDaX5o7lws4GWcIGacunEDF3yJKflvqP4o+1rGLMtOYPw1ML4cEASeEkfvvl8Qo4Gfj6X7/DdJmQbZAZ9BmRNQxOsIwX4XBVzBhR+Ei6tkG4IyjNxb38fqxwqKzLpOHLTtRRrwqnWmYYpx71WOcaYJmld+roG5BuYamGtgroG5BuYamJoG/h/ff6XOIB4wOAAAAABJRU5ErkJggg=="/>
     <style>
-
-      body, div, header, footer {
+      html, body {
         margin: 0;
-        padding: 0;
+        padding 0;
+        height: 100%;
       }
-
       body {
-        overflow: hidden;
+        display: flex;
+        flex-direction: column;
       }
-
-      .container {
-        min-width: 100%;
-        min-height: 100%;
-        max-height: 100%;
+      content {
+        flex: 1 0 auto;
+        background-color: #FCEFD3;
+      }
+      footer {
+        flex-shrink: 0;
+        background-color: #ffa500;
+        font-size: 1em;
+        text-align: center;
+        padding: 20px;
       }
 
       header {
@@ -447,12 +465,7 @@ func GetMultipleChoicesErrorPage() string {
       content-body {
         display: block;
         margin: 0 auto;
-        /* width: 50%; */
-        min-height: 60vh;
-        max-height: 60vh;
         padding: 50px 20px;
-        opacity: 0.6;
-        background-color: #FCEFD3;
       }
 
       table {
@@ -480,13 +493,11 @@ func GetMultipleChoicesErrorPage() string {
       }
 
       footer {
-        height: 20vh;
         background-color: #ffa500;
         font-size: 1em;
         text-align: center;
         padding: 20px;
       }
-
     </style>
 
     <title>Swarm::HTTP Disambiguation Page</title>
@@ -494,7 +505,7 @@ func GetMultipleChoicesErrorPage() string {
 
 
   <body>
-    <div class="container">
+    <content>
 
       <header>
         <div class="header-left">
@@ -513,21 +524,10 @@ func GetMultipleChoicesErrorPage() string {
           <table>
             <thead>
               <td style="height: 150px; font-size: 1.3em; color: black; font-weight: bold">
-                Your request yields ambiguous results!
+                Your request may refer to {{ .Details}}.
               </td>
             </thead>
             <tbody>
-              <tr>
-                <td class="key">
-                  Your request may refer to:
-                </td>
-              </tr>
-              <tr>
-                <td class="value">
-                    {{ .Details}}
-                </td>
-              </tr>
-
               <tr>
                 <td class="key">
                   Error code:
@@ -543,16 +543,14 @@ func GetMultipleChoicesErrorPage() string {
           </table>
         </section>
       </content-body>
+    </content>
 
-      <footer>
-        <p>
-          Swarm: Serverless Hosting Incentivised Peer-To-Peer Storage And Content Distribution<br/>
-          <a href="/bzz:/theswarm.eth">Swarm</a>
-        </p>
-      </footer>
+    <footer>
+      <p>
+        <a href="/bzz:/theswarm.eth">Swarm</a>: Serverless Hosting Incentivised peer-to-peer Storage and Content Distribution
+      </p>
+    </footer>
 
-
-    </div>
   </body>
 
 </html>

--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -469,7 +469,6 @@ func (s *Server) HandlePostResource(ctx context.Context, w http.ResponseWriter, 
 
 		log.Debug("handle.post.resource: resolved", "ruid", r.ruid, "manifestkey", manifestAddr, "rootchunkkey", addr)
 
-		//name, _, err = s.api.ResourceLookup(r.Context(), addr, 0, 0, &mru.LookupParams{})
 		params := &mru.LookupParams{
 			Root: addr,
 		}
@@ -489,7 +488,6 @@ func (s *Server) HandlePostResource(ctx context.Context, w http.ResponseWriter, 
 
 	// Multihash will be passed as hex-encoded data, so we need to parse this to bytes
 	if isRaw {
-		//_, _, _, err = s.api.ResourceUpdate(r.Context(), name, data)
 		_, _, _, err = s.api.ResourceUpdate(r.Context(), addr, data)
 		if err != nil {
 			Respond(w, r, err.Error(), http.StatusBadRequest)
@@ -501,7 +499,6 @@ func (s *Server) HandlePostResource(ctx context.Context, w http.ResponseWriter, 
 			Respond(w, r, err.Error(), http.StatusBadRequest)
 			return
 		}
-		//_, _, _, err = s.api.ResourceUpdateMultihash(r.Context(), name, bytesdata)
 		_, _, _, err = s.api.ResourceUpdateMultihash(r.Context(), addr, bytesdata)
 		if err != nil {
 			Respond(w, r, err.Error(), http.StatusBadRequest)

--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -469,7 +469,11 @@ func (s *Server) HandlePostResource(ctx context.Context, w http.ResponseWriter, 
 
 		log.Debug("handle.post.resource: resolved", "ruid", r.ruid, "manifestkey", manifestAddr, "rootchunkkey", addr)
 
-		name, _, err = s.api.ResourceLookup(r.Context(), addr, 0, 0, &mru.LookupParams{})
+		//name, _, err = s.api.ResourceLookup(r.Context(), addr, 0, 0, &mru.LookupParams{})
+		params := &mru.LookupParams{
+			Root: addr,
+		}
+		name, _, err = s.api.ResourceLookup(r.Context(), params)
 		if err != nil {
 			Respond(w, r, err.Error(), http.StatusNotFound)
 			return
@@ -485,7 +489,8 @@ func (s *Server) HandlePostResource(ctx context.Context, w http.ResponseWriter, 
 
 	// Multihash will be passed as hex-encoded data, so we need to parse this to bytes
 	if isRaw {
-		_, _, _, err = s.api.ResourceUpdate(r.Context(), name, data)
+		//_, _, _, err = s.api.ResourceUpdate(r.Context(), name, data)
+		_, _, _, err = s.api.ResourceUpdate(r.Context(), addr, data)
 		if err != nil {
 			Respond(w, r, err.Error(), http.StatusBadRequest)
 			return
@@ -496,7 +501,8 @@ func (s *Server) HandlePostResource(ctx context.Context, w http.ResponseWriter, 
 			Respond(w, r, err.Error(), http.StatusBadRequest)
 			return
 		}
-		_, _, _, err = s.api.ResourceUpdateMultihash(r.Context(), name, bytesdata)
+		//_, _, _, err = s.api.ResourceUpdateMultihash(r.Context(), name, bytesdata)
+		_, _, _, err = s.api.ResourceUpdateMultihash(r.Context(), addr, bytesdata)
 		if err != nil {
 			Respond(w, r, err.Error(), http.StatusBadRequest)
 			return
@@ -557,30 +563,34 @@ func (s *Server) handleGetResource(ctx context.Context, w http.ResponseWriter, r
 		params = strings.Split(r.uri.Path, "/")
 	}
 	var name string
-	var period uint64
-	var version uint64
 	var data []byte
 	now := time.Now()
+	lookupParams := &mru.LookupParams{
+		Root: key,
+	}
 
 	switch len(params) {
 	case 0: // latest only
-		name, data, err = s.api.ResourceLookup(r.Context(), key, 0, 0, nil)
+		name, data, err = s.api.ResourceLookup(r.Context(), lookupParams)
 	case 2: // specific period and version
-		version, err = strconv.ParseUint(params[1], 10, 32)
+		version, err := strconv.ParseUint(params[1], 10, 32)
 		if err != nil {
 			break
 		}
-		period, err = strconv.ParseUint(params[0], 10, 32)
+		period, err := strconv.ParseUint(params[0], 10, 32)
 		if err != nil {
 			break
 		}
-		name, data, err = s.api.ResourceLookup(r.Context(), key, uint32(period), uint32(version), nil)
+		lookupParams.Version = uint32(version)
+		lookupParams.Period = uint32(period)
+		name, data, err = s.api.ResourceLookup(r.Context(), lookupParams)
 	case 1: // last version of specific period
-		period, err = strconv.ParseUint(params[0], 10, 32)
+		period, err := strconv.ParseUint(params[0], 10, 32)
 		if err != nil {
 			break
 		}
-		name, data, err = s.api.ResourceLookup(r.Context(), key, uint32(period), uint32(version), nil)
+		lookupParams.Period = uint32(period)
+		name, data, err = s.api.ResourceLookup(r.Context(), lookupParams)
 	default: // bogus
 		err = mru.NewError(storage.ErrInvalidValue, "invalid mutable resource request")
 	}

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -383,15 +383,19 @@ func testBzzGetPath(encrypted bool, t *testing.T) {
 
 	for i, mf := range testmanifest {
 		reader[i] = bytes.NewReader([]byte(mf))
-		var wait func()
-		addr[i], wait, err = srv.FileStore.Store(context.TODO(), reader[i], int64(len(mf)), encrypted)
+		var wait func(context.Context) error
+		ctx := context.TODO()
+		addr[i], wait, err = srv.FileStore.Store(ctx, reader[i], int64(len(mf)), encrypted)
 		for j := i + 1; j < len(testmanifest); j++ {
 			testmanifest[j] = strings.Replace(testmanifest[j], fmt.Sprintf("<key%v>", i), addr[i].Hex(), -1)
 		}
 		if err != nil {
 			t.Fatal(err)
 		}
-		wait()
+		err = wait(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	rootRef := addr[2].Hex()

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -18,6 +18,7 @@ package http
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/json"
 	"errors"
@@ -383,7 +384,7 @@ func testBzzGetPath(encrypted bool, t *testing.T) {
 	for i, mf := range testmanifest {
 		reader[i] = bytes.NewReader([]byte(mf))
 		var wait func()
-		addr[i], wait, err = srv.FileStore.Store(reader[i], int64(len(mf)), encrypted)
+		addr[i], wait, err = srv.FileStore.Store(context.TODO(), reader[i], int64(len(mf)), encrypted)
 		for j := i + 1; j < len(testmanifest); j++ {
 			testmanifest[j] = strings.Replace(testmanifest[j], fmt.Sprintf("<key%v>", i), addr[i].Hex(), -1)
 		}

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -146,7 +146,7 @@ func TestBzzResourceMultihash(t *testing.T) {
 		t.Fatalf("data %s could not be unmarshaled: %v", b, err)
 	}
 
-	correctManifestAddrHex := "9f01bcf171d70bbe588d931aaa316e9c9d5a6b9832d50c8b602b5ce9b905c6ac"
+	correctManifestAddrHex := "3e07feb9559158cf8000453880e786cb46a12d45b7e6bc94a7f8a5bbddbced68"
 	if rsrcResp.Hex() != correctManifestAddrHex {
 		t.Fatalf("Response resource key mismatch, expected '%s', got '%s'", correctManifestAddrHex, rsrcResp)
 	}
@@ -205,7 +205,7 @@ func TestBzzResource(t *testing.T) {
 		t.Fatalf("data %s could not be unmarshaled: %v", b, err)
 	}
 
-	correctManifestAddrHex := "9f01bcf171d70bbe588d931aaa316e9c9d5a6b9832d50c8b602b5ce9b905c6ac"
+	correctManifestAddrHex := "3e07feb9559158cf8000453880e786cb46a12d45b7e6bc94a7f8a5bbddbced68"
 	if rsrcResp.Hex() != correctManifestAddrHex {
 		t.Fatalf("Response resource key mismatch, expected '%s', got '%s'", correctManifestAddrHex, rsrcResp.Hex())
 	}
@@ -232,7 +232,7 @@ func TestBzzResource(t *testing.T) {
 	if len(manifest.Entries) != 1 {
 		t.Fatalf("Manifest has %d entries", len(manifest.Entries))
 	}
-	correctRootKeyHex := "e85df225aca2f6e571c7f6da179b8e19fd1caed17abd70ae2b062cd125c142aa"
+	correctRootKeyHex := "538291e3aa75628e598f8cecb6e1d63b7ef005aef6c979f4a9154149afe3f0f6"
 	if manifest.Entries[0].Hash != correctRootKeyHex {
 		t.Fatalf("Expected manifest path '%s', got '%s'", correctRootKeyHex, manifest.Entries[0].Hash)
 	}

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -146,7 +146,7 @@ func TestBzzResourceMultihash(t *testing.T) {
 		t.Fatalf("data %s could not be unmarshaled: %v", b, err)
 	}
 
-	correctManifestAddrHex := "d689648fb9e00ddc7ebcf474112d5881c5bf7dbc6e394681b1d224b11b59b5e0"
+	correctManifestAddrHex := "76477ecebf6955aa1cda553ce530a8204490e2b589e593e17576ecd07c955103"
 	if rsrcResp.Hex() != correctManifestAddrHex {
 		t.Fatalf("Response resource key mismatch, expected '%s', got '%s'", correctManifestAddrHex, rsrcResp)
 	}
@@ -205,7 +205,7 @@ func TestBzzResource(t *testing.T) {
 		t.Fatalf("data %s could not be unmarshaled: %v", b, err)
 	}
 
-	correctManifestAddrHex := "d689648fb9e00ddc7ebcf474112d5881c5bf7dbc6e394681b1d224b11b59b5e0"
+	correctManifestAddrHex := "76477ecebf6955aa1cda553ce530a8204490e2b589e593e17576ecd07c955103"
 	if rsrcResp.Hex() != correctManifestAddrHex {
 		t.Fatalf("Response resource key mismatch, expected '%s', got '%s'", correctManifestAddrHex, rsrcResp.Hex())
 	}
@@ -233,7 +233,7 @@ func TestBzzResource(t *testing.T) {
 		t.Fatalf("Manifest has %d entries", len(manifest.Entries))
 	}
 
-	correctRootKeyHex := "f667277e004e8486c7a3631fd226802430e84e9a81b6085d31f512a591ae0065"
+	correctRootKeyHex := "b904f65cb6db57fab00a7a0f921c70db82b57f19af2e0815a27762c08cefd2d4"
 	if manifest.Entries[0].Hash != correctRootKeyHex {
 		t.Fatalf("Expected manifest path '%s', got '%s'", correctRootKeyHex, manifest.Entries[0].Hash)
 	}

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -146,7 +146,7 @@ func TestBzzResourceMultihash(t *testing.T) {
 		t.Fatalf("data %s could not be unmarshaled: %v", b, err)
 	}
 
-	correctManifestAddrHex := "47bec48c6f148e9a44d985beb337cea7e0462309715afe5a32f415d75688900b"
+	correctManifestAddrHex := "2a6f57966187ce8d5165c570755e4c4f03c1176ff49ba84e9c654c5fb1ae205e"
 	if rsrcResp.Hex() != correctManifestAddrHex {
 		t.Fatalf("Response resource key mismatch, expected '%s', got '%s'", correctManifestAddrHex, rsrcResp)
 	}
@@ -205,7 +205,7 @@ func TestBzzResource(t *testing.T) {
 		t.Fatalf("data %s could not be unmarshaled: %v", b, err)
 	}
 
-	correctManifestAddrHex := "47bec48c6f148e9a44d985beb337cea7e0462309715afe5a32f415d75688900b"
+	correctManifestAddrHex := "2a6f57966187ce8d5165c570755e4c4f03c1176ff49ba84e9c654c5fb1ae205e"
 	if rsrcResp.Hex() != correctManifestAddrHex {
 		t.Fatalf("Response resource key mismatch, expected '%s', got '%s'", correctManifestAddrHex, rsrcResp.Hex())
 	}
@@ -232,7 +232,7 @@ func TestBzzResource(t *testing.T) {
 	if len(manifest.Entries) != 1 {
 		t.Fatalf("Manifest has %d entries", len(manifest.Entries))
 	}
-	correctRootKeyHex := "43de91e5b1b02f11bb7cf15d3880bf016f5b2dca265b849cd0aaf1ad47c61a00"
+	correctRootKeyHex := "1117bba54a84a0e85955bd234bae0b84b9f5a629c69a74889f5a93bcc0284dc4"
 	if manifest.Entries[0].Hash != correctRootKeyHex {
 		t.Fatalf("Expected manifest path '%s', got '%s'", correctRootKeyHex, manifest.Entries[0].Hash)
 	}

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -146,7 +146,7 @@ func TestBzzResourceMultihash(t *testing.T) {
 		t.Fatalf("data %s could not be unmarshaled: %v", b, err)
 	}
 
-	correctManifestAddrHex := "76477ecebf6955aa1cda553ce530a8204490e2b589e593e17576ecd07c955103"
+	correctManifestAddrHex := "9f01bcf171d70bbe588d931aaa316e9c9d5a6b9832d50c8b602b5ce9b905c6ac"
 	if rsrcResp.Hex() != correctManifestAddrHex {
 		t.Fatalf("Response resource key mismatch, expected '%s', got '%s'", correctManifestAddrHex, rsrcResp)
 	}
@@ -205,7 +205,7 @@ func TestBzzResource(t *testing.T) {
 		t.Fatalf("data %s could not be unmarshaled: %v", b, err)
 	}
 
-	correctManifestAddrHex := "76477ecebf6955aa1cda553ce530a8204490e2b589e593e17576ecd07c955103"
+	correctManifestAddrHex := "9f01bcf171d70bbe588d931aaa316e9c9d5a6b9832d50c8b602b5ce9b905c6ac"
 	if rsrcResp.Hex() != correctManifestAddrHex {
 		t.Fatalf("Response resource key mismatch, expected '%s', got '%s'", correctManifestAddrHex, rsrcResp.Hex())
 	}
@@ -232,8 +232,7 @@ func TestBzzResource(t *testing.T) {
 	if len(manifest.Entries) != 1 {
 		t.Fatalf("Manifest has %d entries", len(manifest.Entries))
 	}
-
-	correctRootKeyHex := "b904f65cb6db57fab00a7a0f921c70db82b57f19af2e0815a27762c08cefd2d4"
+	correctRootKeyHex := "e85df225aca2f6e571c7f6da179b8e19fd1caed17abd70ae2b062cd125c142aa"
 	if manifest.Entries[0].Hash != correctRootKeyHex {
 		t.Fatalf("Expected manifest path '%s', got '%s'", correctRootKeyHex, manifest.Entries[0].Hash)
 	}

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -146,7 +146,7 @@ func TestBzzResourceMultihash(t *testing.T) {
 		t.Fatalf("data %s could not be unmarshaled: %v", b, err)
 	}
 
-	correctManifestAddrHex := "3e07feb9559158cf8000453880e786cb46a12d45b7e6bc94a7f8a5bbddbced68"
+	correctManifestAddrHex := "47bec48c6f148e9a44d985beb337cea7e0462309715afe5a32f415d75688900b"
 	if rsrcResp.Hex() != correctManifestAddrHex {
 		t.Fatalf("Response resource key mismatch, expected '%s', got '%s'", correctManifestAddrHex, rsrcResp)
 	}
@@ -205,7 +205,7 @@ func TestBzzResource(t *testing.T) {
 		t.Fatalf("data %s could not be unmarshaled: %v", b, err)
 	}
 
-	correctManifestAddrHex := "3e07feb9559158cf8000453880e786cb46a12d45b7e6bc94a7f8a5bbddbced68"
+	correctManifestAddrHex := "47bec48c6f148e9a44d985beb337cea7e0462309715afe5a32f415d75688900b"
 	if rsrcResp.Hex() != correctManifestAddrHex {
 		t.Fatalf("Response resource key mismatch, expected '%s', got '%s'", correctManifestAddrHex, rsrcResp.Hex())
 	}
@@ -232,7 +232,7 @@ func TestBzzResource(t *testing.T) {
 	if len(manifest.Entries) != 1 {
 		t.Fatalf("Manifest has %d entries", len(manifest.Entries))
 	}
-	correctRootKeyHex := "538291e3aa75628e598f8cecb6e1d63b7ef005aef6c979f4a9154149afe3f0f6"
+	correctRootKeyHex := "43de91e5b1b02f11bb7cf15d3880bf016f5b2dca265b849cd0aaf1ad47c61a00"
 	if manifest.Entries[0].Hash != correctRootKeyHex {
 		t.Fatalf("Expected manifest path '%s', got '%s'", correctRootKeyHex, manifest.Entries[0].Hash)
 	}

--- a/swarm/api/http/templates.go
+++ b/swarm/api/http/templates.go
@@ -79,20 +79,25 @@ var landingPageTemplate = template.Must(template.New("landingPage").Parse(`
     <meta http-equiv="X-UA-Compatible" ww="chrome=1">
     <meta name="description" content="Ethereum/Swarm Landing page">
 		<style>
-
-      body, div, header, footer {
+      html, body {
         margin: 0;
-        padding: 0;
+        padding 0;
+        height: 100%;
       }
-
       body {
-        overflow: hidden;
+        display: flex;
+        flex-direction: column;
       }
-
-      .container {
-        min-width: 100%;
-        min-height: 100%;
-        max-height: 100%;
+      content {
+        flex: 1 0 auto;
+        background-color: #FCEFD3;
+      }
+      footer {
+        flex-shrink: 0;
+        background-color: #ffa500;
+        font-size: 1em;
+        text-align: center;
+        padding: 20px;
       }
 
       header {
@@ -129,12 +134,7 @@ var landingPageTemplate = template.Must(template.New("landingPage").Parse(`
         display: block;
         margin: 0 auto;
 				text-align: center;
-        /* width: 50%; */
-        min-height: 60vh;
-        max-height: 60vh;
         padding: 50px 20px;
-        opacity: 0.6;
-        background-color: #FCEFD3;
       }
 
       table {
@@ -160,56 +160,46 @@ var landingPageTemplate = template.Must(template.New("landingPage").Parse(`
         color: red;
         font-weight: bold
       }
-
-      footer {
-        height: 20vh;
-        background-color: #ffa500;
-        font-size: 1em;
-        text-align: center;
-        padding: 20px;
-      }
-
     </style>
     <title>Swarm :: Welcome to Swarm</title>
   </head>
-  <body>
+<body>
+  <content>
+    <header>
+      <div class="header-left">
+        <img style="height:18vh;margin-left:40px" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJYAAACrCAYAAACE5WWRAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4QMKDzsK7uq5KAAAGndJREFUeNrtnXuU3MV15z+3qnokjYQkQA8wD4NsApg4WfzaEIN5GQgxWSfxiWObtZOsE++exDl2nGTxcZKTk3iPj53jRxwM8XHYYHsdP9aQALIBARbExDjGMbGDMCwvIQGWkITempGm+1d3/6j6df+6p3tmeqZ75tet+p6jwzDd0/37Vn3r3lu3qm5BQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkLCbGALPzszkI+dUEYsEgt2HcgqMr8bACOg5X5sST1XMhgHvhZ+HnGnU+OdwOWQLQVuA67H6wt1C1bzSVgJXcDZ/0EmVwMVBAPZ6vjKAeCTeP183Xr58pmv5ApnbEnEIHIKIhnKBAjYHrikim0Iw9ilGHsBYq9DuRTwcfgL6Gg0BIuAqxC5CJHNwE6UDAOIAy2HBUsWq+OQM5D5XFQvBX4f+AXgYeAGvH4rtKCAzlJd1kKW5S7wUuDXUF5NkKsv9JKBbFVLfzmgBtwHfA6v3y2TBUvC6tgsuRWR9wJ/CCyOvzwSO/QHwHvxuqvrzqxYqEZBOXccykfwvDKKRds8TjthFVED/hn4AF73l0FcyRU2XF2jS42MInIhIl8D3tZkPUInWuA04LcQGQe2oozNaMZWqUC1Bs6twcg78PIZlBOn0XnRFbZ9euBM4F2I7AOeQxlPFqsMoqrHOXIF8G7gDbHDssI7FThcaDeJluxR4GvRJfkgLu0sMOsuRvkQyqpoAafrpeksVlFgI8Am4K8x3EFtYYIue9QLSqKojKxA5MYYS51eEFI7tyMt/78SeD1wNSKP4nVrPU5rF39Z2YaIB141o8E9vcUqCr8GOIR9wHdQkrDm3e0pILIGkXcB/wicwfTzvFqHDhZgKfAORF6GyNPAi2gb9+g1w/sfMWK+AXIKypo429NZCkuiux5H2IkwATwN3J+ENZ8InW0R+V3gIzGOqrW4vW6FVXz9HOAq4DREHsfrvsmxloOJ2kG8vwtjfoSwFOGcKBDtSljCGMI+hIMFl/hUEta8MG0Kzi8EbgZ+ETg2imGmmE5YRIEuAk5CeA7l4Unv8D7MAT2gfjvIRoT7MfI6YHmTuDoLKwNeRDgUfy7GfgsqLDP0gjKSWymDkTMxcj2wHnhJHyYveZ5iHOEn0YLIlBKtP6d6fPYw2fI3AzcCO2P/SAfh7ovfMVHGZndDP9MLgfmpwPuBXwJWAYf6NMM+FK3HRNez7syDqYDfrXiux7rbUK4C3omyLFgtfBRrbqFKaxiG02LZKConYOSDwP3A24FlMV3Qa2TADoQ9BVF1D1+FUQEqkNWew1Y+i+hVGL0LOILwAmGt0Jc9VTScFksZxcjP4fkIIXF4uE/flEUrtb9nHT2mQDUKbQKybA+WP0HMCtB1MW8mlHzjzHAIqznBeRnw3wkJTumDqEy0GAcQxmYYzM9Stvkk1SwOlkqeCoG9rgGWAD4Jq29uLy4WG1kLfLogqKxP3zgWk49Z13HU3GM4D+wF2Qe6CjixrJZr8GOszMOxKwT4akFU/UIVYUcfRTtzZ4+8APIIsK+MMddwBO/79wvCiwjPxGl6P2dMUqK+y0C2gmwOlqxjeiIJa86uQtiPsAV4kaMHY0FgPDmnWWkS1gxcRbBgW0Ojl3963qOxdRDkUWBHFNiCxV9umFs5xkTbgCUoxwKjlP58y9ymMkAF5A7gTvBZElZ/MY4wjjIKrKHTTs3BH0g7gS+Q8cRCZyKOFmHlTX8I2IJyHCELX+mzwLRpBlncR987MRlgF/AdhNupeQ3fQxLWPI9qRdgF7AeOiS6y15lsRVGQlcDVGDbh9eGYb+vVfvQKIfm7AfhO4zBrz8WbhNV1/AW7CWtva2L81aseWYSakxFGQVcDt2PkZuDP8bqvB+JyhMMc/0Dm99etIZRCVEezsIoSqwLPohxD2Ju1aPZuT0ZQjkVlNSAoGueiVeCtwCUY+Thwe3Rf3Rwfs3FAbAa+QeYfaXKvWblWd4Zjo58RiR23bNbyEiYQDsX9TYs7BPgZUk9EFuMoQWUtyEtQWd7yyfnO1Iywvnc58IZ48PXh+PxTO2Iji4CzgJuAW8n89sa3a0nH61BMssUAXwfW9qxdQuy1sqWNJmJ23zZiKTkG5GS0wyAVPQx6uIO3eAx4H15/PK3sEUPFZkzUYs0GLfXENlmsqWaQYRbpYqBsmiyWMgrmJFROmHKABovVbuuzB1YDv4nIWkSeRaN7bG/BtO7ufPkzJUlYU1vzsGNTGG8ITMbAnBzjqMXTmo3OwiqmI84FrkDkdEQewuvhQe+S5Aq7Q4aaM9EuAvzOrrBTf+wGLsPrQK91plnhTKwWHAR2gFQRfxjMS6Y9C9g9aoTdqEcYgjXcJKwpHCywH2QXMB4FNBLco98S9p/LWlROidLSOQh3f9yNmg1LnyRhdXJ58BzIgQ5hgwBHQLciug3MWWjLWcCZYSwewNChCk2SsCZZjyqwD2QnM99qU0X8D8GsAU5CWcbUS0RK2NJyAGkqMDJUSMJqdOxOkL2x06XLDreI3xX+Xo9FzUuZfNhBCHmw/cHaDfcesSQsOATyfCElILMXqGYIuxC/C5XTUHlJ4fW9hdoKMOQbD49mYY0De6KV6n0niz6J6HZUVkVBHSW7WI9OYZng6mQHYVdD1sfOdsA4os8SMveL6P/+rySsBcKOGJjPlzvKPz/Pvldi7CVJWIMfmGcxjtoRg+aF7NRqFNgiQk4sBe8D6vZaE5xl6Mi8julEFNf0641JWKVBBvJsjKOkpLMwXxDYKENWBG+YhGVoTnAqg+FqfBwAI9FFumFwkUNyYPVcHyqxyI4YSzFgnSPRch0h7G6oDnqPDL75tQ6y50H1LozsJ2zhNX1sr2V9iokM4YDEH5HpnmGYNQ2BEzShWCyANccDvwz8LHAM3RWunQ4V0LX07jSPjZ/1CPB1Mn0wfItAdbDj+eEIGPMDBeefBVt2jmPk32NnLSFcBtBLIfTKYo0STtx8GvgymW5hsQ172f3gd8lgWqzWc3lWIOvQ19acAbyHcLRrzpfA9chi1YAvY7iJqmZtn7+VY0nvJRwei2WbykKuRDkc5CKTO8Y5qGW7Ub0bIxOEiskr5yCwuVgsR6h2/C/A/yLTB/FoW1E1czwOZXzQMl2DI6wRAV+vhlwB+SDw5/GEy/dRzZpOtyixSH+8aFL1SYw8RChQdgazW7ebjbBMdMn3AZ8i02+iHMLFnTm+g6WqiAW5JnI8MXCkNgj3QQ+GK5zsEq4EPg6cQKP21U7gj4H78DHgauc68lPD1qwAfhP4mS7d2mxc4QvAJ8l0U8fnmszxCuATkeNhwrLUTuCDwLem5JiE1bXAzgfeC1wRcz6exuKuicHwBuC6pttGobnxKwaq9Rnk2YQ7b86Kr/oeCEui29sC3AXcTKZ+yjiwwfH1hNvHihyzmNfKLd89wGfw+kBHjklYUz1WPcZYB3wYOI9wx0y1JQiutbiqMeAB4MN43TytFbRmJArrrcCpTH1/4HTCqsS//wfgHjLd1XFyUfxd4PgXwM9HjkVOWQvnnOO/An+J16eTxZrO5RnCdHuxwGEWYXg/4aqSTnvIpzoMKsD1wHXAoY4juuEeBbgyWrDKLIQlwPeAT5Pp3uldu4BlBOV9wB9Ei9TuIVuF1fqdnwWunZLjURu857MgD1gZJeNtCH8PvJmplzf8NG7pQuBNwDgiz4Tb52m+CSzPgamC6hMgDyAsgbbnBluDdxsF8UPgM2T6VZTDbW+3t4U7Eo2MIvw6cAPwK9Nw1Gk4viEOhmaOCxzkSylE1XAJb45B+DoaWenp8kHTZdZzS/A48Am8bmifC8ur4NXjr5OB/xJdcB7vFC3WCPAM8DngYbJ42rldQO0kFvEAjFwF/E/g5TPkmDH92mHO8Qng43WOC3gzysILy4gBTokzvYvo/u7Abt6/BPg2cA3wTMfZVfMS0U/FGeSqYMF0TRTa/wW+QhbvgJ7KDYkIhlNQ/gq4tMtnnomwihglXEp1DYbN9Tuh53kGKQsgpGLyb13stN8mbHg70uWndSusPMA+DHwR+Apen5hBesJGQZwPugflS3jd2TEwb+Z4WuT4O1HY3XLsVljdcRw6i2XkzwhXva2i3XW1/RNWztsC2wk3rX4sWC8Jv810srjCz0tBx2dkpQLHDwFXE8oVzZbjbITVyvGfgI/i1YcFbvruImWeLdQIcDHwN8BxzH3nQa0HnzESk49/hHAvmWZdj+5mjpU4abg2Dpq5Pt9shdWO4x/j2QiR40xya6UUVt7gIiBcRLju7RcKwTAlEFYe/C4C7gb+N17vm/HEA4qTj4sIC95X9pBjL4SV93WeYL0Br/cOnsVqHsEnxcD8vBhY9rICea+EVUwnHAIeAv60nmCdLsFp5QSUT8QE59Iec+yVsFo5/hD4k3qCtcfWqz95LBEQWYbIB4CvxFmf7YNj9/R295ISlmNOBf4bIh4jm8h0cseqgJVliLwvzhBPpT83XmifOJ4C/FaYscp/tOVYOotlZRnK5+NM6kgfI8VeW6zWthkFHkS4mkz3tXAcRbkB+MU4A+sXx15brHbu8QcYeRu1WDO+R7FFP+AQLMIThGp4g3ZoQwj37zyNUIkCa8fRIDxOOGUzqBw3I1hUR3srgP4gN9/57Vv7UVYzGMfNPLAnFrTNU9c6xXurCNuBAwPGcW+sItiX9Lybp5FxCGEMZSVh9X6Ecm1Xy4uujSEcoPsziUcDx9IJqxHLhRrpB+L1IqsK1m2hm3wvjU2Ds409jwaOpRNWczAa6m7uR1nLwlZfmUDYTe8vYcsvGtiHcsKQciydsPLR4hF+AixFWRHzPzpP33247rr62+GK8BOUpYRDHEuYny0H88mxVMIqNsBYvP003wPVr9tPBahFS3KE+avtILFzxwlXCK+mfwXYFopj6YRVHNljwOZ4++nKHk/ffbwXZ/+CcgyD6Jkh5lg6YRVH927gYJxdLWP2Gfu8OP9YrAE6QTlyTUWOKwhlAHrFsUpJtpuXMeeS3z6/E9iLcjyzO8s3hrCPRmbelJDjrhjgHxdTFN0s3dgYQxU5luYMQ9mTeSHB2nz7/ExmZLti8DoIx9vyBOu+OEseCo6DkCXOg98t0XWsIGxx8ZMsAPU7Bget9HW+vDI9x8Cv9BzdADU80ewfBJahrCo07P7Y4FnZXEIPOe4rXORUeo6DWCoyi418EGVZXJ7IGK4KxAPP0Q3kqA4jeifCSJy2jzA89VQLHGUXopawjXugOLoBa/AJkO2ENa8a6GIatdMtIbPdjw2FC8iRYyPHKiGxungQOA6KsBTYNcWtEho74UBs+EEszu+B3dPcnJELrPQcXclHb4g1wiUAM01wjsfGH4n/ym6hwt4o5EWY8bW947E9FpWVY1mFZWJj76CxLdd0Kci88RdTzsuRTBw0L8ySo28jME3C6owqyLYYoM/V1Gfxc/LLkcyQcjwUBVYajmURVrxjmT0gu+ntqrzE+OtgwT0uRPBb5LiH3iY4pRBjLlpAjqURVt6wO6Kg+rm7UWPHFi9Hmi+OGjnuof8JzoXgWCphaczVbGN+V+Xz27eqhfhrWDnm7rEy7MLKG/ZAtFB5jCEL8Bxhu0log17ffiol4agx/pr3G17dPBOdALaBjFGe27lq0T3ZHgS/+WL4T0rEUXrMsVTCymhO/pUtsdeLBGvOcRflvNJuXpPI/RSWIT/8GVzCBIORDR8vBL+LZuhudrdwlCHiWDphHQI5QKOC3aAsseTx1+EZDIYxkKeHgGPPXWN/qs2YkSOgm4CTCNuK++XT+zXjyRt+C/BRMn2qA8fH5oFj7rb6FdxvjRyf7McsrT+wxgA/B7wReFkcHT2MGfS4KK5etscosIlQXvHe+q0S0L5+VIPjpYRKyL3muJJw5rLXHB8pcMyoSIgSe1SjVPooqmLtzgrwekI9TktvTuX2Wlj5ndLXA/fVy2tPfWVdg6MzIyjnAf+1xxx7KSwThf/ZKKjpOZbSYtUjOQM1D8YsQXgn4XKkJcytoFivhGViMPsDwiUA+7pu6BET5lvegzVLorh+JloGXwJh5Rwfihz39rP+6PwGm821088gFLl9XSGemW9hmWhZNgLryfSRMAgKxf7nZqVfHjn+5zlynIuwTJygbQRuq3Pss6jmfxbT3PAWeCmhGOwJdF+1bi7CGomB+ceAp+uVkntxF/NkjqdGjifOkuNshbWIcHPGx4DNZFqbL1Et7PTYWahleQdcAVxG2L8eG7Tnwsq5vgjcQqY3972hm0V2OXA54WiXdMGxG2HlHHdHjjfVOSpDfjNF5044lnDh0MWEwwNHeiiskdjY3wA2kOmOBbLSKyPHS7rgOFNhVYA9keNdZPrCQifKKJG4JI7oX4kdUJujsPLirXcAfwfsJVMNdzbECcXCcFweOV44A47TCStPH9xOuE1sD5nqlCmSo1BYxdF9JvCOGH+127Q2lbDy1MEW4DoyfWw+44upQwAHtVpxEnN15Og6cOwkrAZH5Tp8iThSxiWI5qm7iTPHywi3oI7TdJ34JGFJDFo3Abch8m1qvlqWxm48pYRLFrImjm+MHA+3cGwVVpHjeuDbZDpRtvuhy7u21Wy9RoDXxPxQXtOgVVj5ove1wD+T6XidoQ4Mx1cD72zhWBSWISReryckOMfLZKUGQ1jFxod8dI8Srmg7G1gchTVK2LD3b8Cn6tnkQYJEF1mt5QnW3wDOCYNGVxDWIscISdy/JtOxQaA0GGhOT5wBXAT6RuDfCcm/H5d19M7SgsUEq14C/AfznOA8umBN8WeLlVVYcUPF0dlWjquHjmOpYaT5v8M8kKxJ/Z2QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJBwdMCZLt+7LPxsl1HfkjtTmOKib5u1XlPp/L3FNbyR+DnFtUtrYMS151ZpfK50fOaRsK/UCZg2p+zdovBawgwwOlroGFmKtWdg7csxprGL0rbpbGeDuqTltREBawXboWziMctzUR3T5jOLojsLUzkfa89seo/Ez80FOhr3HR4zaUuSY6TwOxveP+oKvzNmGabyGsSdXWiQVmH+NMa+CiuxSswqqNikmymRD8qRyjqM/SLOPoBzd+LcBpy7H+P+FuOODyO+YC2WW4ux92Ds6rafa+2pWHcLzq6g0maEW/cWrLu2rWVx9iycW4+rbMC4r+Aqd2PcHVj3n8LrlZtw5oymv63YMzHu8/H10zHuizj3XZy9vEW4x+Mqd8dn+CDOfQfrbqVS2YB1d2LMKwuW9QKsuxdXuR3rbsO5B7GVdyfRzBS2cjzOfR3rfh1nljcaVo7Fud/D2jsYcaOTXZb7S5z7wya3lIvPufcg7hGcfU2H7/xHXOWyNm7ycoy7F+eubBHqpVh3O85ehavcgnOvaHn9HMT9H4x5NcZ9E2t/B2fWTraIbg2u8n2M+1Os/QNMYf++sZdiK7dgKyfj7M9j3XpM4fmNOxlX+RKu8m5Gka7Ch6NTWO5crPtY55jI/R3O/vZky+LOwbgNLG1Tmsm4m7DuL3Dur8J7i3FQ5Wysu5MTW1yXtWdj3T0YWdchHjsN476Ac9/DFV0X4OwrEHcrxq7H2Fc2f27Rsrk1GPdYfUCELyk+99tx7pNYdwvWva6NJV6NdZ/H2lVl68Yyynw/yqlYe0zbeMf4ryHyXP33+dnAWu0RRPZyxJ0X3VH8u8prEUYwtWvJOJcRljfVZhC5ANjINrQu0kUYvLwF9G/x+nQ9sPdZI8jPas8gbMQz2maDtwLHI+Y2fPZw0yuTa9CM4XVDY5AUzjq67Ftk/DSeF8hqD7aICrC7gW3A6UlYU87wHIjfAvwrmBsx9gNYdyXWnY2XNWAsNX8P1dqdVNrM4MTfipcLGEWoZnkX/wbwNarswshWMvemesdU3BK8fy3Kzc0itYtxnIwx97M6zhmywrnS/GflBwiH250GRKjgql+dhnGoC2r1iabvzzGhOwDF6cYwWIoCzSCbyBCeB3lpEtZUqNWg5mv42qdRrgGeBP0p0HcDH8fZv8HYc4FG5ZqmbpKNiL6CqlsaXckq0LPQ7NYgvOwGlLc3OoY14X26Hdck1AqeGqpVdh7q/LyeHbQ/yWxQnucIB6ZhLAgTVP00R+1NqCjYtqSIeKR8h2LKtUm/ePrEV5/ieJ5inxUUg+DwejEi12Hl/WS+2TVUDHjdg8pevK4jnGy5AOV7eD0YLcJ3seKx7hVktR8jegHIY9SyZvWI5NeR2GmG5WI6n3Sa/hiaKogx01u1eH5wgFAui5UpOPvy+uztRaCWKVmWkdWO4Gt3IvJRsB+a9LdVD1l2BOHfQN4U7cF5wDdjoJyr5m7g/PjzLyF8u60oVCYI9UXbJ05Dn5/N3KsOD2WGs4TBu/wsmEsndWjdVWXbQaYoBKL34rkE51aDrEVkE9aGw6ABG1DOwZnXAsupyUNtXHIV9RtR+UA9pio+S8XBUgTkKvpVIDgJq8dQ/RFeX4V1y5oC5lotzH3Uvg+Jta3aWr1sK5bnQf8M4f8h1YNkphgXbQMs3vw+sJ56lN8aP2XrQSeoVD41KXiv1uCwvQb0ECLPDqvVGR5hVQxYsxnhX4DrMO6tWHsh1r0BW3krz1a+AH4rtdrncO9qE6NF4+H1y2RyCV4foIZvinq1dghhE3AumK+3jzyjTlaveQ9ewbobMe4tOHcxxv0q1t2Il5NYlH2Yxt3NzWH91OWJGoH39FX+PFMWytVpXl+gcLlUT+MVMq+s9t9n3D4FnILwMpBTQBS4hdHal0LJ+4cnV1dRzfNMzyLyIqIbUZ3cccbsQHiUrPoQdiW0lnvwgKvA/n3g/F14eR5kHcKpgEN0PSuyv+cAE4h5EngK9bXC548h8jjqt0/d+qaK8jjqt3bWntkC/lFU2wvVyG6Qp/D+ULKTU85TTfPP1kr4V9g2MJPlC+ekY1hdcY2Yyc5w2I04wdnwr47CKk3+eS2L4KZiOufsoLE+ajpMEJa3WONOPmfp0qSdhISEhISEhISEhISEhISEhISEhISEhISEhISEhIThxP8HhRpz3L2ZmSwAAAAASUVORK5CYII="/>
+      </div>
+      <div class="page-title">
+        <h1>Welcome to Swarm</h1>
+      </div>
+    </header>
 
+    <script type="text/javascript">
+    function goToPage() {
+        var page = document.getElementById('page').value;
+        if (page == "") {
+          var page = "theswarm.eth"
+        }
+        var address = "/bzz:/" + page;
+        location.href = address;
+        console.log(address)
+    }
+    </script>
+    <content-body>
 
-      <header>
-        <div class="header-left">
-          <img style="height:18vh;margin-left:40px" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJYAAACrCAYAAACE5WWRAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4QMKDzsK7uq5KAAAGndJREFUeNrtnXuU3MV15z+3qnokjYQkQA8wD4NsApg4WfzaEIN5GQgxWSfxiWObtZOsE++exDl2nGTxcZKTk3iPj53jRxwM8XHYYHsdP9aQALIBARbExDjGMbGDMCwvIQGWkITempGm+1d3/6j6df+6p3tmeqZ75tet+p6jwzDd0/37Vn3r3lu3qm5BQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkLCbGALPzszkI+dUEYsEgt2HcgqMr8bACOg5X5sST1XMhgHvhZ+HnGnU+OdwOWQLQVuA67H6wt1C1bzSVgJXcDZ/0EmVwMVBAPZ6vjKAeCTeP183Xr58pmv5ApnbEnEIHIKIhnKBAjYHrikim0Iw9ilGHsBYq9DuRTwcfgL6Gg0BIuAqxC5CJHNwE6UDAOIAy2HBUsWq+OQM5D5XFQvBX4f+AXgYeAGvH4rtKCAzlJd1kKW5S7wUuDXUF5NkKsv9JKBbFVLfzmgBtwHfA6v3y2TBUvC6tgsuRWR9wJ/CCyOvzwSO/QHwHvxuqvrzqxYqEZBOXccykfwvDKKRds8TjthFVED/hn4AF73l0FcyRU2XF2jS42MInIhIl8D3tZkPUInWuA04LcQGQe2oozNaMZWqUC1Bs6twcg78PIZlBOn0XnRFbZ9euBM4F2I7AOeQxlPFqsMoqrHOXIF8G7gDbHDssI7FThcaDeJluxR4GvRJfkgLu0sMOsuRvkQyqpoAafrpeksVlFgI8Am4K8x3EFtYYIue9QLSqKojKxA5MYYS51eEFI7tyMt/78SeD1wNSKP4nVrPU5rF39Z2YaIB141o8E9vcUqCr8GOIR9wHdQkrDm3e0pILIGkXcB/wicwfTzvFqHDhZgKfAORF6GyNPAi2gb9+g1w/sfMWK+AXIKypo429NZCkuiux5H2IkwATwN3J+ENZ8InW0R+V3gIzGOqrW4vW6FVXz9HOAq4DREHsfrvsmxloOJ2kG8vwtjfoSwFOGcKBDtSljCGMI+hIMFl/hUEta8MG0Kzi8EbgZ+ETg2imGmmE5YRIEuAk5CeA7l4Unv8D7MAT2gfjvIRoT7MfI6YHmTuDoLKwNeRDgUfy7GfgsqLDP0gjKSWymDkTMxcj2wHnhJHyYveZ5iHOEn0YLIlBKtP6d6fPYw2fI3AzcCO2P/SAfh7ovfMVHGZndDP9MLgfmpwPuBXwJWAYf6NMM+FK3HRNez7syDqYDfrXiux7rbUK4C3omyLFgtfBRrbqFKaxiG02LZKConYOSDwP3A24FlMV3Qa2TADoQ9BVF1D1+FUQEqkNWew1Y+i+hVGL0LOILwAmGt0Jc9VTScFksZxcjP4fkIIXF4uE/flEUrtb9nHT2mQDUKbQKybA+WP0HMCtB1MW8mlHzjzHAIqznBeRnw3wkJTumDqEy0GAcQxmYYzM9Stvkk1SwOlkqeCoG9rgGWAD4Jq29uLy4WG1kLfLogqKxP3zgWk49Z13HU3GM4D+wF2Qe6CjixrJZr8GOszMOxKwT4akFU/UIVYUcfRTtzZ4+8APIIsK+MMddwBO/79wvCiwjPxGl6P2dMUqK+y0C2gmwOlqxjeiIJa86uQtiPsAV4kaMHY0FgPDmnWWkS1gxcRbBgW0Ojl3963qOxdRDkUWBHFNiCxV9umFs5xkTbgCUoxwKjlP58y9ymMkAF5A7gTvBZElZ/MY4wjjIKrKHTTs3BH0g7gS+Q8cRCZyKOFmHlTX8I2IJyHCELX+mzwLRpBlncR987MRlgF/AdhNupeQ3fQxLWPI9qRdgF7AeOiS6y15lsRVGQlcDVGDbh9eGYb+vVfvQKIfm7AfhO4zBrz8WbhNV1/AW7CWtva2L81aseWYSakxFGQVcDt2PkZuDP8bqvB+JyhMMc/0Dm99etIZRCVEezsIoSqwLPohxD2Ju1aPZuT0ZQjkVlNSAoGueiVeCtwCUY+Thwe3Rf3Rwfs3FAbAa+QeYfaXKvWblWd4Zjo58RiR23bNbyEiYQDsX9TYs7BPgZUk9EFuMoQWUtyEtQWd7yyfnO1Iywvnc58IZ48PXh+PxTO2Iji4CzgJuAW8n89sa3a0nH61BMssUAXwfW9qxdQuy1sqWNJmJ23zZiKTkG5GS0wyAVPQx6uIO3eAx4H15/PK3sEUPFZkzUYs0GLfXENlmsqWaQYRbpYqBsmiyWMgrmJFROmHKABovVbuuzB1YDv4nIWkSeRaN7bG/BtO7ufPkzJUlYU1vzsGNTGG8ITMbAnBzjqMXTmo3OwiqmI84FrkDkdEQewuvhQe+S5Aq7Q4aaM9EuAvzOrrBTf+wGLsPrQK91plnhTKwWHAR2gFQRfxjMS6Y9C9g9aoTdqEcYgjXcJKwpHCywH2QXMB4FNBLco98S9p/LWlROidLSOQh3f9yNmg1LnyRhdXJ58BzIgQ5hgwBHQLciug3MWWjLWcCZYSwewNChCk2SsCZZjyqwD2QnM99qU0X8D8GsAU5CWcbUS0RK2NJyAGkqMDJUSMJqdOxOkL2x06XLDreI3xX+Xo9FzUuZfNhBCHmw/cHaDfcesSQsOATyfCElILMXqGYIuxC/C5XTUHlJ4fW9hdoKMOQbD49mYY0De6KV6n0niz6J6HZUVkVBHSW7WI9OYZng6mQHYVdD1sfOdsA4os8SMveL6P/+rySsBcKOGJjPlzvKPz/Pvldi7CVJWIMfmGcxjtoRg+aF7NRqFNgiQk4sBe8D6vZaE5xl6Mi8julEFNf0641JWKVBBvJsjKOkpLMwXxDYKENWBG+YhGVoTnAqg+FqfBwAI9FFumFwkUNyYPVcHyqxyI4YSzFgnSPRch0h7G6oDnqPDL75tQ6y50H1LozsJ2zhNX1sr2V9iokM4YDEH5HpnmGYNQ2BEzShWCyANccDvwz8LHAM3RWunQ4V0LX07jSPjZ/1CPB1Mn0wfItAdbDj+eEIGPMDBeefBVt2jmPk32NnLSFcBtBLIfTKYo0STtx8GvgymW5hsQ172f3gd8lgWqzWc3lWIOvQ19acAbyHcLRrzpfA9chi1YAvY7iJqmZtn7+VY0nvJRwei2WbykKuRDkc5CKTO8Y5qGW7Ub0bIxOEiskr5yCwuVgsR6h2/C/A/yLTB/FoW1E1czwOZXzQMl2DI6wRAV+vhlwB+SDw5/GEy/dRzZpOtyixSH+8aFL1SYw8RChQdgazW7ebjbBMdMn3AZ8i02+iHMLFnTm+g6WqiAW5JnI8MXCkNgj3QQ+GK5zsEq4EPg6cQKP21U7gj4H78DHgauc68lPD1qwAfhP4mS7d2mxc4QvAJ8l0U8fnmszxCuATkeNhwrLUTuCDwLem5JiE1bXAzgfeC1wRcz6exuKuicHwBuC6pttGobnxKwaq9Rnk2YQ7b86Kr/oeCEui29sC3AXcTKZ+yjiwwfH1hNvHihyzmNfKLd89wGfw+kBHjklYUz1WPcZYB3wYOI9wx0y1JQiutbiqMeAB4MN43TytFbRmJArrrcCpTH1/4HTCqsS//wfgHjLd1XFyUfxd4PgXwM9HjkVOWQvnnOO/An+J16eTxZrO5RnCdHuxwGEWYXg/4aqSTnvIpzoMKsD1wHXAoY4juuEeBbgyWrDKLIQlwPeAT5Pp3uldu4BlBOV9wB9Ei9TuIVuF1fqdnwWunZLjURu857MgD1gZJeNtCH8PvJmplzf8NG7pQuBNwDgiz4Tb52m+CSzPgamC6hMgDyAsgbbnBluDdxsF8UPgM2T6VZTDbW+3t4U7Eo2MIvw6cAPwK9Nw1Gk4viEOhmaOCxzkSylE1XAJb45B+DoaWenp8kHTZdZzS/A48Am8bmifC8ur4NXjr5OB/xJdcB7vFC3WCPAM8DngYbJ42rldQO0kFvEAjFwF/E/g5TPkmDH92mHO8Qng43WOC3gzysILy4gBTokzvYvo/u7Abt6/BPg2cA3wTMfZVfMS0U/FGeSqYMF0TRTa/wW+QhbvgJ7KDYkIhlNQ/gq4tMtnnomwihglXEp1DYbN9Tuh53kGKQsgpGLyb13stN8mbHg70uWndSusPMA+DHwR+Apen5hBesJGQZwPugflS3jd2TEwb+Z4WuT4O1HY3XLsVljdcRw6i2XkzwhXva2i3XW1/RNWztsC2wk3rX4sWC8Jv810srjCz0tBx2dkpQLHDwFXE8oVzZbjbITVyvGfgI/i1YcFbvruImWeLdQIcDHwN8BxzH3nQa0HnzESk49/hHAvmWZdj+5mjpU4abg2Dpq5Pt9shdWO4x/j2QiR40xya6UUVt7gIiBcRLju7RcKwTAlEFYe/C4C7gb+N17vm/HEA4qTj4sIC95X9pBjL4SV93WeYL0Br/cOnsVqHsEnxcD8vBhY9rICea+EVUwnHAIeAv60nmCdLsFp5QSUT8QE59Iec+yVsFo5/hD4k3qCtcfWqz95LBEQWYbIB4CvxFmf7YNj9/R295ISlmNOBf4bIh4jm8h0cseqgJVliLwvzhBPpT83XmifOJ4C/FaYscp/tOVYOotlZRnK5+NM6kgfI8VeW6zWthkFHkS4mkz3tXAcRbkB+MU4A+sXx15brHbu8QcYeRu1WDO+R7FFP+AQLMIThGp4g3ZoQwj37zyNUIkCa8fRIDxOOGUzqBw3I1hUR3srgP4gN9/57Vv7UVYzGMfNPLAnFrTNU9c6xXurCNuBAwPGcW+sItiX9Lybp5FxCGEMZSVh9X6Ecm1Xy4uujSEcoPsziUcDx9IJqxHLhRrpB+L1IqsK1m2hm3wvjU2Ds409jwaOpRNWczAa6m7uR1nLwlZfmUDYTe8vYcsvGtiHcsKQciydsPLR4hF+AixFWRHzPzpP33247rr62+GK8BOUpYRDHEuYny0H88mxVMIqNsBYvP003wPVr9tPBahFS3KE+avtILFzxwlXCK+mfwXYFopj6YRVHNljwOZ4++nKHk/ffbwXZ/+CcgyD6Jkh5lg6YRVH927gYJxdLWP2Gfu8OP9YrAE6QTlyTUWOKwhlAHrFsUpJtpuXMeeS3z6/E9iLcjyzO8s3hrCPRmbelJDjrhjgHxdTFN0s3dgYQxU5luYMQ9mTeSHB2nz7/ExmZLti8DoIx9vyBOu+OEseCo6DkCXOg98t0XWsIGxx8ZMsAPU7Bget9HW+vDI9x8Cv9BzdADU80ewfBJahrCo07P7Y4FnZXEIPOe4rXORUeo6DWCoyi418EGVZXJ7IGK4KxAPP0Q3kqA4jeifCSJy2jzA89VQLHGUXopawjXugOLoBa/AJkO2ENa8a6GIatdMtIbPdjw2FC8iRYyPHKiGxungQOA6KsBTYNcWtEho74UBs+EEszu+B3dPcnJELrPQcXclHb4g1wiUAM01wjsfGH4n/ym6hwt4o5EWY8bW947E9FpWVY1mFZWJj76CxLdd0Kci88RdTzsuRTBw0L8ySo28jME3C6owqyLYYoM/V1Gfxc/LLkcyQcjwUBVYajmURVrxjmT0gu+ntqrzE+OtgwT0uRPBb5LiH3iY4pRBjLlpAjqURVt6wO6Kg+rm7UWPHFi9Hmi+OGjnuof8JzoXgWCphaczVbGN+V+Xz27eqhfhrWDnm7rEy7MLKG/ZAtFB5jCEL8Bxhu0log17ffiol4agx/pr3G17dPBOdALaBjFGe27lq0T3ZHgS/+WL4T0rEUXrMsVTCymhO/pUtsdeLBGvOcRflvNJuXpPI/RSWIT/8GVzCBIORDR8vBL+LZuhudrdwlCHiWDphHQI5QKOC3aAsseTx1+EZDIYxkKeHgGPPXWN/qs2YkSOgm4CTCNuK++XT+zXjyRt+C/BRMn2qA8fH5oFj7rb6FdxvjRyf7McsrT+wxgA/B7wReFkcHT2MGfS4KK5etscosIlQXvHe+q0S0L5+VIPjpYRKyL3muJJw5rLXHB8pcMyoSIgSe1SjVPooqmLtzgrwekI9TktvTuX2Wlj5ndLXA/fVy2tPfWVdg6MzIyjnAf+1xxx7KSwThf/ZKKjpOZbSYtUjOQM1D8YsQXgn4XKkJcytoFivhGViMPsDwiUA+7pu6BET5lvegzVLorh+JloGXwJh5Rwfihz39rP+6PwGm821088gFLl9XSGemW9hmWhZNgLryfSRMAgKxf7nZqVfHjn+5zlynIuwTJygbQRuq3Pss6jmfxbT3PAWeCmhGOwJdF+1bi7CGomB+ceAp+uVkntxF/NkjqdGjifOkuNshbWIcHPGx4DNZFqbL1Et7PTYWahleQdcAVxG2L8eG7Tnwsq5vgjcQqY3972hm0V2OXA54WiXdMGxG2HlHHdHjjfVOSpDfjNF5044lnDh0MWEwwNHeiiskdjY3wA2kOmOBbLSKyPHS7rgOFNhVYA9keNdZPrCQifKKJG4JI7oX4kdUJujsPLirXcAfwfsJVMNdzbECcXCcFweOV44A47TCStPH9xOuE1sD5nqlCmSo1BYxdF9JvCOGH+127Q2lbDy1MEW4DoyfWw+44upQwAHtVpxEnN15Og6cOwkrAZH5Tp8iThSxiWI5qm7iTPHywi3oI7TdJ34JGFJDFo3Abch8m1qvlqWxm48pYRLFrImjm+MHA+3cGwVVpHjeuDbZDpRtvuhy7u21Wy9RoDXxPxQXtOgVVj5ove1wD+T6XidoQ4Mx1cD72zhWBSWISReryckOMfLZKUGQ1jFxod8dI8Srmg7G1gchTVK2LD3b8Cn6tnkQYJEF1mt5QnW3wDOCYNGVxDWIscISdy/JtOxQaA0GGhOT5wBXAT6RuDfCcm/H5d19M7SgsUEq14C/AfznOA8umBN8WeLlVVYcUPF0dlWjquHjmOpYaT5v8M8kKxJ/Z2QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJBwdMCZLt+7LPxsl1HfkjtTmOKib5u1XlPp/L3FNbyR+DnFtUtrYMS151ZpfK50fOaRsK/UCZg2p+zdovBawgwwOlroGFmKtWdg7csxprGL0rbpbGeDuqTltREBawXboWziMctzUR3T5jOLojsLUzkfa89seo/Ez80FOhr3HR4zaUuSY6TwOxveP+oKvzNmGabyGsSdXWiQVmH+NMa+CiuxSswqqNikmymRD8qRyjqM/SLOPoBzd+LcBpy7H+P+FuOODyO+YC2WW4ux92Ds6rafa+2pWHcLzq6g0maEW/cWrLu2rWVx9iycW4+rbMC4r+Aqd2PcHVj3n8LrlZtw5oymv63YMzHu8/H10zHuizj3XZy9vEW4x+Mqd8dn+CDOfQfrbqVS2YB1d2LMKwuW9QKsuxdXuR3rbsO5B7GVdyfRzBS2cjzOfR3rfh1nljcaVo7Fud/D2jsYcaOTXZb7S5z7wya3lIvPufcg7hGcfU2H7/xHXOWyNm7ycoy7F+eubBHqpVh3O85ehavcgnOvaHn9HMT9H4x5NcZ9E2t/B2fWTraIbg2u8n2M+1Os/QNMYf++sZdiK7dgKyfj7M9j3XpM4fmNOxlX+RKu8m5Gka7Ch6NTWO5crPtY55jI/R3O/vZky+LOwbgNLG1Tmsm4m7DuL3Dur8J7i3FQ5Wysu5MTW1yXtWdj3T0YWdchHjsN476Ac9/DFV0X4OwrEHcrxq7H2Fc2f27Rsrk1GPdYfUCELyk+99tx7pNYdwvWva6NJV6NdZ/H2lVl68Yyynw/yqlYe0zbeMf4ryHyXP33+dnAWu0RRPZyxJ0X3VH8u8prEUYwtWvJOJcRljfVZhC5ANjINrQu0kUYvLwF9G/x+nQ9sPdZI8jPas8gbMQz2maDtwLHI+Y2fPZw0yuTa9CM4XVDY5AUzjq67Ftk/DSeF8hqD7aICrC7gW3A6UlYU87wHIjfAvwrmBsx9gNYdyXWnY2XNWAsNX8P1dqdVNrM4MTfipcLGEWoZnkX/wbwNarswshWMvemesdU3BK8fy3Kzc0itYtxnIwx97M6zhmywrnS/GflBwiH250GRKjgql+dhnGoC2r1iabvzzGhOwDF6cYwWIoCzSCbyBCeB3lpEtZUqNWg5mv42qdRrgGeBP0p0HcDH8fZv8HYc4FG5ZqmbpKNiL6CqlsaXckq0LPQ7NYgvOwGlLc3OoY14X26Hdck1AqeGqpVdh7q/LyeHbQ/yWxQnucIB6ZhLAgTVP00R+1NqCjYtqSIeKR8h2LKtUm/ePrEV5/ieJ5inxUUg+DwejEi12Hl/WS+2TVUDHjdg8pevK4jnGy5AOV7eD0YLcJ3seKx7hVktR8jegHIY9SyZvWI5NeR2GmG5WI6n3Sa/hiaKogx01u1eH5wgFAui5UpOPvy+uztRaCWKVmWkdWO4Gt3IvJRsB+a9LdVD1l2BOHfQN4U7cF5wDdjoJyr5m7g/PjzLyF8u60oVCYI9UXbJ05Dn5/N3KsOD2WGs4TBu/wsmEsndWjdVWXbQaYoBKL34rkE51aDrEVkE9aGw6ABG1DOwZnXAsupyUNtXHIV9RtR+UA9pio+S8XBUgTkKvpVIDgJq8dQ/RFeX4V1y5oC5lotzH3Uvg+Jta3aWr1sK5bnQf8M4f8h1YNkphgXbQMs3vw+sJ56lN8aP2XrQSeoVD41KXiv1uCwvQb0ECLPDqvVGR5hVQxYsxnhX4DrMO6tWHsh1r0BW3krz1a+AH4rtdrncO9qE6NF4+H1y2RyCV4foIZvinq1dghhE3AumK+3jzyjTlaveQ9ewbobMe4tOHcxxv0q1t2Il5NYlH2Yxt3NzWH91OWJGoH39FX+PFMWytVpXl+gcLlUT+MVMq+s9t9n3D4FnILwMpBTQBS4hdHal0LJ+4cnV1dRzfNMzyLyIqIbUZ3cccbsQHiUrPoQdiW0lnvwgKvA/n3g/F14eR5kHcKpgEN0PSuyv+cAE4h5EngK9bXC548h8jjqt0/d+qaK8jjqt3bWntkC/lFU2wvVyG6Qp/D+ULKTU85TTfPP1kr4V9g2MJPlC+ekY1hdcY2Yyc5w2I04wdnwr47CKk3+eS2L4KZiOufsoLE+ajpMEJa3WONOPmfp0qSdhISEhISEhISEhISEhISEhISEhISEhISEhISEhIThxP8HhRpz3L2ZmSwAAAAASUVORK5CYII="/>
-        </div>
-        <div class="page-title">
-          <h1>Welcome to Swarm</h1>
-        </div>
-      </header>
-
-			<script type="text/javascript">
-			function goToPage() {
-					var page = document.getElementById('page').value;
-					if (page == "") {
-						var page = "theswarm.eth"
-					}
-					var address = "/bzz:/" + page;
-					location.href = address;
-					console.log(address)
-			}
-			</script>
-				<content-body>
-
-	            <h1>Enter the hash or ENS of a Swarm-hosted file below:</h1>
-							<form action="javascript:goToPage();">
-								<input type="text" id="page" size="64"/>
-								<input type="submit" value="submit" onclick="goToPage();" />
-							</form>
-				</content-body>
-      <footer>
-        <p>
-          Swarm: Serverless Hosting Incentivised Peer-To-Peer Storage And Content Distribution<br/>
-          <a href="/bzz:/theswarm.eth">Swarm</a>
-        </p>
-      </footer>
-
+      <h1>Enter the hash or ENS of a Swarm-hosted file below:</h1>
+      <form action="javascript:goToPage();">
+        <input type="text" id="page" size="64"/>
+        <input type="submit" value="submit" onclick="goToPage();" />
+      </form>
+    </content-body>
+  </content>
+  <footer>
+    <p>
+      <a href="/bzz:/theswarm.eth">Swarm</a>: Serverless Hosting Incentivised peer-to-peer Storage and Content Distribution
+    </p>
+  </footer>
+  
   </body>
 </html>
 `[1:]))

--- a/swarm/api/http/templates.go
+++ b/swarm/api/http/templates.go
@@ -198,9 +198,10 @@ var landingPageTemplate = template.Must(template.New("landingPage").Parse(`
 				<content-body>
 
 	            <h1>Enter the hash or ENS of a Swarm-hosted file below:</h1>
+							<form action="javascript:goToPage();">
 								<input type="text" id="page" size="64"/>
 								<input type="submit" value="submit" onclick="goToPage();" />
-
+							</form>
 				</content-body>
       <footer>
         <p>

--- a/swarm/api/http/templates.go
+++ b/swarm/api/http/templates.go
@@ -134,7 +134,7 @@ var landingPageTemplate = template.Must(template.New("landingPage").Parse(`
         max-height: 60vh;
         padding: 50px 20px;
         opacity: 0.6;
-        background-color: #A9F5BF;
+        background-color: #FCEFD3;
       }
 
       table {

--- a/swarm/api/manifest.go
+++ b/swarm/api/manifest.go
@@ -18,6 +18,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -61,20 +62,20 @@ type ManifestList struct {
 }
 
 // NewManifest creates and stores a new, empty manifest
-func (a *API) NewManifest(toEncrypt bool) (storage.Address, error) {
+func (a *API) NewManifest(ctx context.Context, toEncrypt bool) (storage.Address, error) {
 	var manifest Manifest
 	data, err := json.Marshal(&manifest)
 	if err != nil {
 		return nil, err
 	}
-	key, wait, err := a.Store(bytes.NewReader(data), int64(len(data)), toEncrypt)
+	key, wait, err := a.Store(ctx, bytes.NewReader(data), int64(len(data)), toEncrypt)
 	wait()
 	return key, err
 }
 
 // Manifest hack for supporting Mutable Resource Updates from the bzz: scheme
 // see swarm/api/api.go:API.Get() for more information
-func (a *API) NewResourceManifest(resourceAddr string) (storage.Address, error) {
+func (a *API) NewResourceManifest(ctx context.Context, resourceAddr string) (storage.Address, error) {
 	var manifest Manifest
 	entry := ManifestEntry{
 		Hash:        resourceAddr,
@@ -85,7 +86,7 @@ func (a *API) NewResourceManifest(resourceAddr string) (storage.Address, error) 
 	if err != nil {
 		return nil, err
 	}
-	key, _, err := a.Store(bytes.NewReader(data), int64(len(data)), false)
+	key, _, err := a.Store(ctx, bytes.NewReader(data), int64(len(data)), false)
 	return key, err
 }
 
@@ -96,8 +97,8 @@ type ManifestWriter struct {
 	quitC chan bool
 }
 
-func (a *API) NewManifestWriter(addr storage.Address, quitC chan bool) (*ManifestWriter, error) {
-	trie, err := loadManifest(a.fileStore, addr, quitC)
+func (a *API) NewManifestWriter(ctx context.Context, addr storage.Address, quitC chan bool) (*ManifestWriter, error) {
+	trie, err := loadManifest(ctx, a.fileStore, addr, quitC)
 	if err != nil {
 		return nil, fmt.Errorf("error loading manifest %s: %s", addr, err)
 	}
@@ -105,9 +106,8 @@ func (a *API) NewManifestWriter(addr storage.Address, quitC chan bool) (*Manifes
 }
 
 // AddEntry stores the given data and adds the resulting key to the manifest
-func (m *ManifestWriter) AddEntry(data io.Reader, e *ManifestEntry) (storage.Address, error) {
-
-	key, _, err := m.api.Store(data, e.Size, m.trie.encrypted)
+func (m *ManifestWriter) AddEntry(ctx context.Context, data io.Reader, e *ManifestEntry) (storage.Address, error) {
+	key, _, err := m.api.Store(ctx, data, e.Size, m.trie.encrypted)
 	if err != nil {
 		return nil, err
 	}
@@ -136,8 +136,8 @@ type ManifestWalker struct {
 	quitC chan bool
 }
 
-func (a *API) NewManifestWalker(addr storage.Address, quitC chan bool) (*ManifestWalker, error) {
-	trie, err := loadManifest(a.fileStore, addr, quitC)
+func (a *API) NewManifestWalker(ctx context.Context, addr storage.Address, quitC chan bool) (*ManifestWalker, error) {
+	trie, err := loadManifest(ctx, a.fileStore, addr, quitC)
 	if err != nil {
 		return nil, fmt.Errorf("error loading manifest %s: %s", addr, err)
 	}
@@ -204,10 +204,10 @@ type manifestTrieEntry struct {
 	subtrie *manifestTrie
 }
 
-func loadManifest(fileStore *storage.FileStore, hash storage.Address, quitC chan bool) (trie *manifestTrie, err error) { // non-recursive, subtrees are downloaded on-demand
+func loadManifest(ctx context.Context, fileStore *storage.FileStore, hash storage.Address, quitC chan bool) (trie *manifestTrie, err error) { // non-recursive, subtrees are downloaded on-demand
 	log.Trace("manifest lookup", "key", hash)
 	// retrieve manifest via FileStore
-	manifestReader, isEncrypted := fileStore.Retrieve(hash)
+	manifestReader, isEncrypted := fileStore.Retrieve(ctx, hash)
 	log.Trace("reader retrieved", "key", hash)
 	return readManifest(manifestReader, hash, fileStore, isEncrypted, quitC)
 }
@@ -382,7 +382,7 @@ func (mt *manifestTrie) recalcAndStore() error {
 	}
 
 	sr := bytes.NewReader(manifest)
-	key, wait, err2 := mt.fileStore.Store(sr, int64(len(manifest)), mt.encrypted)
+	key, wait, err2 := mt.fileStore.Store(context.TODO(), sr, int64(len(manifest)), mt.encrypted)
 	wait()
 	mt.ref = key
 	return err2
@@ -391,7 +391,7 @@ func (mt *manifestTrie) recalcAndStore() error {
 func (mt *manifestTrie) loadSubTrie(entry *manifestTrieEntry, quitC chan bool) (err error) {
 	if entry.subtrie == nil {
 		hash := common.Hex2Bytes(entry.Hash)
-		entry.subtrie, err = loadManifest(mt.fileStore, hash, quitC)
+		entry.subtrie, err = loadManifest(context.TODO(), mt.fileStore, hash, quitC)
 		entry.Hash = "" // might not match, should be recalculated
 	}
 	return

--- a/swarm/api/manifest.go
+++ b/swarm/api/manifest.go
@@ -69,7 +69,7 @@ func (a *API) NewManifest(ctx context.Context, toEncrypt bool) (storage.Address,
 		return nil, err
 	}
 	key, wait, err := a.Store(ctx, bytes.NewReader(data), int64(len(data)), toEncrypt)
-	wait()
+	wait(ctx)
 	return key, err
 }
 
@@ -382,8 +382,12 @@ func (mt *manifestTrie) recalcAndStore() error {
 	}
 
 	sr := bytes.NewReader(manifest)
-	key, wait, err2 := mt.fileStore.Store(context.TODO(), sr, int64(len(manifest)), mt.encrypted)
-	wait()
+	ctx := context.TODO()
+	key, wait, err2 := mt.fileStore.Store(ctx, sr, int64(len(manifest)), mt.encrypted)
+	if err2 != nil {
+		return err2
+	}
+	err2 = wait(ctx)
 	mt.ref = key
 	return err2
 }

--- a/swarm/api/storage.go
+++ b/swarm/api/storage.go
@@ -46,7 +46,7 @@ func NewStorage(api *API) *Storage {
 // its content type
 //
 // DEPRECATED: Use the HTTP API instead
-func (s *Storage) Put(ctx context.Context, content string, contentType string, toEncrypt bool) (storage.Address, func(), error) {
+func (s *Storage) Put(ctx context.Context, content string, contentType string, toEncrypt bool) (storage.Address, func(context.Context) error, error) {
 	return s.api.Put(ctx, content, contentType, toEncrypt)
 }
 

--- a/swarm/api/storage.go
+++ b/swarm/api/storage.go
@@ -17,6 +17,7 @@
 package api
 
 import (
+	"context"
 	"path"
 
 	"github.com/ethereum/go-ethereum/swarm/storage"
@@ -45,8 +46,8 @@ func NewStorage(api *API) *Storage {
 // its content type
 //
 // DEPRECATED: Use the HTTP API instead
-func (s *Storage) Put(content, contentType string, toEncrypt bool) (storage.Address, func(), error) {
-	return s.api.Put(content, contentType, toEncrypt)
+func (s *Storage) Put(ctx context.Context, content string, contentType string, toEncrypt bool) (storage.Address, func(), error) {
+	return s.api.Put(ctx, content, contentType, toEncrypt)
 }
 
 // Get retrieves the content from bzzpath and reads the response in full
@@ -57,16 +58,16 @@ func (s *Storage) Put(content, contentType string, toEncrypt bool) (storage.Addr
 // size is resp.Size
 //
 // DEPRECATED: Use the HTTP API instead
-func (s *Storage) Get(bzzpath string) (*Response, error) {
+func (s *Storage) Get(ctx context.Context, bzzpath string) (*Response, error) {
 	uri, err := Parse(path.Join("bzz:/", bzzpath))
 	if err != nil {
 		return nil, err
 	}
-	addr, err := s.api.Resolve(uri)
+	addr, err := s.api.Resolve(ctx, uri)
 	if err != nil {
 		return nil, err
 	}
-	reader, mimeType, status, _, err := s.api.Get(addr, uri.Path)
+	reader, mimeType, status, _, err := s.api.Get(ctx, addr, uri.Path)
 	if err != nil {
 		return nil, err
 	}
@@ -87,16 +88,16 @@ func (s *Storage) Get(bzzpath string) (*Response, error) {
 // and merge on  to it. creating an entry w conentType (mime)
 //
 // DEPRECATED: Use the HTTP API instead
-func (s *Storage) Modify(rootHash, path, contentHash, contentType string) (newRootHash string, err error) {
+func (s *Storage) Modify(ctx context.Context, rootHash, path, contentHash, contentType string) (newRootHash string, err error) {
 	uri, err := Parse("bzz:/" + rootHash)
 	if err != nil {
 		return "", err
 	}
-	addr, err := s.api.Resolve(uri)
+	addr, err := s.api.Resolve(ctx, uri)
 	if err != nil {
 		return "", err
 	}
-	addr, err = s.api.Modify(addr, path, contentHash, contentType)
+	addr, err = s.api.Modify(ctx, addr, path, contentHash, contentType)
 	if err != nil {
 		return "", err
 	}

--- a/swarm/api/storage_test.go
+++ b/swarm/api/storage_test.go
@@ -32,11 +32,15 @@ func TestStoragePutGet(t *testing.T) {
 		content := "hello"
 		exp := expResponse(content, "text/plain", 0)
 		// exp := expResponse([]byte(content), "text/plain", 0)
-		bzzkey, wait, err := api.Put(context.TODO(), content, exp.MimeType, toEncrypt)
+		ctx := context.TODO()
+		bzzkey, wait, err := api.Put(ctx, content, exp.MimeType, toEncrypt)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		wait()
+		err = wait(ctx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		bzzhash := bzzkey.Hex()
 		// to check put against the API#Get
 		resp0 := testGet(t, api.api, bzzhash, "")

--- a/swarm/api/storage_test.go
+++ b/swarm/api/storage_test.go
@@ -17,6 +17,7 @@
 package api
 
 import (
+	"context"
 	"testing"
 )
 
@@ -31,7 +32,7 @@ func TestStoragePutGet(t *testing.T) {
 		content := "hello"
 		exp := expResponse(content, "text/plain", 0)
 		// exp := expResponse([]byte(content), "text/plain", 0)
-		bzzkey, wait, err := api.Put(content, exp.MimeType, toEncrypt)
+		bzzkey, wait, err := api.Put(context.TODO(), content, exp.MimeType, toEncrypt)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -42,7 +43,7 @@ func TestStoragePutGet(t *testing.T) {
 		checkResponse(t, resp0, exp)
 
 		// check storage#Get
-		resp, err := api.Get(bzzhash)
+		resp, err := api.Get(context.TODO(), bzzhash)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/swarm/bmt/bmt_r.go
+++ b/swarm/bmt/bmt_r.go
@@ -80,6 +80,5 @@ func (rh *RefHasher) hash(data []byte, length int) []byte {
 	}
 	rh.hasher.Reset()
 	rh.hasher.Write(section)
-	s := rh.hasher.Sum(nil)
-	return s
+	return rh.hasher.Sum(nil)
 }

--- a/swarm/fuse/fuse_file.go
+++ b/swarm/fuse/fuse_file.go
@@ -84,7 +84,7 @@ func (sf *SwarmFile) Attr(ctx context.Context, a *fuse.Attr) error {
 	a.Gid = uint32(os.Getegid())
 
 	if sf.fileSize == -1 {
-		reader, _ := sf.mountInfo.swarmApi.Retrieve(sf.addr)
+		reader, _ := sf.mountInfo.swarmApi.Retrieve(ctx, sf.addr)
 		quitC := make(chan bool)
 		size, err := reader.Size(quitC)
 		if err != nil {
@@ -104,7 +104,7 @@ func (sf *SwarmFile) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse
 	sf.lock.RLock()
 	defer sf.lock.RUnlock()
 	if sf.reader == nil {
-		sf.reader, _ = sf.mountInfo.swarmApi.Retrieve(sf.addr)
+		sf.reader, _ = sf.mountInfo.swarmApi.Retrieve(ctx, sf.addr)
 	}
 	buf := make([]byte, req.Size)
 	n, err := sf.reader.ReadAt(buf, req.Offset)

--- a/swarm/fuse/swarmfs_test.go
+++ b/swarm/fuse/swarmfs_test.go
@@ -20,6 +20,7 @@ package fuse
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"flag"
 	"fmt"
@@ -110,7 +111,7 @@ func createTestFilesAndUploadToSwarm(t *testing.T, api *api.API, files map[strin
 	}
 
 	//upload directory to swarm and return hash
-	bzzhash, err := api.Upload(uploadDir, "", toEncrypt)
+	bzzhash, err := api.Upload(context.TODO(), uploadDir, "", toEncrypt)
 	if err != nil {
 		t.Fatalf("Error uploading directory %v: %vm encryption: %v", uploadDir, err, toEncrypt)
 	}

--- a/swarm/fuse/swarmfs_unix.go
+++ b/swarm/fuse/swarmfs_unix.go
@@ -19,6 +19,7 @@
 package fuse
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -104,7 +105,7 @@ func (swarmfs *SwarmFS) Mount(mhash, mountpoint string) (*MountInfo, error) {
 	}
 
 	log.Trace("swarmfs mount: getting manifest tree")
-	_, manifestEntryMap, err := swarmfs.swarmApi.BuildDirectoryTree(mhash, true)
+	_, manifestEntryMap, err := swarmfs.swarmApi.BuildDirectoryTree(context.TODO(), mhash, true)
 	if err != nil {
 		return nil, err
 	}

--- a/swarm/fuse/swarmfs_util.go
+++ b/swarm/fuse/swarmfs_util.go
@@ -47,7 +47,7 @@ func externalUnmount(mountPoint string) error {
 }
 
 func addFileToSwarm(sf *SwarmFile, content []byte, size int) error {
-	fkey, mhash, err := sf.mountInfo.swarmApi.AddFile(sf.mountInfo.LatestManifest, sf.path, sf.name, content, true)
+	fkey, mhash, err := sf.mountInfo.swarmApi.AddFile(context.TODO(), sf.mountInfo.LatestManifest, sf.path, sf.name, content, true)
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func addFileToSwarm(sf *SwarmFile, content []byte, size int) error {
 }
 
 func removeFileFromSwarm(sf *SwarmFile) error {
-	mkey, err := sf.mountInfo.swarmApi.RemoveFile(sf.mountInfo.LatestManifest, sf.path, sf.name, true)
+	mkey, err := sf.mountInfo.swarmApi.RemoveFile(context.TODO(), sf.mountInfo.LatestManifest, sf.path, sf.name, true)
 	if err != nil {
 		return err
 	}
@@ -102,7 +102,7 @@ func removeDirectoryFromSwarm(sd *SwarmDir) error {
 }
 
 func appendToExistingFileInSwarm(sf *SwarmFile, content []byte, offset int64, length int64) error {
-	fkey, mhash, err := sf.mountInfo.swarmApi.AppendFile(sf.mountInfo.LatestManifest, sf.path, sf.name, sf.fileSize, content, sf.addr, offset, length, true)
+	fkey, mhash, err := sf.mountInfo.swarmApi.AppendFile(context.TODO(), sf.mountInfo.LatestManifest, sf.path, sf.name, sf.fileSize, content, sf.addr, offset, length, true)
 	if err != nil {
 		return err
 	}

--- a/swarm/metrics/flags.go
+++ b/swarm/metrics/flags.go
@@ -81,6 +81,9 @@ func Setup(ctx *cli.Context) {
 			hosttag      = ctx.GlobalString(metricsInfluxDBHostTagFlag.Name)
 		)
 
+		// Start system runtime metrics collection
+		go gethmetrics.CollectProcessMetrics(2 * time.Second)
+
 		if enableExport {
 			log.Info("Enabling swarm metrics export to InfluxDB")
 			go influxdb.InfluxDBWithTags(gethmetrics.DefaultRegistry, 10*time.Second, endpoint, database, username, password, "swarm.", map[string]string{

--- a/swarm/network/networkid_test.go
+++ b/swarm/network/networkid_test.go
@@ -1,0 +1,266 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package network
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/discover"
+	"github.com/ethereum/go-ethereum/p2p/simulations"
+	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+var (
+	currentNetworkID int
+	cnt              int
+	nodeMap          map[int][]discover.NodeID
+	kademlias        map[discover.NodeID]*Kademlia
+)
+
+const (
+	NumberOfNets = 4
+	MaxTimeout   = 6
+)
+
+func init() {
+	flag.Parse()
+	rand.Seed(time.Now().Unix())
+}
+
+/*
+Run the network ID test.
+The test creates one simulations.Network instance,
+a number of nodes, then connects nodes with each other in this network.
+
+Each node gets a network ID assigned according to the number of networks.
+Having more network IDs is just arbitrary in order to exclude
+false positives.
+
+Nodes should only connect with other nodes with the same network ID.
+After the setup phase, the test checks on each node if it has the
+expected node connections (excluding those not sharing the network ID).
+*/
+func TestNetworkID(t *testing.T) {
+	log.Debug("Start test")
+	//arbitrarily set the number of nodes. It could be any number
+	numNodes := 24
+	//the nodeMap maps all nodes (slice value) with the same network ID (key)
+	nodeMap = make(map[int][]discover.NodeID)
+	//set up the network and connect nodes
+	net, err := setupNetwork(numNodes)
+	if err != nil {
+		t.Fatalf("Error setting up network: %v", err)
+	}
+	defer func() {
+		//shutdown the snapshot network
+		log.Trace("Shutting down network")
+		net.Shutdown()
+	}()
+	//let's sleep to ensure all nodes are connected
+	time.Sleep(1 * time.Second)
+	//for each group sharing the same network ID...
+	for _, netIDGroup := range nodeMap {
+		log.Trace("netIDGroup size", "size", len(netIDGroup))
+		//...check that their size of the kademlia is of the expected size
+		//the assumption is that it should be the size of the group minus 1 (the node itself)
+		for _, node := range netIDGroup {
+			if kademlias[node].addrs.Size() != len(netIDGroup)-1 {
+				t.Fatalf("Kademlia size has not expected peer size. Kademlia size: %d, expected size: %d", kademlias[node].addrs.Size(), len(netIDGroup)-1)
+			}
+			kademlias[node].EachAddr(nil, 0, func(addr OverlayAddr, _ int, _ bool) bool {
+				found := false
+				for _, nd := range netIDGroup {
+					p := ToOverlayAddr(nd.Bytes())
+					if bytes.Equal(p, addr.Address()) {
+						found = true
+					}
+				}
+				if !found {
+					t.Fatalf("Expected node not found for node %s", node.String())
+				}
+				return true
+			})
+		}
+	}
+	log.Info("Test terminated successfully")
+}
+
+// setup simulated network with bzz/discovery and pss services.
+// connects nodes in a circle
+// if allowRaw is set, omission of builtin pss encryption is enabled (see PssParams)
+func setupNetwork(numnodes int) (net *simulations.Network, err error) {
+	log.Debug("Setting up network")
+	quitC := make(chan struct{})
+	errc := make(chan error)
+	nodes := make([]*simulations.Node, numnodes)
+	if numnodes < 16 {
+		return nil, fmt.Errorf("Minimum sixteen nodes in network")
+	}
+	adapter := adapters.NewSimAdapter(newServices())
+	//create the network
+	net = simulations.NewNetwork(adapter, &simulations.NetworkConfig{
+		ID:             "NetworkIdTestNet",
+		DefaultService: "bzz",
+	})
+	log.Debug("Creating networks and nodes")
+
+	var connCount int
+
+	//create nodes and connect them to each other
+	for i := 0; i < numnodes; i++ {
+		log.Trace("iteration: ", "i", i)
+		nodeconf := adapters.RandomNodeConfig()
+		nodes[i], err = net.NewNodeWithConfig(nodeconf)
+		if err != nil {
+			return nil, fmt.Errorf("error creating node %d: %v", i, err)
+		}
+		err = net.Start(nodes[i].ID())
+		if err != nil {
+			return nil, fmt.Errorf("error starting node %d: %v", i, err)
+		}
+		client, err := nodes[i].Client()
+		if err != nil {
+			return nil, fmt.Errorf("create node %d rpc client fail: %v", i, err)
+		}
+		//now setup and start event watching in order to know when we can upload
+		ctx, watchCancel := context.WithTimeout(context.Background(), MaxTimeout*time.Second)
+		defer watchCancel()
+		watchSubscriptionEvents(ctx, nodes[i].ID(), client, errc, quitC)
+		//on every iteration we connect to all previous ones
+		for k := i - 1; k >= 0; k-- {
+			connCount++
+			log.Debug(fmt.Sprintf("Connecting node %d with node %d; connection count is %d", i, k, connCount))
+			err = net.Connect(nodes[i].ID(), nodes[k].ID())
+			if err != nil {
+				if !strings.Contains(err.Error(), "already connected") {
+					return nil, fmt.Errorf("error connecting nodes: %v", err)
+				}
+			}
+		}
+	}
+	//now wait until the number of expected subscriptions has been finished
+	//`watchSubscriptionEvents` will write with a `nil` value to errc
+	for err := range errc {
+		if err != nil {
+			return nil, err
+		}
+		//`nil` received, decrement count
+		connCount--
+		log.Trace("count down", "cnt", connCount)
+		//all subscriptions received
+		if connCount == 0 {
+			close(quitC)
+			break
+		}
+	}
+	log.Debug("Network setup phase terminated")
+	return net, nil
+}
+
+func newServices() adapters.Services {
+	kademlias = make(map[discover.NodeID]*Kademlia)
+	kademlia := func(id discover.NodeID) *Kademlia {
+		if k, ok := kademlias[id]; ok {
+			return k
+		}
+		addr := NewAddrFromNodeID(id)
+		params := NewKadParams()
+		params.MinProxBinSize = 2
+		params.MaxBinSize = 3
+		params.MinBinSize = 1
+		params.MaxRetries = 1000
+		params.RetryExponent = 2
+		params.RetryInterval = 1000000
+		kademlias[id] = NewKademlia(addr.Over(), params)
+		return kademlias[id]
+	}
+	return adapters.Services{
+		"bzz": func(ctx *adapters.ServiceContext) (node.Service, error) {
+			addr := NewAddrFromNodeID(ctx.Config.ID)
+			hp := NewHiveParams()
+			hp.Discovery = false
+			cnt++
+			//assign the network ID
+			currentNetworkID = cnt % NumberOfNets
+			if ok := nodeMap[currentNetworkID]; ok == nil {
+				nodeMap[currentNetworkID] = make([]discover.NodeID, 0)
+			}
+			//add this node to the group sharing the same network ID
+			nodeMap[currentNetworkID] = append(nodeMap[currentNetworkID], ctx.Config.ID)
+			log.Debug("current network ID:", "id", currentNetworkID)
+			config := &BzzConfig{
+				OverlayAddr:  addr.Over(),
+				UnderlayAddr: addr.Under(),
+				HiveParams:   hp,
+				NetworkID:    uint64(currentNetworkID),
+			}
+			return NewBzz(config, kademlia(ctx.Config.ID), nil, nil, nil), nil
+		},
+	}
+}
+
+func watchSubscriptionEvents(ctx context.Context, id discover.NodeID, client *rpc.Client, errc chan error, quitC chan struct{}) {
+	events := make(chan *p2p.PeerEvent)
+	sub, err := client.Subscribe(context.Background(), "admin", events, "peerEvents")
+	if err != nil {
+		log.Error(err.Error())
+		errc <- fmt.Errorf("error getting peer events for node %v: %s", id, err)
+		return
+	}
+	go func() {
+		defer func() {
+			sub.Unsubscribe()
+			log.Trace("watch subscription events: unsubscribe", "id", id)
+		}()
+
+		for {
+			select {
+			case <-quitC:
+				return
+			case <-ctx.Done():
+				select {
+				case errc <- ctx.Err():
+				case <-quitC:
+				}
+				return
+			case e := <-events:
+				if e.Type == p2p.PeerEventTypeAdd {
+					errc <- nil
+				}
+			case err := <-sub.Err():
+				if err != nil {
+					select {
+					case errc <- fmt.Errorf("error getting peer events for node %v: %v", id, err):
+					case <-quitC:
+					}
+					return
+				}
+			}
+		}
+	}()
+}

--- a/swarm/network/stream/common_test.go
+++ b/swarm/network/stream/common_test.go
@@ -250,7 +250,7 @@ func (r *TestRegistry) APIs() []rpc.API {
 }
 
 func readAll(fileStore *storage.FileStore, hash []byte) (int64, error) {
-	r, _ := fileStore.Retrieve(hash)
+	r, _ := fileStore.Retrieve(context.TODO(), hash)
 	buf := make([]byte, 1024)
 	var n int
 	var total int64

--- a/swarm/network/stream/delivery_test.go
+++ b/swarm/network/stream/delivery_test.go
@@ -345,7 +345,7 @@ func testDeliveryFromNodes(t *testing.T, nodes, conns, chunkCount int, skipCheck
 	// here we distribute chunks of a random file into Stores of nodes 1 to nodes
 	rrFileStore := storage.NewFileStore(newRoundRobinStore(sim.Stores[1:]...), storage.NewFileStoreParams())
 	size := chunkCount * chunkSize
-	fileHash, wait, err := rrFileStore.Store(io.LimitReader(crand.Reader, int64(size)), int64(size), false)
+	fileHash, wait, err := rrFileStore.Store(context.TODO(), io.LimitReader(crand.Reader, int64(size)), int64(size), false)
 	// wait until all chunks stored
 	wait()
 	if err != nil {
@@ -627,7 +627,7 @@ Loop:
 		hashes := make([]storage.Address, chunkCount)
 		for i := 0; i < chunkCount; i++ {
 			// create actual size real chunks
-			hash, wait, err := remoteFileStore.Store(io.LimitReader(crand.Reader, int64(chunkSize)), int64(chunkSize), false)
+			hash, wait, err := remoteFileStore.Store(context.TODO(), io.LimitReader(crand.Reader, int64(chunkSize)), int64(chunkSize), false)
 			// wait until all chunks stored
 			wait()
 			if err != nil {

--- a/swarm/network/stream/delivery_test.go
+++ b/swarm/network/stream/delivery_test.go
@@ -345,9 +345,13 @@ func testDeliveryFromNodes(t *testing.T, nodes, conns, chunkCount int, skipCheck
 	// here we distribute chunks of a random file into Stores of nodes 1 to nodes
 	rrFileStore := storage.NewFileStore(newRoundRobinStore(sim.Stores[1:]...), storage.NewFileStoreParams())
 	size := chunkCount * chunkSize
-	fileHash, wait, err := rrFileStore.Store(context.TODO(), io.LimitReader(crand.Reader, int64(size)), int64(size), false)
+	ctx := context.TODO()
+	fileHash, wait, err := rrFileStore.Store(ctx, io.LimitReader(crand.Reader, int64(size)), int64(size), false)
 	// wait until all chunks stored
-	wait()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	err = wait(ctx)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -627,9 +631,13 @@ Loop:
 		hashes := make([]storage.Address, chunkCount)
 		for i := 0; i < chunkCount; i++ {
 			// create actual size real chunks
-			hash, wait, err := remoteFileStore.Store(context.TODO(), io.LimitReader(crand.Reader, int64(chunkSize)), int64(chunkSize), false)
+			ctx := context.TODO()
+			hash, wait, err := remoteFileStore.Store(ctx, io.LimitReader(crand.Reader, int64(chunkSize)), int64(chunkSize), false)
+			if err != nil {
+				b.Fatalf("expected no error. got %v", err)
+			}
 			// wait until all chunks stored
-			wait()
+			err = wait(ctx)
 			if err != nil {
 				b.Fatalf("expected no error. got %v", err)
 			}

--- a/swarm/network/stream/intervals_test.go
+++ b/swarm/network/stream/intervals_test.go
@@ -117,8 +117,12 @@ func testIntervals(t *testing.T, live bool, history *Range, skipCheck bool) {
 
 	fileStore := storage.NewFileStore(sim.Stores[0], storage.NewFileStoreParams())
 	size := chunkCount * chunkSize
-	_, wait, err := fileStore.Store(context.TODO(), io.LimitReader(crand.Reader, int64(size)), int64(size), false)
-	wait()
+	ctx := context.TODO()
+	_, wait, err := fileStore.Store(ctx, io.LimitReader(crand.Reader, int64(size)), int64(size), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = wait(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swarm/network/stream/intervals_test.go
+++ b/swarm/network/stream/intervals_test.go
@@ -117,7 +117,7 @@ func testIntervals(t *testing.T, live bool, history *Range, skipCheck bool) {
 
 	fileStore := storage.NewFileStore(sim.Stores[0], storage.NewFileStoreParams())
 	size := chunkCount * chunkSize
-	_, wait, err := fileStore.Store(io.LimitReader(crand.Reader, int64(size)), int64(size), false)
+	_, wait, err := fileStore.Store(context.TODO(), io.LimitReader(crand.Reader, int64(size)), int64(size), false)
 	wait()
 	if err != nil {
 		t.Fatal(err)

--- a/swarm/network/stream/snapshot_retrieval_test.go
+++ b/swarm/network/stream/snapshot_retrieval_test.go
@@ -410,7 +410,7 @@ func runFileRetrievalTest(nodeCount int) error {
 		fileStore := registries[id].fileStore
 		//check all chunks
 		for i, hash := range conf.hashes {
-			reader, _ := fileStore.Retrieve(hash)
+			reader, _ := fileStore.Retrieve(context.TODO(), hash)
 			//check that we can read the file size and that it corresponds to the generated file size
 			if s, err := reader.Size(nil); err != nil || s != int64(len(randomFiles[i])) {
 				allSuccess = false
@@ -697,7 +697,7 @@ func runRetrievalTest(chunkCount int, nodeCount int) error {
 		fileStore := registries[id].fileStore
 		//check all chunks
 		for _, chnk := range conf.hashes {
-			reader, _ := fileStore.Retrieve(chnk)
+			reader, _ := fileStore.Retrieve(context.TODO(), chnk)
 			//assuming that reading the Size of the chunk is enough to know we found it
 			if s, err := reader.Size(nil); err != nil || s != chunkSize {
 				allSuccess = false
@@ -765,7 +765,7 @@ func uploadFilesToNodes(nodes []*simulations.Node) ([]storage.Address, []string,
 			return nil, nil, err
 		}
 		//store it (upload it) on the FileStore
-		rk, wait, err := fileStore.Store(strings.NewReader(rfiles[i]), int64(len(rfiles[i])), false)
+		rk, wait, err := fileStore.Store(context.TODO(), strings.NewReader(rfiles[i]), int64(len(rfiles[i])), false)
 		log.Debug("Uploaded random string file to node")
 		wait()
 		if err != nil {

--- a/swarm/network/stream/snapshot_retrieval_test.go
+++ b/swarm/network/stream/snapshot_retrieval_test.go
@@ -765,9 +765,13 @@ func uploadFilesToNodes(nodes []*simulations.Node) ([]storage.Address, []string,
 			return nil, nil, err
 		}
 		//store it (upload it) on the FileStore
-		rk, wait, err := fileStore.Store(context.TODO(), strings.NewReader(rfiles[i]), int64(len(rfiles[i])), false)
+		ctx := context.TODO()
+		rk, wait, err := fileStore.Store(ctx, strings.NewReader(rfiles[i]), int64(len(rfiles[i])), false)
 		log.Debug("Uploaded random string file to node")
-		wait()
+		if err != nil {
+			return nil, nil, err
+		}
+		err = wait(ctx)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/swarm/network/stream/snapshot_sync_test.go
+++ b/swarm/network/stream/snapshot_sync_test.go
@@ -581,7 +581,7 @@ func uploadFileToSingleNodeStore(id discover.NodeID, chunkCount int) ([]storage.
 	fileStore := storage.NewFileStore(lstore, storage.NewFileStoreParams())
 	var rootAddrs []storage.Address
 	for i := 0; i < chunkCount; i++ {
-		rk, wait, err := fileStore.Store(io.LimitReader(crand.Reader, int64(size)), int64(size), false)
+		rk, wait, err := fileStore.Store(context.TODO(), io.LimitReader(crand.Reader, int64(size)), int64(size), false)
 		wait()
 		if err != nil {
 			return nil, err

--- a/swarm/network/stream/snapshot_sync_test.go
+++ b/swarm/network/stream/snapshot_sync_test.go
@@ -581,8 +581,12 @@ func uploadFileToSingleNodeStore(id discover.NodeID, chunkCount int) ([]storage.
 	fileStore := storage.NewFileStore(lstore, storage.NewFileStoreParams())
 	var rootAddrs []storage.Address
 	for i := 0; i < chunkCount; i++ {
-		rk, wait, err := fileStore.Store(context.TODO(), io.LimitReader(crand.Reader, int64(size)), int64(size), false)
-		wait()
+		ctx := context.TODO()
+		rk, wait, err := fileStore.Store(ctx, io.LimitReader(crand.Reader, int64(size)), int64(size), false)
+		if err != nil {
+			return nil, err
+		}
+		err = wait(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/swarm/network/stream/syncer_test.go
+++ b/swarm/network/stream/syncer_test.go
@@ -202,9 +202,12 @@ func testSyncBetweenNodes(t *testing.T, nodes, conns, chunkCount int, skipCheck 
 		// here we distribute chunks of a random file into stores 1...nodes
 		rrFileStore := storage.NewFileStore(newRoundRobinStore(sim.Stores[1:]...), storage.NewFileStoreParams())
 		size := chunkCount * chunkSize
-		_, wait, err := rrFileStore.Store(context.TODO(), io.LimitReader(crand.Reader, int64(size)), int64(size), false)
+		_, wait, err := rrFileStore.Store(ctx, io.LimitReader(crand.Reader, int64(size)), int64(size), false)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
 		// need to wait cos we then immediately collect the relevant bin content
-		wait()
+		wait(ctx)
 		if err != nil {
 			t.Fatal(err.Error())
 		}

--- a/swarm/network/stream/syncer_test.go
+++ b/swarm/network/stream/syncer_test.go
@@ -202,7 +202,7 @@ func testSyncBetweenNodes(t *testing.T, nodes, conns, chunkCount int, skipCheck 
 		// here we distribute chunks of a random file into stores 1...nodes
 		rrFileStore := storage.NewFileStore(newRoundRobinStore(sim.Stores[1:]...), storage.NewFileStoreParams())
 		size := chunkCount * chunkSize
-		_, wait, err := rrFileStore.Store(io.LimitReader(crand.Reader, int64(size)), int64(size), false)
+		_, wait, err := rrFileStore.Store(context.TODO(), io.LimitReader(crand.Reader, int64(size)), int64(size), false)
 		// need to wait cos we then immediately collect the relevant bin content
 		wait()
 		if err != nil {

--- a/swarm/network_test.go
+++ b/swarm/network_test.go
@@ -508,14 +508,15 @@ func uploadFile(swarm *Swarm) (storage.Address, string, error) {
 	// File data is very short, but it is ensured that its
 	// uniqueness is very certain.
 	data := fmt.Sprintf("test content %s %x", time.Now().Round(0), b)
-	k, wait, err := swarm.api.Put(context.TODO(), data, "text/plain", false)
+	ctx := context.TODO()
+	k, wait, err := swarm.api.Put(ctx, data, "text/plain", false)
 	if err != nil {
 		return nil, "", err
 	}
 	if wait != nil {
-		wait()
+		err = wait(ctx)
 	}
-	return k, data, nil
+	return k, data, err
 }
 
 // retrieve is the function that is used for checking the availability of

--- a/swarm/network_test.go
+++ b/swarm/network_test.go
@@ -508,7 +508,7 @@ func uploadFile(swarm *Swarm) (storage.Address, string, error) {
 	// File data is very short, but it is ensured that its
 	// uniqueness is very certain.
 	data := fmt.Sprintf("test content %s %x", time.Now().Round(0), b)
-	k, wait, err := swarm.api.Put(data, "text/plain", false)
+	k, wait, err := swarm.api.Put(context.TODO(), data, "text/plain", false)
 	if err != nil {
 		return nil, "", err
 	}
@@ -570,7 +570,7 @@ func retrieve(
 
 				log.Debug("api get: check file", "node", id.String(), "key", f.addr.String(), "total files found", atomic.LoadUint64(totalFoundCount))
 
-				r, _, _, _, err := swarm.api.Get(f.addr, "/")
+				r, _, _, _, err := swarm.api.Get(context.TODO(), f.addr, "/")
 				if err != nil {
 					errc <- fmt.Errorf("api get: node %s, key %s, kademlia %s: %v", id, f.addr, swarm.bzz.Hive, err)
 					return

--- a/swarm/pss/handshake.go
+++ b/swarm/pss/handshake.go
@@ -385,7 +385,7 @@ func (ctl *HandshakeController) sendKey(pubkeyid string, topic *Topic, keycount 
 	// generate new keys to send
 	for i := 0; i < len(recvkeyids); i++ {
 		var err error
-		recvkeyids[i], err = ctl.pss.generateSymmetricKey(*topic, to, true)
+		recvkeyids[i], err = ctl.pss.GenerateSymmetricKey(*topic, to, true)
 		if err != nil {
 			return []string{}, fmt.Errorf("set receive symkey fail (pubkey %x topic %x): %v", pubkeyid, topic, err)
 		}

--- a/swarm/pss/notify/notify.go
+++ b/swarm/pss/notify/notify.go
@@ -1,0 +1,394 @@
+package notify
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/swarm/log"
+	"github.com/ethereum/go-ethereum/swarm/pss"
+)
+
+const (
+	// sent from requester to updater to request start of notifications
+	MsgCodeStart = iota
+
+	// sent from updater to requester, contains a notification plus a new symkey to replace the old
+	MsgCodeNotifyWithKey
+
+	// sent from updater to requester, contains a notification
+	MsgCodeNotify
+
+	// sent from requester to updater to request stop of notifications (currently unused)
+	MsgCodeStop
+	MsgCodeMax
+)
+
+const (
+	DefaultAddressLength = 1
+	symKeyLength         = 32 // this should be gotten from source
+)
+
+var (
+	// control topic is used before symmetric key issuance completes
+	controlTopic = pss.Topic{0x00, 0x00, 0x00, 0x01}
+)
+
+// when code is MsgCodeStart, Payload is address
+// when code is MsgCodeNotifyWithKey, Payload is notification | symkey
+// when code is MsgCodeNotify, Payload is notification
+// when code is MsgCodeStop, Payload is address
+type Msg struct {
+	Code       byte
+	Name       []byte
+	Payload    []byte
+	namestring string
+}
+
+// NewMsg creates a new notification message object
+func NewMsg(code byte, name string, payload []byte) *Msg {
+	return &Msg{
+		Code:       code,
+		Name:       []byte(name),
+		Payload:    payload,
+		namestring: name,
+	}
+}
+
+// NewMsgFromPayload decodes a serialized message payload into a new notification message object
+func NewMsgFromPayload(payload []byte) (*Msg, error) {
+	msg := &Msg{}
+	err := rlp.DecodeBytes(payload, msg)
+	if err != nil {
+		return nil, err
+	}
+	msg.namestring = string(msg.Name)
+	return msg, nil
+}
+
+// a notifier has one sendBin entry for each address space it sends messages to
+type sendBin struct {
+	address  pss.PssAddress
+	symKeyId string
+	count    int
+}
+
+// represents a single notification service
+// only subscription address bins that match the address of a notification client have entries.
+type notifier struct {
+	bins      map[string]*sendBin
+	topic     pss.Topic // identifies the resource for pss receiver
+	threshold int       // amount of address bytes used in bins
+	updateC   <-chan []byte
+	quitC     chan struct{}
+}
+
+func (n *notifier) removeSubscription() {
+	n.quitC <- struct{}{}
+}
+
+// represents an individual subscription made by a public key at a specific address/neighborhood
+type subscription struct {
+	pubkeyId string
+	address  pss.PssAddress
+	handler  func(string, []byte) error
+}
+
+// Controller is the interface to control, add and remove notification services and subscriptions
+type Controller struct {
+	pss           *pss.Pss
+	notifiers     map[string]*notifier
+	subscriptions map[string]*subscription
+	mu            sync.Mutex
+}
+
+// NewController creates a new Controller object
+func NewController(ps *pss.Pss) *Controller {
+	ctrl := &Controller{
+		pss:           ps,
+		notifiers:     make(map[string]*notifier),
+		subscriptions: make(map[string]*subscription),
+	}
+	ctrl.pss.Register(&controlTopic, ctrl.Handler)
+	return ctrl
+}
+
+// IsActive is used to check if a notification service exists for a specified id string
+// Returns true if exists, false if not
+func (c *Controller) IsActive(name string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.isActive(name)
+}
+
+func (c *Controller) isActive(name string) bool {
+	_, ok := c.notifiers[name]
+	return ok
+}
+
+// Subscribe is used by a client to request notifications from a notification service provider
+// It will create a MsgCodeStart message and send asymmetrically to the provider using its public key and routing address
+// The handler function is a callback that will be called when notifications are received
+// Fails if the request pss cannot be sent or if the update message could not be serialized
+func (c *Controller) Subscribe(name string, pubkey *ecdsa.PublicKey, address pss.PssAddress, handler func(string, []byte) error) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	msg := NewMsg(MsgCodeStart, name, c.pss.BaseAddr())
+	c.pss.SetPeerPublicKey(pubkey, controlTopic, &address)
+	pubkeyId := hexutil.Encode(crypto.FromECDSAPub(pubkey))
+	smsg, err := rlp.EncodeToBytes(msg)
+	if err != nil {
+		return err
+	}
+	err = c.pss.SendAsym(pubkeyId, controlTopic, smsg)
+	if err != nil {
+		return err
+	}
+	c.subscriptions[name] = &subscription{
+		pubkeyId: pubkeyId,
+		address:  address,
+		handler:  handler,
+	}
+	return nil
+}
+
+// Unsubscribe, perhaps unsurprisingly, undoes the effects of Subscribe
+// Fails if the subscription does not exist, if the request pss cannot be sent or if the update message could not be serialized
+func (c *Controller) Unsubscribe(name string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	sub, ok := c.subscriptions[name]
+	if !ok {
+		return fmt.Errorf("Unknown subscription '%s'", name)
+	}
+	msg := NewMsg(MsgCodeStop, name, sub.address)
+	smsg, err := rlp.EncodeToBytes(msg)
+	if err != nil {
+		return err
+	}
+	err = c.pss.SendAsym(sub.pubkeyId, controlTopic, smsg)
+	if err != nil {
+		return err
+	}
+	delete(c.subscriptions, name)
+	return nil
+}
+
+// NewNotifier is used by a notification service provider to create a new notification service
+// It takes a name as identifier for the resource, a threshold indicating the granularity of the subscription address bin
+// It then starts an event loop which listens to the supplied update channel and executes notifications on channel receives
+// Fails if a notifier already is registered on the name
+//func (c *Controller) NewNotifier(name string, threshold int, contentFunc func(string) ([]byte, error)) error {
+func (c *Controller) NewNotifier(name string, threshold int, updateC <-chan []byte) (func(), error) {
+	c.mu.Lock()
+	if c.isActive(name) {
+		c.mu.Unlock()
+		return nil, fmt.Errorf("Notification service %s already exists in controller", name)
+	}
+	quitC := make(chan struct{})
+	c.notifiers[name] = &notifier{
+		bins:      make(map[string]*sendBin),
+		topic:     pss.BytesToTopic([]byte(name)),
+		threshold: threshold,
+		updateC:   updateC,
+		quitC:     quitC,
+		//contentFunc: contentFunc,
+	}
+	c.mu.Unlock()
+	go func() {
+		for {
+			select {
+			case <-quitC:
+				return
+			case data := <-updateC:
+				c.notify(name, data)
+			}
+		}
+	}()
+
+	return c.notifiers[name].removeSubscription, nil
+}
+
+// RemoveNotifier is used to stop a notification service.
+// It cancels the event loop listening to the notification provider's update channel
+func (c *Controller) RemoveNotifier(name string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	currentNotifier, ok := c.notifiers[name]
+	if !ok {
+		return fmt.Errorf("Unknown notification service %s", name)
+	}
+	currentNotifier.removeSubscription()
+	delete(c.notifiers, name)
+	return nil
+}
+
+// Notify is called by a notification service provider to issue a new notification
+// It takes the name of the notification service and the data to be sent.
+// It fails if a notifier with this name does not exist or if data could not be serialized
+// Note that it does NOT fail on failure to send a message
+func (c *Controller) notify(name string, data []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.isActive(name) {
+		return fmt.Errorf("Notification service %s doesn't exist", name)
+	}
+	msg := NewMsg(MsgCodeNotify, name, data)
+	smsg, err := rlp.EncodeToBytes(msg)
+	if err != nil {
+		return err
+	}
+	for _, m := range c.notifiers[name].bins {
+		log.Debug("sending pss notify", "name", name, "addr", fmt.Sprintf("%x", m.address), "topic", fmt.Sprintf("%x", c.notifiers[name].topic), "data", data)
+		go func(m *sendBin) {
+			err = c.pss.SendSym(m.symKeyId, c.notifiers[name].topic, smsg)
+			if err != nil {
+				log.Warn("Failed to send notify to addr %x: %v", m.address, err)
+			}
+		}(m)
+	}
+	return nil
+}
+
+// check if we already have the bin
+// if we do, retrieve the symkey from it and increment the count
+// if we dont make a new symkey and a new bin entry
+func (c *Controller) addToBin(ntfr *notifier, address []byte) (symKeyId string, pssAddress pss.PssAddress, err error) {
+
+	// parse the address from the message and truncate if longer than our bins threshold
+	if len(address) > ntfr.threshold {
+		address = address[:ntfr.threshold]
+	}
+
+	pssAddress = pss.PssAddress(address)
+	hexAddress := fmt.Sprintf("%x", address)
+	currentBin, ok := ntfr.bins[hexAddress]
+	if ok {
+		currentBin.count++
+		symKeyId = currentBin.symKeyId
+	} else {
+		symKeyId, err = c.pss.GenerateSymmetricKey(ntfr.topic, &pssAddress, false)
+		if err != nil {
+			return "", nil, err
+		}
+		ntfr.bins[hexAddress] = &sendBin{
+			address:  address,
+			symKeyId: symKeyId,
+			count:    1,
+		}
+	}
+	return symKeyId, pssAddress, nil
+}
+
+func (c *Controller) handleStartMsg(msg *Msg, keyid string) (err error) {
+
+	keyidbytes, err := hexutil.Decode(keyid)
+	if err != nil {
+		return err
+	}
+	pubkey, err := crypto.UnmarshalPubkey(keyidbytes)
+	if err != nil {
+		return err
+	}
+
+	// if name is not registered for notifications we will not react
+	currentNotifier, ok := c.notifiers[msg.namestring]
+	if !ok {
+		return fmt.Errorf("Subscribe attempted on unknown resource '%s'", msg.namestring)
+	}
+
+	// add to or open new bin
+	symKeyId, pssAddress, err := c.addToBin(currentNotifier, msg.Payload)
+	if err != nil {
+		return err
+	}
+
+	// add to address book for send initial notify
+	symkey, err := c.pss.GetSymmetricKey(symKeyId)
+	if err != nil {
+		return err
+	}
+	err = c.pss.SetPeerPublicKey(pubkey, controlTopic, &pssAddress)
+	if err != nil {
+		return err
+	}
+
+	// TODO this is set to zero-length byte pending decision on protocol for initial message, whether it should include message or not, and how to trigger the initial message so that current state of MRU is sent upon subscription
+	notify := []byte{}
+	replyMsg := NewMsg(MsgCodeNotifyWithKey, msg.namestring, make([]byte, len(notify)+symKeyLength))
+	copy(replyMsg.Payload, notify)
+	copy(replyMsg.Payload[len(notify):], symkey)
+	sReplyMsg, err := rlp.EncodeToBytes(replyMsg)
+	if err != nil {
+		return err
+	}
+	return c.pss.SendAsym(keyid, controlTopic, sReplyMsg)
+}
+
+func (c *Controller) handleNotifyWithKeyMsg(msg *Msg) error {
+	symkey := msg.Payload[len(msg.Payload)-symKeyLength:]
+	topic := pss.BytesToTopic(msg.Name)
+
+	// \TODO keep track of and add actual address
+	updaterAddr := pss.PssAddress([]byte{})
+	c.pss.SetSymmetricKey(symkey, topic, &updaterAddr, true)
+	c.pss.Register(&topic, c.Handler)
+	return c.subscriptions[msg.namestring].handler(msg.namestring, msg.Payload[:len(msg.Payload)-symKeyLength])
+}
+
+func (c *Controller) handleStopMsg(msg *Msg) error {
+	// if name is not registered for notifications we will not react
+	currentNotifier, ok := c.notifiers[msg.namestring]
+	if !ok {
+		return fmt.Errorf("Unsubscribe attempted on unknown resource '%s'", msg.namestring)
+	}
+
+	// parse the address from the message and truncate if longer than our bins' address length threshold
+	address := msg.Payload
+	if len(msg.Payload) > currentNotifier.threshold {
+		address = address[:currentNotifier.threshold]
+	}
+
+	// remove the entry from the bin if it exists, and remove the bin if it's the last remaining one
+	hexAddress := fmt.Sprintf("%x", address)
+	currentBin, ok := currentNotifier.bins[hexAddress]
+	if !ok {
+		return fmt.Errorf("found no active bin for address %s", hexAddress)
+	}
+	currentBin.count--
+	if currentBin.count == 0 { // if no more clients in this bin, remove it
+		delete(currentNotifier.bins, hexAddress)
+	}
+	return nil
+}
+
+// Handler is the pss topic handler to be used to process notification service messages
+// It should be registered in the pss of both to any notification service provides and clients using the service
+func (c *Controller) Handler(smsg []byte, p *p2p.Peer, asymmetric bool, keyid string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	log.Debug("notify controller handler", "keyid", keyid)
+
+	// see if the message is valid
+	msg, err := NewMsgFromPayload(smsg)
+	if err != nil {
+		return err
+	}
+
+	switch msg.Code {
+	case MsgCodeStart:
+		return c.handleStartMsg(msg, keyid)
+	case MsgCodeNotifyWithKey:
+		return c.handleNotifyWithKeyMsg(msg)
+	case MsgCodeNotify:
+		return c.subscriptions[msg.namestring].handler(msg.namestring, msg.Payload)
+	case MsgCodeStop:
+		return c.handleStopMsg(msg)
+	}
+
+	return fmt.Errorf("Invalid message code: %d", msg.Code)
+}

--- a/swarm/pss/notify/notify_test.go
+++ b/swarm/pss/notify/notify_test.go
@@ -1,0 +1,252 @@
+package notify
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/p2p/discover"
+	"github.com/ethereum/go-ethereum/p2p/simulations"
+	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
+	"github.com/ethereum/go-ethereum/swarm/network"
+	"github.com/ethereum/go-ethereum/swarm/pss"
+	"github.com/ethereum/go-ethereum/swarm/state"
+	whisper "github.com/ethereum/go-ethereum/whisper/whisperv5"
+)
+
+var (
+	loglevel = flag.Int("l", 3, "loglevel")
+	psses    map[string]*pss.Pss
+	w        *whisper.Whisper
+	wapi     *whisper.PublicWhisperAPI
+)
+
+func init() {
+	flag.Parse()
+	hs := log.StreamHandler(os.Stderr, log.TerminalFormat(true))
+	hf := log.LvlFilterHandler(log.Lvl(*loglevel), hs)
+	h := log.CallerFileHandler(hf)
+	log.Root().SetHandler(h)
+
+	w = whisper.New(&whisper.DefaultConfig)
+	wapi = whisper.NewPublicWhisperAPI(w)
+	psses = make(map[string]*pss.Pss)
+}
+
+// Creates a client node and notifier node
+// Client sends pss notifications requests
+// notifier sends initial notification with symmetric key, and
+// second notification symmetrically encrypted
+func TestStart(t *testing.T) {
+	adapter := adapters.NewSimAdapter(newServices(false))
+	net := simulations.NewNetwork(adapter, &simulations.NetworkConfig{
+		ID:             "0",
+		DefaultService: "bzz",
+	})
+	leftNodeConf := adapters.RandomNodeConfig()
+	leftNodeConf.Services = []string{"bzz", "pss"}
+	leftNode, err := net.NewNodeWithConfig(leftNodeConf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = net.Start(leftNode.ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rightNodeConf := adapters.RandomNodeConfig()
+	rightNodeConf.Services = []string{"bzz", "pss"}
+	rightNode, err := net.NewNodeWithConfig(rightNodeConf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = net.Start(rightNode.ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = net.Connect(rightNode.ID(), leftNode.ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	leftRpc, err := leftNode.Client()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rightRpc, err := rightNode.Client()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var leftAddr string
+	err = leftRpc.Call(&leftAddr, "pss_baseAddr")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var rightAddr string
+	err = rightRpc.Call(&rightAddr, "pss_baseAddr")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var leftPub string
+	err = leftRpc.Call(&leftPub, "pss_getPublicKey")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var rightPub string
+	err = rightRpc.Call(&rightPub, "pss_getPublicKey")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rsrcName := "foo.eth"
+	rsrcTopic := pss.BytesToTopic([]byte(rsrcName))
+
+	// wait for kademlia table to populate
+	time.Sleep(time.Second)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+	rmsgC := make(chan *pss.APIMsg)
+	rightSub, err := rightRpc.Subscribe(ctx, "pss", rmsgC, "receive", controlTopic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rightSub.Unsubscribe()
+
+	updateC := make(chan []byte)
+	updateMsg := []byte{}
+	ctrlClient := NewController(psses[rightPub])
+	ctrlNotifier := NewController(psses[leftPub])
+	ctrlNotifier.NewNotifier("foo.eth", 2, updateC)
+
+	pubkeybytes, err := hexutil.Decode(leftPub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubkey, err := crypto.UnmarshalPubkey(pubkeybytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addrbytes, err := hexutil.Decode(leftAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctrlClient.Subscribe(rsrcName, pubkey, addrbytes, func(s string, b []byte) error {
+		if s != "foo.eth" || !bytes.Equal(updateMsg, b) {
+			t.Fatalf("unexpected result in client handler: '%s':'%x'", s, b)
+		}
+		log.Info("client handler receive", "s", s, "b", b)
+		return nil
+	})
+
+	var inMsg *pss.APIMsg
+	select {
+	case inMsg = <-rmsgC:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+
+	dMsg, err := NewMsgFromPayload(inMsg.Msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dMsg.namestring != rsrcName {
+		t.Fatalf("expected name '%s', got '%s'", rsrcName, dMsg.namestring)
+	}
+	if !bytes.Equal(dMsg.Payload[:len(updateMsg)], updateMsg) {
+		t.Fatalf("expected payload first %d bytes '%x', got '%x'", len(updateMsg), updateMsg, dMsg.Payload[:len(updateMsg)])
+	}
+	if len(updateMsg)+symKeyLength != len(dMsg.Payload) {
+		t.Fatalf("expected payload length %d, have %d", len(updateMsg)+symKeyLength, len(dMsg.Payload))
+	}
+
+	rightSubUpdate, err := rightRpc.Subscribe(ctx, "pss", rmsgC, "receive", rsrcTopic)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rightSubUpdate.Unsubscribe()
+
+	updateMsg = []byte("plugh")
+	updateC <- updateMsg
+	select {
+	case inMsg = <-rmsgC:
+	case <-ctx.Done():
+		log.Error("timed out waiting for msg", "topic", fmt.Sprintf("%x", rsrcTopic))
+		t.Fatal(ctx.Err())
+	}
+	dMsg, err = NewMsgFromPayload(inMsg.Msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dMsg.namestring != rsrcName {
+		t.Fatalf("expected name %s, got %s", rsrcName, dMsg.namestring)
+	}
+	if !bytes.Equal(dMsg.Payload, updateMsg) {
+		t.Fatalf("expected payload '%x', got '%x'", updateMsg, dMsg.Payload)
+	}
+
+}
+
+func newServices(allowRaw bool) adapters.Services {
+	stateStore := state.NewInmemoryStore()
+	kademlias := make(map[discover.NodeID]*network.Kademlia)
+	kademlia := func(id discover.NodeID) *network.Kademlia {
+		if k, ok := kademlias[id]; ok {
+			return k
+		}
+		addr := network.NewAddrFromNodeID(id)
+		params := network.NewKadParams()
+		params.MinProxBinSize = 2
+		params.MaxBinSize = 3
+		params.MinBinSize = 1
+		params.MaxRetries = 1000
+		params.RetryExponent = 2
+		params.RetryInterval = 1000000
+		kademlias[id] = network.NewKademlia(addr.Over(), params)
+		return kademlias[id]
+	}
+	return adapters.Services{
+		"pss": func(ctx *adapters.ServiceContext) (node.Service, error) {
+			ctxlocal, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			keys, err := wapi.NewKeyPair(ctxlocal)
+			privkey, err := w.GetPrivateKey(keys)
+			pssp := pss.NewPssParams().WithPrivateKey(privkey)
+			pssp.MsgTTL = time.Second * 30
+			pssp.AllowRaw = allowRaw
+			pskad := kademlia(ctx.Config.ID)
+			ps, err := pss.NewPss(pskad, pssp)
+			if err != nil {
+				return nil, err
+			}
+			//psses[common.ToHex(crypto.FromECDSAPub(&privkey.PublicKey))] = ps
+			psses[hexutil.Encode(crypto.FromECDSAPub(&privkey.PublicKey))] = ps
+			return ps, nil
+		},
+		"bzz": func(ctx *adapters.ServiceContext) (node.Service, error) {
+			addr := network.NewAddrFromNodeID(ctx.Config.ID)
+			hp := network.NewHiveParams()
+			hp.Discovery = false
+			config := &network.BzzConfig{
+				OverlayAddr:  addr.Over(),
+				UnderlayAddr: addr.Under(),
+				HiveParams:   hp,
+			}
+			return network.NewBzz(config, kademlia(ctx.Config.ID), stateStore, nil, nil), nil
+		},
+	}
+}

--- a/swarm/pss/protocol.go
+++ b/swarm/pss/protocol.go
@@ -172,6 +172,8 @@ func (p *Protocol) Handle(msg []byte, peer *p2p.Peer, asymmetric bool, keyid str
 		rw, err := p.AddPeer(peer, *p.topic, asymmetric, keyid)
 		if err != nil {
 			return err
+		} else if rw == nil {
+			return fmt.Errorf("handle called on nil MsgReadWriter for new key " + keyid)
 		}
 		vrw = rw.(*PssReadWriter)
 	}
@@ -181,8 +183,14 @@ func (p *Protocol) Handle(msg []byte, peer *p2p.Peer, asymmetric bool, keyid str
 		return fmt.Errorf("could not decode pssmsg")
 	}
 	if asymmetric {
+		if p.pubKeyRWPool[keyid] == nil {
+			return fmt.Errorf("handle called on nil MsgReadWriter for key " + keyid)
+		}
 		vrw = p.pubKeyRWPool[keyid].(*PssReadWriter)
 	} else {
+		if p.symKeyRWPool[keyid] == nil {
+			return fmt.Errorf("handle called on nil MsgReadWriter for key " + keyid)
+		}
 		vrw = p.symKeyRWPool[keyid].(*PssReadWriter)
 	}
 	vrw.injectMsg(pmsg)

--- a/swarm/pss/pss.go
+++ b/swarm/pss/pss.go
@@ -41,7 +41,7 @@ import (
 
 const (
 	defaultPaddingByteSize     = 16
-	defaultMsgTTL              = time.Second * 120
+	DefaultMsgTTL              = time.Second * 120
 	defaultDigestCacheTTL      = time.Second * 10
 	defaultSymKeyCacheCapacity = 512
 	digestLength               = 32 // byte length of digest used for pss cache (currently same as swarm chunk hash)
@@ -94,7 +94,7 @@ type PssParams struct {
 // Sane defaults for Pss
 func NewPssParams() *PssParams {
 	return &PssParams{
-		MsgTTL:              defaultMsgTTL,
+		MsgTTL:              DefaultMsgTTL,
 		CacheTTL:            defaultDigestCacheTTL,
 		SymKeyCacheCapacity: defaultSymKeyCacheCapacity,
 	}
@@ -354,11 +354,11 @@ func (p *Pss) handlePssMsg(msg interface{}) error {
 	}
 	if int64(pssmsg.Expire) < time.Now().Unix() {
 		metrics.GetOrRegisterCounter("pss.expire", nil).Inc(1)
-		log.Warn("pss filtered expired message", "from", fmt.Sprintf("%x", p.Overlay.BaseAddr()), "to", fmt.Sprintf("%x", common.ToHex(pssmsg.To)))
+		log.Warn("pss filtered expired message", "from", common.ToHex(p.Overlay.BaseAddr()), "to", common.ToHex(pssmsg.To))
 		return nil
 	}
 	if p.checkFwdCache(pssmsg) {
-		log.Trace(fmt.Sprintf("pss relay block-cache match (process): FROM %x TO %x", p.Overlay.BaseAddr(), common.ToHex(pssmsg.To)))
+		log.Trace("pss relay block-cache match (process)", "from", common.ToHex(p.Overlay.BaseAddr()), "to", (common.ToHex(pssmsg.To)))
 		return nil
 	}
 	p.addFwdCache(pssmsg)
@@ -480,7 +480,7 @@ func (p *Pss) SetPeerPublicKey(pubkey *ecdsa.PublicKey, topic Topic, address *Ps
 }
 
 // Automatically generate a new symkey for a topic and address hint
-func (p *Pss) generateSymmetricKey(topic Topic, address *PssAddress, addToCache bool) (string, error) {
+func (p *Pss) GenerateSymmetricKey(topic Topic, address *PssAddress, addToCache bool) (string, error) {
 	keyid, err := p.w.GenerateSymKey()
 	if err != nil {
 		return "", err

--- a/swarm/pss/pss_test.go
+++ b/swarm/pss/pss_test.go
@@ -469,7 +469,7 @@ func TestKeys(t *testing.T) {
 	}
 
 	// make a symmetric key that we will send to peer for encrypting messages to us
-	inkeyid, err := ps.generateSymmetricKey(topicobj, &addr, true)
+	inkeyid, err := ps.GenerateSymmetricKey(topicobj, &addr, true)
 	if err != nil {
 		t.Fatalf("failed to set 'our' incoming symmetric key")
 	}
@@ -1282,7 +1282,7 @@ func benchmarkSymKeySend(b *testing.B) {
 	topic := BytesToTopic([]byte("foo"))
 	to := make(PssAddress, 32)
 	copy(to[:], network.RandomAddr().Over())
-	symkeyid, err := ps.generateSymmetricKey(topic, &to, true)
+	symkeyid, err := ps.GenerateSymmetricKey(topic, &to, true)
 	if err != nil {
 		b.Fatalf("could not generate symkey: %v", err)
 	}
@@ -1375,7 +1375,7 @@ func benchmarkSymkeyBruteforceChangeaddr(b *testing.B) {
 	for i := 0; i < int(keycount); i++ {
 		to := make(PssAddress, 32)
 		copy(to[:], network.RandomAddr().Over())
-		keyid, err = ps.generateSymmetricKey(topic, &to, true)
+		keyid, err = ps.GenerateSymmetricKey(topic, &to, true)
 		if err != nil {
 			b.Fatalf("cant generate symkey #%d: %v", i, err)
 		}
@@ -1457,7 +1457,7 @@ func benchmarkSymkeyBruteforceSameaddr(b *testing.B) {
 	topic := BytesToTopic([]byte("foo"))
 	for i := 0; i < int(keycount); i++ {
 		copy(addr[i], network.RandomAddr().Over())
-		keyid, err = ps.generateSymmetricKey(topic, &addr[i], true)
+		keyid, err = ps.GenerateSymmetricKey(topic, &addr[i], true)
 		if err != nil {
 			b.Fatalf("cant generate symkey #%d: %v", i, err)
 		}

--- a/swarm/storage/filestore.go
+++ b/swarm/storage/filestore.go
@@ -17,6 +17,7 @@
 package storage
 
 import (
+	"context"
 	"io"
 )
 
@@ -78,7 +79,7 @@ func NewFileStore(store ChunkStore, params *FileStoreParams) *FileStore {
 // Chunk retrieval blocks on netStore requests with a timeout so reader will
 // report error if retrieval of chunks within requested range time out.
 // It returns a reader with the chunk data and whether the content was encrypted
-func (f *FileStore) Retrieve(addr Address) (reader *LazyChunkReader, isEncrypted bool) {
+func (f *FileStore) Retrieve(ctx context.Context, addr Address) (reader *LazyChunkReader, isEncrypted bool) {
 	isEncrypted = len(addr) > f.hashFunc().Size()
 	getter := NewHasherStore(f.ChunkStore, f.hashFunc, isEncrypted)
 	reader = TreeJoin(addr, getter, 0)
@@ -87,7 +88,7 @@ func (f *FileStore) Retrieve(addr Address) (reader *LazyChunkReader, isEncrypted
 
 // Public API. Main entry point for document storage directly. Used by the
 // FS-aware API and httpaccess
-func (f *FileStore) Store(data io.Reader, size int64, toEncrypt bool) (addr Address, wait func(), err error) {
+func (f *FileStore) Store(ctx context.Context, data io.Reader, size int64, toEncrypt bool) (addr Address, wait func(), err error) {
 	putter := NewHasherStore(f.ChunkStore, f.hashFunc, toEncrypt)
 	return PyramidSplit(data, putter, putter)
 }

--- a/swarm/storage/filestore.go
+++ b/swarm/storage/filestore.go
@@ -82,15 +82,15 @@ func NewFileStore(store ChunkStore, params *FileStoreParams) *FileStore {
 func (f *FileStore) Retrieve(ctx context.Context, addr Address) (reader *LazyChunkReader, isEncrypted bool) {
 	isEncrypted = len(addr) > f.hashFunc().Size()
 	getter := NewHasherStore(f.ChunkStore, f.hashFunc, isEncrypted)
-	reader = TreeJoin(addr, getter, 0)
+	reader = TreeJoin(ctx, addr, getter, 0)
 	return
 }
 
 // Public API. Main entry point for document storage directly. Used by the
 // FS-aware API and httpaccess
-func (f *FileStore) Store(ctx context.Context, data io.Reader, size int64, toEncrypt bool) (addr Address, wait func(), err error) {
+func (f *FileStore) Store(ctx context.Context, data io.Reader, size int64, toEncrypt bool) (addr Address, wait func(context.Context) error, err error) {
 	putter := NewHasherStore(f.ChunkStore, f.hashFunc, toEncrypt)
-	return PyramidSplit(data, putter, putter)
+	return PyramidSplit(ctx, data, putter, putter)
 }
 
 func (f *FileStore) HashSize() int {

--- a/swarm/storage/filestore_test.go
+++ b/swarm/storage/filestore_test.go
@@ -50,11 +50,15 @@ func testFileStoreRandom(toEncrypt bool, t *testing.T) {
 	defer os.RemoveAll("/tmp/bzz")
 
 	reader, slice := generateRandomData(testDataSize)
-	key, wait, err := fileStore.Store(context.TODO(), reader, testDataSize, toEncrypt)
+	ctx := context.TODO()
+	key, wait, err := fileStore.Store(ctx, reader, testDataSize, toEncrypt)
 	if err != nil {
 		t.Errorf("Store error: %v", err)
 	}
-	wait()
+	err = wait(ctx)
+	if err != nil {
+		t.Fatalf("Store waitt error: %v", err.Error())
+	}
 	resultReader, isEncrypted := fileStore.Retrieve(context.TODO(), key)
 	if isEncrypted != toEncrypt {
 		t.Fatalf("isEncrypted expected %v got %v", toEncrypt, isEncrypted)
@@ -111,11 +115,15 @@ func testFileStoreCapacity(toEncrypt bool, t *testing.T) {
 	}
 	fileStore := NewFileStore(localStore, NewFileStoreParams())
 	reader, slice := generateRandomData(testDataSize)
-	key, wait, err := fileStore.Store(context.TODO(), reader, testDataSize, toEncrypt)
+	ctx := context.TODO()
+	key, wait, err := fileStore.Store(ctx, reader, testDataSize, toEncrypt)
 	if err != nil {
 		t.Errorf("Store error: %v", err)
 	}
-	wait()
+	err = wait(ctx)
+	if err != nil {
+		t.Errorf("Store error: %v", err)
+	}
 	resultReader, isEncrypted := fileStore.Retrieve(context.TODO(), key)
 	if isEncrypted != toEncrypt {
 		t.Fatalf("isEncrypted expected %v got %v", toEncrypt, isEncrypted)

--- a/swarm/storage/filestore_test.go
+++ b/swarm/storage/filestore_test.go
@@ -18,6 +18,7 @@ package storage
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"io/ioutil"
 	"os"
@@ -49,12 +50,12 @@ func testFileStoreRandom(toEncrypt bool, t *testing.T) {
 	defer os.RemoveAll("/tmp/bzz")
 
 	reader, slice := generateRandomData(testDataSize)
-	key, wait, err := fileStore.Store(reader, testDataSize, toEncrypt)
+	key, wait, err := fileStore.Store(context.TODO(), reader, testDataSize, toEncrypt)
 	if err != nil {
 		t.Errorf("Store error: %v", err)
 	}
 	wait()
-	resultReader, isEncrypted := fileStore.Retrieve(key)
+	resultReader, isEncrypted := fileStore.Retrieve(context.TODO(), key)
 	if isEncrypted != toEncrypt {
 		t.Fatalf("isEncrypted expected %v got %v", toEncrypt, isEncrypted)
 	}
@@ -72,7 +73,7 @@ func testFileStoreRandom(toEncrypt bool, t *testing.T) {
 	ioutil.WriteFile("/tmp/slice.bzz.16M", slice, 0666)
 	ioutil.WriteFile("/tmp/result.bzz.16M", resultSlice, 0666)
 	localStore.memStore = NewMemStore(NewDefaultStoreParams(), db)
-	resultReader, isEncrypted = fileStore.Retrieve(key)
+	resultReader, isEncrypted = fileStore.Retrieve(context.TODO(), key)
 	if isEncrypted != toEncrypt {
 		t.Fatalf("isEncrypted expected %v got %v", toEncrypt, isEncrypted)
 	}
@@ -110,12 +111,12 @@ func testFileStoreCapacity(toEncrypt bool, t *testing.T) {
 	}
 	fileStore := NewFileStore(localStore, NewFileStoreParams())
 	reader, slice := generateRandomData(testDataSize)
-	key, wait, err := fileStore.Store(reader, testDataSize, toEncrypt)
+	key, wait, err := fileStore.Store(context.TODO(), reader, testDataSize, toEncrypt)
 	if err != nil {
 		t.Errorf("Store error: %v", err)
 	}
 	wait()
-	resultReader, isEncrypted := fileStore.Retrieve(key)
+	resultReader, isEncrypted := fileStore.Retrieve(context.TODO(), key)
 	if isEncrypted != toEncrypt {
 		t.Fatalf("isEncrypted expected %v got %v", toEncrypt, isEncrypted)
 	}
@@ -134,7 +135,7 @@ func testFileStoreCapacity(toEncrypt bool, t *testing.T) {
 	memStore.setCapacity(0)
 	// check whether it is, indeed, empty
 	fileStore.ChunkStore = memStore
-	resultReader, isEncrypted = fileStore.Retrieve(key)
+	resultReader, isEncrypted = fileStore.Retrieve(context.TODO(), key)
 	if isEncrypted != toEncrypt {
 		t.Fatalf("isEncrypted expected %v got %v", toEncrypt, isEncrypted)
 	}
@@ -144,7 +145,7 @@ func testFileStoreCapacity(toEncrypt bool, t *testing.T) {
 	// check how it works with localStore
 	fileStore.ChunkStore = localStore
 	//	localStore.dbStore.setCapacity(0)
-	resultReader, isEncrypted = fileStore.Retrieve(key)
+	resultReader, isEncrypted = fileStore.Retrieve(context.TODO(), key)
 	if isEncrypted != toEncrypt {
 		t.Fatalf("isEncrypted expected %v got %v", toEncrypt, isEncrypted)
 	}

--- a/swarm/storage/hasherstore.go
+++ b/swarm/storage/hasherstore.go
@@ -17,6 +17,7 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -126,9 +127,10 @@ func (h *hasherStore) Close() {
 // Wait returns when
 //    1) the Close() function has been called and
 //    2) all the chunks which has been Put has been stored
-func (h *hasherStore) Wait() {
+func (h *hasherStore) Wait(ctx context.Context) error {
 	<-h.closed
 	h.wg.Wait()
+	return nil
 }
 
 func (h *hasherStore) createHash(chunkData ChunkData) Address {

--- a/swarm/storage/hasherstore_test.go
+++ b/swarm/storage/hasherstore_test.go
@@ -18,6 +18,7 @@ package storage
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/swarm/storage/encryption"
@@ -60,7 +61,10 @@ func TestHasherStore(t *testing.T) {
 		hasherStore.Close()
 
 		// Wait until chunks are really stored
-		hasherStore.Wait()
+		err = hasherStore.Wait(context.TODO())
+		if err != nil {
+			t.Fatalf("Expected no error got \"%v\"", err)
+		}
 
 		// Get the first chunk
 		retrievedChunkData1, err := hasherStore.Get(key1)

--- a/swarm/storage/ldbstore_test.go
+++ b/swarm/storage/ldbstore_test.go
@@ -59,12 +59,12 @@ func newTestDbStore(mock bool, trusted bool) (*testDbStore, func(), error) {
 	}
 
 	cleanup := func() {
-		if err != nil {
+		if db != nil {
 			db.Close()
 		}
 		err = os.RemoveAll(dir)
 		if err != nil {
-			panic("db cleanup failed")
+			panic(fmt.Sprintf("db cleanup failed: %v", err))
 		}
 	}
 

--- a/swarm/storage/mru/doc.go
+++ b/swarm/storage/mru/doc.go
@@ -1,0 +1,52 @@
+// Mutable resource is an entity which allows updates to a resource
+// without resorting to ENS on each update.
+// The update scheme is built on swarm chunks with chunk keys following
+// a predictable, versionable pattern.
+//
+// Updates are defined to be periodic in nature, where periods are
+// expressed in terms of number of blocks.
+//
+// The root entry of a mutable resource is tied to a unique identifier,
+// typically - but not necessarily - an ens name.  The identifier must be
+// an valid IDNA string. It also contains the block number
+// when the resource update was first registered, and
+// the block frequency with which the resource will be updated, both of
+// which are stored as little-endian uint64 values in the database (for a
+// total of 16 bytes). It also contains the unique identifier.
+// It is stored in a separate content-addressed chunk (call it the metadata chunk),
+// with the following layout:
+//
+// (0x0000|startblock|frequency|publickey|identifier)
+//
+// (The two first zero-value bytes are used for disambiguation by the chunk validator,
+// and update chunk will always have a value > 0 there.)
+//
+// The root entry tells the requester from when the mutable resource was
+// first added (block number) and in which block number to look for the
+// actual updates. Thus, a resource update for identifier "føø.bar"
+// starting at block 4200 with frequency 42 will have updates on block 4242,
+// 4284, 4326 and so on.
+//
+// Actual data updates are also made in the form of swarm chunks. The keys
+// of the updates are the hash of a concatenation of properties as follows:
+//
+// sha256(period|version|publickey|namehash)
+//
+// The period is (currentblock - startblock) / frequency
+//
+// Using our previous example, this means that a period 3 will have 4326 as
+// the block number.
+//
+// If more than one update is made to the same block number, incremental
+// version numbers are used successively.
+//
+// A lookup agent need only know the identifier name in order to get the versions
+//
+// the resourcedata is:
+// headerlength|period|version|identifier|data
+//
+// the full update data that goes in the chunk payload is:
+// resourcedata|sign(resourcedata)
+//
+// headerlength is a 16 bit value containing the byte length of period|version|name
+package mru

--- a/swarm/storage/mru/doc.go
+++ b/swarm/storage/mru/doc.go
@@ -13,10 +13,10 @@
 // the block frequency with which the resource will be updated, both of
 // which are stored as little-endian uint64 values in the database (for a
 // total of 16 bytes). It also contains the unique identifier.
-// It is stored in a separate content-addressed chunk (call it the metadata chunk),
-// with the following layout:
+// This MRU info is stored in a separate content-addressed chunk
+// (call it the metadata chunk), with the following layout:
 //
-// (0x0000|startblock|frequency|publickey|identifier)
+// (startblock|frequency|address|identifier)
 //
 // (The two first zero-value bytes are used for disambiguation by the chunk validator,
 // and update chunk will always have a value > 0 there.)
@@ -30,7 +30,7 @@
 // Actual data updates are also made in the form of swarm chunks. The keys
 // of the updates are the hash of a concatenation of properties as follows:
 //
-// sha256(period|version|publickey|namehash)
+// sha256(period|version|address|namehash)
 //
 // The period is (currentblock - startblock) / frequency
 //

--- a/swarm/storage/mru/resource.go
+++ b/swarm/storage/mru/resource.go
@@ -400,7 +400,7 @@ func (h *Handler) newMetaChunk(name string, startBlock uint64, frequency uint64,
 // It starts at the next period after the current block height, and upon failure
 // tries the corresponding keys of each previous period until one is found
 // (or startBlock is reached, in which case there are no updates).
-func (h *Handler) Lookup(ctx context.Context, params *LookupParams) (*resource, error) { //nameHash common.Hash, refresh bool, maxLookup *LookupParams) (*resource, error) {
+func (h *Handler) Lookup(ctx context.Context, params *LookupParams) (*resource, error) {
 
 	rsrc := h.get(params.Root.Hex())
 	if rsrc == nil {
@@ -426,7 +426,7 @@ func (h *Handler) Lookup(ctx context.Context, params *LookupParams) (*resource, 
 // This is useful where resource updates are used incrementally in contrast to
 // merely replacing content.
 // Requires a synced resource object
-func (h *Handler) LookupPrevious(ctx context.Context, params *LookupParams) (*resource, error) { //nameHash common.Hash, maxLookup *LookupParams) (*resource, error) {
+func (h *Handler) LookupPrevious(ctx context.Context, params *LookupParams) (*resource, error) {
 	rsrc := h.get(params.Root.Hex())
 	if rsrc == nil {
 		return nil, NewError(ErrNothingToReturn, "resource not loaded")

--- a/swarm/storage/mru/resource.go
+++ b/swarm/storage/mru/resource.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -917,18 +916,11 @@ func (h *Handler) set(nameHash string, rsrc *resource) {
 }
 
 // used for chunk keys
-func (h *Handler) resourceHash(period uint32, version uint32, namehash common.Hash, publicKeyBytes [publicKeyLength]byte) storage.Address {
-	// format is: hash(period|version|namehash)
+func (h *Handler) resourceHash(period uint32, version uint32, nameHash common.Hash, publicKeyBytes [publicKeyLength]byte) storage.Address {
 	hasher := h.hashPool.Get().(storage.SwarmHash)
 	defer h.hashPool.Put(hasher)
 	hasher.Reset()
-	b := make([]byte, 4)
-	binary.LittleEndian.PutUint32(b, period)
-	hasher.Write(b)
-	binary.LittleEndian.PutUint32(b, version)
-	hasher.Write(b)
-	hasher.Write(publicKeyBytes[:])
-	hasher.Write(namehash[:])
+	hasher.Write(NewResourceHash(period, version, nameHash, publicKeyBytes))
 	return hasher.Sum(nil)
 }
 
@@ -1022,21 +1014,16 @@ func isSafeName(name string) bool {
 	return validname == name
 }
 
-func NewTestHandler(datadir string, params *HandlerParams) (*Handler, error) {
-	path := filepath.Join(datadir, DbDirName)
-	rh, err := NewHandler(params)
-	if err != nil {
-		return nil, fmt.Errorf("resource handler create fail: %v", err)
-	}
-	localstoreparams := storage.NewDefaultLocalStoreParams()
-	localstoreparams.Init(path)
-	localStore, err := storage.NewLocalStore(localstoreparams, nil)
-	if err != nil {
-		return nil, fmt.Errorf("localstore create fail, path %s: %v", path, err)
-	}
-	localStore.Validators = append(localStore.Validators, storage.NewContentAddressValidator(storage.MakeHashFunc(resourceHash)))
-	localStore.Validators = append(localStore.Validators, rh)
-	netStore := storage.NewNetStore(localStore, nil)
-	rh.SetStore(netStore)
-	return rh, nil
+// NewResourceHash will create a deterministic address from the update metadata
+// format is: hash(period|version|publickey|namehash)
+func NewResourceHash(period uint32, version uint32, namehash common.Hash, publicKeyBytes [publicKeyLength]byte) []byte {
+	buf := bytes.NewBuffer(nil)
+	b := make([]byte, 4)
+	binary.LittleEndian.PutUint32(b, period)
+	buf.Write(b)
+	binary.LittleEndian.PutUint32(b, version)
+	buf.Write(b)
+	buf.Write(publicKeyBytes[:])
+	buf.Write(namehash[:])
+	return buf.Bytes()
 }

--- a/swarm/storage/mru/resource.go
+++ b/swarm/storage/mru/resource.go
@@ -148,20 +148,20 @@ func (r *resource) Name() string {
 	return r.name
 }
 
-func (self *resource) UnmarshalBinary(data []byte) error {
-	self.startBlock = binary.LittleEndian.Uint64(data)
-	self.frequency = binary.LittleEndian.Uint64(data[8:])
-	copy(self.publicKey[:], data[16:16+publicKeyLength])
-	self.name = string(data[16+publicKeyLength:])
+func (r *resource) UnmarshalBinary(data []byte) error {
+	r.startBlock = binary.LittleEndian.Uint64(data)
+	r.frequency = binary.LittleEndian.Uint64(data[8:])
+	copy(r.publicKey[:], data[16:16+publicKeyLength])
+	r.name = string(data[16+publicKeyLength:])
 	return nil
 }
 
-func (self *resource) MarshalBinary() ([]byte, error) {
-	b := make([]byte, 16+len(self.name))
-	binary.LittleEndian.PutUint64(b, self.startBlock)
-	binary.LittleEndian.PutUint64(b[8:], self.frequency)
-	copy(b[16:], self.publicKey[:])
-	copy(b[16+publicKeyLength:], []byte(self.name))
+func (r *resource) MarshalBinary() ([]byte, error) {
+	b := make([]byte, 16+len(r.name))
+	binary.LittleEndian.PutUint64(b, r.startBlock)
+	binary.LittleEndian.PutUint64(b[8:], r.frequency)
+	copy(b[16:], r.publicKey[:])
+	copy(b[16+publicKeyLength:], []byte(r.name))
 	return b, nil
 }
 
@@ -298,7 +298,7 @@ func (h *Handler) Validate(addr storage.Address, data []byte) bool {
 		return false
 	}
 
-	digest := self.keyDataHash(addr, parseddata)
+	digest := h.keyDataHash(addr, parseddata)
 	publicKey, err := crypto.SigToPub(digest.Bytes(), signature[:])
 	//addrSig, err := getAddressFromDataSig(digest, *signature)
 	if err != nil {
@@ -308,12 +308,12 @@ func (h *Handler) Validate(addr storage.Address, data []byte) bool {
 	nameHash := ens.EnsNode(name)
 	var publicKeyBytes [65]byte
 	copy(publicKeyBytes[:], crypto.FromECDSAPub(publicKey))
-	checkAddr := self.resourceHash(period, version, nameHash, publicKeyBytes)
+	checkAddr := h.resourceHash(period, version, nameHash, publicKeyBytes)
 	if !bytes.Equal(checkAddr, addr) {
 		log.Error("Invalid signature on resource chunk")
 		return false
 	}
-	//ok, _ := self.checkAccess(name, addrSig)
+	//ok, _ := h.checkAccess(name, addrSig)
 	return true
 }
 
@@ -369,7 +369,7 @@ func (h *Handler) chunkSize() int64 {
 //
 // The start block of the resource update will be the actual current block height of the connected network.
 func (h *Handler) New(ctx context.Context, name string, frequency uint64) (storage.Address, *resource, error) {
-	return self.NewWithPublicKey(ctx, name, frequency, self.signer.PublicKey())
+	return h.NewWithPublicKey(ctx, name, frequency, h.signer.PublicKey())
 }
 
 func (h *Handler) NewWithPublicKey(ctx context.Context, name string, frequency uint64, publicKey *ecdsa.PublicKey) (storage.Address, *resource, error) {

--- a/swarm/storage/mru/resource.go
+++ b/swarm/storage/mru/resource.go
@@ -43,7 +43,7 @@ const (
 	chunkSize               = 4096 // temporary until we implement FileStore in the resourcehandler
 	defaultStoreTimeout     = 4000 * time.Millisecond
 	hasherCount             = 8
-	resourceHash            = storage.SHA3Hash
+	resourceHash            = storage.DefaultHash
 	defaultRetrieveTimeout  = 100 * time.Millisecond
 )
 
@@ -369,7 +369,8 @@ func (h *Handler) newMetaChunk(name string, startBlock uint64, frequency uint64,
 	// the metadata chunk points to data of first blockheight + update frequency
 	// from this we know from what blockheight we should look for updates, and how often
 	// it also contains the name of the resource, so we know what resource we are working with
-	data := make([]byte, metadataChunkOffsetSize+len(name))
+	metadataChunkLength := metadataChunkOffsetSize + len(name)
+	data := make([]byte, metadataChunkLength)
 
 	// root block has first two bytes both set to 0, which distinguishes from update bytes
 	val := make([]byte, 8)
@@ -379,20 +380,24 @@ func (h *Handler) newMetaChunk(name string, startBlock uint64, frequency uint64,
 	copy(data[8:16], val)
 	copy(data[16:], ownerAddr[:])
 	copy(data[16+common.AddressLength:], []byte(name))
+	binary.LittleEndian.PutUint64(val, uint64(metadataChunkLength))
 
 	// the key of the metadata chunk is content-addressed
 	// if it wasn't we couldn't replace it later
 	// resolving this relationship is left up to external agents (for example ENS)
 	hasher := h.hashPool.Get().(storage.SwarmHash)
-	hasher.Reset()
+	hasher.ResetWithLength(val)
 	hasher.Write(data)
 	key := hasher.Sum(nil)
 	h.hashPool.Put(hasher)
 
 	// make the chunk and send it to swarm
 	chunk := storage.NewChunk(key, nil)
-	chunk.SData = make([]byte, metadataChunkOffsetSize+len(name))
-	copy(chunk.SData, data)
+	chunk.SData = make([]byte, metadataChunkLength+8)
+	copy(chunk.SData[:8], val)
+	copy(chunk.SData[8:], data)
+	//chunk.SData = make([]byte, metadataChunkLength)
+	//copy(chunk.SData[:], data)
 	return chunk
 }
 
@@ -520,7 +525,7 @@ func (h *Handler) Load(addr storage.Address) (*resource, error) {
 
 	// create the index entry
 	rsrc := &resource{}
-	rsrc.UnmarshalBinary(chunk.SData[:])
+	rsrc.UnmarshalBinary(chunk.SData[8:])
 	rsrc.nameHash = ens.EnsNode(rsrc.name)
 	h.set(addr.Hex(), rsrc)
 	log.Trace("resource index load", "rootkey", addr, "name", rsrc.name, "namehash", rsrc.nameHash, "startblock", rsrc.startBlock, "frequency", rsrc.frequency)

--- a/swarm/storage/mru/resource.go
+++ b/swarm/storage/mru/resource.go
@@ -263,9 +263,6 @@ func (h *Handler) Validate(addr storage.Address, data []byte) bool {
 	}
 	signAddr := crypto.PubkeyToAddress(*publicKey)
 	nameHash := ens.EnsNode(name)
-	//var publicKeyBytes [65]byte
-	//copy(publicKeyBytes[:], crypto.FromECDSAPub(publicKey))
-	//checkAddr := h.resourceHash(period, version, nameHash, publicKeyBytes)
 	checkAddr := h.resourceHash(period, version, nameHash, signAddr)
 	if !bytes.Equal(checkAddr, addr) {
 		log.Error("Invalid signature on resource chunk")
@@ -399,57 +396,10 @@ func (h *Handler) newMetaChunk(name string, startBlock uint64, frequency uint64,
 	return chunk
 }
 
-// LookupVersionByName searches and retrieves the specific version of the resource update identified by `name`
-// at the specific block height
-// If refresh is set to true, the resource data will be reloaded from the resource update
-// metadata chunk.
-// It is the callers responsibility to make sure that this chunk exists (if the resource
-// update root data was retrieved externally, it typically doesn't)
-//func (h *Handler) LookupVersionByName(ctx context.Context, name string, period uint32, version uint32, refresh bool, maxLookup *LookupParams) (*resource, error) {
-//	return h.LookupVersion(ctx, ens.EnsNode(name), period, version, refresh, maxLookup)
-//}
-
-// LookupVersion performs the same action as LookupVersionByName, but takes the name hash instead of the cleartext name as identifier
-//func (h *Handler) LookupVersion(ctx context.Context, params *LookupParams) (*resource, Error) { //nameHash common.Hash, period uint32, version uint32, refresh bool, maxLookup *LookupParams) (*resource, error) {
-//	rsrc := h.get(params.Root)
-//	if rsrc == nil {
-//		return nil, NewError(ErrNothingToReturn, "resource not loaded")
-//	}
-//	return h.lookup(rsrc, params.Period, params.Version, param.Limit)
-//}
-
-// LookupHistoricalByName etrieves the latest version of the resource update identified by `name`
-// at the specified block height
-// If an update is found, version numbers are iterated until failure, and the last
-// successfully retrieved version is copied to the corresponding resources map entry
-// and returned.
-// See also (*Handler).LookupVersionByName
-//func (h *Handler) LookupHistoricalByName(ctx context.Context, name string, period uint32, refresh bool, maxLookup *LookupParams) (*resource, error) {
-//	return h.LookupHistorical(ctx, ens.EnsNode(name), period, refresh, maxLookup)
-//}
-
-// LookupHistorical performs the same action as LookupHistoricalByName, but takes the name hash instead of the cleartext name as identifier
-//func (h *Handler) LookupHistorical(ctx context.Context, nameHash common.Hash, period uint32, refresh bool, maxLookup *LookupParams) (*resource, error) {
-//func (h *Handler) LookupHistorical(ctx context.Context, params *LookupParams) (*resource, error) { //name string, period uint32, refresh bool, maxLookup *LookupParams) (*resource, error) {
-//	rsrc := h.get(params.Root)
-//	if rsrc == nil {
-//		return nil, NewError(ErrNothingToReturn, "resource not loaded")
-//	}
-//	return h.lookup(rsrc, rsrc.Period, 0, param.Limit)
-//}
-
-// LookupLatestByName retrieves the latest version of the resource update identified by `name`
-// at the next update block height
+// LookupLatest retrieves the latest version of the resource update with metadata chunk at params.Root
 // It starts at the next period after the current block height, and upon failure
 // tries the corresponding keys of each previous period until one is found
 // (or startBlock is reached, in which case there are no updates).
-// See also (*Handler).LookupHistoricalByName
-//func (h *Handler) LookupLatestByName(ctx context.Context, name string, refresh bool, maxLookup *LookupParams) (*resource, error) {
-//	return h.LookupLatest(ctx, ens.EnsNode(name), refresh, maxLookup)
-//}
-
-// LookupLatest performs the same action as LookupLatestByName, but takes the name hash instead of the cleartext name as identifier
-//func (h *Handler) LookupLatest(ctx context.Context, nameHash common.Hash, refresh bool, maxLookup *LookupParams) (*resource, error) {
 func (h *Handler) Lookup(ctx context.Context, params *LookupParams) (*resource, error) { //nameHash common.Hash, refresh bool, maxLookup *LookupParams) (*resource, error) {
 
 	rsrc := h.get(params.Root.Hex())
@@ -476,11 +426,6 @@ func (h *Handler) Lookup(ctx context.Context, params *LookupParams) (*resource, 
 // This is useful where resource updates are used incrementally in contrast to
 // merely replacing content.
 // Requires a synced resource object
-//func (h *Handler) LookupPreviousByName(ctx context.Context, name string, maxLookup *LookupParams) (*resource, error) {
-//	return h.LookupPrevious(ctx, ens.EnsNode(name), maxLookup)
-//}
-
-// LookupPrevious performs the same action as LookupPreviousByName, but takes the name hash instead of the cleartext name as identifier
 func (h *Handler) LookupPrevious(ctx context.Context, params *LookupParams) (*resource, error) { //nameHash common.Hash, maxLookup *LookupParams) (*resource, error) {
 	rsrc := h.get(params.Root.Hex())
 	if rsrc == nil {
@@ -758,9 +703,6 @@ func (h *Handler) update(ctx context.Context, addr storage.Address, data []byte,
 	}
 
 	// get the cached information
-	//nameHash := ens.EnsNode(name)
-	//nameHashHex := nameHash.Hex()
-	//rsrc := h.get(nameHashHex)
 	addrHex := addr.Hex()
 	rsrc := h.get(addrHex)
 	if rsrc == nil {

--- a/swarm/storage/mru/resource.go
+++ b/swarm/storage/mru/resource.go
@@ -41,8 +41,7 @@ import (
 const (
 	signatureLength         = 65
 	publicKeyLength         = 65
-	metadataChunkOffsetSize = 83
-	DbDirName               = "resource"
+	metadataChunkOffsetSize = 81
 	chunkSize               = 4096 // temporary until we implement FileStore in the resourcehandler
 	defaultStoreTimeout     = 4000 * time.Millisecond
 	hasherCount             = 8
@@ -85,7 +84,7 @@ type Error struct {
 	err  string
 }
 
-// Error implements the Error interface
+// Error implements the error interface
 func (e *Error) Error() string {
 	return e.err
 }
@@ -200,7 +199,7 @@ type Handler struct {
 }
 
 // HandlerParams pass parameters to the Handler constructor NewHandler
-// Signer and HeaderGetter are manfatory parameters
+// Signer and HeaderGetter are mandatory parameters
 type HandlerParams struct {
 	QueryMaxPeriods *LookupParams
 	Signer          Signer
@@ -222,7 +221,6 @@ func NewHandler(params *HandlerParams) (*Handler, error) {
 	}
 	rh := &Handler{
 		headerGetter: params.HeaderGetter,
-		//		ownerValidator: params.OwnerValidator,
 		resources:    make(map[string]*resource),
 		storeTimeout: defaultStoreTimeout,
 		signer:       params.Signer,
@@ -252,24 +250,21 @@ func (h *Handler) SetStore(store *storage.NetStore) {
 
 // Validate is a chunk validation method
 // If it's a resource update, the chunk address is checked against the public key of the update's signature
-// If not a resource update, it validates are root chunk if length is metadataChunkOffsetSize and first two bytes are 0
 // It implements the storage.ChunkValidator interface
 func (h *Handler) Validate(addr storage.Address, data []byte) bool {
+
+	// does the chunk data make sense?
+	// This is not 100% safe evaluation, since content addressed data can coincidentally produce data with length header matching content size
 	signature, period, version, name, parseddata, _, err := h.parseUpdate(data)
 	if err != nil {
-		log.Warn(err.Error())
-		if len(data) > metadataChunkOffsetSize { // identifier comes after this byte range, and must be at least one byte
-			if bytes.Equal(data[:2], []byte{0, 0}) {
-				return true
-			}
-		}
 		log.Error("Invalid resource chunk")
 		return false
 	}
 
+	// Check if signature is valid against the chunk address
+	// Since we force signatures to be used, we can know be sure that this is valid data
 	digest := h.keyDataHash(addr, parseddata)
 	publicKey, err := crypto.SigToPub(digest.Bytes(), signature[:])
-	//addrSig, err := getAddressFromDataSig(digest, *signature)
 	if err != nil {
 		log.Error("Unparseable signature in resource chunk %s", addr)
 		return false
@@ -282,7 +277,6 @@ func (h *Handler) Validate(addr storage.Address, data []byte) bool {
 		log.Error("Invalid signature on resource chunk")
 		return false
 	}
-	//ok, _ := h.checkAccess(name, addrSig)
 	return true
 }
 
@@ -396,11 +390,11 @@ func (h *Handler) newMetaChunk(name string, startBlock uint64, frequency uint64,
 	// root block has first two bytes both set to 0, which distinguishes from update bytes
 	val := make([]byte, 8)
 	binary.LittleEndian.PutUint64(val, startBlock)
-	copy(data[2:10], val)
+	copy(data[:8], val)
 	binary.LittleEndian.PutUint64(val, frequency)
-	copy(data[10:18], val)
-	copy(data[18:83], publicKeyBytes[:])
-	copy(data[83:], []byte(name))
+	copy(data[8:16], val)
+	copy(data[16:], publicKeyBytes[:])
+	copy(data[81:], []byte(name))
 
 	// the key of the metadata chunk is content-addressed
 	// if it wasn't we couldn't replace it later
@@ -581,17 +575,14 @@ func (h *Handler) Load(addr storage.Address) (*resource, error) {
 		return nil, NewError(ErrNotFound, err.Error())
 	}
 
-	// minimum sanity check for chunk data (an update chunk first two bytes is headerlength uint16, and cannot be 0)
 	// \TODO this is not enough to make sure the data isn't bogus. A normal content addressed chunk could still satisfy these criteria
-	if !bytes.Equal(chunk.SData[:2], []byte{0x0, 0x0}) {
-		return nil, NewError(ErrCorruptData, fmt.Sprintf("Chunk is not a resource metadata chunk"))
-	} else if len(chunk.SData) <= metadataChunkOffsetSize {
+	if len(chunk.SData) <= metadataChunkOffsetSize {
 		return nil, NewError(ErrNothingToReturn, fmt.Sprintf("Invalid chunk length %d, should be minimum %d", len(chunk.SData), metadataChunkOffsetSize+1))
 	}
 
 	// create the index entry
 	rsrc := &resource{}
-	rsrc.UnmarshalBinary(chunk.SData[2:])
+	rsrc.UnmarshalBinary(chunk.SData[:])
 	rsrc.nameHash = ens.EnsNode(rsrc.name)
 	h.set(rsrc.nameHash.Hex(), rsrc)
 	log.Trace("resource index load", "rootkey", addr, "name", rsrc.name, "namehash", rsrc.nameHash, "startblock", rsrc.startBlock, "frequency", rsrc.frequency)
@@ -645,6 +636,11 @@ func (h *Handler) parseUpdate(chunkdata []byte) (*Signature, uint32, uint32, str
 	cursor += 2
 	datalength := binary.LittleEndian.Uint16(chunkdata[cursor : cursor+2])
 	cursor += 2
+
+	if int(headerlength+datalength) > len(chunkdata) {
+		return nil, 0, 0, "", nil, false, NewError(ErrNothingToReturn, "length specified in header is greater than actual chunk size")
+	}
+
 	var exclsignlength int
 	// we need extra magic if it's a multihash, since we used datalength 0 in header as an indicator of multihash content
 	// retrieve the second varint and set this as the data length
@@ -842,12 +838,6 @@ func (h *Handler) update(ctx context.Context, name string, data []byte, multihas
 	rsrc.data = make([]byte, len(data))
 	copy(rsrc.data, data)
 	return key, nil
-}
-
-// Close closes the datastore.
-// Always call this at shutdown to avoid data corruption.
-func (h *Handler) Close() {
-	h.chunkStore.Close()
 }
 
 // gets the current block height

--- a/swarm/storage/mru/resource.go
+++ b/swarm/storage/mru/resource.go
@@ -368,7 +368,11 @@ func (h *Handler) chunkSize() int64 {
 // The signature data should match the hash of the idna-converted name by the validator's namehash function, NOT the raw name bytes.
 //
 // The start block of the resource update will be the actual current block height of the connected network.
-func (h *Handler) New(ctx context.Context, name string, frequency uint64, publicKey *ecdsa.PublicKey) (storage.Address, *resource, error) {
+func (h *Handler) New(ctx context.Context, name string, frequency uint64) (storage.Address, *resource, error) {
+	return self.NewWithPublicKey(ctx, name, frequency, self.signer.PublicKey())
+}
+
+func (h *Handler) NewWithPublicKey(ctx context.Context, name string, frequency uint64, publicKey *ecdsa.PublicKey) (storage.Address, *resource, error) {
 
 	// frequency 0 is invalid
 	if frequency == 0 {

--- a/swarm/storage/mru/resource.go
+++ b/swarm/storage/mru/resource.go
@@ -249,7 +249,7 @@ func (h *Handler) Validate(addr storage.Address, data []byte) bool {
 	// This is not 100% safe evaluation, since content addressed data can coincidentally produce data with length header matching content size
 	signature, period, version, name, parseddata, _, err := h.parseUpdate(data)
 	if err != nil {
-		log.Error("Invalid resource chunk")
+		log.Warn("Invalid resource chunk")
 		return false
 	}
 
@@ -258,14 +258,14 @@ func (h *Handler) Validate(addr storage.Address, data []byte) bool {
 	digest := h.keyDataHash(addr, parseddata)
 	publicKey, err := crypto.SigToPub(digest.Bytes(), signature[:])
 	if err != nil {
-		log.Error("Unparseable signature in resource chunk %s", addr)
+		log.Warn("Unparseable signature in resource chunk %s", addr)
 		return false
 	}
 	signAddr := crypto.PubkeyToAddress(*publicKey)
 	nameHash := ens.EnsNode(name)
 	checkAddr := h.resourceHash(period, version, nameHash, signAddr)
 	if !bytes.Equal(checkAddr, addr) {
-		log.Error("Invalid signature on resource chunk")
+		log.Warn("Invalid signature on resource chunk")
 		return false
 	}
 	return true

--- a/swarm/storage/mru/resource.go
+++ b/swarm/storage/mru/resource.go
@@ -285,8 +285,8 @@ func (h *Handler) keyDataHash(addr storage.Address, data []byte) common.Hash {
 }
 
 // GetContent retrieves the data payload of the last synced update of the Mutable Resource
-func (h *Handler) GetContent(name string) (storage.Address, []byte, error) {
-	rsrc := h.get(name)
+func (h *Handler) GetContent(addr storage.Address) (storage.Address, []byte, error) {
+	rsrc := h.get(addr.Hex())
 	if rsrc == nil || !rsrc.isSynced() {
 		return nil, nil, NewError(ErrNotFound, " does not exist or is not synced")
 	}
@@ -294,8 +294,8 @@ func (h *Handler) GetContent(name string) (storage.Address, []byte, error) {
 }
 
 // GetLastPeriod retrieves the period of the last synced update of the Mutable Resource
-func (h *Handler) GetLastPeriod(nameHash string) (uint32, error) {
-	rsrc := h.get(nameHash)
+func (h *Handler) GetLastPeriod(addr storage.Address) (uint32, error) {
+	rsrc := h.get(addr.Hex())
 	if rsrc == nil {
 		return 0, NewError(ErrNotFound, " does not exist")
 	} else if !rsrc.isSynced() {
@@ -305,8 +305,8 @@ func (h *Handler) GetLastPeriod(nameHash string) (uint32, error) {
 }
 
 // GetVersion retrieves the period of the last synced update of the Mutable Resource
-func (h *Handler) GetVersion(nameHash string) (uint32, error) {
-	rsrc := h.get(nameHash)
+func (h *Handler) GetVersion(addr storage.Address) (uint32, error) {
+	rsrc := h.get(addr.Hex())
 	if rsrc == nil {
 		return 0, NewError(ErrNotFound, " does not exist")
 	} else if !rsrc.isSynced() {

--- a/swarm/storage/mru/resource.go
+++ b/swarm/storage/mru/resource.go
@@ -19,6 +19,7 @@ package mru
 import (
 	"bytes"
 	"context"
+	"crypto/ecdsa"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -40,7 +41,8 @@ import (
 
 const (
 	signatureLength         = 65
-	metadataChunkOffsetSize = 18
+	publicKeyLength         = 65
+	metadataChunkOffsetSize = 83
 	DbDirName               = "resource"
 	chunkSize               = 4096 // temporary until we implement FileStore in the resourcehandler
 	defaultStoreTimeout     = 4000 * time.Millisecond
@@ -122,6 +124,7 @@ type resource struct {
 	frequency  uint64
 	version    uint32
 	data       []byte
+	publicKey  [publicKeyLength]byte
 	updated    time.Time
 }
 
@@ -145,27 +148,25 @@ func (r *resource) Name() string {
 	return r.name
 }
 
-func (r *resource) UnmarshalBinary(data []byte) error {
-	r.startBlock = binary.LittleEndian.Uint64(data[:8])
-	r.frequency = binary.LittleEndian.Uint64(data[8:16])
-	r.name = string(data[16:])
+func (self *resource) UnmarshalBinary(data []byte) error {
+	self.startBlock = binary.LittleEndian.Uint64(data)
+	self.frequency = binary.LittleEndian.Uint64(data[8:])
+	copy(self.publicKey[:], data[16:16+publicKeyLength])
+	self.name = string(data[16+publicKeyLength:])
 	return nil
 }
 
-func (r *resource) MarshalBinary() ([]byte, error) {
-	b := make([]byte, 16+len(r.name))
-	binary.LittleEndian.PutUint64(b, r.startBlock)
-	binary.LittleEndian.PutUint64(b[8:], r.frequency)
-	copy(b[16:], []byte(r.name))
+func (self *resource) MarshalBinary() ([]byte, error) {
+	b := make([]byte, 16+len(self.name))
+	binary.LittleEndian.PutUint64(b, self.startBlock)
+	binary.LittleEndian.PutUint64(b[8:], self.frequency)
+	copy(b[16:], self.publicKey[:])
+	copy(b[16+publicKeyLength:], []byte(self.name))
 	return b, nil
 }
 
 type headerGetter interface {
 	HeaderByNumber(context.Context, string, *big.Int) (*types.Header, error)
-}
-
-type ownerValidator interface {
-	ValidateOwner(name string, address common.Address) (bool, error)
 }
 
 // Mutable resource is an entity which allows updates to a resource
@@ -227,7 +228,6 @@ type Handler struct {
 	HashSize        int
 	signer          Signer
 	headerGetter    headerGetter
-	ownerValidator  ownerValidator
 	resources       map[string]*resource
 	hashPool        sync.Pool
 	resourceLock    sync.RWMutex
@@ -239,7 +239,6 @@ type HandlerParams struct {
 	QueryMaxPeriods *LookupParams
 	Signer          Signer
 	HeaderGetter    headerGetter
-	OwnerValidator  ownerValidator
 }
 
 // Create or open resource update chunk store
@@ -249,12 +248,15 @@ func NewHandler(params *HandlerParams) (*Handler, error) {
 			Limit: false,
 		}
 	}
+	if params.Signer == nil {
+		return nil, NewError(ErrInit, "signer cannot be nil")
+	}
 	rh := &Handler{
-		headerGetter:   params.HeaderGetter,
-		ownerValidator: params.OwnerValidator,
-		resources:      make(map[string]*resource),
-		storeTimeout:   defaultStoreTimeout,
-		signer:         params.Signer,
+		headerGetter: params.HeaderGetter,
+		//		ownerValidator: params.OwnerValidator,
+		resources:    make(map[string]*resource),
+		storeTimeout: defaultStoreTimeout,
+		signer:       params.Signer,
 		hashPool: sync.Pool{
 			New: func() interface{} {
 				return storage.MakeHashFunc(resourceHash)()
@@ -282,7 +284,6 @@ func (h *Handler) SetStore(store *storage.NetStore) {
 // Validate is a chunk validation method (matches ChunkValidatorFunc signature)
 //
 // If resource update, owner is checked against ENS record of resource name inferred from chunk data
-// If parsed signature is nil, validates automatically
 // If not resource update, it validates are root chunk if length is metadataChunkOffsetSize and first two bytes are 0
 func (h *Handler) Validate(addr storage.Address, data []byte) bool {
 	signature, period, version, name, parseddata, _, err := h.parseUpdate(data)
@@ -295,23 +296,25 @@ func (h *Handler) Validate(addr storage.Address, data []byte) bool {
 		}
 		log.Error("Invalid resource chunk")
 		return false
-	} else if signature == nil {
-		return bytes.Equal(h.resourceHash(period, version, ens.EnsNode(name)), addr)
 	}
 
-	digest := h.keyDataHash(addr, parseddata)
-	addrSig, err := getAddressFromDataSig(digest, *signature)
+	digest := self.keyDataHash(addr, parseddata)
+	publicKey, err := crypto.SigToPub(digest.Bytes(), signature[:])
+	//addrSig, err := getAddressFromDataSig(digest, *signature)
 	if err != nil {
+		log.Error("Unparseable signature in resource chunk %s", addr)
+		return false
+	}
+	nameHash := ens.EnsNode(name)
+	var publicKeyBytes [65]byte
+	copy(publicKeyBytes[:], crypto.FromECDSAPub(publicKey))
+	checkAddr := self.resourceHash(period, version, nameHash, publicKeyBytes)
+	if !bytes.Equal(checkAddr, addr) {
 		log.Error("Invalid signature on resource chunk")
 		return false
 	}
-	ok, _ := h.checkAccess(name, addrSig)
-	return ok
-}
-
-// If no ens client is supplied, resource updates are not validated
-func (h *Handler) IsValidated() bool {
-	return h.ownerValidator != nil
+	//ok, _ := self.checkAccess(name, addrSig)
+	return true
 }
 
 // Create the resource update digest used in signatures
@@ -322,14 +325,6 @@ func (h *Handler) keyDataHash(addr storage.Address, data []byte) common.Hash {
 	hasher.Write(addr[:])
 	hasher.Write(data)
 	return common.BytesToHash(hasher.Sum(nil))
-}
-
-// Checks if current address matches owner address of ENS
-func (h *Handler) checkAccess(name string, address common.Address) (bool, error) {
-	if h.ownerValidator == nil {
-		return true, nil
-	}
-	return h.ownerValidator.ValidateOwner(name, address)
 }
 
 // get data from current resource
@@ -373,36 +368,21 @@ func (h *Handler) chunkSize() int64 {
 // The signature data should match the hash of the idna-converted name by the validator's namehash function, NOT the raw name bytes.
 //
 // The start block of the resource update will be the actual current block height of the connected network.
-func (h *Handler) New(ctx context.Context, name string, frequency uint64) (storage.Address, *resource, error) {
+func (h *Handler) New(ctx context.Context, name string, frequency uint64, publicKey *ecdsa.PublicKey) (storage.Address, *resource, error) {
 
 	// frequency 0 is invalid
 	if frequency == 0 {
-		return nil, nil, NewError(ErrInvalidValue, "Frequency cannot be 0")
+		return nil, nil, NewError(ErrInvalidValue, "frequency cannot be 0")
+	}
+
+	// nil publickey
+	if publicKey == nil {
+		return nil, nil, NewError(ErrInvalidValue, "publickey cannot be nil")
 	}
 
 	// make sure name only contains ascii values
 	if !isSafeName(name) {
-		return nil, nil, NewError(ErrInvalidValue, fmt.Sprintf("Invalid name: '%s'", name))
-	}
-
-	nameHash := ens.EnsNode(name)
-
-	// if the signer function is set, validate that the key of the signer has access to modify this ENS name
-	if h.signer != nil {
-		signature, err := h.signer.Sign(nameHash)
-		if err != nil {
-			return nil, nil, NewError(ErrInvalidSignature, fmt.Sprintf("Sign fail: %v", err))
-		}
-		addr, err := getAddressFromDataSig(nameHash, signature)
-		if err != nil {
-			return nil, nil, NewError(ErrInvalidSignature, fmt.Sprintf("Retrieve address from signature fail: %v", err))
-		}
-		ok, err := h.checkAccess(name, addr)
-		if err != nil {
-			return nil, nil, err
-		} else if !ok {
-			return nil, nil, NewError(ErrUnauthorized, fmt.Sprintf("Not owner of '%s'", name))
-		}
+		return nil, nil, NewError(ErrInvalidValue, fmt.Sprintf("invalid name: '%s'", name))
 	}
 
 	// get our blockheight at this time
@@ -411,10 +391,14 @@ func (h *Handler) New(ctx context.Context, name string, frequency uint64) (stora
 		return nil, nil, err
 	}
 
-	chunk := h.newMetaChunk(name, currentblock, frequency)
-
+	// create the meta chunk and store it in swarm
+	var publicKeyBytes [publicKeyLength]byte
+	copy(publicKeyBytes[:], crypto.FromECDSAPub(publicKey)[:])
+	chunk := h.newMetaChunk(name, currentblock, frequency, publicKeyBytes)
 	h.chunkStore.Put(chunk)
-	log.Debug("new resource", "name", name, "key", nameHash, "startBlock", currentblock, "frequency", frequency)
+
+	nameHash := ens.EnsNode(name)
+	log.Debug("new resource", "name", name, "key", nameHash, "startBlock", currentblock, "frequency", frequency, "pubkey", publicKey)
 
 	// create the internal index for the resource and populate it with the data of the first version
 	rsrc := &resource{
@@ -424,12 +408,13 @@ func (h *Handler) New(ctx context.Context, name string, frequency uint64) (stora
 		nameHash:   nameHash,
 		updated:    time.Now(),
 	}
+	copy(rsrc.publicKey[:], publicKeyBytes[:])
 	h.set(nameHash.Hex(), rsrc)
 
 	return chunk.Addr, rsrc, nil
 }
 
-func (h *Handler) newMetaChunk(name string, startBlock uint64, frequency uint64) *storage.Chunk {
+func (h *Handler) newMetaChunk(name string, startBlock uint64, frequency uint64, publicKeyBytes [publicKeyLength]byte) *storage.Chunk {
 	// the metadata chunk points to data of first blockheight + update frequency
 	// from this we know from what blockheight we should look for updates, and how often
 	// it also contains the name of the resource, so we know what resource we are working with
@@ -441,7 +426,8 @@ func (h *Handler) newMetaChunk(name string, startBlock uint64, frequency uint64)
 	copy(data[2:10], val)
 	binary.LittleEndian.PutUint64(val, frequency)
 	copy(data[10:18], val)
-	copy(data[18:], []byte(name))
+	copy(data[18:83], publicKeyBytes[:])
+	copy(data[83:], []byte(name))
 
 	// the key of the metadata chunk is content-addressed
 	// if it wasn't we couldn't replace it later
@@ -592,7 +578,7 @@ func (h *Handler) lookup(rsrc *resource, period uint32, version uint32, refresh 
 		if maxLookup.Limit && hops > maxLookup.Max {
 			return nil, NewError(ErrPeriodDepth, fmt.Sprintf("Lookup exceeded max period hops (%d)", maxLookup.Max))
 		}
-		key := h.resourceHash(period, version, rsrc.nameHash)
+		key := h.resourceHash(period, version, rsrc.nameHash, rsrc.publicKey)
 		chunk, err := h.chunkStore.GetWithTimeout(key, defaultRetrieveTimeout)
 		if err == nil {
 			if specificversion {
@@ -602,7 +588,7 @@ func (h *Handler) lookup(rsrc *resource, period uint32, version uint32, refresh 
 			log.Trace("rsrc update version 1 found, checking for version updates", "period", period, "key", key)
 			for {
 				newversion := version + 1
-				key := h.resourceHash(period, newversion, rsrc.nameHash)
+				key := h.resourceHash(period, newversion, rsrc.nameHash, rsrc.publicKey)
 				newchunk, err := h.chunkStore.GetWithTimeout(key, defaultRetrieveTimeout)
 				if err != nil {
 					return h.updateIndex(rsrc, chunk)
@@ -810,12 +796,6 @@ func (h *Handler) update(ctx context.Context, name string, data []byte, multihas
 		return nil, NewError(ErrInit, "Call Handler.SetStore() before updating")
 	}
 
-	// signature length is 0 if we are not using them
-	var signaturelength int
-	if h.signer != nil {
-		signaturelength = signatureLength
-	}
-
 	// get the cached information
 	nameHash := ens.EnsNode(name)
 	nameHashHex := nameHash.Hex()
@@ -828,7 +808,7 @@ func (h *Handler) update(ctx context.Context, name string, data []byte, multihas
 
 	// an update can be only one chunk long; data length less header and signature data
 	// 12 = length of header and data length fields (2xuint16) plus period and frequency value fields (2xuint32)
-	datalimit := h.chunkSize() - int64(signaturelength-len(name)-12)
+	datalimit := h.chunkSize() - int64(signatureLength-len(name)-12)
 	if int64(len(data)) > datalimit {
 		return nil, NewError(ErrDataOverflow, fmt.Sprintf("Data overflow: %d / %d bytes", len(data), datalimit))
 	}
@@ -852,7 +832,7 @@ func (h *Handler) update(ctx context.Context, name string, data []byte, multihas
 	version++
 
 	// calculate the chunk key
-	key := h.resourceHash(nextperiod, version, rsrc.nameHash)
+	key := h.resourceHash(nextperiod, version, rsrc.nameHash, rsrc.publicKey)
 
 	// if we have a signing function, sign the update
 	// \TODO this code should probably be consolidated with corresponding code in New()
@@ -867,18 +847,9 @@ func (h *Handler) update(ctx context.Context, name string, data []byte, multihas
 		signature = &sig
 
 		// get the address of the signer (which also checks that it's a valid signature)
-		addr, err := getAddressFromDataSig(digest, *signature)
+		_, err = getAddressFromDataSig(digest, *signature)
 		if err != nil {
 			return nil, NewError(ErrInvalidSignature, fmt.Sprintf("Invalid data/signature: %v", err))
-		}
-		if h.signer != nil {
-			// check if the signer has access to update
-			ok, err := h.checkAccess(name, addr)
-			if err != nil {
-				return nil, NewError(ErrIO, fmt.Sprintf("Access check fail: %v", err))
-			} else if !ok {
-				return nil, NewError(ErrUnauthorized, fmt.Sprintf("Address %x does not have access to update %s", addr, name))
-			}
 		}
 	}
 
@@ -942,7 +913,7 @@ func (h *Handler) set(nameHash string, rsrc *resource) {
 }
 
 // used for chunk keys
-func (h *Handler) resourceHash(period uint32, version uint32, namehash common.Hash) storage.Address {
+func (h *Handler) resourceHash(period uint32, version uint32, namehash common.Hash, publicKeyBytes [publicKeyLength]byte) storage.Address {
 	// format is: hash(period|version|namehash)
 	hasher := h.hashPool.Get().(storage.SwarmHash)
 	defer h.hashPool.Put(hasher)
@@ -952,6 +923,7 @@ func (h *Handler) resourceHash(period uint32, version uint32, namehash common.Ha
 	hasher.Write(b)
 	binary.LittleEndian.PutUint32(b, version)
 	hasher.Write(b)
+	hasher.Write(publicKeyBytes[:])
 	hasher.Write(namehash[:])
 	return hasher.Sum(nil)
 }

--- a/swarm/storage/mru/resource.go
+++ b/swarm/storage/mru/resource.go
@@ -116,8 +116,10 @@ type Signature [signatureLength]byte
 // If Limit is set to true then Max defines the amount of hops that can be performed
 // \TODO this is redundant, just use uint32 with 0 for unlimited hops
 type LookupParams struct {
-	Limit bool
-	Max   uint32
+	Period  uint32
+	Version uint32
+	Root    storage.Address
+	Limit   uint32
 }
 
 // encapsulates an specific resource update. When synced it contains the most recent
@@ -190,24 +192,19 @@ type Handler struct {
 	hashPool        sync.Pool
 	resourceLock    sync.RWMutex
 	storeTimeout    time.Duration
-	queryMaxPeriods *LookupParams
+	queryMaxPeriods uint32
 }
 
 // HandlerParams pass parameters to the Handler constructor NewHandler
 // Signer and HeaderGetter are mandatory parameters
 type HandlerParams struct {
-	QueryMaxPeriods *LookupParams
+	QueryMaxPeriods uint32
 	Signer          Signer
 	HeaderGetter    headerGetter
 }
 
 // NewHandler creates a new Mutable Resource API
 func NewHandler(params *HandlerParams) (*Handler, error) {
-	if params.QueryMaxPeriods == nil {
-		params.QueryMaxPeriods = &LookupParams{
-			Limit: false,
-		}
-	}
 	if params.Signer == nil {
 		return nil, NewError(ErrInit, "Signer cannot be nil")
 	}
@@ -365,7 +362,7 @@ func (h *Handler) NewWithAddress(ctx context.Context, name string, frequency uin
 		updated:    time.Now(),
 	}
 	copy(rsrc.owner[:], ownerAddr[:])
-	h.set(nameHash.Hex(), rsrc)
+	h.set(chunk.Addr.Hex(), rsrc)
 
 	return chunk.Addr, rsrc, nil
 }
@@ -408,18 +405,18 @@ func (h *Handler) newMetaChunk(name string, startBlock uint64, frequency uint64,
 // metadata chunk.
 // It is the callers responsibility to make sure that this chunk exists (if the resource
 // update root data was retrieved externally, it typically doesn't)
-func (h *Handler) LookupVersionByName(ctx context.Context, name string, period uint32, version uint32, refresh bool, maxLookup *LookupParams) (*resource, error) {
-	return h.LookupVersion(ctx, ens.EnsNode(name), period, version, refresh, maxLookup)
-}
+//func (h *Handler) LookupVersionByName(ctx context.Context, name string, period uint32, version uint32, refresh bool, maxLookup *LookupParams) (*resource, error) {
+//	return h.LookupVersion(ctx, ens.EnsNode(name), period, version, refresh, maxLookup)
+//}
 
 // LookupVersion performs the same action as LookupVersionByName, but takes the name hash instead of the cleartext name as identifier
-func (h *Handler) LookupVersion(ctx context.Context, nameHash common.Hash, period uint32, version uint32, refresh bool, maxLookup *LookupParams) (*resource, error) {
-	rsrc := h.get(nameHash.Hex())
-	if rsrc == nil {
-		return nil, NewError(ErrNothingToReturn, "resource not loaded")
-	}
-	return h.lookup(rsrc, period, version, refresh, maxLookup)
-}
+//func (h *Handler) LookupVersion(ctx context.Context, params *LookupParams) (*resource, Error) { //nameHash common.Hash, period uint32, version uint32, refresh bool, maxLookup *LookupParams) (*resource, error) {
+//	rsrc := h.get(params.Root)
+//	if rsrc == nil {
+//		return nil, NewError(ErrNothingToReturn, "resource not loaded")
+//	}
+//	return h.lookup(rsrc, params.Period, params.Version, param.Limit)
+//}
 
 // LookupHistoricalByName etrieves the latest version of the resource update identified by `name`
 // at the specified block height
@@ -427,18 +424,19 @@ func (h *Handler) LookupVersion(ctx context.Context, nameHash common.Hash, perio
 // successfully retrieved version is copied to the corresponding resources map entry
 // and returned.
 // See also (*Handler).LookupVersionByName
-func (h *Handler) LookupHistoricalByName(ctx context.Context, name string, period uint32, refresh bool, maxLookup *LookupParams) (*resource, error) {
-	return h.LookupHistorical(ctx, ens.EnsNode(name), period, refresh, maxLookup)
-}
+//func (h *Handler) LookupHistoricalByName(ctx context.Context, name string, period uint32, refresh bool, maxLookup *LookupParams) (*resource, error) {
+//	return h.LookupHistorical(ctx, ens.EnsNode(name), period, refresh, maxLookup)
+//}
 
 // LookupHistorical performs the same action as LookupHistoricalByName, but takes the name hash instead of the cleartext name as identifier
-func (h *Handler) LookupHistorical(ctx context.Context, nameHash common.Hash, period uint32, refresh bool, maxLookup *LookupParams) (*resource, error) {
-	rsrc := h.get(nameHash.Hex())
-	if rsrc == nil {
-		return nil, NewError(ErrNothingToReturn, "resource not loaded")
-	}
-	return h.lookup(rsrc, period, 0, refresh, maxLookup)
-}
+//func (h *Handler) LookupHistorical(ctx context.Context, nameHash common.Hash, period uint32, refresh bool, maxLookup *LookupParams) (*resource, error) {
+//func (h *Handler) LookupHistorical(ctx context.Context, params *LookupParams) (*resource, error) { //name string, period uint32, refresh bool, maxLookup *LookupParams) (*resource, error) {
+//	rsrc := h.get(params.Root)
+//	if rsrc == nil {
+//		return nil, NewError(ErrNothingToReturn, "resource not loaded")
+//	}
+//	return h.lookup(rsrc, rsrc.Period, 0, param.Limit)
+//}
 
 // LookupLatestByName retrieves the latest version of the resource update identified by `name`
 // at the next update block height
@@ -446,40 +444,45 @@ func (h *Handler) LookupHistorical(ctx context.Context, nameHash common.Hash, pe
 // tries the corresponding keys of each previous period until one is found
 // (or startBlock is reached, in which case there are no updates).
 // See also (*Handler).LookupHistoricalByName
-func (h *Handler) LookupLatestByName(ctx context.Context, name string, refresh bool, maxLookup *LookupParams) (*resource, error) {
-	return h.LookupLatest(ctx, ens.EnsNode(name), refresh, maxLookup)
-}
+//func (h *Handler) LookupLatestByName(ctx context.Context, name string, refresh bool, maxLookup *LookupParams) (*resource, error) {
+//	return h.LookupLatest(ctx, ens.EnsNode(name), refresh, maxLookup)
+//}
 
 // LookupLatest performs the same action as LookupLatestByName, but takes the name hash instead of the cleartext name as identifier
-func (h *Handler) LookupLatest(ctx context.Context, nameHash common.Hash, refresh bool, maxLookup *LookupParams) (*resource, error) {
+//func (h *Handler) LookupLatest(ctx context.Context, nameHash common.Hash, refresh bool, maxLookup *LookupParams) (*resource, error) {
+func (h *Handler) Lookup(ctx context.Context, params *LookupParams) (*resource, error) { //nameHash common.Hash, refresh bool, maxLookup *LookupParams) (*resource, error) {
 
-	// get our blockheight at this time and the next block of the update period
-	rsrc := h.get(nameHash.Hex())
+	rsrc := h.get(params.Root.Hex())
 	if rsrc == nil {
 		return nil, NewError(ErrNothingToReturn, "resource not loaded")
 	}
-	currentblock, err := h.getBlock(ctx, rsrc.name)
-	if err != nil {
-		return nil, err
+	if params.Period == 0 {
+		// get our blockheight at this time and the next block of the update period
+		currentblock, err := h.getBlock(ctx, rsrc.name)
+		if err != nil {
+			return nil, err
+		}
+		var period uint32
+		period, err = getNextPeriod(rsrc.startBlock, currentblock, rsrc.frequency)
+		if err != nil {
+			return nil, err
+		}
+		params.Period = period
 	}
-	nextperiod, err := getNextPeriod(rsrc.startBlock, currentblock, rsrc.frequency)
-	if err != nil {
-		return nil, err
-	}
-	return h.lookup(rsrc, nextperiod, 0, refresh, maxLookup)
+	return h.lookup(rsrc, params.Period, params.Version, params.Limit)
 }
 
 // LookupPreviousByName returns the resource before the one currently loaded in the resource index
 // This is useful where resource updates are used incrementally in contrast to
 // merely replacing content.
 // Requires a synced resource object
-func (h *Handler) LookupPreviousByName(ctx context.Context, name string, maxLookup *LookupParams) (*resource, error) {
-	return h.LookupPrevious(ctx, ens.EnsNode(name), maxLookup)
-}
+//func (h *Handler) LookupPreviousByName(ctx context.Context, name string, maxLookup *LookupParams) (*resource, error) {
+//	return h.LookupPrevious(ctx, ens.EnsNode(name), maxLookup)
+//}
 
 // LookupPrevious performs the same action as LookupPreviousByName, but takes the name hash instead of the cleartext name as identifier
-func (h *Handler) LookupPrevious(ctx context.Context, nameHash common.Hash, maxLookup *LookupParams) (*resource, error) {
-	rsrc := h.get(nameHash.Hex())
+func (h *Handler) LookupPrevious(ctx context.Context, params *LookupParams) (*resource, error) { //nameHash common.Hash, maxLookup *LookupParams) (*resource, error) {
+	rsrc := h.get(params.Root.Hex())
 	if rsrc == nil {
 		return nil, NewError(ErrNothingToReturn, "resource not loaded")
 	}
@@ -496,11 +499,11 @@ func (h *Handler) LookupPrevious(ctx context.Context, nameHash common.Hash, maxL
 		rsrc.version = 0
 		rsrc.lastPeriod--
 	}
-	return h.lookup(rsrc, rsrc.lastPeriod, rsrc.version, false, maxLookup)
+	return h.lookup(rsrc, rsrc.lastPeriod, rsrc.version, params.Limit)
 }
 
 // base code for public lookup methods
-func (h *Handler) lookup(rsrc *resource, period uint32, version uint32, refresh bool, maxLookup *LookupParams) (*resource, error) {
+func (h *Handler) lookup(rsrc *resource, period uint32, version uint32, limit uint32) (*resource, error) {
 
 	// we can't look for anything without a store
 	if h.chunkStore == nil {
@@ -522,13 +525,13 @@ func (h *Handler) lookup(rsrc *resource, period uint32, version uint32, refresh 
 	}
 
 	var hops uint32
-	if maxLookup == nil {
-		maxLookup = h.queryMaxPeriods
+	if limit == 0 {
+		limit = h.queryMaxPeriods
 	}
-	log.Trace("resource lookup", "period", period, "version", version, "limit", maxLookup.Limit, "max", maxLookup.Max)
+	log.Trace("resource lookup", "period", period, "version", version, "limit", limit)
 	for period > 0 {
-		if maxLookup.Limit && hops > maxLookup.Max {
-			return nil, NewError(ErrPeriodDepth, fmt.Sprintf("Lookup exceeded max period hops (%d)", maxLookup.Max))
+		if limit != 0 && hops > limit {
+			return nil, NewError(ErrPeriodDepth, fmt.Sprintf("Lookup exceeded max period hops (%d)", limit))
 		}
 		key := h.resourceHash(period, version, rsrc.nameHash, rsrc.owner)
 		chunk, err := h.chunkStore.GetWithTimeout(key, defaultRetrieveTimeout)
@@ -574,7 +577,7 @@ func (h *Handler) Load(addr storage.Address) (*resource, error) {
 	rsrc := &resource{}
 	rsrc.UnmarshalBinary(chunk.SData[:])
 	rsrc.nameHash = ens.EnsNode(rsrc.name)
-	h.set(rsrc.nameHash.Hex(), rsrc)
+	h.set(addr.Hex(), rsrc)
 	log.Trace("resource index load", "rootkey", addr, "name", rsrc.name, "namehash", rsrc.nameHash, "startblock", rsrc.startBlock, "frequency", rsrc.frequency)
 	return rsrc, nil
 }
@@ -609,7 +612,7 @@ func (h *Handler) updateIndex(rsrc *resource, chunk *storage.Chunk) (*resource, 
 	rsrc.Reader = bytes.NewReader(rsrc.data)
 	copy(rsrc.data, data)
 	log.Debug(" synced", "name", rsrc.name, "key", chunk.Addr, "period", rsrc.lastPeriod, "version", rsrc.version)
-	h.set(rsrc.nameHash.Hex(), rsrc)
+	h.set(chunk.Addr.Hex(), rsrc)
 	return rsrc, nil
 }
 
@@ -725,24 +728,24 @@ func (h *Handler) parseUpdate(chunkdata []byte) (*Signature, uint32, uint32, str
 // It is the caller's responsibility to make sure that this data is not stale.
 //
 // A resource update cannot span chunks, and thus has max length 4096
-func (h *Handler) UpdateMultihash(ctx context.Context, name string, data []byte) (storage.Address, error) {
+func (h *Handler) UpdateMultihash(ctx context.Context, addr storage.Address, data []byte) (storage.Address, error) {
 	// \TODO perhaps this check should be in newUpdateChunk()
 	if _, _, err := multihash.GetMultihashLength(data); err != nil {
 		return nil, NewError(ErrNothingToReturn, err.Error())
 	}
-	return h.update(ctx, name, data, true)
+	return h.update(ctx, addr, data, true)
 }
 
 // Update adds an actual data update
 // Uses the Mutable Resource metadata currently loaded in the resources map entry.
 // It is the caller's responsibility to make sure that this data is not stale.
 // Note that a Mutable Resource update cannot span chunks, and thus has a MAX NET LENGTH 4096, INCLUDING update header data and signature. An error will be returned if the total length of the chunk payload will exceed this limit.
-func (h *Handler) Update(ctx context.Context, name string, data []byte) (storage.Address, error) {
-	return h.update(ctx, name, data, false)
+func (h *Handler) Update(ctx context.Context, addr storage.Address, data []byte) (storage.Address, error) {
+	return h.update(ctx, addr, data, false)
 }
 
 // create and commit an update
-func (h *Handler) update(ctx context.Context, name string, data []byte, multihash bool) (storage.Address, error) {
+func (h *Handler) update(ctx context.Context, addr storage.Address, data []byte, multihash bool) (storage.Address, error) {
 
 	// zero-length updates are bogus
 	if len(data) == 0 {
@@ -755,24 +758,26 @@ func (h *Handler) update(ctx context.Context, name string, data []byte, multihas
 	}
 
 	// get the cached information
-	nameHash := ens.EnsNode(name)
-	nameHashHex := nameHash.Hex()
-	rsrc := h.get(nameHashHex)
+	//nameHash := ens.EnsNode(name)
+	//nameHashHex := nameHash.Hex()
+	//rsrc := h.get(nameHashHex)
+	addrHex := addr.Hex()
+	rsrc := h.get(addrHex)
 	if rsrc == nil {
-		return nil, NewError(ErrNotFound, fmt.Sprintf(" object '%s' not in index", name))
+		return nil, NewError(ErrNotFound, fmt.Sprintf(" object '%s' not in index", rsrc.name))
 	} else if !rsrc.isSynced() {
 		return nil, NewError(ErrNotSynced, " object not in sync")
 	}
 
 	// an update can be only one chunk long; data length less header and signature data
 	// 12 = length of header and data length fields (2xuint16) plus period and frequency value fields (2xuint32)
-	datalimit := h.chunkSize() - int64(signatureLength-len(name)-12)
+	datalimit := h.chunkSize() - int64(signatureLength-len(rsrc.name)-12)
 	if int64(len(data)) > datalimit {
 		return nil, NewError(ErrDataOverflow, fmt.Sprintf("Data overflow: %d / %d bytes", len(data), datalimit))
 	}
 
 	// get our blockheight at this time and the next block of the update period
-	currentblock, err := h.getBlock(ctx, name)
+	currentblock, err := h.getBlock(ctx, rsrc.name)
 	if err != nil {
 		return nil, NewError(ErrIO, fmt.Sprintf("Could not get block height: %v", err))
 	}
@@ -784,7 +789,7 @@ func (h *Handler) update(ctx context.Context, name string, data []byte, multihas
 	// if we already have an update for this block then increment version
 	// resource object MUST be in sync for version to be correct, but we checked this earlier in the method already
 	var version uint32
-	if h.hasUpdate(nameHashHex, nextperiod) {
+	if h.hasUpdate(addr, nextperiod) {
 		version = rsrc.version
 	}
 	version++
@@ -816,11 +821,11 @@ func (h *Handler) update(ctx context.Context, name string, data []byte, multihas
 	if !multihash {
 		datalength = len(data)
 	}
-	chunk := newUpdateChunk(key, signature, nextperiod, version, name, data, datalength)
+	chunk := newUpdateChunk(key, signature, nextperiod, version, rsrc.name, data, datalength)
 
 	// send the chunk
 	h.chunkStore.Put(chunk)
-	log.Trace("resource update", "name", name, "key", key, "currentblock", currentblock, "lastperiod", nextperiod, "version", version, "data", chunk.SData, "multihash", multihash)
+	log.Trace("resource update", "name", rsrc.name, "key", key, "currentblock", currentblock, "lastperiod", nextperiod, "version", version, "data", chunk.SData, "multihash", multihash)
 
 	// update our resources map entry and return the new key
 	rsrc.lastPeriod = nextperiod
@@ -875,8 +880,8 @@ func (h *Handler) resourceHash(period uint32, version uint32, nameHash common.Ha
 }
 
 // Checks if we already have an update on this resource, according to the value in the current state of the resource index
-func (h *Handler) hasUpdate(nameHash string, period uint32) bool {
-	return h.resources[nameHash].lastPeriod == period
+func (h *Handler) hasUpdate(addr storage.Address, period uint32) bool {
+	return h.resources[addr.Hex()].lastPeriod == period
 }
 
 func getAddressFromDataSig(datahash common.Hash, signature Signature) (common.Address, error) {

--- a/swarm/storage/mru/resource_sign.go
+++ b/swarm/storage/mru/resource_sign.go
@@ -26,13 +26,21 @@ import (
 // Signer signs Mutable Resource update payloads
 type Signer interface {
 	Sign(common.Hash) (Signature, error)
-	PublicKey() *ecdsa.PublicKey
+	Address() common.Address
 }
 
 // GenericSigner implements the Signer interface
 // It is the vanilla signer that probably should be used in most cases
 type GenericSigner struct {
 	PrivKey *ecdsa.PrivateKey
+	address common.Address
+}
+
+func NewGenericSigner(privKey *ecdsa.PrivateKey) *GenericSigner {
+	return &GenericSigner{
+		PrivKey: privKey,
+		address: crypto.PubkeyToAddress(privKey.PublicKey),
+	}
 }
 
 // Sign signs the supplied data
@@ -47,6 +55,6 @@ func (s *GenericSigner) Sign(data common.Hash) (signature Signature, err error) 
 }
 
 // PublicKey returns the public key of the signer's private key
-func (s *GenericSigner) PublicKey() *ecdsa.PublicKey {
-	return &s.PrivKey.PublicKey
+func (s *GenericSigner) Address() common.Address {
+	return s.address
 }

--- a/swarm/storage/mru/resource_sign.go
+++ b/swarm/storage/mru/resource_sign.go
@@ -23,16 +23,20 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-// Signs resource updates
+// Signer signs Mutable Resource update payloads
 type Signer interface {
 	Sign(common.Hash) (Signature, error)
 	PublicKey() *ecdsa.PublicKey
 }
 
+// GenericSigner implements the Signer interface
+// It is the vanilla signer that probably should be used in most cases
 type GenericSigner struct {
 	PrivKey *ecdsa.PrivateKey
 }
 
+// Sign signs the supplied data
+// It wraps the ethereum crypto.Sign() method
 func (s *GenericSigner) Sign(data common.Hash) (signature Signature, err error) {
 	signaturebytes, err := crypto.Sign(data.Bytes(), s.PrivKey)
 	if err != nil {
@@ -42,6 +46,7 @@ func (s *GenericSigner) Sign(data common.Hash) (signature Signature, err error) 
 	return
 }
 
+// PublicKey returns the public key of the signer's private key
 func (s *GenericSigner) PublicKey() *ecdsa.PublicKey {
 	return &s.PrivKey.PublicKey
 }

--- a/swarm/storage/mru/resource_sign.go
+++ b/swarm/storage/mru/resource_sign.go
@@ -26,17 +26,22 @@ import (
 // Signs resource updates
 type Signer interface {
 	Sign(common.Hash) (Signature, error)
+	PublicKey() *ecdsa.PublicKey
 }
 
 type GenericSigner struct {
 	PrivKey *ecdsa.PrivateKey
 }
 
-func (self *GenericSigner) Sign(data common.Hash) (signature Signature, err error) {
-	signaturebytes, err := crypto.Sign(data.Bytes(), self.PrivKey)
+func (s *GenericSigner) Sign(data common.Hash) (signature Signature, err error) {
+	signaturebytes, err := crypto.Sign(data.Bytes(), s.PrivKey)
 	if err != nil {
 		return
 	}
 	copy(signature[:], signaturebytes)
 	return
+}
+
+func (s *GenericSigner) PublicKey() *ecdsa.PublicKey {
+	return &s.PrivKey.PublicKey
 }

--- a/swarm/storage/mru/resource_test.go
+++ b/swarm/storage/mru/resource_test.go
@@ -195,8 +195,8 @@ func TestResourceHandler(t *testing.T) {
 	} else if len(chunk.SData) < 16 {
 		t.Fatalf("chunk data must be minimum 16 bytes, is %d", len(chunk.SData))
 	}
-	startblocknumber := binary.LittleEndian.Uint64(chunk.SData[:8])
-	chunkfrequency := binary.LittleEndian.Uint64(chunk.SData[8:16])
+	startblocknumber := binary.LittleEndian.Uint64(chunk.SData[8:16])
+	chunkfrequency := binary.LittleEndian.Uint64(chunk.SData[16:24])
 	if startblocknumber != uint64(backend.blocknumber) {
 		t.Fatalf("stored block number %d does not match provided block number %d", startblocknumber, backend.blocknumber)
 	}

--- a/swarm/storage/mru/resource_test.go
+++ b/swarm/storage/mru/resource_test.go
@@ -41,7 +41,6 @@ import (
 var (
 	loglevel          = flag.Int("loglevel", 3, "loglevel")
 	testHasher        = storage.MakeHashFunc(storage.SHA3Hash)()
-	zeroAddr          = common.Address{}
 	startBlock        = uint64(4200)
 	resourceFrequency = uint64(42)
 	cleanF            func()

--- a/swarm/storage/mru/resource_test.go
+++ b/swarm/storage/mru/resource_test.go
@@ -605,18 +605,6 @@ func fwdBlocks(count int, backend *fakeBackend) {
 	}
 }
 
-type ensOwnerValidator struct {
-	*ens.ENS
-}
-
-func (e ensOwnerValidator) ValidateOwner(name string, address common.Address) (bool, error) {
-	addr, err := e.Owner(ens.EnsNode(name))
-	if err != nil {
-		return false, err
-	}
-	return address == addr, nil
-}
-
 // create rpc and resourcehandler
 //func setupTest(backend headerGetter, ensBackend *ens.ENS, signer Signer) (rh *Handler, datadir string, teardown func(), err error) {
 func setupTest(backend headerGetter, signer Signer) (rh *Handler, datadir string, teardown func(), err error) {

--- a/swarm/storage/mru/resource_test.go
+++ b/swarm/storage/mru/resource_test.go
@@ -216,7 +216,7 @@ func TestResourceHandler(t *testing.T) {
 	resourcekey := make(map[string]storage.Address)
 	fwdBlocks(int(resourceFrequency/2), backend)
 	data := []byte(updates[0])
-	resourcekey[updates[0]], err = rh.Update(ctx, safeName, data)
+	resourcekey[updates[0]], err = rh.Update(ctx, rootChunkKey, data)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,7 +224,7 @@ func TestResourceHandler(t *testing.T) {
 	// update on first period
 	fwdBlocks(int(resourceFrequency/2), backend)
 	data = []byte(updates[1])
-	resourcekey[updates[1]], err = rh.Update(ctx, safeName, data)
+	resourcekey[updates[1]], err = rh.Update(ctx, rootChunkKey, data)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -232,7 +232,7 @@ func TestResourceHandler(t *testing.T) {
 	// update on second period
 	fwdBlocks(int(resourceFrequency), backend)
 	data = []byte(updates[2])
-	resourcekey[updates[2]], err = rh.Update(ctx, safeName, data)
+	resourcekey[updates[2]], err = rh.Update(ctx, rootChunkKey, data)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -240,7 +240,7 @@ func TestResourceHandler(t *testing.T) {
 	// update just after second period
 	fwdBlocks(1, backend)
 	data = []byte(updates[3])
-	resourcekey[updates[3]], err = rh.Update(ctx, safeName, data)
+	resourcekey[updates[3]], err = rh.Update(ctx, rootChunkKey, data)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -252,9 +252,6 @@ func TestResourceHandler(t *testing.T) {
 	fwdBlocks(int(resourceFrequency*2)-1, backend)
 
 	rhparams := &HandlerParams{
-		QueryMaxPeriods: &LookupParams{
-			Limit: false,
-		},
 		Signer:       signer,
 		HeaderGetter: rh.headerGetter,
 	}
@@ -264,7 +261,14 @@ func TestResourceHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 	rsrc2, err := rh2.Load(rootChunkKey)
-	_, err = rh2.LookupLatest(ctx, nameHash, true, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	//_, err = rh2.LookupLatest(ctx, nameHash, true, nil)
+	lookupParams := &LookupParams{
+		Root: rootChunkKey,
+	}
+	_, err = rh2.Lookup(ctx, lookupParams)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -282,7 +286,9 @@ func TestResourceHandler(t *testing.T) {
 	log.Debug("Latest lookup", "period", rsrc2.lastPeriod, "version", rsrc2.version, "data", rsrc2.data)
 
 	// specific block, latest version
-	rsrc, err := rh2.LookupHistorical(ctx, nameHash, 3, true, rh2.queryMaxPeriods)
+	//rsrc, err := rh2.LookupHistorical(ctx, nameHash, 3, true, rh2.queryMaxPeriods)
+	lookupParams.Period = 3
+	rsrc, err := rh2.Lookup(ctx, lookupParams)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -293,7 +299,9 @@ func TestResourceHandler(t *testing.T) {
 	log.Debug("Historical lookup", "period", rsrc2.lastPeriod, "version", rsrc2.version, "data", rsrc2.data)
 
 	// specific block, specific version
-	rsrc, err = rh2.LookupVersion(ctx, nameHash, 3, 1, true, rh2.queryMaxPeriods)
+	lookupParams.Version = 1
+	//rsrc, err = rh2.LookupVersion(ctx, nameHash, 3, 1, true, rh2.queryMaxPeriods)
+	rsrc, err = rh2.Lookup(ctx, lookupParams)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -306,7 +314,8 @@ func TestResourceHandler(t *testing.T) {
 	// we are now at third update
 	// check backwards stepping to the first
 	for i := 1; i >= 0; i-- {
-		rsrc, err := rh2.LookupPreviousByName(ctx, safeName, rh2.queryMaxPeriods)
+		//rsrc, err := rh2.LookupPreviousByName(ctx, safeName, rh2.queryMaxPeriods)
+		rsrc, err := rh2.LookupPrevious(ctx, lookupParams)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -317,7 +326,8 @@ func TestResourceHandler(t *testing.T) {
 	}
 
 	// beyond the first should yield an error
-	rsrc, err = rh2.LookupPreviousByName(ctx, safeName, rh2.queryMaxPeriods)
+	//rsrc, err = rh2.LookupPreviousByName(ctx, safeName, rh2.queryMaxPeriods)
+	rsrc, err = rh2.LookupPrevious(ctx, lookupParams)
 	if err == nil {
 		t.Fatalf("expeected previous to fail, returned period %d version %d data %v", rsrc2.lastPeriod, rsrc2.version, rsrc2.data)
 	}
@@ -347,7 +357,7 @@ func TestMultihash(t *testing.T) {
 	// create a new resource
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	_, _, err = rh.New(ctx, safeName, resourceFrequency)
+	rootChunkAddr, _, err := rh.New(ctx, safeName, resourceFrequency)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -356,24 +366,24 @@ func TestMultihash(t *testing.T) {
 	// if it ever changes this test should also change
 	multihashbytes := ens.EnsNode("foo")
 	multihashmulti := multihash.ToMultihash(multihashbytes.Bytes())
-	multihashkey, err := rh.UpdateMultihash(ctx, safeName, multihashmulti)
+	multihashkey, err := rh.UpdateMultihash(ctx, rootChunkAddr, multihashmulti)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	sha1bytes := make([]byte, multihash.MultihashLength)
 	sha1multi := multihash.ToMultihash(sha1bytes)
-	sha1key, err := rh.UpdateMultihash(ctx, safeName, sha1multi)
+	sha1key, err := rh.UpdateMultihash(ctx, rootChunkAddr, sha1multi)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// invalid multihashes
-	_, err = rh.UpdateMultihash(ctx, safeName, multihashmulti[1:])
+	_, err = rh.UpdateMultihash(ctx, rootChunkAddr, multihashmulti[1:])
 	if err == nil {
 		t.Fatalf("Expected update to fail with first byte skipped")
 	}
-	_, err = rh.UpdateMultihash(ctx, safeName, multihashmulti[:len(multihashmulti)-2])
+	_, err = rh.UpdateMultihash(ctx, rootChunkAddr, multihashmulti[:len(multihashmulti)-2])
 	if err == nil {
 		t.Fatalf("Expected update to fail with last byte skipped")
 	}
@@ -403,9 +413,6 @@ func TestMultihash(t *testing.T) {
 	rh.Close()
 
 	rhparams := &HandlerParams{
-		QueryMaxPeriods: &LookupParams{
-			Limit: false,
-		},
 		Signer:       signer,
 		HeaderGetter: rh.headerGetter,
 	}
@@ -414,15 +421,15 @@ func TestMultihash(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, _, err = rh2.New(ctx, safeName, resourceFrequency)
+	rootChunkAddr, _, err = rh2.New(ctx, safeName, resourceFrequency)
 	if err != nil {
 		t.Fatal(err)
 	}
-	multihashsignedkey, err := rh2.UpdateMultihash(ctx, safeName, multihashmulti)
+	multihashsignedkey, err := rh2.UpdateMultihash(ctx, rootChunkAddr, multihashmulti)
 	if err != nil {
 		t.Fatal(err)
 	}
-	sha1signedkey, err := rh2.UpdateMultihash(ctx, safeName, sha1multi)
+	sha1signedkey, err := rh2.UpdateMultihash(ctx, rootChunkAddr, sha1multi)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -622,9 +629,6 @@ func setupTest(backend headerGetter, signer Signer) (rh *TestHandler, datadir st
 	}
 
 	rhparams := &HandlerParams{
-		QueryMaxPeriods: &LookupParams{
-			Limit: false,
-		},
 		Signer:       signer,
 		HeaderGetter: backend,
 	}

--- a/swarm/storage/mru/resource_test.go
+++ b/swarm/storage/mru/resource_test.go
@@ -181,7 +181,7 @@ func TestHandler(t *testing.T) {
 	// create a new resource
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	rootChunkKey, _, err := rh.New(ctx, safeName, resourceFrequency, signer.PublicKey())
+	rootChunkKey, _, err := rh.New(ctx, safeName, resourceFrequency)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -344,7 +344,7 @@ func TestMultihash(t *testing.T) {
 	// create a new resource
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	_, _, err = rh.New(ctx, safeName, resourceFrequency, signer.PublicKey())
+	_, _, err = rh.New(ctx, safeName, resourceFrequency)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -411,7 +411,7 @@ func TestMultihash(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, _, err = rh2.New(ctx, safeName, resourceFrequency, signer.PublicKey())
+	_, _, err = rh2.New(ctx, safeName, resourceFrequency)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -472,7 +472,7 @@ func TestChunkValidator(t *testing.T) {
 	// create new resource when we are owner = ok
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	key, rsrc, err := rh.New(ctx, safeName, resourceFrequency, signer.PublicKey())
+	key, rsrc, err := rh.New(ctx, safeName, resourceFrequency)
 	if err != nil {
 		t.Fatalf("Create resource fail: %v", err)
 	}

--- a/swarm/storage/mru/resource_test.go
+++ b/swarm/storage/mru/resource_test.go
@@ -264,7 +264,6 @@ func TestResourceHandler(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	//_, err = rh2.LookupLatest(ctx, nameHash, true, nil)
 	lookupParams := &LookupParams{
 		Root: rootChunkKey,
 	}
@@ -286,7 +285,6 @@ func TestResourceHandler(t *testing.T) {
 	log.Debug("Latest lookup", "period", rsrc2.lastPeriod, "version", rsrc2.version, "data", rsrc2.data)
 
 	// specific block, latest version
-	//rsrc, err := rh2.LookupHistorical(ctx, nameHash, 3, true, rh2.queryMaxPeriods)
 	lookupParams.Period = 3
 	rsrc, err := rh2.Lookup(ctx, lookupParams)
 	if err != nil {
@@ -300,7 +298,6 @@ func TestResourceHandler(t *testing.T) {
 
 	// specific block, specific version
 	lookupParams.Version = 1
-	//rsrc, err = rh2.LookupVersion(ctx, nameHash, 3, 1, true, rh2.queryMaxPeriods)
 	rsrc, err = rh2.Lookup(ctx, lookupParams)
 	if err != nil {
 		t.Fatal(err)
@@ -326,7 +323,6 @@ func TestResourceHandler(t *testing.T) {
 	}
 
 	// beyond the first should yield an error
-	//rsrc, err = rh2.LookupPreviousByName(ctx, safeName, rh2.queryMaxPeriods)
 	rsrc, err = rh2.LookupPrevious(ctx, lookupParams)
 	if err == nil {
 		t.Fatalf("expeected previous to fail, returned period %d version %d data %v", rsrc2.lastPeriod, rsrc2.version, rsrc2.data)

--- a/swarm/storage/mru/resource_test.go
+++ b/swarm/storage/mru/resource_test.go
@@ -109,9 +109,7 @@ func TestReverse(t *testing.T) {
 	defer teardownTest()
 
 	// generate a hash for block 4200 version 1
-	var publicKeyBytes [publicKeyLength]byte
-	copy(publicKeyBytes[:], crypto.FromECDSAPub(signer.PublicKey()))
-	key := rh.resourceHash(period, version, ens.EnsNode(safeName), publicKeyBytes)
+	key := rh.resourceHash(period, version, ens.EnsNode(safeName), signer.Address())
 
 	// generate some bogus data for the chunk and sign it
 	data := make([]byte, 8)
@@ -490,9 +488,7 @@ func TestValidator(t *testing.T) {
 
 	// chunk with address
 	data := []byte("foo")
-	var publicKeyBytes [publicKeyLength]byte
-	copy(publicKeyBytes[:], crypto.FromECDSAPub(signer.PublicKey()))
-	key = rh.resourceHash(1, 1, rsrc.nameHash, publicKeyBytes)
+	key = rh.resourceHash(1, 1, rsrc.nameHash, signer.Address())
 	digest := rh.keyDataHash(key, data)
 	sig, err := rh.signer.Sign(digest)
 	if err != nil {
@@ -504,8 +500,7 @@ func TestValidator(t *testing.T) {
 	}
 
 	// chunk with address made from different publickey
-	copy(publicKeyBytes[:], crypto.FromECDSAPub(falseSigner.PublicKey()))
-	key = rh.resourceHash(1, 1, rsrc.nameHash, publicKeyBytes)
+	key = rh.resourceHash(1, 1, rsrc.nameHash, falseSigner.Address())
 	digest = rh.keyDataHash(key, data)
 	sig, err = rh.signer.Sign(digest)
 	if err != nil {
@@ -522,7 +517,7 @@ func TestValidator(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	chunk = rh.newMetaChunk(safeName, startBlock, resourceFrequency, publicKeyBytes)
+	chunk = rh.newMetaChunk(safeName, startBlock, resourceFrequency, signer.Address())
 	if rh.Validate(chunk.Addr, chunk.SData) {
 		t.Fatal("Chunk validator fail on metadata chunk")
 	}
@@ -544,8 +539,6 @@ func TestValidatorInStore(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var publicKeyBytes [publicKeyLength]byte
-	copy(publicKeyBytes[:], crypto.FromECDSAPub(signer.PublicKey()))
 
 	// set up localstore
 	datadir, err := ioutil.TempDir("", "storage-testresourcevalidator")
@@ -579,7 +572,7 @@ func TestValidatorInStore(t *testing.T) {
 	badChunk.SData = goodChunk.SData
 
 	// create a resource update chunk with correct publickey
-	key := rh.resourceHash(42, 1, ens.EnsNode("xyzzy.eth"), publicKeyBytes)
+	key := rh.resourceHash(42, 1, ens.EnsNode("xyzzy.eth"), signer.Address())
 	data := []byte("bar")
 	digestToSign := rh.keyDataHash(key, data)
 	digestSignature, err := signer.Sign(digestToSign)
@@ -644,9 +637,7 @@ func newTestSigner() (*GenericSigner, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &GenericSigner{
-		PrivKey: privKey,
-	}, nil
+	return NewGenericSigner(privKey), nil
 }
 
 func getUpdateDirect(rh *Handler, addr storage.Address) ([]byte, error) {

--- a/swarm/storage/mru/resource_test.go
+++ b/swarm/storage/mru/resource_test.go
@@ -90,6 +90,11 @@ func TestReverse(t *testing.T) {
 	period := uint32(4)
 	version := uint32(2)
 
+	// make fake backend, set up rpc and create resourcehandler
+	backend := &fakeBackend{
+		blocknumber: int64(startBlock),
+	}
+
 	// signer containing private key
 	signer, err := newTestSigner()
 	if err != nil {
@@ -97,7 +102,7 @@ func TestReverse(t *testing.T) {
 	}
 
 	// set up rpc and create resourcehandler
-	rh, _, teardownTest, err := setupTest(nil, signer)
+	rh, _, teardownTest, err := setupTest(backend, signer)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -529,6 +534,11 @@ func TestValidator(t *testing.T) {
 // which should be evaluated as invalid chunks by this validator
 func TestValidatorInStore(t *testing.T) {
 
+	// make fake backend, set up rpc and create resourcehandler
+	backend := &fakeBackend{
+		blocknumber: int64(startBlock),
+	}
+
 	// signer containing private key
 	signer, err := newTestSigner()
 	if err != nil {
@@ -553,7 +563,8 @@ func TestValidatorInStore(t *testing.T) {
 
 	// set up resource handler and add is as a validator to the localstore
 	rhParams := &HandlerParams{
-		Signer: signer,
+		HeaderGetter: backend,
+		Signer:       signer,
 	}
 	rh, err := NewHandler(rhParams)
 	if err != nil {

--- a/swarm/storage/mru/testutil.go
+++ b/swarm/storage/mru/testutil.go
@@ -23,9 +23,21 @@ import (
 	"github.com/ethereum/go-ethereum/swarm/storage"
 )
 
+const (
+	testDbDirName = "mru"
+)
+
+type TestHandler struct {
+	*Handler
+}
+
+func (t *TestHandler) Close() {
+	t.chunkStore.Close()
+}
+
 // NewTestHandler creates Handler object to be used for testing purposes.
-func NewTestHandler(datadir string, params *HandlerParams) (*Handler, error) {
-	path := filepath.Join(datadir, DbDirName)
+func NewTestHandler(datadir string, params *HandlerParams) (*TestHandler, error) {
+	path := filepath.Join(datadir, testDbDirName)
 	rh, err := NewHandler(params)
 	if err != nil {
 		return nil, fmt.Errorf("resource handler create fail: %v", err)
@@ -40,5 +52,5 @@ func NewTestHandler(datadir string, params *HandlerParams) (*Handler, error) {
 	localStore.Validators = append(localStore.Validators, rh)
 	netStore := storage.NewNetStore(localStore, nil)
 	rh.SetStore(netStore)
-	return rh, nil
+	return &TestHandler{rh}, nil
 }

--- a/swarm/storage/mru/testutil.go
+++ b/swarm/storage/mru/testutil.go
@@ -1,0 +1,44 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package mru
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/ethereum/go-ethereum/swarm/storage"
+)
+
+// NewTestHandler creates Handler object to be used for testing purposes.
+func NewTestHandler(datadir string, params *HandlerParams) (*Handler, error) {
+	path := filepath.Join(datadir, DbDirName)
+	rh, err := NewHandler(params)
+	if err != nil {
+		return nil, fmt.Errorf("resource handler create fail: %v", err)
+	}
+	localstoreparams := storage.NewDefaultLocalStoreParams()
+	localstoreparams.Init(path)
+	localStore, err := storage.NewLocalStore(localstoreparams, nil)
+	if err != nil {
+		return nil, fmt.Errorf("localstore create fail, path %s: %v", path, err)
+	}
+	localStore.Validators = append(localStore.Validators, storage.NewContentAddressValidator(storage.MakeHashFunc(resourceHash)))
+	localStore.Validators = append(localStore.Validators, rh)
+	netStore := storage.NewNetStore(localStore, nil)
+	rh.SetStore(netStore)
+	return rh, nil
+}

--- a/swarm/storage/types.go
+++ b/swarm/storage/types.go
@@ -18,6 +18,7 @@ package storage
 
 import (
 	"bytes"
+	"context"
 	"crypto"
 	"crypto/rand"
 	"encoding/binary"
@@ -303,7 +304,7 @@ type Putter interface {
 	// Close is to indicate that no more chunk data will be Put on this Putter
 	Close()
 	// Wait returns if all data has been store and the Close() was called.
-	Wait()
+	Wait(context.Context) error
 }
 
 // Getter is an interface to retrieve a chunk's data by its reference

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -190,9 +190,6 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 	var resourceHandler *mru.Handler
 	rhparams := &mru.HandlerParams{
 		// TODO: config parameter to set limits
-		QueryMaxPeriods: &mru.LookupParams{
-			Limit: false,
-		},
 		Signer: &mru.GenericSigner{
 			PrivKey: self.privateKey,
 		},

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -190,9 +190,7 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 	var resourceHandler *mru.Handler
 	rhparams := &mru.HandlerParams{
 		// TODO: config parameter to set limits
-		Signer: &mru.GenericSigner{
-			PrivKey: self.privateKey,
-		},
+		Signer: mru.NewGenericSigner(self.privateKey),
 	}
 	if resolver != nil {
 		resolver.SetNameHash(ens.EnsNode)

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -199,9 +199,8 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 	}
 	if resolver != nil {
 		resolver.SetNameHash(ens.EnsNode)
-		// Set HeaderGetter and OwnerValidator interfaces to resolver only if it is not nil.
+		// Set HeaderGetter to resolver only if it is not nil.
 		rhparams.HeaderGetter = resolver
-		rhparams.OwnerValidator = resolver
 	} else {
 		log.Warn("No ETH API specified, resource updates will use block height approximation")
 		// TODO: blockestimator should use saved values derived from last time ethclient was connected

--- a/swarm/swarm_test.go
+++ b/swarm/swarm_test.go
@@ -348,12 +348,16 @@ func testLocalStoreAndRetrieve(t *testing.T, swarm *Swarm, n int, randomData boo
 	}
 	dataPut := string(slice)
 
-	k, wait, err := swarm.api.Store(context.TODO(), strings.NewReader(dataPut), int64(len(dataPut)), false)
+	ctx := context.TODO()
+	k, wait, err := swarm.api.Store(ctx, strings.NewReader(dataPut), int64(len(dataPut)), false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if wait != nil {
-		wait()
+		err = wait(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	r, _ := swarm.api.Retrieve(context.TODO(), k)

--- a/swarm/swarm_test.go
+++ b/swarm/swarm_test.go
@@ -17,6 +17,7 @@
 package swarm
 
 import (
+	"context"
 	"encoding/hex"
 	"io/ioutil"
 	"math/rand"
@@ -347,7 +348,7 @@ func testLocalStoreAndRetrieve(t *testing.T, swarm *Swarm, n int, randomData boo
 	}
 	dataPut := string(slice)
 
-	k, wait, err := swarm.api.Store(strings.NewReader(dataPut), int64(len(dataPut)), false)
+	k, wait, err := swarm.api.Store(context.TODO(), strings.NewReader(dataPut), int64(len(dataPut)), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -355,7 +356,7 @@ func testLocalStoreAndRetrieve(t *testing.T, swarm *Swarm, n int, randomData boo
 		wait()
 	}
 
-	r, _ := swarm.api.Retrieve(k)
+	r, _ := swarm.api.Retrieve(context.TODO(), k)
 
 	d, err := ioutil.ReadAll(r)
 	if err != nil {

--- a/swarm/swarm_test.go
+++ b/swarm/swarm_test.go
@@ -17,10 +17,12 @@
 package swarm
 
 import (
+	"encoding/hex"
 	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -41,6 +43,13 @@ func TestNewSwarm(t *testing.T) {
 
 	// a simple rpc endpoint for testing dialing
 	ipcEndpoint := path.Join(dir, "TestSwarm.ipc")
+
+	// windows namedpipes are not on filesystem but on NPFS
+	if runtime.GOOS == "windows" {
+		b := make([]byte, 8)
+		rand.Read(b)
+		ipcEndpoint = `\\.\pipe\TestSwarm-` + hex.EncodeToString(b)
+	}
 
 	_, server, err := rpc.StartIPCEndpoint(ipcEndpoint, nil)
 	if err != nil {

--- a/swarm/testutil/http.go
+++ b/swarm/testutil/http.go
@@ -79,9 +79,7 @@ func NewTestSwarmServer(t *testing.T, serverFunc func(*api.API) TestServer) *Tes
 	if err != nil {
 		t.Fatal(err)
 	}
-	signer := &mru.GenericSigner{
-		PrivKey: privKey,
-	}
+	signer := mru.NewGenericSigner(privKey)
 	rhparams := &mru.HandlerParams{
 		QueryMaxPeriods: &mru.LookupParams{},
 		Signer:          signer,

--- a/swarm/testutil/http.go
+++ b/swarm/testutil/http.go
@@ -27,8 +27,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/metrics"
-	"github.com/ethereum/go-ethereum/metrics/influxdb"
 	"github.com/ethereum/go-ethereum/swarm/api"
 	"github.com/ethereum/go-ethereum/swarm/storage"
 	"github.com/ethereum/go-ethereum/swarm/storage/mru"
@@ -91,7 +89,7 @@ func NewTestSwarmServer(t *testing.T, serverFunc func(*api.API) TestServer) *Tes
 		t.Fatal(err)
 	}
 
-	a := api.NewApi(fileStore, nil, rh.Handler)
+	a := api.NewAPI(fileStore, nil, rh.Handler)
 	srv := httptest.NewServer(serverFunc(a))
 	return &TestSwarmServer{
 		Server:    srv,

--- a/swarm/testutil/http.go
+++ b/swarm/testutil/http.go
@@ -94,7 +94,7 @@ func NewTestSwarmServer(t *testing.T, serverFunc func(*api.API) TestServer) *Tes
 		t.Fatal(err)
 	}
 
-	a := api.NewAPI(fileStore, nil, rh)
+	a := api.NewApi(fileStore, nil, rh.Handler)
 	srv := httptest.NewServer(serverFunc(a))
 	return &TestSwarmServer{
 		Server:    srv,

--- a/swarm/testutil/http.go
+++ b/swarm/testutil/http.go
@@ -26,6 +26,9 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethereum/go-ethereum/metrics/influxdb"
 	"github.com/ethereum/go-ethereum/swarm/api"
 	"github.com/ethereum/go-ethereum/swarm/storage"
 	"github.com/ethereum/go-ethereum/swarm/storage/mru"
@@ -68,8 +71,20 @@ func NewTestSwarmServer(t *testing.T, serverFunc func(*api.API) TestServer) *Tes
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// signer
+	privKeyBytes := [32]byte{}
+	privKeyBytes[0] = 0x2a
+	privKey, err := crypto.ToECDSA(privKeyBytes[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer := &mru.GenericSigner{
+		PrivKey: privKey,
+	}
 	rhparams := &mru.HandlerParams{
 		QueryMaxPeriods: &mru.LookupParams{},
+		Signer:          signer,
 		HeaderGetter: &fakeBackend{
 			blocknumber: 42,
 		},

--- a/swarm/testutil/http.go
+++ b/swarm/testutil/http.go
@@ -81,8 +81,7 @@ func NewTestSwarmServer(t *testing.T, serverFunc func(*api.API) TestServer) *Tes
 	}
 	signer := mru.NewGenericSigner(privKey)
 	rhparams := &mru.HandlerParams{
-		QueryMaxPeriods: &mru.LookupParams{},
-		Signer:          signer,
+		Signer: signer,
 		HeaderGetter: &fakeBackend{
 			blocknumber: 42,
 		},


### PR DESCRIPTION
#667

Also part of #418

This PR removes ENS validation from MRU. It removes the OwnerValidator member of the Handler, and other code related to ENS. It however keeps the ens namehash as the hashing algorithm for the mutable resource identifier.

Updates are now validated by a public key embedded in the metadata chunk. The key of individual updates now also includes the public key in the hash. Validation is done by getting the public key from the signature, and redoing the hash comparing the result to the existing key.

Signatures are now mandatory. The HeaderGetter is also made mandatory.

The PR also removes the "self" name of receivers, and adds godoc comments throughout.