### PR TITLE
Fix goroutine leak by closing accounts manager on Node.Stop

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -147,6 +147,14 @@ func (n *Node) Start() error {
 		return err
 	}
 
+	if n.accman == nil {
+		var err error
+		n.accman, n.ephemeralKeystore, err = makeAccountManager(n.config)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Initialize the p2p server. This creates the node key and
 	// discovery databases.
 	n.serverConfig = n.config.P2P
@@ -434,6 +442,13 @@ func (n *Node) Stop() error {
 
 	// unblock n.Wait
 	close(n.stop)
+
+	if n.accman != nil {
+		if err := n.accman.Close(); err != nil {
+			return err
+		}
+		n.accman = nil
+	}
 
 	// Remove the keystore if it was created ephemerally.
 	var keystoreErr error


### PR DESCRIPTION
Fixes: https://github.com/ethersphere/go-ethereum/issues/1142

While performing the test described in https://github.com/ethersphere/go-ethereum/issues/1142 issue, a large number of gorutines were created and not terminated. Stack trace shows many goroutines:

```
goroutine 3370 [select]:
github.com/ethereum/go-ethereum/accounts.(*Manager).update(0xc0000b7520)
	/Users/janos/go/src/github.com/ethereum/go-ethereum/accounts/manager.go:95 +0x22a
created by github.com/ethereum/go-ethereum/accounts.NewManager
	/Users/janos/go/src/github.com/ethereum/go-ethereum/accounts/manager.go:68 +0x6f2

goroutine 4481 [select]:
github.com/ethereum/go-ethereum/accounts/keystore.(*watcher).loop(0xc0035ac9a0)
	/Users/janos/go/src/github.com/ethereum/go-ethereum/accounts/keystore/watch.go:94 +0x65b
created by github.com/ethereum/go-ethereum/accounts/keystore.(*watcher).start
	/Users/janos/go/src/github.com/ethereum/go-ethereum/accounts/keystore/watch.go:52 +0xb6
```

Accounts manager is created but not closed for node.Node, leaving large number of goroutines alive. This change closes accounts manager on Node.Stop, but Node initializes accounts manager in constructor, not no Start, so for Restart and Start to work as expected, accounts manager construction and closing is handled in Start as well, preserving the original required initialization in constructor.

Keystore watch creates fs watchers and we have noticed before a lot of `(FSEvents.framework) FSEventStreamStart: register_with_server: ERROR: f2d_register_rpc() => (null) (-21)` errors on macOS while running a large scale simulations. This change may improve simulations performance as it closes unneeded file watchers.

Note: Running tests described in https://github.com/ethersphere/go-ethereum/issues/1142 `time go test -race -count 100 github.com/ethereum/go-ethereum/swarm/network/simulation` require changes from PR https://github.com/ethereum/go-ethereum/pull/18464 to fix race conditions, but this PR solves goroutine leak. This tests run for about 20 minutes.