### PR TITLE
Bumped swarm handshake protocol version to 6

### DIFF
--- a/swarm/network/protocol.go
+++ b/swarm/network/protocol.go
@@ -44,7 +44,7 @@ const (
 // BzzSpec is the spec of the generic swarm handshake
 var BzzSpec = &protocols.Spec{
 	Name:       "bzz",
-	Version:    5,
+	Version:    6,
 	MaxMsgSize: 10 * 1024 * 1024,
 	Messages: []interface{}{
 		HandshakeMsg{},


### PR DESCRIPTION
https://github.com/ethersphere/go-ethereum/pull/816 introduced breaking change in the network protocol but the protocol version didn't change.

This PR fixes that.