### PR TITLE
Fix data race in TestNetworkID test

### DIFF
--- a/swarm/network/networkid_test.go
+++ b/swarm/network/networkid_test.go
@@ -76,13 +76,12 @@ func TestNetworkID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error setting up network: %v", err)
 	}
-	defer func() {
-		//shutdown the snapshot network
-		log.Trace("Shutting down network")
-		net.Shutdown()
-	}()
 	//let's sleep to ensure all nodes are connected
 	time.Sleep(1 * time.Second)
+	// shutdown the the network to avoid race conditions
+	// on accessing kademlias global map while network nodes
+	// are accepting messages
+	net.Shutdown()
 	//for each group sharing the same network ID...
 	for _, netIDGroup := range nodeMap {
 		log.Trace("netIDGroup size", "size", len(netIDGroup))


### PR DESCRIPTION
This PR fixes data races described in https://github.com/ethersphere/go-ethereum/issues/1112 issue.