### PR TITLE
Lightnode phase0 task1

### DIFF
--- a/swarm/network/kademlia_test.go
+++ b/swarm/network/kademlia_test.go
@@ -254,25 +254,35 @@ func TestSuggestPeerFindPeers(t *testing.T) {
 
 }
 
+// a node should stay in the address book if it's removed from the kademlia
 func TestOffEffectingAddressBookNormalNode(t *testing.T) {
 	k := newTestKademlia("00000000")
+	// peer added to kademlia
 	k.On(newTestKadPeer(k, "01000000", false))
+	// peer should be in the address book
 	if k.addrs.Size() != 1 {
 		t.Fatal("known peer addresses should contain 1 entry")
 	}
+	// remove peer from kademlia
 	k.Off(newTestKadPeer(k, "01000000", false))
+	// peer should not be in the address book
 	if k.addrs.Size() != 1 {
 		t.Fatal("known peer addresses should contain 1 entry")
 	}
 }
 
+// a light node should not be in the address book
 func TestOffEffectingAddressBookLightNode(t *testing.T) {
 	k := newTestKademlia("00000000")
+	// light node peer added to kademlia
 	k.On(newTestKadPeer(k, "01000000", true))
+	// peer should not be in the address book
 	if k.addrs.Size() != 0 {
 		t.Fatal("known peer addresses should contain 0 entry")
 	}
+	// remove peer from kademlia
 	k.Off(newTestKadPeer(k, "01000000", true))
+	// peer should not be in the address book
 	if k.addrs.Size() != 0 {
 		t.Fatal("known peer addresses should contain 0 entry")
 	}

--- a/swarm/network/kademlia_test.go
+++ b/swarm/network/kademlia_test.go
@@ -263,11 +263,19 @@ func TestOffEffectingAddressBookNormalNode(t *testing.T) {
 	if k.addrs.Size() != 1 {
 		t.Fatal("known peer addresses should contain 1 entry")
 	}
+	// peer should be among live connections
+	if k.conns.Size() != 1 {
+		t.Fatal("live peers should contain 1 entry")
+	}
 	// remove peer from kademlia
 	k.Off(newTestKadPeer(k, "01000000", false))
-	// peer should not be in the address book
+	// peer should be in the address book
 	if k.addrs.Size() != 1 {
 		t.Fatal("known peer addresses should contain 1 entry")
+	}
+	// peer should not be among live connections
+	if k.conns.Size() != 0 {
+		t.Fatal("live peers should contain 0 entry")
 	}
 }
 
@@ -280,11 +288,19 @@ func TestOffEffectingAddressBookLightNode(t *testing.T) {
 	if k.addrs.Size() != 0 {
 		t.Fatal("known peer addresses should contain 0 entry")
 	}
+	// peer should be among live connections
+	if k.conns.Size() != 1 {
+		t.Fatal("live peers should contain 1 entry")
+	}
 	// remove peer from kademlia
 	k.Off(newTestKadPeer(k, "01000000", true))
 	// peer should not be in the address book
 	if k.addrs.Size() != 0 {
 		t.Fatal("known peer addresses should contain 0 entry")
+	}
+	// peer should not be among live connections
+	if k.conns.Size() != 0 {
+		t.Fatal("live peers should contain 0 entry")
 	}
 }
 

--- a/swarm/network/kademlia_test.go
+++ b/swarm/network/kademlia_test.go
@@ -46,19 +46,19 @@ func newTestKademlia(b string) *Kademlia {
 	return NewKademlia(base, params)
 }
 
-func newTestKadPeer(k *Kademlia, s string) *Peer {
-	return NewPeer(&BzzPeer{BzzAddr: testKadPeerAddr(s)}, k)
+func newTestKadPeer(k *Kademlia, s string, lightNode bool) *Peer {
+	return NewPeer(&BzzPeer{BzzAddr: testKadPeerAddr(s), LightNode: lightNode}, k)
 }
 
 func On(k *Kademlia, ons ...string) {
 	for _, s := range ons {
-		k.On(newTestKadPeer(k, s))
+		k.On(newTestKadPeer(k, s, false))
 	}
 }
 
 func Off(k *Kademlia, offs ...string) {
 	for _, s := range offs {
-		k.Off(newTestKadPeer(k, s))
+		k.Off(newTestKadPeer(k, s, false))
 	}
 }
 
@@ -252,6 +252,30 @@ func TestSuggestPeerFindPeers(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
+}
+
+func TestOffEffectingAddressBookNormalNode(t *testing.T) {
+	k := newTestKademlia("00000000")
+	k.On(newTestKadPeer(k, "01000000", false))
+	if k.addrs.Size() != 1 {
+		t.Fatal("known peer addresses should contain 1 entry")
+	}
+	k.Off(newTestKadPeer(k, "01000000", false))
+	if k.addrs.Size() != 1 {
+		t.Fatal("known peer addresses should contain 1 entry")
+	}
+}
+
+func TestOffEffectingAddressBookLightNode(t *testing.T) {
+	k := newTestKademlia("00000000")
+	k.On(newTestKadPeer(k, "01000000", true))
+	if k.addrs.Size() != 0 {
+		t.Fatal("known peer addresses should contain 0 entry")
+	}
+	k.Off(newTestKadPeer(k, "01000000", true))
+	if k.addrs.Size() != 0 {
+		t.Fatal("known peer addresses should contain 0 entry")
+	}
 }
 
 func TestSuggestPeerRetries(t *testing.T) {

--- a/swarm/network/stream/delivery.go
+++ b/swarm/network/stream/delivery.go
@@ -235,7 +235,7 @@ func (d *Delivery) RequestFromPeers(ctx context.Context, req *network.Request) (
 		d.kad.EachConn(req.Addr[:], 255, func(p *network.Peer, po int, nn bool) bool {
 			id := p.ID()
 			if p.LightNode {
-				log.Trace("Delivery.RequestFromPeers: skip lightnode peer", "peer id", id)
+				// skip light nodes
 				return true
 			}
 			if req.SkipPeer(id.String()) {

--- a/swarm/network/stream/delivery.go
+++ b/swarm/network/stream/delivery.go
@@ -234,7 +234,10 @@ func (d *Delivery) RequestFromPeers(ctx context.Context, req *network.Request) (
 	} else {
 		d.kad.EachConn(req.Addr[:], 255, func(p *network.Peer, po int, nn bool) bool {
 			id := p.ID()
-			// TODO: skip light nodes that do not accept retrieve requests
+			if p.LightNode {
+				log.Trace("Delivery.RequestFromPeers: skip lightnode peer", "peer id", id)
+				return true
+			}
 			if req.SkipPeer(id.String()) {
 				log.Trace("Delivery.RequestFromPeers: skip peer", "peer id", id)
 				return true

--- a/swarm/network/stream/delivery_test.go
+++ b/swarm/network/stream/delivery_test.go
@@ -306,6 +306,7 @@ func TestRequestFromPeersWithLightNode(t *testing.T) {
 		t.Fatalf("expected '%v', got %v", expectedError, err)
 	}
 }
+
 func TestStreamerDownstreamChunkDeliveryMsgExchange(t *testing.T) {
 	tester, streamer, localStore, teardown, err := newStreamerTester(t, &RegistryOptions{
 		DoServeRetrieve: true,

--- a/swarm/network/stream/delivery_test.go
+++ b/swarm/network/stream/delivery_test.go
@@ -228,12 +228,12 @@ func TestStreamerUpstreamRetrieveRequestMsgExchange(t *testing.T) {
 }
 
 func TestRequestFromPeers(t *testing.T) {
-	dummyPeerId := enode.HexID("3431c3939e1ee2a6345e976a8234f9870152d64879f30bc272a074f6859e75e8")
+	dummyPeerID := enode.HexID("3431c3939e1ee2a6345e976a8234f9870152d64879f30bc272a074f6859e75e8")
 
 	addr := network.RandomAddr()
 	to := network.NewKademlia(addr.OAddr, network.NewKadParams())
 	delivery := NewDelivery(to, nil)
-	protocolsPeer := protocols.NewPeer(p2p.NewPeer(dummyPeerId, "dummy", nil), nil, nil)
+	protocolsPeer := protocols.NewPeer(p2p.NewPeer(dummyPeerID, "dummy", nil), nil, nil)
 	peer := network.NewPeer(&network.BzzPeer{
 		BzzAddr:   network.RandomAddr(),
 		LightNode: false,
@@ -254,18 +254,18 @@ func TestRequestFromPeers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if *id != dummyPeerId {
+	if *id != dummyPeerID {
 		t.Fatalf("Expected an id, got %v", id)
 	}
 }
 
 func TestRequestFromPeersWithLightNode(t *testing.T) {
-	dummyPeerId := enode.HexID("3431c3939e1ee2a6345e976a8234f9870152d64879f30bc272a074f6859e75e8")
+	dummyPeerID := enode.HexID("3431c3939e1ee2a6345e976a8234f9870152d64879f30bc272a074f6859e75e8")
 
 	addr := network.RandomAddr()
 	to := network.NewKademlia(addr.OAddr, network.NewKadParams())
 	delivery := NewDelivery(to, nil)
-	protocolsPeer := protocols.NewPeer(p2p.NewPeer(dummyPeerId, "dummy", nil), nil, nil)
+	protocolsPeer := protocols.NewPeer(p2p.NewPeer(dummyPeerID, "dummy", nil), nil, nil)
 	peer := network.NewPeer(&network.BzzPeer{
 		BzzAddr:   network.RandomAddr(),
 		LightNode: true,


### PR DESCRIPTION
This PR implements changes RequestFromPeers so it won't try to use peers marked as LightNodes, and makes sure LightNodes won't be stored in the AddressBook. 
It's part of a bigger initiative for enabling Swarm Light Nodes. For more information, see https://hackmd.io/s/ry1kbJZfm