### PR TITLE
Fix data races in fetcher tests

### DIFF
--- a/swarm/network/fetcher.go
+++ b/swarm/network/fetcher.go
@@ -106,7 +106,7 @@ func NewFetcherFactory(request RequestFunc, skipCheck bool) *FetcherFactory {
 // The created Fetcher is started and returned.
 func (f *FetcherFactory) New(ctx context.Context, source storage.Address, peersToSkip *sync.Map) storage.NetFetcher {
 	fetcher := NewFetcher(source, f.request, f.skipCheck)
-	go fetcher.run(ctx, peersToSkip)
+	go fetcher.run(ctx, peersToSkip, nil)
 	return fetcher
 }
 
@@ -162,7 +162,12 @@ func (f *Fetcher) Request(ctx context.Context, hopCount uint8) {
 
 // start prepares the Fetcher
 // it keeps the Fetcher alive within the lifecycle of the passed context
-func (f *Fetcher) run(ctx context.Context, peers *sync.Map) {
+// If doneC is not nil it will be closed to signal that the run function has returned.
+// Not nil doneC is used in tests to synchronize cleanup operations when the test is done.
+func (f *Fetcher) run(ctx context.Context, peers *sync.Map, doneC chan struct{}) {
+	if doneC != nil {
+		defer close(doneC)
+	}
 	var (
 		doRequest bool             // determines if retrieval is initiated in the current iteration
 		wait      *time.Timer      // timer for search timeout

--- a/swarm/network/fetcher_test.go
+++ b/swarm/network/fetcher_test.go
@@ -52,7 +52,11 @@ func (m *mockRequester) doRequest(ctx context.Context, request *Request) (*enode
 		m.count++
 	}
 	time.Sleep(waitTime)
-	m.requestC <- request
+	select {
+	case m.requestC <- request:
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	}
 
 	// if there is a Source in the request use that, if not use the global requestedPeerId
 	source := request.Source


### PR DESCRIPTION
This PR addresses https://github.com/ethersphere/go-ethereum/issues/1109 issue and fixes another set of data races.

This PR introduces no changes to function signatures, but adds one if statement to Fetcher.run with insignificant performance degradation on production code.

Fetcher.run function is controlled by the provided Context, but there is no synchronization between the termination of Fetcher.run goroutine and test termination. Some of the fetcher tests change the global variable searchTimeout and Fetcher.run reads it. If Fetcher.run goroutine is not terminated before serachTimeout is set back to the original value (with defer), or another tests starts, there is a race between reading and writing serachTimeout.

The first race is described in https://github.com/ethersphere/go-ethereum/issues/1109, and the second type of race is `go test -race -count 1 -v github.com/ethereum/go-ethereum/swarm/network`

```
=== RUN   TestDiscovery
--- PASS: TestDiscovery (0.02s)
=== RUN   TestFetcherSingleRequest
--- PASS: TestFetcherSingleRequest (0.10s)
=== RUN   TestFetcherCancelStopsFetcher
--- PASS: TestFetcherCancelStopsFetcher (0.21s)
=== RUN   TestFetcherCancelStopsRequest
--- PASS: TestFetcherCancelStopsRequest (0.31s)
=== RUN   TestFetcherOfferUsesSource
--- PASS: TestFetcherOfferUsesSource (0.60s)
=== RUN   TestFetcherOfferAfterRequestUsesSourceFromContext
--- PASS: TestFetcherOfferAfterRequestUsesSourceFromContext (0.21s)
=== RUN   TestFetcherRetryOnTimeout
==================
WARNING: DATA RACE
Write at 0x000005136cf8 by goroutine 102:
  github.com/ethereum/go-ethereum/swarm/network.TestFetcherRetryOnTimeout()
      /Users/janos/go/src/github.com/ethereum/go-ethereum/swarm/network/fetcher_test.go:294 +0x3f7
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:827 +0x162

Previous read at 0x000005136cf8 by goroutine 92:
  github.com/ethereum/go-ethereum/swarm/network.(*Fetcher).run()
      /Users/janos/go/src/github.com/ethereum/go-ethereum/swarm/network/fetcher.go:239 +0x4d5

Goroutine 102 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:878 +0x659
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1119 +0xa8
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:827 +0x162
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1117 +0x4ee
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1034 +0x2ee
  main.main()
      _testmain.go:106 +0x221

Goroutine 92 (finished) created at:
  github.com/ethereum/go-ethereum/swarm/network.TestFetcherCancelStopsRequest()
      /Users/janos/go/src/github.com/ethereum/go-ethereum/swarm/network/fetcher_test.go:153 +0x4b8
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:827 +0x162
==================
--- FAIL: TestFetcherRetryOnTimeout (0.51s)
    testing.go:771: race detected during execution of test
```

where two goroutines from two different tests are racing on the same global value.

Synchronization is achieved by providing a test hook function that waits for a channel to be closed when Fetcher.run goroutine is done. The right order of defer functions in Fetcher tests is important to avoid races on changing searchTimeout and testHookFetcherRun. Function testHookFetcherRun is added to avoid changes to FetcherFactory.New function signature which calls Fetcher.runs in a goroutine in some of the tests.

With Fetcher.run goroutine synchronization, a deadlock in mockRequester.doRequest function was detected when context is canceled and nothing is receiving on requestC channel.

All races and problems handled in this PR are not affecting production code, just tests.

All Fetcher tests should finish without races:

`go test -race -count 1 -v -run '^(TestFetcherSingleRequest|TestFetcherCancelStopsFetcher|TestFetcherCancelStopsRequest|TestFetcherOfferUsesSource|TestFetcherOfferAfterRequestUsesSourceFromContext|TestFetcherRetryOnTimeout|TestFetcherFactory|TestFetcherRequestQuitRetriesRequest|TestRequestSkipPeer|TestRequestSkipPeerExpired|TestRequestSkipPeerPermanent|TestFetcherMaxHopCount|TestSetTestHookFetcherRun)$' github.com/ethereum/go-ethereum/swarm/network`