### PR TITLE
BMT hasher fixes

### DIFF
--- a/swarm/bmt/bmt_r.go
+++ b/swarm/bmt/bmt_r.go
@@ -80,6 +80,5 @@ func (rh *RefHasher) hash(data []byte, length int) []byte {
 	}
 	rh.hasher.Reset()
 	rh.hasher.Write(section)
-	s := rh.hasher.Sum(nil)
-	return s
+	return rh.hasher.Sum(nil)
 }


### PR DESCRIPTION
This PR takes up some technical dept in the bmt package.
While bmt Hasher implemented the io.Writer interface, it never was tested if worked correctly on arbitrary variable writes. The PR adds extensive testing for this case. 

Also, the PR brings about similification and more optimisation of the algorithm (benchmarks improved) and streamlining the code to antipipate 

 * SegmentWriter/SectioWriter (async unordered write) and Prover interfaces https://github.com/ethersphere/go-ethereum/issues/749
 * change in the length encoding interface (not at Reset)

In addition to the above the BMT can now handle zero byte input and partially fixes https://github.com/ethersphere/go-ethereum/issues/755