### PR TITLE
[PREVIEW] MRU query strings and manifest-less queries

### DIFF
--- a/cmd/swarm/mru.go
+++ b/cmd/swarm/mru.go
@@ -64,7 +64,7 @@ func resourceCreate(ctx *cli.Context) {
 
 	relatedTopicBytes, _ := hexutil.Decode(relatedTopic)
 
-	viewID := &mru.ResourceID{
+	resource := &mru.Resource{
 		Topic:     mru.NewTopic(name, relatedTopicBytes),
 		Frequency: frequency,
 	}
@@ -77,7 +77,7 @@ func resourceCreate(ctx *cli.Context) {
 			cli.ShowCommandHelpAndExit(ctx, "create", 1)
 			return
 		}
-		newResourceRequest, err = mru.NewCreateUpdateRequest(viewID)
+		newResourceRequest, err = mru.NewCreateUpdateRequest(resource)
 		if err != nil {
 			utils.Fatalf("Error creating new resource request: %s", err)
 		}
@@ -86,7 +86,7 @@ func resourceCreate(ctx *cli.Context) {
 			utils.Fatalf("Error signing resource update: %s", err.Error())
 		}
 	} else {
-		newResourceRequest, err = mru.NewCreateRequest(viewID, signer.Address())
+		newResourceRequest, err = mru.NewCreateRequest(resource, signer.Address())
 		if err != nil {
 			utils.Fatalf("Error creating new resource request: %s", err)
 		}

--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -956,7 +956,7 @@ func (a *API) ResourceLookup(ctx context.Context, params *mru.LookupParams) ([]b
 		return nil, err
 	}
 	var data []byte
-	_, data, err = a.resource.GetContent(params.View())
+	_, data, err = a.resource.GetContent(&params.View)
 	if err != nil {
 		return nil, err
 	}

--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -970,7 +970,7 @@ func (a *API) ResourceNewRequest(ctx context.Context, view *mru.View) (*mru.Requ
 
 // ResourceUpdate updates a Mutable Resource with arbitrary data.
 // Upon retrieval the update will be retrieved verbatim as bytes.
-func (a *API) ResourceUpdate(ctx context.Context, request *mru.SignedResourceUpdate) (storage.Address, error) {
+func (a *API) ResourceUpdate(ctx context.Context, request *mru.Request) (storage.Address, error) {
 	return a.resource.Update(ctx, request)
 }
 

--- a/swarm/api/api.go
+++ b/swarm/api/api.go
@@ -408,10 +408,10 @@ func (a *API) Get(ctx context.Context, decrypt DecryptFunc, manifestAddr storage
 
 		// we need to do some extra work if this is a mutable resource manifest
 		if entry.ContentType == ResourceContentType {
-			if entry.ResourceViewID == nil {
-				return reader, mimeType, status, nil, fmt.Errorf("Cannot decode ResourceViewID in manifest")
+			if entry.ResourceView == nil {
+				return reader, mimeType, status, nil, fmt.Errorf("Cannot decode ResourceView in manifest")
 			}
-			_, err := a.resource.Lookup(ctx, mru.LookupLatest(entry.ResourceViewID))
+			_, err := a.resource.Lookup(ctx, mru.LookupLatest(entry.ResourceView))
 			if err != nil {
 				apiGetNotFound.Inc(1)
 				status = http.StatusNotFound
@@ -419,7 +419,7 @@ func (a *API) Get(ctx context.Context, decrypt DecryptFunc, manifestAddr storage
 				return reader, mimeType, status, nil, err
 			}
 			// get the data of the update
-			_, rsrcData, err := a.resource.GetContent(entry.ResourceViewID)
+			_, rsrcData, err := a.resource.GetContent(entry.ResourceView)
 			if err != nil {
 				apiGetNotFound.Inc(1)
 				status = http.StatusNotFound
@@ -956,7 +956,7 @@ func (a *API) ResourceLookup(ctx context.Context, params *mru.LookupParams) ([]b
 		return nil, err
 	}
 	var data []byte
-	_, data, err = a.resource.GetContent(params.ViewID())
+	_, data, err = a.resource.GetContent(params.View())
 	if err != nil {
 		return nil, err
 	}
@@ -964,8 +964,8 @@ func (a *API) ResourceLookup(ctx context.Context, params *mru.LookupParams) ([]b
 }
 
 // ResourceNewRequest creates a Request object to update a specific mutable resource
-func (a *API) ResourceNewRequest(ctx context.Context, viewID *mru.ResourceViewID) (*mru.Request, error) {
-	return a.resource.NewUpdateRequest(ctx, viewID)
+func (a *API) ResourceNewRequest(ctx context.Context, view *mru.View) (*mru.Request, error) {
+	return a.resource.NewUpdateRequest(ctx, view)
 }
 
 // ResourceUpdate updates a Mutable Resource with arbitrary data.
@@ -980,7 +980,7 @@ func (a *API) ResourceHashSize() int {
 }
 
 // ResolveResourceManifest retrieves the Mutable Resource manifest for the given address, and returns the Resource's view ID.
-func (a *API) ResolveResourceManifest(ctx context.Context, addr storage.Address) (*mru.ResourceViewID, error) {
+func (a *API) ResolveResourceManifest(ctx context.Context, addr storage.Address) (*mru.View, error) {
 	trie, err := loadManifest(ctx, a.fileStore, addr, nil, NOOPDecrypt)
 	if err != nil {
 		return nil, fmt.Errorf("cannot load resource manifest: %v", err)
@@ -991,5 +991,5 @@ func (a *API) ResolveResourceManifest(ctx context.Context, addr storage.Address)
 		return nil, fmt.Errorf("not a resource manifest: %s", addr)
 	}
 
-	return entry.ResourceViewID, nil
+	return entry.ResourceView, nil
 }

--- a/swarm/api/client/client.go
+++ b/swarm/api/client/client.go
@@ -662,7 +662,9 @@ func (c *Client) QueryResource(lookup *mru.LookupParams) (io.ReadCloser, error) 
 	if err != nil {
 		return nil, err
 	}
-	lookup.ToURL(URL)
+	values := URL.Query()
+	lookup.ToValues(values) //adds query parameters
+	URL.RawQuery = values.Encode()
 	res, err := http.Get(URL.String())
 	if err != nil {
 		return nil, err

--- a/swarm/api/client/client.go
+++ b/swarm/api/client/client.go
@@ -28,6 +28,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -649,13 +650,24 @@ func (c *Client) updateResource(request *mru.Request) (io.ReadCloser, error) {
 // manifestAddressOrDomain is the address you obtained in CreateResource or an ENS domain whose Resolver
 // points to that address
 func (c *Client) GetResource(manifestAddressOrDomain string) (io.ReadCloser, error) {
-
 	res, err := http.Get(c.Gateway + "/bzz-resource:/" + manifestAddressOrDomain)
 	if err != nil {
 		return nil, err
 	}
 	return res.Body, nil
+}
 
+func (c *Client) QueryResource(lookup *mru.LookupParams) (io.ReadCloser, error) {
+	URL, err := url.Parse(c.Gateway + "/bzz-resource:/")
+	if err != nil {
+		return nil, err
+	}
+	lookup.ToURL(URL)
+	res, err := http.Get(URL.String())
+	if err != nil {
+		return nil, err
+	}
+	return res.Body, nil
 }
 
 // GetResourceMetadata returns a structure that describes the Mutable Resource

--- a/swarm/api/client/client_test.go
+++ b/swarm/api/client/client_test.go
@@ -394,7 +394,7 @@ func TestClientCreateResourceMultihash(t *testing.T) {
 	// our mutable resource "name"
 	resourceName := "foo.eth"
 
-	createRequest, err := mru.NewCreateUpdateRequest(&mru.ResourceID{
+	createRequest, err := mru.NewCreateUpdateRequest(&mru.Resource{
 		Topic:     mru.NewTopic(resourceName, nil),
 		Frequency: 13,
 		StartTime: srv.GetCurrentTime(),
@@ -413,7 +413,7 @@ func TestClientCreateResourceMultihash(t *testing.T) {
 		t.Fatalf("Error creating resource: %s", err)
 	}
 
-	correctManifestAddrHex := "c29a2902d0ae16a015e220a376001c1f36c426e6419bd3b1aabdcffe6f3cdf06"
+	correctManifestAddrHex := "36651b0613c3fbdba7b83175e282dd2b1b4842c884b794da01ab4b4b14d80179"
 	if resourceManifestHash != correctManifestAddrHex {
 		t.Fatalf("Response resource manifest mismatch, expected '%s', got '%s'", correctManifestAddrHex, resourceManifestHash)
 	}
@@ -447,7 +447,7 @@ func TestClientCreateUpdateResource(t *testing.T) {
 
 	// our mutable resource name
 	resourceName := "El Quijote"
-	resourceID := &mru.ResourceID{
+	resourceID := &mru.Resource{
 		Topic:     mru.NewTopic(resourceName, nil),
 		Frequency: 13,
 		StartTime: srv.GetCurrentTime(),
@@ -463,7 +463,7 @@ func TestClientCreateUpdateResource(t *testing.T) {
 
 	resourceManifestHash, err := client.CreateResource(createRequest)
 
-	correctManifestAddrHex := "98c5984ef8d27cf6d15a46cd3115114d74e87e0d3556c654ee541f1bd334a510"
+	correctManifestAddrHex := "db81418f37cc98aa4509a4f5556b00d703f81f1d36e038fa4267251635cf9979"
 	if resourceManifestHash != correctManifestAddrHex {
 		t.Fatalf("Response resource manifest mismatch, expected '%s', got '%s'", correctManifestAddrHex, resourceManifestHash)
 	}
@@ -513,8 +513,8 @@ func TestClientCreateUpdateResource(t *testing.T) {
 
 	// now try retrieving resource without a manifest
 
-	viewID := mru.NewViewID(resourceID, signer.Address())
-	lookupParams := mru.LookupLatest(viewID)
+	view := mru.NewView(resourceID, signer.Address())
+	lookupParams := mru.LookupLatest(view)
 	reader, err = client.QueryResource(lookupParams)
 	if err != nil {
 		t.Fatalf("Error retrieving resource: %s", err)

--- a/swarm/api/client/client_test.go
+++ b/swarm/api/client/client_test.go
@@ -447,12 +447,12 @@ func TestClientCreateUpdateResource(t *testing.T) {
 
 	// our mutable resource name
 	resourceName := "El Quijote"
-
-	createRequest, err := mru.NewCreateUpdateRequest(&mru.ResourceID{
+	resourceID := &mru.ResourceID{
 		Topic:     mru.NewTopic(resourceName, nil),
 		Frequency: 13,
 		StartTime: srv.GetCurrentTime(),
-	})
+	}
+	createRequest, err := mru.NewCreateUpdateRequest(resourceID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -499,6 +499,23 @@ func TestClientCreateUpdateResource(t *testing.T) {
 	}
 
 	reader, err = client.GetResource(correctManifestAddrHex)
+	if err != nil {
+		t.Fatalf("Error retrieving resource: %s", err)
+	}
+	defer reader.Close()
+	gotData, err = ioutil.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(databytes, gotData) {
+		t.Fatalf("Expected: %v, got %v", databytes, gotData)
+	}
+
+	// now try retrieving resource without a manifest
+
+	viewID := mru.NewViewID(resourceID, signer.Address())
+	lookupParams := mru.LookupLatest(viewID)
+	reader, err = client.QueryResource(lookupParams)
 	if err != nil {
 		t.Fatalf("Error retrieving resource: %s", err)
 	}

--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -503,7 +503,7 @@ func (s *Server) HandlePostResource(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var updateRequest mru.Request
-	*updateRequest.View() = *view
+	updateRequest.View = *view
 	query := r.URL.Query()
 
 	if err := updateRequest.FromValues(query, body, false); err != nil { // decodes request from query parameters
@@ -530,7 +530,7 @@ func (s *Server) HandlePostResource(w http.ResponseWriter, r *http.Request) {
 		// we create a manifest so we can retrieve the resource with bzz:// later
 		// this manifest has a special "resource type" manifest, and saves the
 		// resource view ID used to retrieve the resource later
-		m, err := s.api.NewResourceManifest(r.Context(), updateRequest.View())
+		m, err := s.api.NewResourceManifest(r.Context(), &updateRequest.View)
 		if err != nil {
 			RespondError(w, r, fmt.Sprintf("failed to create resource manifest: %v", err), http.StatusInternalServerError)
 			return

--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -519,7 +519,7 @@ func (s *Server) HandlePostResource(w http.ResponseWriter, r *http.Request) {
 			RespondError(w, r, err.Error(), http.StatusForbidden)
 			return
 		}
-		_, err = s.api.ResourceUpdate(r.Context(), &updateRequest.SignedResourceUpdate)
+		_, err = s.api.ResourceUpdate(r.Context(), &updateRequest)
 		if err != nil {
 			RespondError(w, r, err.Error(), http.StatusInternalServerError)
 			return

--- a/swarm/api/http/server.go
+++ b/swarm/api/http/server.go
@@ -578,7 +578,7 @@ func (s *Server) HandleGetResource(w http.ResponseWriter, r *http.Request) {
 		log.Debug("handle.get.resource: resolved", "ruid", ruid, "manifestkey", manifestAddr, "view", view.Hex())
 	} else {
 		var v mru.View
-		if err := v.FromURL(r.URL); err != nil {
+		if err := v.FromValues(r.URL.Query()); err != nil {
 			getFail.Inc(1)
 			RespondError(w, r, fmt.Sprintf("error parsing view ID parameters: %s", err), http.StatusBadRequest)
 			return
@@ -606,7 +606,7 @@ func (s *Server) HandleGetResource(w http.ResponseWriter, r *http.Request) {
 	}
 
 	lookupParams := mru.NewLookupParams(view, 0, 0, 0)
-	if err = lookupParams.FromURL(r.URL, false); err != nil { // àrse period, version
+	if err = lookupParams.FromValues(r.URL.Query(), false); err != nil { // parse period, version
 		RespondError(w, r, fmt.Sprintf("invalid mutable resource request:%s", err), http.StatusBadRequest)
 		return
 	}

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -164,7 +164,7 @@ func TestBzzResourceMultihash(t *testing.T) {
 	testUrl.RawQuery = query.Encode()
 
 	// create the multihash update
-	resp, err = http.Post(testUrl.String(), "application/octect-stream", bytes.NewReader(body))
+	resp, err = http.Post(testUrl.String(), "application/octet-stream", bytes.NewReader(body))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -376,7 +376,7 @@ func TestBzzResource(t *testing.T) {
 	body = updateRequest.ToValues(query) // this adds all query parameters
 	testUrl.RawQuery = query.Encode()
 
-	resp, err = http.Post(testUrl.String(), "application/octect-stream", bytes.NewReader(body))
+	resp, err = http.Post(testUrl.String(), "application/octet-stream", bytes.NewReader(body))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -449,7 +449,7 @@ func TestBzzResource(t *testing.T) {
 		t.Fatal(err)
 	}
 	values := urlq.Query()
-	updateRequest.View().ToValues(values) // this adds view query parameters
+	updateRequest.View.ToValues(values) // this adds view query parameters
 	urlq.RawQuery = values.Encode()
 	resp, err = http.Get(urlq.String())
 	if err != nil {

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -438,7 +438,9 @@ func TestBzzResource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	updateRequest.View().ToURL(urlq) // this adds view query parameters
+	values := urlq.Query()
+	updateRequest.View().ToValues(values) // this adds view query parameters
+	urlq.RawQuery = values.Encode()
 	resp, err = http.Get(urlq.String())
 	if err != nil {
 		t.Fatal(err)

--- a/swarm/api/http/server_test.go
+++ b/swarm/api/http/server_test.go
@@ -139,7 +139,7 @@ func TestBzzResourceMultihash(t *testing.T) {
 
 	log.Info("added data", "manifest", string(b), "data", common.ToHex(mh))
 
-	updateRequest, err := mru.NewCreateUpdateRequest(&mru.ResourceID{
+	updateRequest, err := mru.NewCreateUpdateRequest(&mru.Resource{
 		Topic:     mru.NewTopic("foo.eth", nil),
 		Frequency: 13,
 		StartTime: srv.GetCurrentTime(),
@@ -179,7 +179,7 @@ func TestBzzResourceMultihash(t *testing.T) {
 		t.Fatalf("data %s could not be unmarshaled: %v", b, err)
 	}
 
-	correctManifestAddrHex := "c29a2902d0ae16a015e220a376001c1f36c426e6419bd3b1aabdcffe6f3cdf06"
+	correctManifestAddrHex := "36651b0613c3fbdba7b83175e282dd2b1b4842c884b794da01ab4b4b14d80179"
 	if rsrcResp.Hex() != correctManifestAddrHex {
 		t.Fatalf("Response resource key mismatch, expected '%s', got '%s'", correctManifestAddrHex, rsrcResp.Hex())
 	}
@@ -217,7 +217,7 @@ func TestBzzResource(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	updateRequest, err := mru.NewCreateUpdateRequest(&mru.ResourceID{
+	updateRequest, err := mru.NewCreateUpdateRequest(&mru.Resource{
 		Topic:     mru.NewTopic("foo.eth", nil),
 		Frequency: 13,
 		StartTime: srv.GetCurrentTime(),
@@ -256,7 +256,7 @@ func TestBzzResource(t *testing.T) {
 		t.Fatalf("data %s could not be unmarshaled: %v", b, err)
 	}
 
-	correctManifestAddrHex := "c29a2902d0ae16a015e220a376001c1f36c426e6419bd3b1aabdcffe6f3cdf06"
+	correctManifestAddrHex := "36651b0613c3fbdba7b83175e282dd2b1b4842c884b794da01ab4b4b14d80179"
 	if rsrcResp.Hex() != correctManifestAddrHex {
 		t.Fatalf("Response resource manifest mismatch, expected '%s', got '%s'", correctManifestAddrHex, rsrcResp.Hex())
 	}
@@ -283,9 +283,9 @@ func TestBzzResource(t *testing.T) {
 	if len(manifest.Entries) != 1 {
 		t.Fatalf("Manifest has %d entries", len(manifest.Entries))
 	}
-	correctViewIDHex := "0x2a000000000000000d00000000000000666f6f2e65746800000000000000000000000000000000000000000000000000c96aaa54e2d44c299564da76e1cd3184a2386b8d"
-	if manifest.Entries[0].ResourceViewID.Hex() != correctViewIDHex {
-		t.Fatalf("Expected manifest ResourceViewID '%s', got '%s'", correctViewIDHex, manifest.Entries[0].ResourceViewID.Hex())
+	correctViewHex := "0x2a000000000000000d00000000000000666f6f2e65746800000000000000000000000000000000000000000000000000c96aaa54e2d44c299564da76e1cd3184a2386b8d"
+	if manifest.Entries[0].ResourceView.Hex() != correctViewHex {
+		t.Fatalf("Expected manifest Resource View '%s', got '%s'", correctViewHex, manifest.Entries[0].ResourceView.Hex())
 	}
 
 	// get bzz manifest transparent resource resolve
@@ -438,7 +438,7 @@ func TestBzzResource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	updateRequest.ViewID().ToURL(urlq) // this adds viewID query parameters
+	updateRequest.View().ToURL(urlq) // this adds view query parameters
 	resp, err = http.Get(urlq.String())
 	if err != nil {
 		t.Fatal(err)

--- a/swarm/api/manifest.go
+++ b/swarm/api/manifest.go
@@ -48,15 +48,15 @@ type Manifest struct {
 
 // ManifestEntry represents an entry in a swarm manifest
 type ManifestEntry struct {
-	Hash           string              `json:"hash,omitempty"`
-	Path           string              `json:"path,omitempty"`
-	ContentType    string              `json:"contentType,omitempty"`
-	Mode           int64               `json:"mode,omitempty"`
-	Size           int64               `json:"size,omitempty"`
-	ModTime        time.Time           `json:"mod_time,omitempty"`
-	Status         int                 `json:"status,omitempty"`
-	Access         *AccessEntry        `json:"access,omitempty"`
-	ResourceViewID *mru.ResourceViewID `json:"resourceViewId,omitempty"`
+	Hash         string       `json:"hash,omitempty"`
+	Path         string       `json:"path,omitempty"`
+	ContentType  string       `json:"contentType,omitempty"`
+	Mode         int64        `json:"mode,omitempty"`
+	Size         int64        `json:"size,omitempty"`
+	ModTime      time.Time    `json:"mod_time,omitempty"`
+	Status       int          `json:"status,omitempty"`
+	Access       *AccessEntry `json:"access,omitempty"`
+	ResourceView *mru.View    `json:"resourceView,omitempty"`
 }
 
 // ManifestList represents the result of listing files in a manifest
@@ -79,11 +79,11 @@ func (a *API) NewManifest(ctx context.Context, toEncrypt bool) (storage.Address,
 
 // Manifest hack for supporting Mutable Resource Updates from the bzz: scheme
 // see swarm/api/api.go:API.Get() for more information
-func (a *API) NewResourceManifest(ctx context.Context, ViewID *mru.ResourceViewID) (storage.Address, error) {
+func (a *API) NewResourceManifest(ctx context.Context, view *mru.View) (storage.Address, error) {
 	var manifest Manifest
 	entry := ManifestEntry{
-		ResourceViewID: ViewID,
-		ContentType:    ResourceContentType,
+		ResourceView: view,
+		ContentType:  ResourceContentType,
 	}
 	manifest.Entries = append(manifest.Entries, entry)
 	data, err := json.Marshal(&manifest)

--- a/swarm/storage/mru/doc.go
+++ b/swarm/storage/mru/doc.go
@@ -1,61 +1,48 @@
-// Package mru defines Mutable resource updates.
-// A Mutable Resource is an entity which allows updates to a resource
-// without resorting to ENS on each update.
-// The update scheme is built on swarm chunks with chunk keys following
-// a predictable, versionable pattern.
-//
-// Updates are defined to be periodic in nature, where the update frequency
-// is expressed in seconds.
-//
-// The root entry of a mutable resource is tied to a unique identifier that
-// is deterministically generated out of the metadata content that describes
-// the resource. This metadata includes a user-defined resource name, a resource
-// start time that indicates when the resource becomes valid,
-// the frequency in seconds with which the resource is expected to be updated, both of
-// which are stored as little-endian uint64 values in the database (for a
-// total of 16 bytes). It also contains the owner's address (ownerAddr)
-// This MRU info is stored in a separate content-addressed chunk
-// (call it the metadata chunk), with the following layout:
-//
-// (00|length|startTime|frequency|name|ownerAddr)
-//
-// (The two first zero-value bytes are used for disambiguation by the chunk validator,
-// and update chunk will always have a value > 0 there.)
-//
-// Each metadata chunk is identified by its rootAddr, calculated as follows:
-// metaHash=H(len(metadata), startTime, frequency,name)
-// rootAddr = H(metaHash, ownerAddr).
-// where H is the SHA3 hash function
-// This scheme effectively locks the root chunk so that only the owner of the private key
-// that ownerAddr was derived from can sign updates.
-//
-// The root entry tells the requester from when the mutable resource was
-// first added (Unix time in seconds) and in which moments to look for the
-// actual updates. Thus, a resource update for identifier "føø.bar"
-// starting at unix time 1528800000 with frequency 300 (every 5 mins) will have updates on 1528800300,
-// 1528800600, 1528800900 and so on.
-//
-// Actual data updates are also made in the form of swarm chunks. The keys
-// of the updates are the hash of a concatenation of properties as follows:
-//
-// updateAddr = H(period, version, rootAddr)
-// where H is the SHA3 hash function
-// The period is (currentTime - startTime) / frequency
-//
-// Using our previous example, this means that a period 3 will happen when the
-// clock hits 1528800900
-//
-// If more than one update is made in the same period, incremental
-// version numbers are used successively.
-//
-// A user looking up a resource would only need to know the rootAddr in order to get the versions
-//
-// the resource update data is:
-// resourcedata = headerlength|period|version|rootAddr|flags|metaHash
-// where flags is a 1-byte flags field. Flag 0 is set to 1 to indicate multihash
-//
-// the full update data that goes in the chunk payload is:
-// resourcedata|sign(resourcedata)
-//
-// headerlength is a 16 bit value containing the byte length of period|version|rootAddr|flags|metaHash
+/*
+Package mru defines Mutable resource updates.
+
+A Mutable Resource is an entity which allows updates to a resource
+without resorting to ENS on each update.
+The update scheme is built on swarm chunks with chunk keys following
+a predictable, versionable pattern.
+
+Updates are defined to be periodic in nature, where the update frequency
+is expressed in seconds.
+
+A Resource is tied to a unique identifier that is deterministically generated out of
+the metadata content that describes it. This metadata includes a user-defined topic, a resource
+start time that indicates when the resource becomes valid, the frequency in seconds with
+which the resource is expected to be updated.
+
+A Resource View is defined as a specific user's point of view about a particular resource.
+Thus, a View is a Resource + the user's addres (userAddr)
+
+The Resource structure tells the requester from when the mutable resource was
+first added (Unix time in seconds) and in which moments to look for the
+actual updates. Thus, a Resource with Topic "føø.bar"
+starting at unix time 1528800000 with frequency 300 (every 5 mins) will have updates on 1528800300,
+1528800600, 1528800900 and so on.
+
+Actual data updates are also made in the form of swarm chunks. The keys
+of the updates are the hash of a concatenation of properties as follows:
+
+updateAddr = H(View, period, version)
+where H is the SHA3 hash function
+The period is (currentTime - startTime) / frequency
+
+Using our previous example, this means that a period 3 will happen when the
+clock hits 1528800900
+
+If more than one update is made in the same period, incremental
+version numbers are used successively.
+
+A user looking up a resource would only need to know the View in order to
+another user's updates
+
+the resource update data is:
+resourcedata = View|period|version|data
+
+the full update data that goes in the chunk payload is:
+resourcedata|sign(resourcedata)
+*/
 package mru

--- a/swarm/storage/mru/doc.go
+++ b/swarm/storage/mru/doc.go
@@ -44,5 +44,20 @@ resourcedata = View|period|version|data
 
 the full update data that goes in the chunk payload is:
 resourcedata|sign(resourcedata)
+
+Structure Summary:
+
+Request: Resource update with signature
+	ResourceUpdate: headers + data
+		UpdateHeader: (placeholder, to be deleted)
+			UpdateLookup: Information about how to locate a specific update
+				View: Author of the update and what is updating
+					Resource: Item that the updates are about
+
+LookupParams: Represents a specific resource query instance
+	UpdateLookup
+
+
+
 */
 package mru

--- a/swarm/storage/mru/doc.go
+++ b/swarm/storage/mru/doc.go
@@ -15,7 +15,7 @@ start time that indicates when the resource becomes valid, the frequency in seco
 which the resource is expected to be updated.
 
 A Resource View is defined as a specific user's point of view about a particular resource.
-Thus, a View is a Resource + the user's addres (userAddr)
+Thus, a View is a Resource + the user's address (userAddr)
 
 The Resource structure tells the requester from when the mutable resource was
 first added (Unix time in seconds) and in which moments to look for the

--- a/swarm/storage/mru/handler.go
+++ b/swarm/storage/mru/handler.go
@@ -92,7 +92,7 @@ func (h *Handler) Validate(chunkAddr storage.Address, data []byte) bool {
 	// to update
 
 	// First, deserialize the chunk
-	var r SignedResourceUpdate
+	var r Request
 	if err := r.fromChunk(chunkAddr, data); err != nil {
 		log.Debug("Invalid resource chunk", "addr", chunkAddr.Hex(), "err", err.Error())
 		return false
@@ -287,7 +287,7 @@ func (h *Handler) lookup(params *LookupParams) (*cacheEntry, error) {
 func (h *Handler) updateCache(view *View, chunk *storage.Chunk) (*cacheEntry, error) {
 
 	// retrieve metadata from chunk data and check that it matches this mutable resource
-	var r SignedResourceUpdate
+	var r Request
 	if err := r.fromChunk(chunk.Addr, chunk.SData); err != nil {
 		return nil, err
 	}
@@ -312,12 +312,12 @@ func (h *Handler) updateCache(view *View, chunk *storage.Chunk) (*cacheEntry, er
 // Note that a Mutable Resource update cannot span chunks, and thus has a MAX NET LENGTH 4096, INCLUDING update header data and signature. An error will be returned if the total length of the chunk payload will exceed this limit.
 // Update can only check if the caller is trying to overwrite the very last known version, otherwise it just puts the update
 // on the network.
-func (h *Handler) Update(ctx context.Context, r *SignedResourceUpdate) (storage.Address, error) {
+func (h *Handler) Update(ctx context.Context, r *Request) (storage.Address, error) {
 	return h.update(ctx, r)
 }
 
 // create and commit an update
-func (h *Handler) update(ctx context.Context, r *SignedResourceUpdate) (updateAddr storage.Address, err error) {
+func (h *Handler) update(ctx context.Context, r *Request) (updateAddr storage.Address, err error) {
 
 	// we can't update anything without a store
 	if h.chunkStore == nil {

--- a/swarm/storage/mru/lookup.go
+++ b/swarm/storage/mru/lookup.go
@@ -34,11 +34,15 @@ type LookupParams struct {
 	Limit uint32
 }
 
+// Values interface represents a string key-value store
+// useful for building query strings
 type Values interface {
 	Get(key string) string
 	Set(key, value string)
 }
 
+// FromValues deserializes this instance from a string key-value store
+// useful to parse query strings
 func (lp *LookupParams) FromValues(values Values, parseView bool) error {
 	limit, _ := strconv.ParseUint(values.Get("limit"), 10, 32)
 
@@ -46,6 +50,8 @@ func (lp *LookupParams) FromValues(values Values, parseView bool) error {
 	return lp.UpdateLookup.FromValues(values, parseView)
 }
 
+// ToValues serializes this structure into the provided string key-value store
+// useful to build query strings
 func (lp *LookupParams) ToValues(values url.Values) {
 	if lp.Limit != 0 {
 		values.Set("limit", fmt.Sprintf("%d", lp.Version))
@@ -53,6 +59,10 @@ func (lp *LookupParams) ToValues(values url.Values) {
 	lp.UpdateLookup.ToValues(values)
 }
 
+// NewLookupParams constructs a LookupParams structure with the provided lookup parameters
+// if period = 0 and version = 0, the last resource version will be looked up
+// if period !=0 and version = 0, the last version in that period will be looked up
+// if both period, version !=0, that specific period, version will be looked up
 func NewLookupParams(view *View, period, version uint32, limit uint32) *LookupParams {
 	return &LookupParams{
 		UpdateLookup: UpdateLookup{
@@ -150,6 +160,8 @@ func (u *UpdateLookup) binaryGet(serializedData []byte) error {
 	return nil
 }
 
+// FromValues deserializes this instance from a string key-value store
+// useful to parse query strings
 func (u *UpdateLookup) FromValues(values Values, parseView bool) error {
 	version, _ := strconv.ParseUint(values.Get("version"), 10, 32)
 	period, _ := strconv.ParseUint(values.Get("period"), 10, 32)
@@ -165,6 +177,8 @@ func (u *UpdateLookup) FromValues(values Values, parseView bool) error {
 	return nil
 }
 
+// ToValues serializes this structure into the provided string key-value store
+// useful to build query strings
 func (u *UpdateLookup) ToValues(values Values) {
 	if u.Period != 0 {
 		values.Set("period", fmt.Sprintf("%d", u.Period))

--- a/swarm/storage/mru/lookup.go
+++ b/swarm/storage/mru/lookup.go
@@ -39,11 +39,6 @@ type Values interface {
 	Set(key, value string)
 }
 
-// RootAddr returns the metadata chunk address
-func (lp *LookupParams) View() *View {
-	return &lp.view
-}
-
 func (lp *LookupParams) FromValues(values Values, parseView bool) error {
 	limit, _ := strconv.ParseUint(values.Get("limit"), 10, 32)
 
@@ -53,7 +48,7 @@ func (lp *LookupParams) FromValues(values Values, parseView bool) error {
 
 func (lp *LookupParams) ToValues(values url.Values) {
 	if lp.Limit != 0 {
-		values.Set("limit", fmt.Sprintf("%d", lp.version))
+		values.Set("limit", fmt.Sprintf("%d", lp.Version))
 	}
 	lp.UpdateLookup.ToValues(values)
 }
@@ -61,9 +56,9 @@ func (lp *LookupParams) ToValues(values url.Values) {
 func NewLookupParams(view *View, period, version uint32, limit uint32) *LookupParams {
 	return &LookupParams{
 		UpdateLookup: UpdateLookup{
-			period:  period,
-			version: version,
-			view:    *view,
+			Period:  period,
+			Version: version,
+			View:    *view,
 		},
 		Limit: limit,
 	}
@@ -86,9 +81,9 @@ func LookupVersion(view *View, period, version uint32) *LookupParams {
 
 // UpdateLookup represents the components of a resource update search key
 type UpdateLookup struct {
-	view    View
-	period  uint32
-	version uint32
+	View
+	Period  uint32
+	Version uint32
 }
 
 // UpdateLookup layout:
@@ -115,15 +110,15 @@ func (u *UpdateLookup) binaryPut(serializedData []byte) error {
 		return NewErrorf(ErrInvalidValue, "Incorrect slice size to serialize UpdateLookup. Expected %d, got %d", updateLookupLength, len(serializedData))
 	}
 	var cursor int
-	if err := u.view.binaryPut(serializedData[cursor : cursor+viewLength]); err != nil {
+	if err := u.View.binaryPut(serializedData[cursor : cursor+viewLength]); err != nil {
 		return err
 	}
 	cursor += viewLength
 
-	binary.LittleEndian.PutUint32(serializedData[cursor:cursor+4], u.period)
+	binary.LittleEndian.PutUint32(serializedData[cursor:cursor+4], u.Period)
 	cursor += 4
 
-	binary.LittleEndian.PutUint32(serializedData[cursor:cursor+4], u.version)
+	binary.LittleEndian.PutUint32(serializedData[cursor:cursor+4], u.Version)
 	cursor += 4
 
 	return nil
@@ -141,15 +136,15 @@ func (u *UpdateLookup) binaryGet(serializedData []byte) error {
 	}
 
 	var cursor int
-	if err := u.view.binaryGet(serializedData[cursor : cursor+viewLength]); err != nil {
+	if err := u.View.binaryGet(serializedData[cursor : cursor+viewLength]); err != nil {
 		return err
 	}
 	cursor += viewLength
 
-	u.period = binary.LittleEndian.Uint32(serializedData[cursor : cursor+4])
+	u.Period = binary.LittleEndian.Uint32(serializedData[cursor : cursor+4])
 	cursor += 4
 
-	u.version = binary.LittleEndian.Uint32(serializedData[cursor : cursor+4])
+	u.Version = binary.LittleEndian.Uint32(serializedData[cursor : cursor+4])
 	cursor += 4
 
 	return nil
@@ -162,20 +157,20 @@ func (u *UpdateLookup) FromValues(values Values, parseView bool) error {
 	if period == 0 && version != 0 {
 		return NewError(ErrInvalidValue, "cannot have version !=0 if period is 0")
 	}
-	u.version = uint32(version)
-	u.period = uint32(period)
+	u.Version = uint32(version)
+	u.Period = uint32(period)
 	if parseView {
-		return u.view.FromValues(values)
+		return u.View.FromValues(values)
 	}
 	return nil
 }
 
 func (u *UpdateLookup) ToValues(values Values) {
-	if u.period != 0 {
-		values.Set("period", fmt.Sprintf("%d", u.period))
+	if u.Period != 0 {
+		values.Set("period", fmt.Sprintf("%d", u.Period))
 	}
-	if u.version != 0 {
-		values.Set("version", fmt.Sprintf("%d", u.version))
+	if u.Version != 0 {
+		values.Set("version", fmt.Sprintf("%d", u.Version))
 	}
-	u.view.ToValues(values)
+	u.View.ToValues(values)
 }

--- a/swarm/storage/mru/lookup_test.go
+++ b/swarm/storage/mru/lookup_test.go
@@ -6,9 +6,9 @@ import (
 
 func getTestUpdateLookup() *UpdateLookup {
 	return &UpdateLookup{
-		view:    *getTestResourceView(),
-		period:  79,
-		version: 2010,
+		View:    *getTestResourceView(),
+		Period:  79,
+		Version: 2010,
 	}
 }
 

--- a/swarm/storage/mru/lookup_test.go
+++ b/swarm/storage/mru/lookup_test.go
@@ -6,7 +6,7 @@ import (
 
 func getTestUpdateLookup() *UpdateLookup {
 	return &UpdateLookup{
-		viewID:  *getTestResourceViewID(),
+		view:    *getTestResourceView(),
 		period:  79,
 		version: 2010,
 	}

--- a/swarm/storage/mru/request.go
+++ b/swarm/storage/mru/request.go
@@ -23,6 +23,8 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
+//TODO AFTER PR REVIEW: Merge this file with signedupdate.go
+
 // updateRequestJSON represents a JSON-serialized UpdateRequest
 type updateRequestJSON struct {
 	View      *View  `json:"view"`
@@ -71,6 +73,7 @@ func (r *Request) SetData(data []byte) {
 	r.Signature = nil
 }
 
+// IsUpdate returns true if this request models a signed update or otherwise it is a signature request
 func (r *Request) IsUpdate() bool {
 	return r.Signature != nil
 }

--- a/swarm/storage/mru/request.go
+++ b/swarm/storage/mru/request.go
@@ -156,6 +156,14 @@ func (r *Request) fromJSON(j *updateRequestJSON) error {
 	return nil
 }
 
+func (r *Request) FromValues(values Values, data []byte, parseView bool) error {
+	return r.SignedResourceUpdate.FromValues(values, data, parseView)
+}
+
+func (r *Request) ToValues(values Values) []byte {
+	return r.SignedResourceUpdate.ToValues(values)
+}
+
 func decodeHexArray(dst []byte, src, name string) error {
 	bytes, err := decodeHexSlice(src, len(dst), name)
 	if err != nil {

--- a/swarm/storage/mru/request.go
+++ b/swarm/storage/mru/request.go
@@ -32,11 +32,6 @@ type updateRequestJSON struct {
 	Signature string `json:"signature,omitempty"`
 }
 
-// Request represents an update and/or resource create message
-type Request struct {
-	SignedResourceUpdate
-}
-
 var zeroAddr = common.Address{}
 
 // NewCreateUpdateRequest returns a ready to sign request to create and initialize a resource with data
@@ -68,14 +63,6 @@ func NewCreateRequest(metadata *Resource, userAddr common.Address) (request *Req
 	request.View.Resource = *metadata
 	request.View.User = userAddr
 	return request, nil
-}
-
-// Sign executes the signature to validate the resource and sets the owner address field
-func (r *Request) Sign(signer Signer) error {
-	if err := r.SignedResourceUpdate.Sign(signer); err != nil {
-		return err
-	}
-	return nil
 }
 
 // SetData stores the payload data the resource will be updated with
@@ -113,14 +100,6 @@ func (r *Request) fromJSON(j *updateRequestJSON) error {
 		copy(r.Signature[:], sigBytes)
 	}
 	return nil
-}
-
-func (r *Request) FromValues(values Values, data []byte, parseView bool) error {
-	return r.SignedResourceUpdate.FromValues(values, data, parseView)
-}
-
-func (r *Request) ToValues(values Values) []byte {
-	return r.SignedResourceUpdate.ToValues(values)
 }
 
 func decodeHexArray(dst []byte, src, name string) error {

--- a/swarm/storage/mru/request_test.go
+++ b/swarm/storage/mru/request_test.go
@@ -70,17 +70,15 @@ func TestEncodingDecodingUpdateRequests(t *testing.T) {
 	//Put together an unsigned update request that we will serialize to send it to the signer.
 	data := []byte("This hour's update: Swarm 99.0 has been released!")
 	request := &Request{
-		SignedResourceUpdate: SignedResourceUpdate{
-			ResourceUpdate: ResourceUpdate{
-				UpdateHeader: UpdateHeader{
-					UpdateLookup: UpdateLookup{
-						Period:  7,
-						Version: 1,
-						View:    createRequest.ResourceUpdate.View,
-					},
+		ResourceUpdate: ResourceUpdate{
+			UpdateHeader: UpdateHeader{
+				UpdateLookup: UpdateLookup{
+					Period:  7,
+					Version: 1,
+					View:    createRequest.ResourceUpdate.View,
 				},
-				data: data,
 			},
+			data: data,
 		},
 	}
 

--- a/swarm/storage/mru/request_test.go
+++ b/swarm/storage/mru/request_test.go
@@ -71,12 +71,12 @@ func TestEncodingDecodingUpdateRequests(t *testing.T) {
 	data := []byte("This hour's update: Swarm 99.0 has been released!")
 	request := &Request{
 		SignedResourceUpdate: SignedResourceUpdate{
-			resourceUpdate: resourceUpdate{
-				updateHeader: updateHeader{
+			ResourceUpdate: ResourceUpdate{
+				UpdateHeader: UpdateHeader{
 					UpdateLookup: UpdateLookup{
-						period:  7,
-						version: 1,
-						view:    createRequest.resourceUpdate.view,
+						Period:  7,
+						Version: 1,
+						View:    createRequest.ResourceUpdate.View,
 					},
 				},
 				data: data,
@@ -110,7 +110,7 @@ func TestEncodingDecodingUpdateRequests(t *testing.T) {
 		t.Fatalf("Error signing request: %s", err)
 	}
 
-	compareByteSliceToExpectedHex(t, "signature", recoveredRequest.signature[:], expectedSignature)
+	compareByteSliceToExpectedHex(t, "signature", recoveredRequest.Signature[:], expectedSignature)
 
 	// mess with the signature and see what happens. To alter the signature, we briefly decode it as JSON
 	// to alter the signature field.
@@ -145,14 +145,14 @@ func TestEncodingDecodingUpdateRequests(t *testing.T) {
 
 	// Before checking what happened with Bob's update, let's see what would happen if we mess
 	// with the signature big time to see if Verify catches it
-	savedSignature := *recoveredRequest.signature                               // save the signature for later
-	binary.LittleEndian.PutUint64(recoveredRequest.signature[5:], 556845463424) // write some random data to break the signature
+	savedSignature := *recoveredRequest.Signature                               // save the signature for later
+	binary.LittleEndian.PutUint64(recoveredRequest.Signature[5:], 556845463424) // write some random data to break the signature
 	if err = recoveredRequest.Verify(); err == nil {
 		t.Fatal("Expected Verify to fail on corrupt signature")
 	}
 
 	// restore the Bob's signature from corruption
-	*recoveredRequest.signature = savedSignature
+	*recoveredRequest.Signature = savedSignature
 
 	// Now the signature is not corrupt
 	if err = recoveredRequest.Verify(); err != nil {
@@ -170,7 +170,7 @@ func TestEncodingDecodingUpdateRequests(t *testing.T) {
 	}
 
 	// mess with the lookup key to make sure Verify fails:
-	recoveredRequest.version = 999
+	recoveredRequest.Version = 999
 	if err = recoveredRequest.Verify(); err == nil {
 		t.Fatalf("Expected Verify to fail since the lookup key has been altered")
 	}

--- a/swarm/storage/mru/request_test.go
+++ b/swarm/storage/mru/request_test.go
@@ -33,7 +33,7 @@ func TestEncodingDecodingUpdateRequests(t *testing.T) {
 	bob := newBobSigner()         //Bob
 
 	// Create a resource to our good guy Charlie's name
-	createRequest, err := NewCreateRequest(&ResourceID{
+	createRequest, err := NewCreateRequest(&Resource{
 		Topic:     NewTopic("a good resource name", nil),
 		Frequency: 300,
 		StartTime: Timestamp{Time: 1528900000},
@@ -65,7 +65,7 @@ func TestEncodingDecodingUpdateRequests(t *testing.T) {
 	// proof of ownership
 
 	const expectedSignature = "0x4d1a7790f06379a3f9ccc1c3952017ebb9aba1aee4b4b767806598663d9472c743f97dc1eaa4aab4ed5db8784346ff681e379160175aebdbc4812167f93a8ec600"
-	const expectedJSON = `{"viewId":{"resourceId":{"startTime":{"time":1528900000},"frequency":300,"topic":"0x6120676f6f64207265736f75726365206e616d65000000000000000000000000"},"ownerAddr":"0x876a8936a7cd0b79ef0735ad0896c1afe278781c"},"version":1,"period":7,"data":"0x5468697320686f75722773207570646174653a20537761726d2039392e3020686173206265656e2072656c656173656421"}`
+	const expectedJSON = `{"view":{"resource":{"startTime":1528900000,"frequency":300,"topic":"0x6120676f6f64207265736f75726365206e616d65000000000000000000000000"},"user":"0x876a8936a7cd0b79ef0735ad0896c1afe278781c"},"version":1,"period":7,"data":"0x5468697320686f75722773207570646174653a20537761726d2039392e3020686173206265656e2072656c656173656421"}`
 
 	//Put together an unsigned update request that we will serialize to send it to the signer.
 	data := []byte("This hour's update: Swarm 99.0 has been released!")
@@ -76,7 +76,7 @@ func TestEncodingDecodingUpdateRequests(t *testing.T) {
 					UpdateLookup: UpdateLookup{
 						period:  7,
 						version: 1,
-						viewID:  createRequest.resourceUpdate.viewID,
+						view:    createRequest.resourceUpdate.view,
 					},
 				},
 				data: data,

--- a/swarm/storage/mru/resource.go
+++ b/swarm/storage/mru/resource.go
@@ -32,19 +32,19 @@ const (
 
 // cacheEntry caches resource data and the metadata of its root chunk.
 type cacheEntry struct {
-	resourceUpdate
+	ResourceUpdate
 	*bytes.Reader
 	lastKey storage.Address
 }
 
 // implements storage.LazySectionReader
 func (r *cacheEntry) Size(ctx context.Context, _ chan bool) (int64, error) {
-	return int64(len(r.resourceUpdate.data)), nil
+	return int64(len(r.ResourceUpdate.data)), nil
 }
 
 //returns the resource's topic
 func (r *cacheEntry) Topic() Topic {
-	return r.view.Topic
+	return r.View.Topic
 }
 
 // Helper function to calculate the next update period number from the current time, start time and frequency

--- a/swarm/storage/mru/resource.go
+++ b/swarm/storage/mru/resource.go
@@ -30,21 +30,21 @@ const (
 	defaultRetrieveTimeout = 100 * time.Millisecond
 )
 
-// resource caches resource data and the metadata of its root chunk.
-type resource struct {
+// cacheEntry caches resource data and the metadata of its root chunk.
+type cacheEntry struct {
 	resourceUpdate
 	*bytes.Reader
 	lastKey storage.Address
 }
 
 // implements storage.LazySectionReader
-func (r *resource) Size(ctx context.Context, _ chan bool) (int64, error) {
+func (r *cacheEntry) Size(ctx context.Context, _ chan bool) (int64, error) {
 	return int64(len(r.resourceUpdate.data)), nil
 }
 
 //returns the resource's topic
-func (r *resource) Topic() Topic {
-	return r.viewID.resourceID.Topic
+func (r *cacheEntry) Topic() Topic {
+	return r.view.Topic
 }
 
 // Helper function to calculate the next update period number from the current time, start time and frequency

--- a/swarm/storage/mru/resource_sign.go
+++ b/swarm/storage/mru/resource_sign.go
@@ -60,7 +60,7 @@ func (s *GenericSigner) Sign(data common.Hash) (signature Signature, err error) 
 	return
 }
 
-// PublicKey returns the public key of the signer's private key
+// Address returns the public key of the signer's private key
 func (s *GenericSigner) Address() common.Address {
 	return s.address
 }

--- a/swarm/storage/mru/resource_test.go
+++ b/swarm/storage/mru/resource_test.go
@@ -119,7 +119,7 @@ func TestResourceHandler(t *testing.T) {
 	if err := request.Sign(signer); err != nil {
 		t.Fatal(err)
 	}
-	resourcekey[updates[0]], err = rh.Update(ctx, &request.SignedResourceUpdate)
+	resourcekey[updates[0]], err = rh.Update(ctx, request)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -139,7 +139,7 @@ func TestResourceHandler(t *testing.T) {
 	if err := request.Sign(signer); err != nil {
 		t.Fatal(err)
 	}
-	resourcekey[updates[1]], err = rh.Update(ctx, &request.SignedResourceUpdate)
+	resourcekey[updates[1]], err = rh.Update(ctx, request)
 	if err == nil {
 		t.Fatal("Expected update to fail since this version already exists")
 	}
@@ -154,7 +154,7 @@ func TestResourceHandler(t *testing.T) {
 	if err := request.Sign(signer); err != nil {
 		t.Fatal(err)
 	}
-	resourcekey[updates[1]], err = rh.Update(ctx, &request.SignedResourceUpdate)
+	resourcekey[updates[1]], err = rh.Update(ctx, request)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -170,7 +170,7 @@ func TestResourceHandler(t *testing.T) {
 	if err := request.Sign(signer); err != nil {
 		t.Fatal(err)
 	}
-	resourcekey[updates[2]], err = rh.Update(ctx, &request.SignedResourceUpdate)
+	resourcekey[updates[2]], err = rh.Update(ctx, request)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -190,7 +190,7 @@ func TestResourceHandler(t *testing.T) {
 	if err := request.Sign(signer); err != nil {
 		t.Fatal(err)
 	}
-	resourcekey[updates[3]], err = rh.Update(ctx, &request.SignedResourceUpdate)
+	resourcekey[updates[3]], err = rh.Update(ctx, request)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -308,7 +308,7 @@ func TestValidator(t *testing.T) {
 		t.Fatalf("sign fail: %v", err)
 	}
 
-	chunk, err := mr.SignedResourceUpdate.toChunk()
+	chunk, err := mr.toChunk()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -383,7 +383,7 @@ func TestValidatorInStore(t *testing.T) {
 	updateAddr := updateLookup.UpdateAddr()
 	data := []byte("bar")
 
-	r := new(SignedResourceUpdate)
+	r := new(Request)
 	r.updateAddr = updateAddr
 	r.ResourceUpdate.UpdateLookup = updateLookup
 	r.data = data
@@ -466,7 +466,7 @@ func getUpdateDirect(rh *Handler, addr storage.Address) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	var r SignedResourceUpdate
+	var r Request
 	if err := r.fromChunk(addr, chunk.SData); err != nil {
 		return nil, err
 	}

--- a/swarm/storage/mru/resource_test.go
+++ b/swarm/storage/mru/resource_test.go
@@ -33,9 +33,8 @@ import (
 )
 
 var (
-	loglevel   = flag.Int("loglevel", 3, "loglevel")
-	testHasher = storage.MakeHashFunc(resourceHashAlgorithm)()
-	startTime  = Timestamp{
+	loglevel  = flag.Int("loglevel", 3, "loglevel")
+	startTime = Timestamp{
 		Time: uint64(4200),
 	}
 	resourceFrequency = uint64(42)

--- a/swarm/storage/mru/resource_test.go
+++ b/swarm/storage/mru/resource_test.go
@@ -85,16 +85,16 @@ func TestResourceHandler(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	viewID := ResourceViewID{
-		resourceID: ResourceID{
+	view := View{
+		Resource: Resource{
 			Topic:     NewTopic("Mess with mru code and see what ghost catches you", nil),
 			StartTime: startTime,
 			Frequency: resourceFrequency,
 		},
-		ownerAddr: signer.Address(),
+		User: signer.Address(),
 	}
 
-	request, err := NewCreateUpdateRequest(&viewID.resourceID)
+	request, err := NewCreateUpdateRequest(&view.Resource)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,7 +125,7 @@ func TestResourceHandler(t *testing.T) {
 	}
 
 	// update on first period with version = 1 to make it fail since there is already one update with version=1
-	request, err = rh.NewUpdateRequest(ctx, &request.viewID)
+	request, err = rh.NewUpdateRequest(ctx, &request.view)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -146,7 +146,7 @@ func TestResourceHandler(t *testing.T) {
 
 	// update on second period with version = 1, correct. period=2, version=1
 	fwdClock(int(resourceFrequency/2), timeProvider)
-	request, err = rh.NewUpdateRequest(ctx, &request.viewID)
+	request, err = rh.NewUpdateRequest(ctx, &request.view)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +161,7 @@ func TestResourceHandler(t *testing.T) {
 
 	fwdClock(int(resourceFrequency), timeProvider)
 	// Update on third period, with version = 1
-	request, err = rh.NewUpdateRequest(ctx, &request.viewID)
+	request, err = rh.NewUpdateRequest(ctx, &request.view)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -177,7 +177,7 @@ func TestResourceHandler(t *testing.T) {
 
 	// update just after third period
 	fwdClock(1, timeProvider)
-	request, err = rh.NewUpdateRequest(ctx, &request.viewID)
+	request, err = rh.NewUpdateRequest(ctx, &request.view)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -209,7 +209,7 @@ func TestResourceHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rsrc2, err := rh2.Lookup(ctx, LookupLatest(&request.viewID))
+	rsrc2, err := rh2.Lookup(ctx, LookupLatest(&request.view))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -227,7 +227,7 @@ func TestResourceHandler(t *testing.T) {
 	log.Debug("Latest lookup", "period", rsrc2.period, "version", rsrc2.version, "data", rsrc2.data)
 
 	// specific period, latest version
-	rsrc, err := rh2.Lookup(ctx, LookupLatestVersionInPeriod(&request.viewID, 3))
+	rsrc, err := rh2.Lookup(ctx, LookupLatestVersionInPeriod(&request.view, 3))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -238,7 +238,7 @@ func TestResourceHandler(t *testing.T) {
 	log.Debug("Historical lookup", "period", rsrc2.period, "version", rsrc2.version, "data", rsrc2.data)
 
 	// specific period, specific version
-	lookupParams := LookupVersion(&request.viewID, 3, 1)
+	lookupParams := LookupVersion(&request.view, 3, 1)
 	rsrc, err = rh2.Lookup(ctx, lookupParams)
 	if err != nil {
 		t.Fatal(err)
@@ -288,15 +288,15 @@ func TestValidator(t *testing.T) {
 	defer teardownTest()
 
 	// create new resource
-	viewID := ResourceViewID{
-		resourceID: ResourceID{
+	view := View{
+		Resource: Resource{
 			Topic:     NewTopic(resourceName, nil),
 			StartTime: timeProvider.Now(),
 			Frequency: resourceFrequency,
 		},
-		ownerAddr: signer.Address(),
+		User: signer.Address(),
 	}
-	mr, err := NewCreateUpdateRequest(&viewID.resourceID)
+	mr, err := NewCreateUpdateRequest(&view.Resource)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -364,20 +364,20 @@ func TestValidatorInStore(t *testing.T) {
 	badChunk := chunks[1]
 	badChunk.SData = goodChunk.SData
 
-	viewID := ResourceViewID{
-		resourceID: ResourceID{
+	view := View{
+		Resource: Resource{
 			Topic:     NewTopic("xyzzy", nil),
 			StartTime: startTime,
 			Frequency: resourceFrequency,
 		},
-		ownerAddr: signer.Address(),
+		User: signer.Address(),
 	}
 
 	// create a resource update chunk with correct publickey
 	updateLookup := UpdateLookup{
 		period:  42,
 		version: 1,
-		viewID:  viewID,
+		view:    view,
 	}
 
 	updateAddr := updateLookup.UpdateAddr()

--- a/swarm/storage/mru/resource_test.go
+++ b/swarm/storage/mru/resource_test.go
@@ -125,15 +125,15 @@ func TestResourceHandler(t *testing.T) {
 	}
 
 	// update on first period with version = 1 to make it fail since there is already one update with version=1
-	request, err = rh.NewUpdateRequest(ctx, &request.view)
+	request, err = rh.NewUpdateRequest(ctx, &request.View)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if request.version != 2 || request.period != 1 {
+	if request.Version != 2 || request.Period != 1 {
 		t.Fatal("Suggested period should be 1 and version should be 2")
 	}
 
-	request.version = 1 // force version 1 instead of 2 to make it fail
+	request.Version = 1 // force version 1 instead of 2 to make it fail
 	data = []byte(updates[1])
 	request.SetData(data)
 	if err := request.Sign(signer); err != nil {
@@ -146,7 +146,7 @@ func TestResourceHandler(t *testing.T) {
 
 	// update on second period with version = 1, correct. period=2, version=1
 	fwdClock(int(resourceFrequency/2), timeProvider)
-	request, err = rh.NewUpdateRequest(ctx, &request.view)
+	request, err = rh.NewUpdateRequest(ctx, &request.View)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +161,7 @@ func TestResourceHandler(t *testing.T) {
 
 	fwdClock(int(resourceFrequency), timeProvider)
 	// Update on third period, with version = 1
-	request, err = rh.NewUpdateRequest(ctx, &request.view)
+	request, err = rh.NewUpdateRequest(ctx, &request.View)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -177,11 +177,11 @@ func TestResourceHandler(t *testing.T) {
 
 	// update just after third period
 	fwdClock(1, timeProvider)
-	request, err = rh.NewUpdateRequest(ctx, &request.view)
+	request, err = rh.NewUpdateRequest(ctx, &request.View)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if request.period != 3 || request.version != 2 {
+	if request.Period != 3 || request.Version != 2 {
 		t.Fatal("Suggested period should be 3 and version should be 2")
 	}
 	data = []byte(updates[3])
@@ -209,7 +209,7 @@ func TestResourceHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rsrc2, err := rh2.Lookup(ctx, LookupLatest(&request.view))
+	rsrc2, err := rh2.Lookup(ctx, LookupLatest(&request.View))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,16 +218,16 @@ func TestResourceHandler(t *testing.T) {
 	if !bytes.Equal(rsrc2.data, []byte(updates[len(updates)-1])) {
 		t.Fatalf("resource data was %v, expected %v", string(rsrc2.data), updates[len(updates)-1])
 	}
-	if rsrc2.version != 2 {
-		t.Fatalf("resource version was %d, expected 2", rsrc2.version)
+	if rsrc2.Version != 2 {
+		t.Fatalf("resource version was %d, expected 2", rsrc2.Version)
 	}
-	if rsrc2.period != 3 {
-		t.Fatalf("resource period was %d, expected 3", rsrc2.period)
+	if rsrc2.Period != 3 {
+		t.Fatalf("resource period was %d, expected 3", rsrc2.Period)
 	}
-	log.Debug("Latest lookup", "period", rsrc2.period, "version", rsrc2.version, "data", rsrc2.data)
+	log.Debug("Latest lookup", "period", rsrc2.Period, "version", rsrc2.Version, "data", rsrc2.data)
 
 	// specific period, latest version
-	rsrc, err := rh2.Lookup(ctx, LookupLatestVersionInPeriod(&request.view, 3))
+	rsrc, err := rh2.Lookup(ctx, LookupLatestVersionInPeriod(&request.View, 3))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -235,10 +235,10 @@ func TestResourceHandler(t *testing.T) {
 	if !bytes.Equal(rsrc.data, []byte(updates[len(updates)-1])) {
 		t.Fatalf("resource data (historical) was %v, expected %v", string(rsrc2.data), updates[len(updates)-1])
 	}
-	log.Debug("Historical lookup", "period", rsrc2.period, "version", rsrc2.version, "data", rsrc2.data)
+	log.Debug("Historical lookup", "period", rsrc2.Period, "version", rsrc2.Version, "data", rsrc2.data)
 
 	// specific period, specific version
-	lookupParams := LookupVersion(&request.view, 3, 1)
+	lookupParams := LookupVersion(&request.View, 3, 1)
 	rsrc, err = rh2.Lookup(ctx, lookupParams)
 	if err != nil {
 		t.Fatal(err)
@@ -247,7 +247,7 @@ func TestResourceHandler(t *testing.T) {
 	if !bytes.Equal(rsrc.data, []byte(updates[2])) {
 		t.Fatalf("resource data (historical) was %v, expected %v", string(rsrc2.data), updates[2])
 	}
-	log.Debug("Specific version lookup", "period", rsrc2.period, "version", rsrc2.version, "data", rsrc2.data)
+	log.Debug("Specific version lookup", "period", rsrc2.Period, "version", rsrc2.Version, "data", rsrc2.data)
 
 	// we are now at third update
 	// check backwards stepping to the first
@@ -265,7 +265,7 @@ func TestResourceHandler(t *testing.T) {
 	// beyond the first should yield an error
 	rsrc, err = rh2.LookupPrevious(ctx, lookupParams)
 	if err == nil {
-		t.Fatalf("expected previous to fail, returned period %d version %d data %v", rsrc.period, rsrc.version, rsrc.data)
+		t.Fatalf("expected previous to fail, returned period %d version %d data %v", rsrc.Period, rsrc.Version, rsrc.data)
 	}
 
 }
@@ -375,9 +375,9 @@ func TestValidatorInStore(t *testing.T) {
 
 	// create a resource update chunk with correct publickey
 	updateLookup := UpdateLookup{
-		period:  42,
-		version: 1,
-		view:    view,
+		Period:  42,
+		Version: 1,
+		View:    view,
 	}
 
 	updateAddr := updateLookup.UpdateAddr()
@@ -385,7 +385,7 @@ func TestValidatorInStore(t *testing.T) {
 
 	r := new(SignedResourceUpdate)
 	r.updateAddr = updateAddr
-	r.resourceUpdate.UpdateLookup = updateLookup
+	r.ResourceUpdate.UpdateLookup = updateLookup
 	r.data = data
 
 	r.Sign(signer)

--- a/swarm/storage/mru/resourceid.go
+++ b/swarm/storage/mru/resourceid.go
@@ -20,8 +20,8 @@ import (
 	"encoding/binary"
 )
 
-// ResourceID encapsulates the immutable information about a mutable resource :)
-type ResourceID struct {
+// Resource encapsulates the immutable information about a mutable resource :)
+type Resource struct {
 	StartTime Timestamp `json:"startTime"` // time at which the resource starts to be valid
 	Frequency uint64    `json:"frequency"` // expected update frequency for the resource
 	Topic     Topic     `json:"topic"`     // resource topic, for the reference of the user, to disambiguate resources with same starttime, frequency or to reference another hash
@@ -34,12 +34,12 @@ const nameLengthLength = 1
 // StartTime Timestamp: timestampLength bytes
 // frequency: frequencyLength bytes
 // TopicLength: topicLength bytes
-const ResourceIDLength = timestampLength + frequencyLength + topicLength
+const ResourceLength = timestampLength + frequencyLength + topicLength
 
 // binaryGet populates the resource metadata from a byte array
-func (r *ResourceID) binaryGet(serializedData []byte) error {
-	if len(serializedData) != ResourceIDLength {
-		return NewErrorf(ErrInvalidValue, "ResourceID to deserialize has an invalid length. Expected it to be exactly %d. Got %d.", ResourceIDLength, len(serializedData))
+func (r *Resource) binaryGet(serializedData []byte) error {
+	if len(serializedData) != ResourceLength {
+		return NewErrorf(ErrInvalidValue, "Resource to deserialize has an invalid length. Expected it to be exactly %d. Got %d.", ResourceLength, len(serializedData))
 	}
 
 	var cursor int
@@ -57,9 +57,9 @@ func (r *ResourceID) binaryGet(serializedData []byte) error {
 }
 
 // binaryPut encodes the metadata into a byte array
-func (r *ResourceID) binaryPut(serializedData []byte) error {
-	if len(serializedData) != ResourceIDLength {
-		return NewErrorf(ErrInvalidValue, "ResourceID to serialize has an invalid length. Expected it to be exactly %d. Got %d.", ResourceIDLength, len(serializedData))
+func (r *Resource) binaryPut(serializedData []byte) error {
+	if len(serializedData) != ResourceLength {
+		return NewErrorf(ErrInvalidValue, "Resource to serialize has an invalid length. Expected it to be exactly %d. Got %d.", ResourceLength, len(serializedData))
 	}
 	var cursor int
 	r.StartTime.binaryPut(serializedData[cursor : cursor+timestampLength])
@@ -74,6 +74,6 @@ func (r *ResourceID) binaryPut(serializedData []byte) error {
 	return nil
 }
 
-func (r *ResourceID) binaryLength() int {
-	return ResourceIDLength
+func (r *Resource) binaryLength() int {
+	return ResourceLength
 }

--- a/swarm/storage/mru/resourceid.go
+++ b/swarm/storage/mru/resourceid.go
@@ -28,13 +28,13 @@ type Resource struct {
 }
 
 const frequencyLength = 8 // sizeof(uint64)
-const nameLengthLength = 1
 
 // ResourceID Layout
 // StartTime Timestamp: timestampLength bytes
 // frequency: frequencyLength bytes
 // TopicLength: topicLength bytes
-const ResourceLength = timestampLength + frequencyLength + topicLength
+// ResourceLength returns the byte length of the Resource structure
+const ResourceLength = timestampLength + frequencyLength + TopicLength
 
 // binaryGet populates the resource metadata from a byte array
 func (r *Resource) binaryGet(serializedData []byte) error {
@@ -51,8 +51,8 @@ func (r *Resource) binaryGet(serializedData []byte) error {
 	r.Frequency = binary.LittleEndian.Uint64(serializedData[cursor : cursor+frequencyLength])
 	cursor += frequencyLength
 
-	copy(r.Topic.content[:], serializedData[cursor:cursor+topicLength])
-	cursor += topicLength
+	copy(r.Topic.content[:], serializedData[cursor:cursor+TopicLength])
+	cursor += TopicLength
 	return nil
 }
 
@@ -68,8 +68,8 @@ func (r *Resource) binaryPut(serializedData []byte) error {
 	binary.LittleEndian.PutUint64(serializedData[cursor:cursor+frequencyLength], r.Frequency)
 	cursor += frequencyLength
 
-	copy(serializedData[cursor:cursor+topicLength], r.Topic.content[:topicLength])
-	cursor += topicLength
+	copy(serializedData[cursor:cursor+TopicLength], r.Topic.content[:TopicLength])
+	cursor += TopicLength
 
 	return nil
 }

--- a/swarm/storage/mru/resourceid_test.go
+++ b/swarm/storage/mru/resourceid_test.go
@@ -19,8 +19,8 @@ import (
 	"testing"
 )
 
-func getTestResourceID() *ResourceID {
-	return &ResourceID{
+func getTestResourceID() *Resource {
+	return &Resource{
 		Topic: NewTopic("world news report, every hour", nil),
 		StartTime: Timestamp{
 			Time: 1528880400,

--- a/swarm/storage/mru/resourceviewid.go
+++ b/swarm/storage/mru/resourceviewid.go
@@ -3,7 +3,6 @@ package mru
 import (
 	"fmt"
 	"hash"
-	"net/url"
 	"strconv"
 	"unsafe"
 
@@ -87,30 +86,27 @@ func (u *View) Hex() string {
 	return hexutil.Encode(serializedData)
 }
 
-func (u *View) FromURL(url *url.URL) error {
-	query := url.Query()
-	startTime, err := strconv.ParseUint(query.Get("starttime"), 10, 64)
+func (u *View) FromValues(values Values) error {
+	startTime, err := strconv.ParseUint(values.Get("starttime"), 10, 64)
 	if err != nil {
 		return err
 	}
-	frequency, err := strconv.ParseUint(query.Get("frequency"), 10, 64)
+	frequency, err := strconv.ParseUint(values.Get("frequency"), 10, 64)
 	if err != nil {
 		return err
 	}
-	if err = u.Topic.FromHex(query.Get("topic")); err != nil {
+	if err = u.Topic.FromHex(values.Get("topic")); err != nil {
 		return err
 	}
-	u.User = common.HexToAddress(query.Get("user"))
+	u.User = common.HexToAddress(values.Get("user"))
 	u.Frequency = frequency
 	u.StartTime.Time = startTime
 	return nil
 }
 
-func (u *View) ToURL(url *url.URL) {
-	query := url.Query()
-	query.Set("starttime", fmt.Sprintf("%d", u.StartTime.Time))
-	query.Set("frequency", fmt.Sprintf("%d", u.Frequency))
-	query.Set("topic", u.Topic.Hex())
-	query.Set("user", u.User.Hex())
-	url.RawQuery = query.Encode()
+func (u *View) ToValues(values Values) {
+	values.Set("starttime", fmt.Sprintf("%d", u.StartTime.Time))
+	values.Set("frequency", fmt.Sprintf("%d", u.Frequency))
+	values.Set("topic", u.Topic.Hex())
+	values.Set("user", u.User.Hex())
 }

--- a/swarm/storage/mru/resourceviewid_test.go
+++ b/swarm/storage/mru/resourceviewid_test.go
@@ -19,15 +19,15 @@ import (
 	"testing"
 )
 
-func getTestResourceViewID() *ResourceViewID {
-	return &ResourceViewID{
-		resourceID: *getTestResourceID(),
-		ownerAddr:  newCharlieSigner().Address(),
+func getTestResourceView() *View {
+	return &View{
+		Resource: *getTestResourceID(),
+		User:     newCharlieSigner().Address(),
 	}
 }
 
-func TestViewIDSerializerDeserializer(t *testing.T) {
-	testBinarySerializerRecovery(t, getTestResourceViewID(), "0x10dd205b00000000100e000000000000776f726c64206e657773207265706f72742c20657665727920686f7572000000876a8936a7cd0b79ef0735ad0896c1afe278781c")
+func TestViewSerializerDeserializer(t *testing.T) {
+	testBinarySerializerRecovery(t, getTestResourceView(), "0x10dd205b00000000100e000000000000776f726c64206e657773207265706f72742c20657665727920686f7572000000876a8936a7cd0b79ef0735ad0896c1afe278781c")
 }
 
 func TestMetadataSerializerLengthCheck(t *testing.T) {

--- a/swarm/storage/mru/signedupdate.go
+++ b/swarm/storage/mru/signedupdate.go
@@ -167,6 +167,8 @@ func (r *Request) GetDigest() (result common.Hash, err error) {
 	return common.BytesToHash(hasher.Sum(nil)), nil
 }
 
+// FromValues deserializes this instance from a string key-value store
+// useful to parse query strings
 func (r *Request) FromValues(values Values, data []byte, parseView bool) error {
 	signatureBytes, err := hexutil.Decode(values.Get("signature"))
 	if err != nil {
@@ -186,8 +188,12 @@ func (r *Request) FromValues(values Values, data []byte, parseView bool) error {
 	return err
 }
 
+// ToValues serializes this structure into the provided string key-value store
+// useful to build query strings
 func (r *Request) ToValues(values Values) []byte {
-	values.Set("signature", hexutil.Encode(r.Signature[:]))
+	if r.Signature != nil {
+		values.Set("signature", hexutil.Encode(r.Signature[:]))
+	}
 	return r.ResourceUpdate.ToValues(values)
 }
 

--- a/swarm/storage/mru/signedupdate.go
+++ b/swarm/storage/mru/signedupdate.go
@@ -169,12 +169,19 @@ func (r *SignedResourceUpdate) FromValues(values Values, data []byte, parseView 
 	signatureBytes, err := hexutil.Decode(values.Get("signature"))
 	if err != nil {
 		r.signature = nil
+	} else {
+		if len(signatureBytes) != signatureLength {
+			return NewError(ErrInvalidSignature, "Incorrect signature length")
+		}
+		r.signature = new(Signature)
+		copy(r.signature[:], signatureBytes)
 	}
-	if len(signatureBytes) != signatureLength {
-		return NewError(ErrInvalidSignature, "Incorrect signature length")
+	err = r.resourceUpdate.FromValues(values, data, parseView)
+	if err != nil {
+		return err
 	}
-	copy(r.signature[:], signatureBytes)
-	return r.resourceUpdate.FromValues(values, data, parseView)
+	r.updateAddr = r.UpdateAddr()
+	return err
 }
 
 func (r *SignedResourceUpdate) ToValues(values Values) []byte {

--- a/swarm/storage/mru/signedupdate_test.go
+++ b/swarm/storage/mru/signedupdate_test.go
@@ -12,7 +12,7 @@ import (
 
 func getTestSignedResourceUpdate() *SignedResourceUpdate {
 	return &SignedResourceUpdate{
-		resourceUpdate: *getTestResourceUpdate(),
+		ResourceUpdate: *getTestResourceUpdate(),
 	}
 }
 
@@ -90,9 +90,9 @@ func TestReverse(t *testing.T) {
 	data := []byte("Donde una puerta se cierra, otra se abre")
 
 	update := new(SignedResourceUpdate)
-	update.view = view
-	update.period = period
-	update.version = version
+	update.View = view
+	update.Period = period
+	update.Version = version
 	update.data = data
 
 	// generate a hash for t=4200 version 1
@@ -116,7 +116,7 @@ func TestReverse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	recoveredaddress, err := getUserAddr(checkdigest, *checkUpdate.signature)
+	recoveredaddress, err := getUserAddr(checkdigest, *checkUpdate.Signature)
 	if err != nil {
 		t.Fatalf("Retrieve address from signature fail: %v", err)
 	}
@@ -130,11 +130,11 @@ func TestReverse(t *testing.T) {
 	if !bytes.Equal(key[:], chunk.Addr[:]) {
 		t.Fatalf("Expected chunk key '%x', was '%x'", key, chunk.Addr)
 	}
-	if period != checkUpdate.period {
-		t.Fatalf("Expected period '%d', was '%d'", period, checkUpdate.period)
+	if period != checkUpdate.Period {
+		t.Fatalf("Expected period '%d', was '%d'", period, checkUpdate.Period)
 	}
-	if version != checkUpdate.version {
-		t.Fatalf("Expected version '%d', was '%d'", version, checkUpdate.version)
+	if version != checkUpdate.Version {
+		t.Fatalf("Expected version '%d', was '%d'", version, checkUpdate.Version)
 	}
 	if !bytes.Equal(data, checkUpdate.data) {
 		t.Fatalf("Expectedn data '%x', was '%x'", data, checkUpdate.data)

--- a/swarm/storage/mru/signedupdate_test.go
+++ b/swarm/storage/mru/signedupdate_test.go
@@ -78,19 +78,19 @@ func TestReverse(t *testing.T) {
 	}
 	defer teardownTest()
 
-	viewID := ResourceViewID{
-		resourceID: ResourceID{
+	view := View{
+		Resource: Resource{
 			Topic:     NewTopic("Cervantes quotes", nil),
 			StartTime: startTime,
 			Frequency: resourceFrequency,
 		},
-		ownerAddr: signer.Address(),
+		User: signer.Address(),
 	}
 
 	data := []byte("Donde una puerta se cierra, otra se abre")
 
 	update := new(SignedResourceUpdate)
-	update.viewID = viewID
+	update.view = view
 	update.period = period
 	update.version = version
 	update.data = data
@@ -116,7 +116,7 @@ func TestReverse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	recoveredaddress, err := getOwner(checkdigest, *checkUpdate.signature)
+	recoveredaddress, err := getUserAddr(checkdigest, *checkUpdate.signature)
 	if err != nil {
 		t.Fatalf("Retrieve address from signature fail: %v", err)
 	}

--- a/swarm/storage/mru/signedupdate_test.go
+++ b/swarm/storage/mru/signedupdate_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/ethereum/go-ethereum/swarm/storage"
 )
 
-func getTestSignedResourceUpdate() *SignedResourceUpdate {
-	return &SignedResourceUpdate{
+func getTestSignedResourceUpdate() *Request {
+	return &Request{
 		ResourceUpdate: *getTestResourceUpdate(),
 	}
 }
@@ -19,7 +19,7 @@ func getTestSignedResourceUpdate() *SignedResourceUpdate {
 func TestUpdateChunkSerializationErrorChecking(t *testing.T) {
 
 	// Test that parseUpdate fails if the chunk is too small
-	var r SignedResourceUpdate
+	var r Request
 	if err := r.fromChunk(storage.ZeroAddr, make([]byte, minimumUpdateDataLength-1)); err == nil {
 		t.Fatalf("Expected parseUpdate to fail when chunkData contains less than %d bytes", minimumUpdateDataLength)
 	}
@@ -48,7 +48,7 @@ func TestUpdateChunkSerializationErrorChecking(t *testing.T) {
 
 	compareByteSliceToExpectedHex(t, "chunk", chunk.SData, "0x10dd205b00000000100e000000000000776f726c64206e657773207265706f72742c20657665727920686f7572000000876a8936a7cd0b79ef0735ad0896c1afe278781c4f000000da070000416c206269656e206861636572206a616dc3a173206c652066616c7461207072656d696f5214c16d60870afb21c679a6020d764c7bb0e7bd8a66cfa7d0aa06e9fbf9c6d0666b013ca47f7a9c44d8d54a14193ba3514a0e1f56234a0618e03f0a836801e100")
 
-	var recovered SignedResourceUpdate
+	var recovered Request
 	l := len(chunk.SData)
 	fmt.Println(l)
 	recovered.fromChunk(chunk.Addr, chunk.SData)
@@ -89,7 +89,7 @@ func TestReverse(t *testing.T) {
 
 	data := []byte("Donde una puerta se cierra, otra se abre")
 
-	update := new(SignedResourceUpdate)
+	update := new(Request)
 	update.View = view
 	update.Period = period
 	update.Version = version
@@ -108,7 +108,7 @@ func TestReverse(t *testing.T) {
 	}
 
 	// check that we can recover the owner account from the update chunk's signature
-	var checkUpdate SignedResourceUpdate
+	var checkUpdate Request
 	if err := checkUpdate.fromChunk(chunk.Addr, chunk.SData); err != nil {
 		t.Fatal(err)
 	}

--- a/swarm/storage/mru/timestampprovider.go
+++ b/swarm/storage/mru/timestampprovider.go
@@ -18,6 +18,7 @@ package mru
 
 import (
 	"encoding/binary"
+	"encoding/json"
 	"time"
 )
 
@@ -53,6 +54,14 @@ func (t *Timestamp) binaryPut(data []byte) error {
 	}
 	binary.LittleEndian.PutUint64(data, t.Time)
 	return nil
+}
+
+func (t *Timestamp) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &t.Time)
+}
+
+func (t *Timestamp) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.Time)
 }
 
 type DefaultTimestampProvider struct {

--- a/swarm/storage/mru/timestampprovider.go
+++ b/swarm/storage/mru/timestampprovider.go
@@ -25,7 +25,7 @@ import (
 // TimestampProvider sets the time source of the mru package
 var TimestampProvider timestampProvider = NewDefaultTimestampProvider()
 
-// Encodes a point in time as a Unix epoch
+// Timestamp encodes a point in time as a Unix epoch
 type Timestamp struct {
 	Time uint64 `json:"time"` // Unix epoch timestamp, in seconds
 }
@@ -56,14 +56,18 @@ func (t *Timestamp) binaryPut(data []byte) error {
 	return nil
 }
 
+// UnmarshalJSON implements the json.Unmarshaller interface
 func (t *Timestamp) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &t.Time)
 }
 
+// MarshalJSON implements the json.Marshaller interface
 func (t *Timestamp) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.Time)
 }
 
+// DefaultTimestampProvider is a TimestampProvider that uses system time
+// as time source
 type DefaultTimestampProvider struct {
 }
 

--- a/swarm/storage/mru/topic.go
+++ b/swarm/storage/mru/topic.go
@@ -9,48 +9,73 @@ import (
 	"github.com/ethereum/go-ethereum/swarm/storage"
 )
 
-const topicLength = storage.KeyLength
+// TopicLength establishes the max length of a topic string
+const TopicLength = storage.KeyLength
 
+// Topic represents what a resource talks about
 type Topic struct {
-	content [topicLength]byte
+	content [TopicLength]byte
 }
 
-func NewTopic(name string, relatedContent storage.Address) Topic {
+// NewTopic creates a new topic from a provided name and "related content" byte array,
+// merging the two together.
+// If relatedContent or name are longer than TopicLength, they will be truncated.
+// name can be an empty string
+// relatedContent can be nil
+func NewTopic(name string, relatedContent []byte) Topic {
 	var topic Topic
-	copy(topic.content[:], relatedContent)
-	nameLength := len(name)
-	if nameLength > topicLength {
-		nameLength = topicLength
+	if relatedContent != nil {
+		contentLength := len(relatedContent)
+		if contentLength > TopicLength {
+			contentLength = TopicLength
+		}
+		copy(topic.content[:], relatedContent[:contentLength])
 	}
-	bitutil.XORBytes(topic.content[:], topic.content[:], []byte(name)[:nameLength])
+	nameBytes := []byte(name)
+	nameLength := len(nameBytes)
+	if nameLength > TopicLength {
+		nameLength = TopicLength
+	}
+	bitutil.XORBytes(topic.content[:], topic.content[:], nameBytes[:nameLength])
 	return topic
 }
 
+// Hex will return the topic encoded as an hex string
 func (t *Topic) Hex() string {
 	return hexutil.Encode(t.content[:])
 }
 
+// FromHex will parse a hex string into this Topic instance
 func (t *Topic) FromHex(hex string) error {
 	return decodeHexArray(t.content[:], hex, "Topic")
 }
 
-func (t *Topic) Name(relatedContent storage.Address) string {
+// Name will try to extract the resource name out of the topic
+func (t *Topic) Name(relatedContent []byte) string {
 	nameBytes := t
-	bitutil.XORBytes(nameBytes.content[:], t.content[:], relatedContent)
+	if relatedContent != nil {
+		contentLength := len(relatedContent)
+		if contentLength > TopicLength {
+			contentLength = TopicLength
+		}
+		bitutil.XORBytes(nameBytes.content[:], t.content[:], relatedContent[:contentLength])
+	}
 	z := bytes.IndexByte(nameBytes.content[:], 0)
 	if z < 0 {
-		z = topicLength
+		z = TopicLength
 	}
 	return string(nameBytes.content[:z])
 
 }
 
+// UnmarshalJSON implements the json.Unmarshaller interface
 func (t *Topic) UnmarshalJSON(data []byte) error {
 	var hex string
 	json.Unmarshal(data, &hex)
 	return t.FromHex(hex)
 }
 
+// MarshalJSON implements the json.Marshaller interface
 func (t *Topic) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.Hex())
 }

--- a/swarm/storage/mru/update.go
+++ b/swarm/storage/mru/update.go
@@ -20,9 +20,9 @@ import (
 	"github.com/ethereum/go-ethereum/swarm/chunk"
 )
 
-// resourceUpdate encapsulates the information sent as part of a resource update
-type resourceUpdate struct {
-	updateHeader        // metainformationa about this resource update
+// ResourceUpdate encapsulates the information sent as part of a resource update
+type ResourceUpdate struct {
+	UpdateHeader        // metainformationa about this resource update
 	data         []byte // actual data payload
 }
 
@@ -35,7 +35,7 @@ const minimumUpdateDataLength = updateHeaderLength + 1
 const maxUpdateDataLength = chunk.DefaultSize - signatureLength - updateHeaderLength
 
 // binaryPut serializes the resource update information into the given slice
-func (r *resourceUpdate) binaryPut(serializedData []byte) error {
+func (r *ResourceUpdate) binaryPut(serializedData []byte) error {
 	datalength := len(r.data)
 	if datalength == 0 {
 		return NewError(ErrInvalidValue, "cannot update a resource with no data")
@@ -51,7 +51,7 @@ func (r *resourceUpdate) binaryPut(serializedData []byte) error {
 
 	var cursor int
 	// serialize header (see updateHeader)
-	if err := r.updateHeader.binaryPut(serializedData[cursor : cursor+updateHeaderLength]); err != nil {
+	if err := r.UpdateHeader.binaryPut(serializedData[cursor : cursor+updateHeaderLength]); err != nil {
 		return err
 	}
 	cursor += updateHeaderLength
@@ -64,19 +64,19 @@ func (r *resourceUpdate) binaryPut(serializedData []byte) error {
 }
 
 // binaryLength returns the expected number of bytes this structure will take to encode
-func (r *resourceUpdate) binaryLength() int {
+func (r *ResourceUpdate) binaryLength() int {
 	return updateHeaderLength + len(r.data)
 }
 
 // binaryGet populates this instance from the information contained in the passed byte slice
-func (r *resourceUpdate) binaryGet(serializedData []byte) error {
+func (r *ResourceUpdate) binaryGet(serializedData []byte) error {
 	if len(serializedData) < minimumUpdateDataLength {
 		return NewErrorf(ErrNothingToReturn, "chunk less than %d bytes cannot be a resource update chunk", minimumUpdateDataLength)
 	}
 	dataLength := len(serializedData) - updateHeaderLength
 	var cursor int
 	// at this point we can be satisfied that we have the correct data length to read
-	if err := r.updateHeader.binaryGet(serializedData[cursor : cursor+updateHeaderLength]); err != nil {
+	if err := r.UpdateHeader.binaryGet(serializedData[cursor : cursor+updateHeaderLength]); err != nil {
 		return err
 	}
 	cursor += updateHeaderLength
@@ -92,12 +92,12 @@ func (r *resourceUpdate) binaryGet(serializedData []byte) error {
 
 }
 
-func (r *resourceUpdate) FromValues(values Values, data []byte, parseView bool) error {
+func (r *ResourceUpdate) FromValues(values Values, data []byte, parseView bool) error {
 	r.data = data
-	return r.updateHeader.FromValues(values, parseView)
+	return r.UpdateHeader.FromValues(values, parseView)
 }
 
-func (r *resourceUpdate) ToValues(values Values) []byte {
-	r.updateHeader.ToValues(values)
+func (r *ResourceUpdate) ToValues(values Values) []byte {
+	r.UpdateHeader.ToValues(values)
 	return r.data
 }

--- a/swarm/storage/mru/update.go
+++ b/swarm/storage/mru/update.go
@@ -91,3 +91,13 @@ func (r *resourceUpdate) binaryGet(serializedData []byte) error {
 	return nil
 
 }
+
+func (r *resourceUpdate) FromValues(values Values, data []byte, parseView bool) error {
+	r.data = data
+	return r.updateHeader.FromValues(values, parseView)
+}
+
+func (r *resourceUpdate) ToValues(values Values) []byte {
+	r.updateHeader.ToValues(values)
+	return r.data
+}

--- a/swarm/storage/mru/update.go
+++ b/swarm/storage/mru/update.go
@@ -92,11 +92,15 @@ func (r *ResourceUpdate) binaryGet(serializedData []byte) error {
 
 }
 
+// FromValues deserializes this instance from a string key-value store
+// useful to parse query strings
 func (r *ResourceUpdate) FromValues(values Values, data []byte, parseView bool) error {
 	r.data = data
 	return r.UpdateHeader.FromValues(values, parseView)
 }
 
+// ToValues serializes this structure into the provided string key-value store
+// useful to build query strings
 func (r *ResourceUpdate) ToValues(values Values) []byte {
 	r.UpdateHeader.ToValues(values)
 	return r.data

--- a/swarm/storage/mru/update_test.go
+++ b/swarm/storage/mru/update_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 )
 
-func getTestResourceUpdate() *resourceUpdate {
-	return &resourceUpdate{
-		updateHeader: *getTestUpdateHeader(),
+func getTestResourceUpdate() *ResourceUpdate {
+	return &ResourceUpdate{
+		UpdateHeader: *getTestUpdateHeader(),
 		data:         []byte("El que lee mucho y anda mucho, ve mucho y sabe mucho"),
 	}
 }

--- a/swarm/storage/mru/updateheader.go
+++ b/swarm/storage/mru/updateheader.go
@@ -53,3 +53,11 @@ func (h *updateHeader) binaryGet(serializedData []byte) error {
 	}
 	return nil
 }
+
+func (h *updateHeader) FromValues(values Values, parseView bool) error {
+	return h.UpdateLookup.FromValues(values, parseView)
+}
+
+func (h *updateHeader) ToValues(values Values) {
+	h.UpdateLookup.ToValues(values)
+}

--- a/swarm/storage/mru/updateheader.go
+++ b/swarm/storage/mru/updateheader.go
@@ -54,10 +54,14 @@ func (h *UpdateHeader) binaryGet(serializedData []byte) error {
 	return nil
 }
 
+// FromValues deserializes this instance from a string key-value store
+// useful to parse query strings
 func (h *UpdateHeader) FromValues(values Values, parseView bool) error {
 	return h.UpdateLookup.FromValues(values, parseView)
 }
 
+// ToValues serializes this structure into the provided string key-value store
+// useful to build query strings
 func (h *UpdateHeader) ToValues(values Values) {
 	h.UpdateLookup.ToValues(values)
 }

--- a/swarm/storage/mru/updateheader.go
+++ b/swarm/storage/mru/updateheader.go
@@ -16,9 +16,9 @@
 
 package mru
 
-// updateHeader models the non-payload components of a Resource Update
+// UpdateHeader models the non-payload components of a Resource Update
 // Extensible placeholder. Right now it contains no additional components.
-type updateHeader struct {
+type UpdateHeader struct {
 	UpdateLookup // UpdateLookup contains the information required to locate this resource (components of the search key used to find it)
 }
 
@@ -27,7 +27,7 @@ type updateHeader struct {
 const updateHeaderLength = updateLookupLength
 
 // binaryPut serializes the resource header information into the given slice
-func (h *updateHeader) binaryPut(serializedData []byte) error {
+func (h *UpdateHeader) binaryPut(serializedData []byte) error {
 	if len(serializedData) != updateHeaderLength {
 		return NewErrorf(ErrInvalidValue, "Incorrect slice size to serialize updateHeaderLength. Expected %d, got %d", updateHeaderLength, len(serializedData))
 	}
@@ -38,12 +38,12 @@ func (h *updateHeader) binaryPut(serializedData []byte) error {
 }
 
 // binaryLength returns the expected size of this structure when serialized
-func (h *updateHeader) binaryLength() int {
+func (h *UpdateHeader) binaryLength() int {
 	return updateHeaderLength
 }
 
 // binaryGet restores the current updateHeader instance from the information contained in the passed slice
-func (h *updateHeader) binaryGet(serializedData []byte) error {
+func (h *UpdateHeader) binaryGet(serializedData []byte) error {
 	if len(serializedData) != updateHeaderLength {
 		return NewErrorf(ErrInvalidValue, "Incorrect slice size to read updateHeaderLength. Expected %d, got %d", updateHeaderLength, len(serializedData))
 	}
@@ -54,10 +54,10 @@ func (h *updateHeader) binaryGet(serializedData []byte) error {
 	return nil
 }
 
-func (h *updateHeader) FromValues(values Values, parseView bool) error {
+func (h *UpdateHeader) FromValues(values Values, parseView bool) error {
 	return h.UpdateLookup.FromValues(values, parseView)
 }
 
-func (h *updateHeader) ToValues(values Values) {
+func (h *UpdateHeader) ToValues(values Values) {
 	h.UpdateLookup.ToValues(values)
 }

--- a/swarm/storage/mru/updateheader_test.go
+++ b/swarm/storage/mru/updateheader_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 )
 
-func getTestUpdateHeader() *updateHeader {
-	return &updateHeader{
+func getTestUpdateHeader() *UpdateHeader {
+	return &UpdateHeader{
 		UpdateLookup: *getTestUpdateLookup(),
 	}
 }


### PR DESCRIPTION
Building on https://github.com/ethersphere/go-ethereum/pull/813, this PR makes the following changes:
Changed from path components to query strings:
`GET /bzz-resource:/<MANIFEST_ADDRESS>/?period=xx&version=xx` for specific period, version.
`GET /bzz-resource:/<MANIFEST_ADDRESS>/?period=xx` for specific period, latest version
`GET /bzz-resource:/<MANIFEST_ADDRESS>/` retrieves the latest, as before.

Added the following parameters allows to skip the manifest altogether by providing the info the manifest would provide:
`GET /bzz-resource:/?starttime=xx&frequency=xx&topic=0x000000...&user=0x00000...` 

you can also add `&period=xx&version=xx` to the above as well, to query a specific period / version.

Changed the way to create / update. You can now either:

POST `/bzz-resource:/<MANIFEST_ADDRESS>/?period=xx&version=xx&signature=0x0000...` (update data must be in the body of the request)

or skip the manifest by providing the info the manifest would provide:
`POST/bzz-resource:/?starttime=xx&frequency=xx&topic=0x000000...&owner=0x00000&period=xx&version=xx&signature=0x...`
again, update data must be in the body of the request.

If you want your node to create and publish a manifest along with the update, add the query flag `&manifest=1` to the above POST query.

Therefore, with this change POST/GET are symmetric and publishing a manifest is now optional, though people using ENS will want to create manifests. This is transparent in the CLI.

Added tests and client method in `client.go` to wrap the above.