### PR TITLE
WIP cmd/swarm: FUSE do not require --ipcpath (#795)

### DIFF
--- a/cmd/swarm/fs_test.go
+++ b/cmd/swarm/fs_test.go
@@ -42,6 +42,22 @@ type testFile struct {
 	content  string
 }
 
+func TestCLISwarmFsDefaultIPCPath(t *testing.T) {
+	cluster := newTestCluster(t, 1)
+	defer cluster.Shutdown()
+
+	handlingNode := cluster.Nodes[0]
+	list := runSwarm(t, []string{
+		"--datadir", handlingNode.Dir,
+		"fs",
+		"list",
+	}...)
+
+	if err := list.WaitExit(); err != nil {
+		t.Error(err)
+	}
+}
+
 // TestCLISwarmFs is a high-level test of swarmfs
 //
 // This test fails on travis for macOS as this executable exits with code 1

--- a/cmd/swarm/run_test.go
+++ b/cmd/swarm/run_test.go
@@ -316,7 +316,7 @@ func newTestNode(t *testing.T, dir string) *testNode {
 		"--bzzaccount", account.Address.String(),
 		"--bzznetworkid", "321",
 		"--bzzport", httpPort,
-		"--verbosity", "6",
+		"--verbosity", fmt.Sprint(*loglevel),
 	)
 	node.Cmd.InputLine(testPassphrase)
 	defer func() {

--- a/internal/cmdtest/test_cmd.go
+++ b/internal/cmdtest/test_cmd.go
@@ -181,8 +181,8 @@ func (tt *TestCmd) ExpectExit() {
 	}
 }
 
-func (tt *TestCmd) WaitExit() {
-	tt.cmd.Wait()
+func (tt *TestCmd) WaitExit() error {
+	return tt.cmd.Wait()
 }
 
 func (tt *TestCmd) Interrupt() {


### PR DESCRIPTION
Use ${DataDir}/bzzd.ipc as default.

Fixes #795

**TODO**
- [ ] `fix help to show `--ipcpath` optional (something like: `[--ipcpath <path>]`)`

**Alternative Solution**
Based on utils.IPCPathFlag create a SwarmIPCPathFlag and provide the default value.
pro: might be easier to understand the default and make it visible (dynamically) in the help
ref: `cmd/swarm/main.go:424`

**Possible Dead Code**
In `dialRPC` I don't think we ever enter the `if endpoint == ""` code path.
- With the old implementation if the flag was not set then we returned with an error. Providing the empty string with the `--ipcflag` explicitly was not possible.
- Now `endpoint==""` would be only possible if `--ipcpath` is omitted and `defaultNodeConfig.IPCPath` would not be specified in `init()` (cmd/swarm/main.go:240).

*Note*: `DefaultIPCEndpoint()` is only used at 2 places in the code and here it would result in a path '${DataDir}/swarm.ipc`.

**Testing Concerns**
`TestCLISwarmFsDefaultIPCPath` tests it the CLI returns without an error. That only implicates that `--ipcpath` is not required anymore. Since the methods under test are all private - and testing private methods can be considered a bad practice - I did not find more simple and explicit way.

What do you think?
- Do you agree about the dead code path? Shall I remove that?
- Do you have a better idea for testing?
- Should I try to go with the alternative solution idea?