### PR TITLE
swarm/network, swarm/pss, p2p/simulations: adapt test kademlia params

### DIFF
--- a/p2p/simulations/network.go
+++ b/p2p/simulations/network.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"sync"
 	"time"
 
@@ -89,6 +90,9 @@ func (net *Network) NewNodeWithConfig(conf *adapters.NodeConfig) (*Node, error) 
 			_, err := net.InitConn(conf.ID, otherID)
 			if err != nil {
 				log.Trace("net.InitConn returned an error", "err", err)
+				r := rand.New(rand.NewSource(time.Now().UnixNano()))
+				t := time.Duration(time.Duration(r.Intn(200)) * time.Millisecond)
+				time.Sleep(t)
 				return false
 			}
 			return true

--- a/swarm/network/kademlia.go
+++ b/swarm/network/kademlia.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/swarm/log"
 	"github.com/ethereum/go-ethereum/swarm/pot"
 )
@@ -62,7 +63,7 @@ type KadParams struct {
 	RetryExponent  int   // exponent to multiply retry intervals with
 	MaxRetries     int   // maximum number of redial attempts
 	// function to sanction or prevent suggesting a peer
-	Reachable func(*BzzAddr) bool
+	Reachable func(id enode.ID) bool
 }
 
 // NewKadParams returns a params struct with default values
@@ -519,9 +520,13 @@ func (k *Kademlia) callable(e *entry) bool {
 		return false
 	}
 	// function to sanction or prevent suggesting a peer
-	if k.Reachable != nil && !k.Reachable(e.BzzAddr) {
-		log.Trace(fmt.Sprintf("%08x: peer %v is temporarily not callable", k.BaseAddr()[:4], e))
-		return false
+	if k.Reachable != nil {
+		enode := enode.ID{}
+		copy(enode[:], e.BzzAddr.Over())
+		if !k.Reachable(enode) {
+			log.Trace(fmt.Sprintf("%08x: peer %v is temporarily not callable", k.BaseAddr()[:4], e))
+			return false
+		}
 	}
 	e.retries++
 	log.Trace(fmt.Sprintf("%08x: peer %v is callable", k.BaseAddr()[:4], e))
@@ -698,6 +703,8 @@ func (k *Kademlia) saturation(n int) int {
 // full returns true if all required bins have connected peers.
 // It is used in Healthy function for testing only
 func (k *Kademlia) full(emptyBins []int) (full bool) {
+	log.Debug("kademlia.full", "node", fmt.Sprintf("%08x", k.BaseAddr()[:4]), "emptyBins", emptyBins)
+
 	prev := 0
 	e := len(emptyBins)
 	ok := true

--- a/swarm/network/kademlia.go
+++ b/swarm/network/kademlia.go
@@ -524,6 +524,9 @@ func (k *Kademlia) callable(e *entry) bool {
 		enode := enode.ID{}
 		copy(enode[:], e.BzzAddr.Over())
 		if !k.Reachable(enode) {
+			r := rand.New(rand.NewSource(time.Now().UnixNano()))
+			t := time.Duration(time.Duration(r.Intn(400)) * time.Millisecond)
+			time.Sleep(t)
 			log.Trace(fmt.Sprintf("%08x: peer %v is temporarily not callable", k.BaseAddr()[:4], e))
 			return false
 		}

--- a/swarm/network/simulation/example_test.go
+++ b/swarm/network/simulation/example_test.go
@@ -47,7 +47,8 @@ func ExampleSimulation_WaitTillHealthy() {
 				UnderlayAddr: addr.Under(),
 				HiveParams:   hp,
 			}
-			kad := network.NewKademlia(addr.Over(), network.NewKadParams())
+			kad := network.NewKademlia(addr.Over(), simulation.NewTestKadParams(ctx))
+
 			// store kademlia in node's bucket under BucketKeyKademlia
 			// so that it can be found by WaitTillHealthy method.
 			b.Store(simulation.BucketKeyKademlia, kad)

--- a/swarm/network/simulation/kademlia.go
+++ b/swarm/network/simulation/kademlia.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
 	"github.com/ethereum/go-ethereum/swarm/network"
 )
 
@@ -93,4 +94,12 @@ func (s *Simulation) kademlias() (ks map[enode.ID]*network.Kademlia) {
 		ks[id] = k
 	}
 	return ks
+}
+
+func NewTestKadParams(ctx *adapters.ServiceContext) *network.KadParams {
+	kadParams := network.NewKadParams()
+	if ctx.Config.Reachable != nil {
+		kadParams.Reachable = ctx.Config.Reachable
+	}
+	return kadParams
 }

--- a/swarm/network/simulation/kademlia_test.go
+++ b/swarm/network/simulation/kademlia_test.go
@@ -39,7 +39,7 @@ func TestWaitTillHealthy(t *testing.T) {
 				UnderlayAddr: addr.Under(),
 				HiveParams:   hp,
 			}
-			kad := network.NewKademlia(addr.Over(), network.NewKadParams())
+			kad := network.NewKademlia(addr.Over(), NewTestKadParams(ctx))
 			// store kademlia in node's bucket under BucketKeyKademlia
 			// so that it can be found by WaitTillHealthy method.
 			b.Store(BucketKeyKademlia, kad)
@@ -48,7 +48,7 @@ func TestWaitTillHealthy(t *testing.T) {
 	})
 	defer sim.Close()
 
-	_, err := sim.AddNodesAndConnectRing(10)
+	_, err := sim.AddNodesAndConnectRing(30)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swarm/network/simulation/kademlia_test.go
+++ b/swarm/network/simulation/kademlia_test.go
@@ -48,7 +48,7 @@ func TestWaitTillHealthy(t *testing.T) {
 	})
 	defer sim.Close()
 
-	_, err := sim.AddNodesAndConnectRing(30)
+	_, err := sim.AddNodesAndConnectRing(10)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swarm/network/simulation/node_test.go
+++ b/swarm/network/simulation/node_test.go
@@ -287,7 +287,7 @@ func TestUploadSnapshot(t *testing.T) {
 				UnderlayAddr: addr.Under(),
 				HiveParams:   hp,
 			}
-			kad := network.NewKademlia(addr.Over(), network.NewKadParams())
+			kad := network.NewKademlia(addr.Over(), NewTestKadParams(ctx))
 			return network.NewBzz(config, kad, nil, nil, nil), nil, nil
 		},
 	})

--- a/swarm/network/simulations/discovery/discovery_test.go
+++ b/swarm/network/simulations/discovery/discovery_test.go
@@ -406,6 +406,7 @@ func discoveryPersistenceSimulation(nodes, conns int, adapter adapters.NodeAdapt
 
 				log.Info(fmt.Sprintf("NODE: %s, IS HEALTHY: %t", addr, healthy.GotNN && healthy.KnowNN && healthy.Full))
 				if !healthy.GotNN || !healthy.Full {
+					log.Trace("node is not healthy", "hive", healthy.Hive)
 					isHealthy = false
 					break
 				}

--- a/swarm/network/simulations/discovery/discovery_test.go
+++ b/swarm/network/simulations/discovery/discovery_test.go
@@ -554,9 +554,10 @@ func newService(ctx *adapters.ServiceContext) (node.Service, error) {
 	kp.MinProxBinSize = testMinProxBinSize
 
 	if ctx.Config.Reachable != nil {
-		kp.Reachable = func(id enode.ID) bool {
-			return ctx.Config.Reachable(id)
-		}
+		log.Error("ctx.config.reachable not null")
+		/*		kp.Reachable = func(id enode.ID) bool {
+				return ctx.Config.Reachable(id)
+			}*/
 	}
 	kad := network.NewKademlia(addr.Over(), kp)
 	hp := network.NewHiveParams()

--- a/swarm/network/simulations/discovery/discovery_test.go
+++ b/swarm/network/simulations/discovery/discovery_test.go
@@ -553,12 +553,6 @@ func newService(ctx *adapters.ServiceContext) (node.Service, error) {
 	kp := network.NewKadParams()
 	kp.MinProxBinSize = testMinProxBinSize
 
-	if ctx.Config.Reachable != nil {
-		log.Error("ctx.config.reachable not null")
-		/*		kp.Reachable = func(id enode.ID) bool {
-				return ctx.Config.Reachable(id)
-			}*/
-	}
 	kad := network.NewKademlia(addr.Over(), kp)
 	hp := network.NewHiveParams()
 	hp.KeepAliveInterval = time.Duration(200) * time.Millisecond

--- a/swarm/network/simulations/discovery/discovery_test.go
+++ b/swarm/network/simulations/discovery/discovery_test.go
@@ -554,8 +554,8 @@ func newService(ctx *adapters.ServiceContext) (node.Service, error) {
 	kp.MinProxBinSize = testMinProxBinSize
 
 	if ctx.Config.Reachable != nil {
-		kp.Reachable = func(o *network.BzzAddr) bool {
-			return ctx.Config.Reachable(o.ID())
+		kp.Reachable = func(id enode.ID) bool {
+			return ctx.Config.Reachable(id)
 		}
 	}
 	kad := network.NewKademlia(addr.Over(), kp)

--- a/swarm/network/simulations/overlay.go
+++ b/swarm/network/simulations/overlay.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/simulations"
 	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
 	"github.com/ethereum/go-ethereum/swarm/network"
+	"github.com/ethereum/go-ethereum/swarm/network/simulation"
 	"github.com/ethereum/go-ethereum/swarm/state"
 	colorable "github.com/mattn/go-colorable"
 )
@@ -84,8 +85,7 @@ func (s *Simulation) NewService(ctx *adapters.ServiceContext) (node.Service, err
 	s.mtx.Unlock()
 
 	addr := network.NewAddr(node)
-
-	kp := network.NewKadParams()
+	kp := simulation.NewTestKadParams(ctx)
 	kp.MinProxBinSize = 2
 	kp.MaxBinSize = 4
 	kp.MinBinSize = 1

--- a/swarm/network/stream/delivery_test.go
+++ b/swarm/network/stream/delivery_test.go
@@ -453,8 +453,6 @@ func TestDeliveryFromNodes(t *testing.T) {
 }
 
 func testDeliveryFromNodes(t *testing.T, nodes, conns, chunkCount int, skipCheck bool) {
-
-	t.Skip("temporarily disabled as simulations.WaitTillHealthy cannot be trusted")
 	sim := simulation.New(map[string]simulation.ServiceFunc{
 		"streamer": func(ctx *adapters.ServiceContext, bucket *sync.Map) (s node.Service, cleanup func(), err error) {
 			node := ctx.Config.Node()

--- a/swarm/network/stream/intervals_test.go
+++ b/swarm/network/stream/intervals_test.go
@@ -52,8 +52,6 @@ func TestIntervalsLiveAndHistory(t *testing.T) {
 }
 
 func testIntervals(t *testing.T, live bool, history *Range, skipCheck bool) {
-
-	t.Skip("temporarily disabled as simulations.WaitTillHealthy cannot be trusted")
 	nodes := 2
 	chunkCount := dataChunkCount
 	externalStreamName := "externalStream"

--- a/swarm/network/stream/snapshot_retrieval_test.go
+++ b/swarm/network/stream/snapshot_retrieval_test.go
@@ -122,7 +122,7 @@ func retrievalStreamerFunc(ctx *adapters.ServiceContext, bucket *sync.Map) (s no
 	if err != nil {
 		return nil, nil, err
 	}
-	kad := network.NewKademlia(addr.Over(), network.NewKadParams())
+	kad := network.NewKademlia(addr.Over(), simulation.NewTestKadParams(ctx))
 	delivery := NewDelivery(kad, netStore)
 	netStore.NewNetFetcherFunc = network.NewFetcherFactory(delivery.RequestFromPeers, true).New
 

--- a/swarm/network/stream/snapshot_sync_test.go
+++ b/swarm/network/stream/snapshot_sync_test.go
@@ -182,8 +182,6 @@ func streamerFunc(ctx *adapters.ServiceContext, bucket *sync.Map) (s node.Servic
 }
 
 func testSyncingViaGlobalSync(t *testing.T, chunkCount int, nodeCount int) {
-
-	t.Skip("temporarily disabled as simulations.WaitTillHealthy cannot be trusted")
 	sim := simulation.New(simServiceMap)
 	defer sim.Close()
 
@@ -331,8 +329,6 @@ assuming that the snapshot file identifies a healthy
 kademlia network. The snapshot should have 'streamer' in its service list.
 */
 func testSyncingViaDirectSubscribe(t *testing.T, chunkCount int, nodeCount int) error {
-
-	t.Skip("temporarily disabled as simulations.WaitTillHealthy cannot be trusted")
 	sim := simulation.New(map[string]simulation.ServiceFunc{
 		"streamer": func(ctx *adapters.ServiceContext, bucket *sync.Map) (s node.Service, cleanup func(), err error) {
 			n := ctx.Config.Node()

--- a/swarm/network/stream/snapshot_sync_test.go
+++ b/swarm/network/stream/snapshot_sync_test.go
@@ -347,7 +347,7 @@ func testSyncingViaDirectSubscribe(t *testing.T, chunkCount int, nodeCount int) 
 			if err != nil {
 				return nil, nil, err
 			}
-			kad := network.NewKademlia(addr.Over(), network.NewKadParams())
+			kad := network.NewKademlia(addr.Over(), simulation.NewTestKadParams(ctx))
 			delivery := NewDelivery(kad, netStore)
 			netStore.NewNetFetcherFunc = network.NewFetcherFactory(dummyRequestFromPeers, true).New
 

--- a/swarm/network/stream/syncer_test.go
+++ b/swarm/network/stream/syncer_test.go
@@ -68,8 +68,6 @@ func createMockStore(globalStore mock.GlobalStorer, id enode.ID, addr *network.B
 }
 
 func testSyncBetweenNodes(t *testing.T, nodes, conns, chunkCount int, skipCheck bool, po uint8) {
-
-	t.Skip("temporarily disabled as simulations.WaitTillHealthy cannot be trusted")
 	sim := simulation.New(map[string]simulation.ServiceFunc{
 		"streamer": func(ctx *adapters.ServiceContext, bucket *sync.Map) (s node.Service, cleanup func(), err error) {
 			var store storage.ChunkStore

--- a/swarm/network/stream/visualized_snapshot_sync_sim_test.go
+++ b/swarm/network/stream/visualized_snapshot_sync_sim_test.go
@@ -84,8 +84,6 @@ func watchSim(sim *simulation.Simulation) (context.Context, context.CancelFunc) 
 
 //This test requests bogus hashes into the network
 func TestNonExistingHashesWithServer(t *testing.T) {
-
-	t.Skip("temporarily disabled as simulations.WaitTillHealthy cannot be trusted")
 	nodeCount, _, sim := setupSim(retrievalSimServiceMap)
 	defer sim.Close()
 
@@ -144,8 +142,6 @@ func sendSimTerminatedEvent(sim *simulation.Simulation) {
 //It also sends some custom events so that the frontend
 //can visualize messages like SendOfferedMsg, WantedHashesMsg, DeliveryMsg
 func TestSnapshotSyncWithServer(t *testing.T) {
-
-	t.Skip("temporarily disabled as simulations.WaitTillHealthy cannot be trusted")
 	nodeCount, chunkCount, sim := setupSim(simServiceMap)
 	defer sim.Close()
 

--- a/swarm/network_test.go
+++ b/swarm/network_test.go
@@ -259,8 +259,6 @@ type testSwarmNetworkOptions struct {
 //  - May wait for Kademlia on every node to be healthy.
 //  - Checking if a file is retrievable from all nodes.
 func testSwarmNetwork(t *testing.T, o *testSwarmNetworkOptions, steps ...testSwarmNetworkStep) {
-
-	t.Skip("temporarily disabled as simulations.WaitTillHealthy cannot be trusted")
 	if o == nil {
 		o = new(testSwarmNetworkOptions)
 	}

--- a/swarm/pss/client/client_test.go
+++ b/swarm/pss/client/client_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/swarm/network"
+	"github.com/ethereum/go-ethereum/swarm/network/simulation"
 	"github.com/ethereum/go-ethereum/swarm/pss"
 	"github.com/ethereum/go-ethereum/swarm/state"
 	whisper "github.com/ethereum/go-ethereum/whisper/whisperv5"
@@ -233,11 +234,11 @@ func setupNetwork(numnodes int) (clients []*rpc.Client, err error) {
 func newServices() adapters.Services {
 	stateStore := state.NewInmemoryStore()
 	kademlias := make(map[enode.ID]*network.Kademlia)
-	kademlia := func(id enode.ID) *network.Kademlia {
+	kademlia := func(id enode.ID, ctx *adapters.ServiceContext) *network.Kademlia {
 		if k, ok := kademlias[id]; ok {
 			return k
 		}
-		params := network.NewKadParams()
+		params := simulation.NewTestKadParams(ctx)
 		params.MinProxBinSize = 2
 		params.MaxBinSize = 3
 		params.MinBinSize = 1
@@ -260,7 +261,7 @@ func newServices() adapters.Services {
 				return nil, err
 			}
 			psparams := pss.NewPssParams().WithPrivateKey(privkey)
-			pskad := kademlia(ctx.Config.ID)
+			pskad := kademlia(ctx.Config.ID, ctx)
 			ps, err := pss.NewPss(pskad, psparams)
 			if err != nil {
 				return nil, err
@@ -282,7 +283,7 @@ func newServices() adapters.Services {
 				UnderlayAddr: addr.Under(),
 				HiveParams:   hp,
 			}
-			return network.NewBzz(config, kademlia(ctx.Config.ID), stateStore, nil, nil), nil
+			return network.NewBzz(config, kademlia(ctx.Config.ID, ctx), stateStore, nil, nil), nil
 		},
 	}
 }

--- a/swarm/pss/pss_test.go
+++ b/swarm/pss/pss_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/swarm/network"
+	"github.com/ethereum/go-ethereum/swarm/network/simulation"
 	"github.com/ethereum/go-ethereum/swarm/pot"
 	"github.com/ethereum/go-ethereum/swarm/state"
 	whisper "github.com/ethereum/go-ethereum/whisper/whisperv5"
@@ -1932,11 +1933,11 @@ func setupNetwork(numnodes int, allowRaw bool) (clients []*rpc.Client, err error
 func newServices(allowRaw bool) adapters.Services {
 	stateStore := state.NewInmemoryStore()
 	kademlias := make(map[enode.ID]*network.Kademlia)
-	kademlia := func(id enode.ID) *network.Kademlia {
+	kademlia := func(id enode.ID, ctx *adapters.ServiceContext) *network.Kademlia {
 		if k, ok := kademlias[id]; ok {
 			return k
 		}
-		params := network.NewKadParams()
+		params := simulation.NewTestKadParams(ctx)
 		params.MinProxBinSize = 2
 		params.MaxBinSize = 3
 		params.MinBinSize = 1
@@ -1957,7 +1958,7 @@ func newServices(allowRaw bool) adapters.Services {
 			privkey, err := w.GetPrivateKey(keys)
 			pssp := NewPssParams().WithPrivateKey(privkey)
 			pssp.AllowRaw = allowRaw
-			pskad := kademlia(ctx.Config.ID)
+			pskad := kademlia(ctx.Config.ID, ctx)
 			ps, err := NewPss(pskad, pssp)
 			if err != nil {
 				return nil, err
@@ -2007,7 +2008,7 @@ func newServices(allowRaw bool) adapters.Services {
 				UnderlayAddr: addr.Under(),
 				HiveParams:   hp,
 			}
-			return network.NewBzz(config, kademlia(ctx.Config.ID), stateStore, nil, nil), nil
+			return network.NewBzz(config, kademlia(ctx.Config.ID, ctx), stateStore, nil, nil), nil
 		},
 	}
 }


### PR DESCRIPTION
This PR addresses an incorrect node setup on certain simulations, in which the `Reachable` function in the Kademlia was not called at all. This resulted in tests flaking due to peer dialups not being sanctioned correctly.

Similar tests that use `ServiceContext` on setup have been amended to correctly reference the correct `Reachable` function pointer from the `ServiceContext`.

fixes https://github.com/ethersphere/go-ethereum/issues/994