### PR TITLE
swarm/storage: Fix garbage collection related index corruption

### DIFF
--- a/swarm/storage/ldbstore.go
+++ b/swarm/storage/ldbstore.go
@@ -601,7 +601,7 @@ func (s *LDBStore) CleanIndex() error {
 		dataKey := getDataKey(idx.Idx, po)
 		_, err = s.db.Get(dataKey)
 		if err != nil {
-			log.Trace("clean delete", "key", chunkHash)
+			log.Warn("deleting inconsistent index (missing data)", "key", chunkHash)
 			batch.Delete(it.Key())
 		} else {
 			gcIdxKey := getGCIdxKey(&idx)

--- a/swarm/storage/ldbstore.go
+++ b/swarm/storage/ldbstore.go
@@ -247,10 +247,6 @@ func getIndexKey(hash Address) []byte {
 	return key
 }
 
-func parseIndexKey(key []byte) (byte, []byte) {
-	return key[0], key[1:]
-}
-
 func getDataKey(idx uint64, po uint8) []byte {
 	key := make([]byte, 10)
 	key[0] = keyData
@@ -591,7 +587,7 @@ func (s *LDBStore) CleanIndex() error {
 	var idx dpaDBIndex
 	var poPtrs [256]uint64
 	for it.Valid() {
-		rowType, chunkHash := parseIndexKey(it.Key())
+		rowType, chunkHash := parseGCIdxKey(it.Key())
 		if rowType != keyIndex {
 			break
 		}
@@ -644,50 +640,6 @@ func (s *LDBStore) CleanIndex() error {
 
 	return nil
 }
-
-// this seems to be unused
-//func (s *LDBStore) ReIndex() {
-//	//Iterates over the database and checks that there are no faulty chunks
-//	it := s.db.NewIterator()
-//	startPosition := []byte{keyOldData}
-//	it.Seek(startPosition)
-//	var key []byte
-//	var errorsFound, total int
-//	for it.Valid() {
-//		key = it.Key()
-//		if (key == nil) || (key[0] != keyOldData) {
-//			break
-//		}
-//		data := it.Value()
-//		hasher := s.hashfunc()
-//		hasher.Write(data)
-//		hash := hasher.Sum(nil)
-//
-//		newKey := make([]byte, 10)
-//		oldCntKey := make([]byte, 2)
-//		newCntKey := make([]byte, 2)
-//		oldCntKey[0] = keyDistanceCnt
-//		newCntKey[0] = keyDistanceCnt
-//		key[0] = keyData
-//		key[1] = s.po(Address(key[1:]))
-//		oldCntKey[1] = key[1]
-//		newCntKey[1] = s.po(Address(newKey[1:]))
-//		copy(newKey[2:], key[1:])
-//		newValue := append(hash, data...)
-//
-//		batch := new(leveldb.Batch)
-//		batch.Delete(key)
-//		s.bucketCnt[oldCntKey[1]]--
-//		batch.Put(oldCntKey, U64ToBytes(s.bucketCnt[oldCntKey[1]]))
-//		batch.Put(newKey, newValue)
-//		s.bucketCnt[newCntKey[1]]++
-//		batch.Put(newCntKey, U64ToBytes(s.bucketCnt[newCntKey[1]]))
-//		s.db.Write(batch)
-//		it.Next()
-//	}
-//	it.Release()
-//	log.Warn(fmt.Sprintf("Found %v errors out of %v entries", errorsFound, total))
-//}
 
 // Delete is removes a chunk and updates indices.
 // Is thread safe
@@ -813,7 +765,6 @@ func (s *LDBStore) doPut(chunk Chunk, index *dpaDBIndex, po uint8) {
 	dkey := getDataKey(s.dataIdx, po)
 	s.batch.Put(dkey, data)
 	index.Idx = s.dataIdx
-	// TODO: why is this indexcount and not the count of items in po
 	s.bucketCnt[po] = s.dataIdx
 	s.entryCnt++
 	dbEntryCount.Inc(1)

--- a/swarm/storage/ldbstore_test.go
+++ b/swarm/storage/ldbstore_test.go
@@ -32,7 +32,6 @@ import (
 	ch "github.com/ethereum/go-ethereum/swarm/chunk"
 	"github.com/ethereum/go-ethereum/swarm/log"
 	"github.com/ethereum/go-ethereum/swarm/storage/mock/mem"
-
 	ldberrors "github.com/syndtr/goleveldb/leveldb/errors"
 )
 
@@ -603,6 +602,7 @@ func TestCleanIndex(t *testing.T) {
 	dataKey := make([]byte, 10)
 	dataKey[0] = keyData
 	dataKey[1] = byte(po)
+	// dataKey[2:10] = first chunk has storageIdx 0 on [2:10]
 	_, err = ldb.db.Get(dataKey)
 	if err != nil {
 		t.Fatal(err)
@@ -628,7 +628,7 @@ func TestCleanIndex(t *testing.T) {
 	ldb.db.Delete(gcSecondCorrectKey)
 	ldb.db.Put(gcSecondCorrectKey, warpedGCVal)
 
-	ldb.CleanIndex()
+	ldb.CleanGCIndex()
 
 	// the index without corresponding data should have been deleted
 	idxKey := make([]byte, 33)

--- a/swarm/storage/ldbstore_test.go
+++ b/swarm/storage/ldbstore_test.go
@@ -19,6 +19,7 @@ package storage
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -582,6 +583,92 @@ func TestLDBStoreCollectGarbageAccessUnlikeIndex(t *testing.T) {
 	}
 
 	log.Info("ldbstore", "total", n, "missing", missing, "entrycnt", ldb.entryCnt, "accesscnt", ldb.accessCnt)
+}
+
+func TestCleanIndex(t *testing.T) {
+	capacity := 5000
+	n := 3
+
+	ldb, cleanup := newLDBStore(t)
+	ldb.setCapacity(uint64(capacity))
+	defer cleanup()
+
+	chunks, err := mputRandomChunks(ldb, n, 4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// remove the data of the first chunk
+	po := ldb.po(chunks[0].Address()[:])
+	dataKey := make([]byte, 10)
+	dataKey[0] = keyData
+	dataKey[1] = byte(po)
+	_, err = ldb.db.Get(dataKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ldb.db.Delete(dataKey)
+
+	// remove the gc index row for the first chunk
+	gcFirstCorrectKey := make([]byte, 9)
+	gcFirstCorrectKey[0] = keyGCIdx
+	ldb.db.Delete(gcFirstCorrectKey)
+
+	// warp the gc data of the second chunk
+	// this data should be correct again after the clean
+	gcSecondCorrectKey := make([]byte, 9)
+	gcSecondCorrectKey[0] = keyGCIdx
+	binary.BigEndian.PutUint64(gcSecondCorrectKey[1:], uint64(1))
+	gcSecondCorrectVal, err := ldb.db.Get(gcSecondCorrectKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	warpedGCVal := make([]byte, len(gcSecondCorrectVal)+1)
+	copy(warpedGCVal[1:], gcSecondCorrectVal)
+	ldb.db.Delete(gcSecondCorrectKey)
+	ldb.db.Put(gcSecondCorrectKey, warpedGCVal)
+
+	ldb.CleanIndex()
+
+	// the index without corresponding data should have been deleted
+	idxKey := make([]byte, 33)
+	idxKey[0] = keyIndex
+	copy(idxKey[1:], chunks[0].Address())
+	_, err = ldb.db.Get(idxKey)
+	if err == nil {
+		t.Fatalf("expected chunk 0 idx to be pruned: %v", idxKey)
+	}
+
+	// the two other indices should be present
+	copy(idxKey[1:], chunks[1].Address())
+	_, err = ldb.db.Get(idxKey)
+	if err != nil {
+		t.Fatalf("expected chunk 1 idx to be present: %v", idxKey)
+	}
+	copy(idxKey[1:], chunks[2].Address())
+	_, err = ldb.db.Get(idxKey)
+	if err != nil {
+		t.Fatalf("expected chunk 2 idx to be present: %v", idxKey)
+	}
+
+	// first gc index should still be gone
+	_, err = ldb.db.Get(gcFirstCorrectKey)
+	if err == nil {
+		t.Fatalf("expected gc 0 idx to be pruned: %v", idxKey)
+	}
+
+	// second gc index should still be fixde
+	_, err = ldb.db.Get(gcSecondCorrectKey)
+	if err != nil {
+		t.Fatalf("expected gc 1 idx to be present: %v", idxKey)
+	}
+
+	// third gc index should be unchanged
+	binary.BigEndian.PutUint64(gcSecondCorrectKey[1:], uint64(2))
+	_, err = ldb.db.Get(gcSecondCorrectKey)
+	if err != nil {
+		t.Fatalf("expected gc 2 idx to be present: %v", idxKey)
+	}
 }
 
 func waitGc(ctx context.Context, ldb *LDBStore) {

--- a/swarm/storage/localstore.go
+++ b/swarm/storage/localstore.go
@@ -205,8 +205,12 @@ func (ls *LocalStore) Migrate() error {
 	if schema != CurrentDbSchema {
 		// run migrations
 
-		if schema == "" {
+		if schema != DbSchemaHalloween {
 			log.Debug("running migrations for", "schema", schema, "runtime-schema", CurrentDbSchema)
+			if schema == DbSchemaPurity {
+				// fix garbage screwed garbage collection and indices
+				ls.DbStore.CleanIndex()
+			}
 
 			// delete chunks that are not valid, i.e. chunks that do not pass any of the ls.Validators
 			ls.DbStore.Cleanup(func(c *chunk) bool {

--- a/swarm/storage/schema.go
+++ b/swarm/storage/schema.go
@@ -2,5 +2,7 @@ package storage
 
 // "purity" is the first formal schema of LevelDB we release together with Swarm 0.3.5
 const DbSchemaPurity = "purity"
+const DbSchemaHalloween = "halloween"
 
-const CurrentDbSchema = DbSchemaPurity
+//const CurrentDbSchema = DbSchemaPurity
+const CurrentDbSchema = DbSchemaHalloween

--- a/swarm/storage/schema.go
+++ b/swarm/storage/schema.go
@@ -1,8 +1,17 @@
 package storage
 
+// The DB schema we want to use. The actual/current DB schema might differ
+// until migrations are run.
+const DesiredDbSchema = DbSchemaHalloween
+
+// There was a time when we had no schema at all.
+const DbSchemaNone = ""
+
 // "purity" is the first formal schema of LevelDB we release together with Swarm 0.3.5
 const DbSchemaPurity = "purity"
-const DbSchemaHalloween = "halloween"
 
-//const CurrentDbSchema = DbSchemaPurity
-const CurrentDbSchema = DbSchemaHalloween
+// "halloween" is here because we had a screw in the garbage collector index.
+// Because of that we had to rebuild the GC index to get rid of erroneous
+// entries and that takes a long time. This schema is used for bookkeeping,
+// so rebuild index will run just once.
+const DbSchemaHalloween = "halloween"


### PR DESCRIPTION
This PR fixes the invalid byte slice passed to the access count incrementer, causing index pointers to persist even though data rows and gc rows persist.

It also introduces a Cleanup method for correcting the damage done to already existing datastores due to the above.

closes #931 

Tasks:

- [x] Fix corrupt data parameter to accesscount updater
- [x] Cleanup method for correcting all entry nodes
- [x] Add test for entry cleanups
- [x] Count remaining chunks and update entrycount and proximity bin pointers
- [x] Add test for summary entries
- [x] Add cleanup to migration
- [x] ~Merge `CleanIndex` with `Cleanup`~ moved to https://github.com/ethersphere/go-ethereum/issues/985