### PR TITLE
swarm/bmt: increase segment count to support 64k chunks

### DIFF
--- a/swarm/bmt/bmt.go
+++ b/swarm/bmt/bmt.go
@@ -57,7 +57,9 @@ Two implementations are provided:
 const (
 	// SegmentCount is the maximum number of segments of the underlying chunk
 	// Should be equal to max-chunk-data-size / hash-size
-	SegmentCount = 128
+	// 128 for max chunk size of 4k
+	// 2048 for max chunk size of 64k
+	SegmentCount = 2048
 	// PoolSize is the maximum number of bmt trees used by the hashers, i.e,
 	// the maximum number of concurrent BMT hashing operations performed by the same hasher
 	PoolSize = 8

--- a/swarm/bmt/bmt_test.go
+++ b/swarm/bmt/bmt_test.go
@@ -251,7 +251,7 @@ func TestBMTConcurrentUse(t *testing.T) {
 			bmt := New(pool)
 			data := newData(BufferSize)
 			n := rand.Intn(bmt.Size())
-			errc <- testHasherCorrectness(bmt, hasher, data, n, 128)
+			errc <- testHasherCorrectness(bmt, hasher, data, n, 2048)
 		}()
 	}
 LOOP:
@@ -356,7 +356,7 @@ func testHasherCorrectness(bmt *Hasher, hasher BaseHasherFunc, d []byte, n, coun
 
 //
 func BenchmarkBMT(t *testing.B) {
-	for size := 4096; size >= 128; size /= 2 {
+	for size := 65536; size >= 128; size /= 2 {
 		t.Run(fmt.Sprintf("%v_size_%v", "SHA3", size), func(t *testing.B) {
 			benchmarkSHA3(t, size)
 		})


### PR DESCRIPTION
Just a playground PR, to see the difference between 64kb chunks and 4kb chunks.