### PR TITLE
swarm: schemas and migrations

### DIFF
--- a/cmd/swarm/db.go
+++ b/cmd/swarm/db.go
@@ -93,21 +93,6 @@ func dbImport(ctx *cli.Context) {
 	log.Info(fmt.Sprintf("successfully imported %d chunks", count))
 }
 
-func dbClean(ctx *cli.Context) {
-	args := ctx.Args()
-	if len(args) != 2 {
-		utils.Fatalf("invalid arguments, please specify <chunkdb> (path to a local chunk database) and the base key")
-	}
-
-	store, err := openLDBStore(args[0], common.Hex2Bytes(args[1]))
-	if err != nil {
-		utils.Fatalf("error opening local chunk database: %s", err)
-	}
-	defer store.Close()
-
-	store.Cleanup()
-}
-
 func openLDBStore(path string, basekey []byte) (*storage.LDBStore, error) {
 	if _, err := os.Stat(filepath.Join(path, "CURRENT")); err != nil {
 		return nil, fmt.Errorf("invalid chunkdb path: %s", err)

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -497,14 +497,6 @@ pv(1) tool to get a progress bar:
 
     pv chunks.tar | swarm db import ~/.ethereum/swarm/bzz-KEY/chunks -`,
 				},
-				{
-					Action:             dbClean,
-					CustomHelpTemplate: helpTemplate,
-					Name:               "clean",
-					Usage:              "remove corrupt entries from a local chunk database",
-					ArgsUsage:          "<chunkdb>",
-					Description:        "Remove corrupt entries from a local chunk database",
-				},
 			},
 		},
 

--- a/swarm/storage/database.go
+++ b/swarm/storage/database.go
@@ -20,8 +20,6 @@ package storage
 // no need for queueing/caching
 
 import (
-	"fmt"
-
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/iterator"
@@ -46,13 +44,10 @@ func NewLDBDatabase(file string) (*LDBDatabase, error) {
 	return database, nil
 }
 
-func (db *LDBDatabase) Put(key []byte, value []byte) {
+func (db *LDBDatabase) Put(key []byte, value []byte) error {
 	metrics.GetOrRegisterCounter("ldbdatabase.put", nil).Inc(1)
 
-	err := db.db.Put(key, value, nil)
-	if err != nil {
-		fmt.Println("Error put", err)
-	}
+	return db.db.Put(key, value, nil)
 }
 
 func (db *LDBDatabase) Get(key []byte) ([]byte, error) {

--- a/swarm/storage/ldbstore.go
+++ b/swarm/storage/ldbstore.go
@@ -61,6 +61,7 @@ var (
 	keyDataIdx     = []byte{4}
 	keyData        = byte(6)
 	keyDistanceCnt = byte(7)
+	keySchema      = byte(8)
 )
 
 var (
@@ -734,7 +735,7 @@ func (s *LDBStore) GetSchema() (string, error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	data, err := s.db.Get([]byte(`schema`))
+	data, err := s.db.Get(keySchema)
 	if err != nil {
 		if err == leveldb.ErrNotFound {
 			return "", nil
@@ -749,7 +750,7 @@ func (s *LDBStore) PutSchema(schema string) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	return s.db.Put([]byte(`schema`), []byte(schema))
+	return s.db.Put(keySchema, []byte(schema))
 }
 
 func (s *LDBStore) Get(_ context.Context, addr Address) (chunk Chunk, err error) {

--- a/swarm/storage/ldbstore.go
+++ b/swarm/storage/ldbstore.go
@@ -730,6 +730,28 @@ func (s *LDBStore) tryAccessIdx(ikey []byte, index *dpaDBIndex) bool {
 	return true
 }
 
+func (s *LDBStore) GetSchema() (string, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	data, err := s.db.Get([]byte(`schema`))
+	if err != nil {
+		if err == leveldb.ErrNotFound {
+			return "", nil
+		}
+		return "", err
+	}
+
+	return string(data), nil
+}
+
+func (s *LDBStore) PutSchema(schema string) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	return s.db.Put([]byte(`schema`), []byte(schema))
+}
+
 func (s *LDBStore) Get(_ context.Context, addr Address) (chunk Chunk, err error) {
 	metrics.GetOrRegisterCounter("ldbstore.get", nil).Inc(1)
 	log.Trace("ldbstore.get", "key", addr)

--- a/swarm/storage/ldbstore.go
+++ b/swarm/storage/ldbstore.go
@@ -418,8 +418,8 @@ func (s *LDBStore) Import(in io.Reader) (int64, error) {
 	}
 }
 
+//Cleanup iterates over the database and deletes chunks if they pass the `f` condition
 func (s *LDBStore) Cleanup(f func(*chunk) bool) {
-	//Iterates over the database and checks that there are no chunks bigger than 4kb
 	var errorsFound, removed, total int
 
 	it := s.db.NewIterator()

--- a/swarm/storage/localstore.go
+++ b/swarm/storage/localstore.go
@@ -211,7 +211,7 @@ func (ls *LocalStore) Migrate() error {
 
 			ls.DbStore.Cleanup(cleanupFunc)
 
-			err := ls.DbStore.PutSchema(DbSchemaHive)
+			err := ls.DbStore.PutSchema(DbSchemaPurity)
 			if err != nil {
 				log.Error(err.Error())
 				return err

--- a/swarm/storage/localstore.go
+++ b/swarm/storage/localstore.go
@@ -184,3 +184,30 @@ func (ls *LocalStore) Iterator(from uint64, to uint64, po uint8, f func(Address,
 func (ls *LocalStore) Close() {
 	ls.DbStore.Close()
 }
+
+func (ls *LocalStore) Migrate() error {
+	schema, err := ls.DbStore.GetSchema()
+	if err != nil {
+		log.Error(err.Error())
+		return err
+	}
+
+	log.Debug("found schema", "schema", schema, "runtime-schema", CurrentDbSchema)
+	if schema != CurrentDbSchema {
+		// run migrations
+
+		if schema == "" {
+			log.Debug("running migrations for", "schema", schema, "runtime-schema", CurrentDbSchema)
+
+			ls.DbStore.Cleanup()
+
+			err := ls.DbStore.PutSchema(DbSchemaHive)
+			if err != nil {
+				log.Error(err.Error())
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/swarm/storage/schema.go
+++ b/swarm/storage/schema.go
@@ -1,6 +1,6 @@
 package storage
 
-// "hive" is the first formal schema of LevelDB we release together with Swarm 0.3.4
-const DbSchemaHive = "hive"
+// "purity" is the first formal schema of LevelDB we release together with Swarm 0.3.5
+const DbSchemaPurity = "purity"
 
-const CurrentDbSchema = DbSchemaHive
+const CurrentDbSchema = DbSchemaPurity

--- a/swarm/storage/schema.go
+++ b/swarm/storage/schema.go
@@ -1,0 +1,6 @@
+package storage
+
+// "hive" is the first formal schema of LevelDB we release together with Swarm 0.3.4
+const DbSchemaHive = "hive"
+
+const CurrentDbSchema = DbSchemaHive

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -169,6 +169,11 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 		return nil, err
 	}
 
+	err = lstore.Migrate()
+	if err != nil {
+		return nil, err
+	}
+
 	self.netStore, err = storage.NewNetStore(lstore, nil)
 	if err != nil {
 		return nil, err

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -169,11 +169,6 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 		return nil, err
 	}
 
-	err = lstore.Migrate()
-	if err != nil {
-		return nil, err
-	}
-
 	self.netStore, err = storage.NewNetStore(lstore, nil)
 	if err != nil {
 		return nil, err
@@ -205,6 +200,11 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 	lstore.Validators = []storage.ChunkValidator{
 		storage.NewContentAddressValidator(storage.MakeHashFunc(storage.DefaultHash)),
 		resourceHandler,
+	}
+
+	err = lstore.Migrate()
+	if err != nil {
+		return nil, err
 	}
 
 	log.Debug("Setup local storage")


### PR DESCRIPTION
The idea of this PR is to add `schema` identifier to every LevelDB instance, so that we can migrate or cleanup in case Swarm binary runs on a LevelDB instance that it doesn't detect.

Schemas have names, and not versions, so that we think carefully what needs to happen once we have 2-3 different schema in production.

The idea for this first formal schema is to run the `ldbstore.Cleanup()` task on start-up. We should review it carefully and make sure all `invalid` chunks are removed (MRU and other).

Addresses https://github.com/ethersphere/go-ethereum/issues/909