### PR TITLE
swarm/docker: Dockerfile for swarm:edge docker image

### DIFF
--- a/swarm/api/http/middleware.go
+++ b/swarm/api/http/middleware.go
@@ -80,7 +80,7 @@ func InitLoggingResponseWriter(h http.Handler) http.Handler {
 		h.ServeHTTP(writer, r)
 
 		ts := time.Since(tn)
-		log.Info("request served", "ruid", GetRUID(r.Context()), "code", writer.statusCode, "time", ts*time.Millisecond)
+		log.Info("request served", "ruid", GetRUID(r.Context()), "code", writer.statusCode, "time", ts)
 		metrics.GetOrRegisterResettingTimer(fmt.Sprintf("http.request.%s.time", r.Method), nil).Update(ts)
 		metrics.GetOrRegisterResettingTimer(fmt.Sprintf("http.request.%s.%d.time", r.Method, writer.statusCode), nil).Update(ts)
 	})

--- a/swarm/docker/Dockerfile
+++ b/swarm/docker/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.11-alpine as builder
+
+RUN apk add --update git gcc g++ linux-headers
+RUN mkdir -p $GOPATH/src/github.com/ethereum && \
+    cd $GOPATH/src/github.com/ethereum && \
+    git clone --depth 1 https://github.com/ethersphere/go-ethereum && \
+    cd $GOPATH/src/github.com/ethereum/go-ethereum && \
+    VERSION=$(git rev-parse --short HEAD) go install -ldflags "-X main.gitCommit=${VERSION}" ./cmd/swarm && \
+    VERSION=$(git rev-parse --short HEAD) go install -ldflags "-X main.gitCommit=${VERSION}" ./cmd/swarm/swarm-smoke && \
+    VERSION=$(git rev-parse --short HEAD) go install -ldflags "-X main.gitCommit=${VERSION}" ./cmd/geth && \
+    cp $GOPATH/bin/swarm /swarm && cp $GOPATH/bin/geth /geth && cp $GOPATH/bin/swarm-smoke /swarm-smoke
+
+
+# Release image with the required binaries and scripts
+FROM alpine:3.8
+WORKDIR /
+COPY --from=builder /swarm /geth /swarm-smoke /
+ADD run.sh /run.sh
+ENTRYPOINT ["/run.sh"]

--- a/swarm/docker/Dockerfile
+++ b/swarm/docker/Dockerfile
@@ -1,13 +1,16 @@
 FROM golang:1.11-alpine as builder
 
+ARG VERSION
+
 RUN apk add --update git gcc g++ linux-headers
 RUN mkdir -p $GOPATH/src/github.com/ethereum && \
     cd $GOPATH/src/github.com/ethereum && \
-    git clone --depth 1 https://github.com/ethersphere/go-ethereum && \
+    git clone https://github.com/ethersphere/go-ethereum && \
     cd $GOPATH/src/github.com/ethereum/go-ethereum && \
-    VERSION=$(git rev-parse --short HEAD) go install -ldflags "-X main.gitCommit=${VERSION}" ./cmd/swarm && \
-    VERSION=$(git rev-parse --short HEAD) go install -ldflags "-X main.gitCommit=${VERSION}" ./cmd/swarm/swarm-smoke && \
-    VERSION=$(git rev-parse --short HEAD) go install -ldflags "-X main.gitCommit=${VERSION}" ./cmd/geth && \
+    git checkout ${VERSION} && \
+    go install -ldflags "-X main.gitCommit=${VERSION}" ./cmd/swarm && \
+    go install -ldflags "-X main.gitCommit=${VERSION}" ./cmd/swarm/swarm-smoke && \
+    go install -ldflags "-X main.gitCommit=${VERSION}" ./cmd/geth && \
     cp $GOPATH/bin/swarm /swarm && cp $GOPATH/bin/geth /geth && cp $GOPATH/bin/swarm-smoke /swarm-smoke
 
 

--- a/swarm/docker/Dockerfile
+++ b/swarm/docker/Dockerfile
@@ -16,4 +16,5 @@ FROM alpine:3.8
 WORKDIR /
 COPY --from=builder /swarm /geth /swarm-smoke /
 ADD run.sh /run.sh
+ADD run-smoke.sh /run-smoke.sh
 ENTRYPOINT ["/run.sh"]

--- a/swarm/docker/run-smoke.sh
+++ b/swarm/docker/run-smoke.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+/swarm-smoke $@ 2>&1 || true

--- a/swarm/docker/run.sh
+++ b/swarm/docker/run.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+PASSWORD=${PASSWORD:-}
+DATADIR=${DATADIR:-/root/.ethereum/}
+
+if [ "$PASSWORD" == "" ]; then echo "Password must be set, in order to use swarm non-interactively." && exit 1; fi
+
+echo $PASSWORD > /password
+
+KEYFILE=`find $DATADIR | grep UTC | head -n 1` || true
+if [ ! -f "$KEYFILE" ]; then echo "No keyfile found. Generating..." && /geth --datadir $DATADIR --password /password account new; fi
+KEYFILE=`find $DATADIR | grep UTC | head -n 1` || true
+if [ ! -f "$KEYFILE" ]; then echo "Could not find nor generate a BZZ keyfile." && exit 1; else echo "Found keyfile $KEYFILE"; fi
+
+VERSION=`/swarm version`
+echo "Running Swarm:"
+echo $VERSION
+
+export BZZACCOUNT="`echo -n $KEYFILE | tail -c 40`" || true
+if [ "$BZZACCOUNT" == "" ]; then echo "Could not parse BZZACCOUNT from keyfile." && exit 1; fi
+
+exec /swarm --bzzaccount=$BZZACCOUNT --password /password --datadir $DATADIR $@ 2>&1


### PR DESCRIPTION
Copying `Dockerfile` to `ethereum/go-ethereum`, so that we can automatically build `ethdevops/swarm:edge` on push to `master`.

~Ideally this image should support smoke tests as well, which is currently not the case, hence the `in progress` tag.~