### PR TITLE
cmd/swarm/swarm-smoke: metrics for each run

### DIFF
--- a/cmd/swarm/swarm-smoke/upload_and_sync.go
+++ b/cmd/swarm/swarm-smoke/upload_and_sync.go
@@ -123,11 +123,14 @@ func uploadAndSync(c *cli.Context) error {
 		wg.Add(1)
 		go func(endpoint string, ruid string) {
 			for {
+				start := time.Now()
 				err := fetch(hash, endpoint, fhash, ruid)
+				fetchTime := time.Since(start)
 				if err != nil {
 					continue
 				}
 
+				metrics.GetOrRegisterMeter("upload-and-sync.single.fetch-time", nil).Mark(int64(fetchTime))
 				wg.Done()
 				return
 			}
@@ -138,11 +141,14 @@ func uploadAndSync(c *cli.Context) error {
 			wg.Add(1)
 			go func(endpoint string, ruid string) {
 				for {
+					start := time.Now()
 					err := fetch(hash, endpoint, fhash, ruid)
+					fetchTime := time.Since(start)
 					if err != nil {
 						continue
 					}
 
+					metrics.GetOrRegisterMeter("upload-and-sync.each.fetch-time", nil).Mark(int64(fetchTime))
 					wg.Done()
 					return
 				}


### PR DESCRIPTION
This PR would add the ability to meter each singular `fetch` and give insights into 

* average durations
* quickest single durations
* longest single durations

If this makes sense, we should add this to the `feed_upload_and_sync.go` as well