### PR TITLE
swarm/fuse: ignore default manifest entry

### DIFF
--- a/swarm/fuse/swarmfs_unix.go
+++ b/swarm/fuse/swarmfs_unix.go
@@ -120,6 +120,10 @@ func (swarmfs *SwarmFS) Mount(mhash, mountpoint string) (*MountInfo, error) {
 
 	log.Trace("swarmfs mount: traversing manifest map")
 	for suffix, entry := range manifestEntryMap {
+		if suffix == "" { //empty suffix means that the file has no name - i.e. this is the default entry in a manifest. Since we cannot have files without a name, let us ignore this entry
+			log.Warn("Manifest has an empty-path (default) entry which will be ignored in FUSE mount."))
+			continue
+		}
 		addr := common.Hex2Bytes(entry.Hash)
 		fullpath := "/" + suffix
 		basepath := filepath.Dir(fullpath)


### PR DESCRIPTION
this fixes the problem I was having in fuse where files would show up, but directories would not.

The issue was caused by manifests with default entries (i.e. manifests in which an entry has an empty 'path'). FUSE cannot handle files without a name. This PR simply ignores the default entry in a manifest.
In future we may think of better solutions the represent the defaultpath in a filesystem.