### PR TITLE
Issue 826: fix leaf links in lists

### DIFF
--- a/swarm/api/http/templates.go
+++ b/swarm/api/http/templates.go
@@ -83,10 +83,11 @@ const bzzList = `{{ define "content" }}
       <td>DIR</td>
       <td>-</td>
     </tr>
-    {{ end }} {{ range .List.Entries }}
+    {{ end }}
+    {{ range .List.Entries }}
     <tr>
       <td>
-        <a class="normal-link" href="{{ basename .Path }}">{{ basename .Path }}</a>
+        <a class="normal-link" href="/{{ $.URI }}{{ basename .Path }}">{{ basename .Path }}</a>
       </td>
       <td>{{ .ContentType }}</td>
       <td>{{ .Size }}</td>


### PR DESCRIPTION
Now, this is the cleanest quickfix with what we have.
Yes, it's possible to inject a function that parses the manifest and outputs the links well formatted but seen as it comes using URI (which is already there) I think it's a bit an overkill.

If instead you want to cleanup things and refactor it's another thing.