### PR TITLE
remove GitHub codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,27 +10,4 @@ les/                            @zsfelfoldi
 light/                          @zsfelfoldi
 mobile/                         @karalabe
 p2p/                            @fjl @zsfelfoldi
-p2p/simulations                 @lmars
-p2p/protocols                   @zelig
-swarm/api/http                  @justelad
-swarm/bmt                       @zelig
-swarm/dev                       @lmars
-swarm/fuse                      @jmozah @holisticode
-swarm/grafana_dashboards        @nonsense
-swarm/metrics                   @nonsense @holisticode
-swarm/multihash                 @nolash
-swarm/network/bitvector         @zelig @janos 
-swarm/network/priorityqueue     @zelig @janos 
-swarm/network/simulations       @zelig @janos
-swarm/network/stream            @janos @zelig @holisticode @justelad
-swarm/network/stream/intervals  @janos
-swarm/network/stream/testing    @zelig
-swarm/pot                       @zelig
-swarm/pss                       @nolash @zelig @nonsense
-swarm/services                  @zelig
-swarm/state                     @justelad
-swarm/storage/encryption        @zelig @nagydani
-swarm/storage/mock              @janos
-swarm/storage/feed              @nolash @jpeletier
-swarm/testutil                  @lmars
 whisper/                        @gballet @gluk256


### PR DESCRIPTION
For many packages we have only one code owner and their approval is a must when merging a PR. What happens when these people go on vacation for example? (see ethereum/go-ethereum#18386) - we won’t be able to merge anything in swarm/api/http when @justelad is on vacation.

We must add at least 2-3 code owners to every single package, or get rid of them altogether.

I don’t really like adding many code owners, because then you have a PR with 4-5 reviewers, and noone feels responsible for reviewing the PR.

Therefore I suggest we remove all the codeowners from .github. What do you think?

I think we all have a good idea of who knows which part of the codebase best, and can make a good educated guess who to add as a reviewer, without the need for codeowners.