### PR TITLE
swarm/pot: each() functions refactored

### DIFF
--- a/swarm/pot/pot.go
+++ b/swarm/pot/pot.go
@@ -447,60 +447,50 @@ func union(t0, t1 *Pot, pof Pof) (*Pot, int) {
 	return n, common
 }
 
-// Each called with (f) is a synchronous iterator over the bins of a node
-// respecting an ordering
-// proximity > pinnedness
-func (t *Pot) Each(f func(Val, int) bool) bool {
+// Each is a synchronous iterator over the elements of pot with function f.
+func (t *Pot) Each(f func(Val) bool) bool {
 	return t.each(f)
 }
 
-func (t *Pot) each(f func(Val, int) bool) bool {
-	var next bool
-	for _, n := range t.bins {
-		if n == nil {
-			return true
-		}
-		next = n.each(f)
-		if !next {
-			return false
-		}
-	}
-	if t.size == 0 {
+// each is a synchronous iterator over the elements of pot with function f.
+// the iteration ends if the function return false or there are no more elements.
+func (t *Pot) each(f func(Val) bool) bool {
+	if t == nil || t.size == 0 {
 		return false
 	}
-	return f(t.pin, t.po)
-}
-
-// eachFrom called with (f, start) is a synchronous iterator over the elements of a Pot
-// within the inclusive range starting from proximity order start
-// the function argument is passed the value and the proximity order wrt the root pin
-// it does NOT include the pinned item of the root
-// respecting an ordering
-// proximity > pinnedness
-// the iteration ends if the function return false or there are no more elements
-// end of a po range can be implemented since po is passed to the function
-func (t *Pot) eachFrom(f func(Val, int) bool, po int) bool {
-	var next bool
-	_, lim := t.getPos(po)
-	for i := lim; i < len(t.bins); i++ {
-		n := t.bins[i]
-		next = n.each(f)
-		if !next {
+	for _, n := range t.bins {
+		if !n.each(f) {
 			return false
 		}
 	}
-	return f(t.pin, t.po)
+	return f(t.pin)
+}
+
+// eachFrom is a synchronous iterator over the elements of pot with function f,
+// starting from certain proximity order po, which is passed as a second parameter.
+// the iteration ends if the function return false or there are no more elements.
+func (t *Pot) eachFrom(f func(Val) bool, po int) bool {
+	if t == nil || t.size == 0 {
+		return false
+	}
+	_, beg := t.getPos(po)
+	for i := beg; i < len(t.bins); i++ {
+		if !t.bins[i].each(f) {
+			return false
+		}
+	}
+	return f(t.pin)
 }
 
 // EachBin iterates over bins of the pivot node and offers iterators to the caller on each
 // subtree passing the proximity order and the size
 // the iteration continues until the function's return value is false
 // or there are no more subtries
-func (t *Pot) EachBin(val Val, pof Pof, po int, f func(int, int, func(func(val Val, i int) bool) bool) bool) {
+func (t *Pot) EachBin(val Val, pof Pof, po int, f func(int, int, func(func(val Val) bool) bool) bool) {
 	t.eachBin(val, pof, po, f)
 }
 
-func (t *Pot) eachBin(val Val, pof Pof, po int, f func(int, int, func(func(val Val, i int) bool) bool) bool) {
+func (t *Pot) eachBin(val Val, pof Pof, po int, f func(int, int, func(func(val Val) bool) bool) bool) {
 	if t == nil || t.size == 0 {
 		return
 	}
@@ -520,8 +510,8 @@ func (t *Pot) eachBin(val Val, pof Pof, po int, f func(int, int, func(func(val V
 	}
 	if lim == len(t.bins) {
 		if spr >= po {
-			f(spr, 1, func(g func(Val, int) bool) bool {
-				return g(t.pin, spr)
+			f(spr, 1, func(g func(Val) bool) bool {
+				return g(t.pin)
 			})
 		}
 		return
@@ -535,9 +525,9 @@ func (t *Pot) eachBin(val Val, pof Pof, po int, f func(int, int, func(func(val V
 		size += n.size
 	}
 	if spr >= po {
-		if !f(spr, t.size-size, func(g func(Val, int) bool) bool {
-			return t.eachFrom(func(v Val, j int) bool {
-				return g(v, spr)
+		if !f(spr, t.size-size, func(g func(Val) bool) bool {
+			return t.eachFrom(func(v Val) bool {
+				return g(v)
 			}, spo)
 		}) {
 			return
@@ -585,7 +575,7 @@ func (t *Pot) eachNeighbour(val Val, pof Pof, f func(Val, int) bool) bool {
 	}
 
 	for i := l - 1; i > ir; i-- {
-		next = t.bins[i].each(func(v Val, _ int) bool {
+		next = t.bins[i].each(func(v Val) bool {
 			return f(v, po)
 		})
 		if !next {
@@ -595,7 +585,7 @@ func (t *Pot) eachNeighbour(val Val, pof Pof, f func(Val, int) bool) bool {
 
 	for i := il - 1; i >= 0; i-- {
 		n := t.bins[i]
-		next = n.each(func(v Val, _ int) bool {
+		next = n.each(func(v Val) bool {
 			return f(v, n.po)
 		})
 		if !next {
@@ -709,7 +699,7 @@ func (t *Pot) eachNeighbourAsync(val Val, pof Pof, max int, maxPos int, f func(V
 				wg.Add(m)
 			}
 			go func(pn *Pot, pm int) {
-				pn.each(func(v Val, _ int) bool {
+				pn.each(func(v Val) bool {
 					if wg != nil {
 						defer wg.Done()
 					}
@@ -736,7 +726,7 @@ func (t *Pot) eachNeighbourAsync(val Val, pof Pof, max int, maxPos int, f func(V
 			wg.Add(m)
 		}
 		go func(pn *Pot, pm int) {
-			pn.each(func(v Val, _ int) bool {
+			pn.each(func(v Val) bool {
 				if wg != nil {
 					defer wg.Done()
 				}

--- a/swarm/pot/pot_test.go
+++ b/swarm/pot/pot_test.go
@@ -65,14 +65,13 @@ func randomtestAddr(n int, i int) *testAddr {
 	return newTestAddr(v, i)
 }
 
-func indexes(t *Pot) (i []int, po []int) {
-	t.Each(func(v Val, p int) bool {
+func indexes(t *Pot) (i []int) {
+	t.Each(func(v Val) bool {
 		a := v.(*testAddr)
 		i = append(i, a.i)
-		po = append(po, p)
 		return true
 	})
-	return i, po
+	return i
 }
 
 func testAdd(t *Pot, pof Pof, j int, values ...string) (_ *Pot, n int, f bool) {
@@ -102,22 +101,17 @@ func TestPotRemoveSameBin(t *testing.T) {
 	n := NewPot(newTestAddr("11111111", 0), 0)
 	n, _, _ = testAdd(n, pof, 1, "00000000", "01000000", "01100000", "01110000", "01111000")
 	n, _, _ = Remove(n, newTestAddr("01110000", 0), pof)
-	inds, po := indexes(n)
+	inds := indexes(n)
 	goti := n.Size()
 	expi := 5
 	if goti != expi {
 		t.Fatalf("incorrect number of elements in Pot. Expected %v, got %v", expi, goti)
 	}
-	inds, po = indexes(n)
+	inds = indexes(n)
 	got := fmt.Sprintf("%v", inds)
 	exp := "[5 3 2 1 0]"
 	if got != exp {
 		t.Fatalf("incorrect indexes in iteration over Pot. Expected %v, got %v", exp, got)
-	}
-	got = fmt.Sprintf("%v", po)
-	exp = "[3 2 1 0 0]"
-	if got != exp {
-		t.Fatalf("incorrect po-s in iteration over Pot. Expected %v, got %v", exp, got)
 	}
 }
 
@@ -129,22 +123,24 @@ func TestPotRemoveDifferentBins(t *testing.T) {
 	n := NewPot(newTestAddr("11111111", 0), 0)
 	n, _, _ = testAdd(n, pof, 1, "00000000", "10000000", "11000000", "11100000", "11110000")
 	n, _, _ = Remove(n, newTestAddr("11100000", 0), pof)
-	inds, po := indexes(n)
+	inds := indexes(n)
 	goti := n.Size()
 	expi := 5
 	if goti != expi {
 		t.Fatalf("incorrect number of elements in Pot. Expected %v, got %v", expi, goti)
 	}
-	inds, po = indexes(n)
+	inds = indexes(n)
 	got := fmt.Sprintf("%v", inds)
 	exp := "[1 2 3 5 0]"
 	if got != exp {
 		t.Fatalf("incorrect indexes in iteration over Pot. Expected %v, got %v", exp, got)
 	}
-	got = fmt.Sprintf("%v", po)
-	exp = "[0 1 2 4 0]"
+	n, _, _ = testAdd(n, pof, 4, "11100000")
+	inds = indexes(n)
+	got = fmt.Sprintf("%v", inds)
+	exp = "[1 2 3 4 5 0]"
 	if got != exp {
-		t.Fatalf("incorrect po-s in iteration over Pot. Expected %v, got %v", exp, got)
+		t.Fatalf("incorrect indexes in iteration over Pot. Expected %v, got %v", exp, got)
 	}
 }
 
@@ -171,16 +167,11 @@ func TestPotAdd(t *testing.T) {
 	if goti != expi {
 		t.Fatalf("incorrect number of elements in Pot. Expected %v, got %v", expi, goti)
 	}
-	inds, po := indexes(n)
+	inds := indexes(n)
 	got = fmt.Sprintf("%v", inds)
 	exp = "[3 4 2]"
 	if got != exp {
 		t.Fatalf("incorrect indexes in iteration over Pot. Expected %v, got %v", exp, got)
-	}
-	got = fmt.Sprintf("%v", po)
-	exp = "[1 2 0]"
-	if got != exp {
-		t.Fatalf("incorrect po-s in iteration over Pot. Expected %v, got %v", exp, got)
 	}
 }
 
@@ -200,25 +191,20 @@ func TestPotRemove(t *testing.T) {
 	if goti != expi {
 		t.Fatalf("incorrect number of elements in Pot. Expected %v, got %v", expi, goti)
 	}
-	inds, po := indexes(n)
-	got = fmt.Sprintf("%v", po)
-	exp = "[1 3 0]"
-	if got != exp {
-		t.Fatalf("incorrect po-s in iteration over Pot. Expected %v, got %v", exp, got)
-	}
+	inds := indexes(n)
 	got = fmt.Sprintf("%v", inds)
 	exp = "[2 4 1]"
 	if got != exp {
 		t.Fatalf("incorrect indexes in iteration over Pot. Expected %v, got %v", exp, got)
 	}
 	n, _, _ = Remove(n, newTestAddr("00111100", 0), pof) // remove again same element
-	inds, _ = indexes(n)
+	inds = indexes(n)
 	got = fmt.Sprintf("%v", inds)
 	if got != exp {
 		t.Fatalf("incorrect indexes in iteration over Pot. Expected %v, got %v", exp, got)
 	}
 	n, _, _ = Remove(n, newTestAddr("00000000", 0), pof) // remove the first element
-	inds, _ = indexes(n)
+	inds = indexes(n)
 	got = fmt.Sprintf("%v", inds)
 	exp = "[2 4]"
 	if got != exp {
@@ -272,7 +258,7 @@ func TestPotSwap(t *testing.T) {
 			})
 		}
 		sum := 0
-		n.Each(func(v Val, i int) bool {
+		n.Each(func(v Val) bool {
 			if v == nil {
 				return true
 			}


### PR DESCRIPTION
second parameter (int) was removed from each() and eachFrom(), since it does not contain any meaningful value. Related functions refactored accordingly.

fixes #1104