### PR TITLE
cmd/swarm: change version of swarm binary

### DIFF
--- a/cmd/swarm/config.go
+++ b/cmd/swarm/config.go
@@ -38,7 +38,7 @@ import (
 	bzzapi "github.com/ethereum/go-ethereum/swarm/api"
 )
 
-const SWARM_VERSION = "0.3"
+const SWARM_VERSION = "0.3.1-unstable"
 
 var (
 	//flag definition for the dumpconfig command


### PR DESCRIPTION
This should have been merged together with the bump of protocol versions due to the OpenTracing backward-incompatible change.