### PR TITLE
swarm/network/stream: fix delivery test errors 

### DIFF
--- a/swarm/network/stream/delivery.go
+++ b/swarm/network/stream/delivery.go
@@ -259,13 +259,6 @@ func (d *Delivery) RequestFromPeers(ctx context.Context, req *network.Request) (
 			if sp == nil {
 				return true
 			}
-			// nodes that do not provide stream protocol
-			// should not be requested, e.g. bootnodes
-			if !p.HasCap("stream") {
-				// TODO: if we have no errors, delete this if
-				log.Error("Delivery.RequestFromPeers: peer doesn't have stream cap. we should have returned at sp == nil")
-				return true
-			}
 			spID = &id
 			return false
 		})

--- a/swarm/network/stream/delivery_test.go
+++ b/swarm/network/stream/delivery_test.go
@@ -285,7 +285,7 @@ func TestRequestFromPeers(t *testing.T) {
 	addr := network.RandomAddr()
 	to := network.NewKademlia(addr.OAddr, network.NewKadParams())
 	delivery := NewDelivery(to, nil)
-	protocolsPeer := protocols.NewPeer(p2p.NewPeer(dummyPeerID, "dummy", []p2p.Cap{{Name: "stream"}}), nil, nil)
+	protocolsPeer := protocols.NewPeer(p2p.NewPeer(dummyPeerID, "dummy", nil), nil, nil)
 	peer := network.NewPeer(&network.BzzPeer{
 		BzzAddr:   network.RandomAddr(),
 		LightNode: false,
@@ -325,7 +325,7 @@ func TestRequestFromPeersWithLightNode(t *testing.T) {
 	to := network.NewKademlia(addr.OAddr, network.NewKadParams())
 	delivery := NewDelivery(to, nil)
 
-	protocolsPeer := protocols.NewPeer(p2p.NewPeer(dummyPeerID, "dummy", []p2p.Cap{{Name: "stream"}}), nil, nil)
+	protocolsPeer := protocols.NewPeer(p2p.NewPeer(dummyPeerID, "dummy", nil), nil, nil)
 	// setting up a lightnode
 	peer := network.NewPeer(&network.BzzPeer{
 		BzzAddr:   network.RandomAddr(),

--- a/swarm/network/stream/delivery_test.go
+++ b/swarm/network/stream/delivery_test.go
@@ -325,7 +325,7 @@ func TestRequestFromPeersWithLightNode(t *testing.T) {
 	to := network.NewKademlia(addr.OAddr, network.NewKadParams())
 	delivery := NewDelivery(to, nil)
 
-	protocolsPeer := protocols.NewPeer(p2p.NewPeer(dummyPeerID, "dummy", nil), nil, nil)
+	protocolsPeer := protocols.NewPeer(p2p.NewPeer(dummyPeerID, "dummy", []p2p.Cap{{Name: "stream"}}), nil, nil)
 	// setting up a lightnode
 	peer := network.NewPeer(&network.BzzPeer{
 		BzzAddr:   network.RandomAddr(),


### PR DESCRIPTION
This PR should fix stream capability problems reported on travis https://travis-ci.org/ethersphere/go-ethereum/jobs/485364722#L808.

```
ERROR[01-28|12:13:08.749|swarm/network/stream/delivery.go:266] Delivery.RequestFromPeers: peer doesn't have stream cap. we should have returned at sp == nil 
ERROR[01-28|12:13:18.259|swarm/network/stream/peer.go:91]      Message send error, dropping peer        peer=c23331d32a5c1e2c err="shutting down"
ERROR[01-28|12:13:18.259|swarm/network/stream/peer.go:91]      Message send error, dropping peer        peer=c23331d32a5c1e2c err="shutting down"
ERROR[01-28|12:13:18.259|swarm/network/stream/peer.go:91]      Message send error, dropping peer        peer=c23331d32a5c1e2c err="shutting down"
ERROR[01-28|12:13:18.801|swarm/network/stream/delivery.go:266] Delivery.RequestFromPeers: peer doesn't have stream cap. we should have returned at sp == nil 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x90327d]
goroutine 167 [running]:
github.com/ethereum/go-ethereum/swarm/network.(*Fetcher).doRequest(0xc002074200, 0xcca740, 0xc00024fe00, 0xc002034480, 0xc0012faf00, 0x0, 0x0, 0x0, 0x1, 0x0, ...)
	/home/travis/gopath/src/github.com/ethereum/go-ethereum/swarm/network/fetcher.go:307 +0x25d
github.com/ethereum/go-ethereum/swarm/network.(*Fetcher).run(0xc002074200, 0xcca740, 0xc00024fe00, 0xc0012faf00)
	/home/travis/gopath/src/github.com/ethereum/go-ethereum/swarm/network/fetcher.go:231 +0x4b8
created by github.com/ethereum/go-ethereum/swarm/network.(*FetcherFactory).New
	/home/travis/gopath/src/github.com/ethereum/go-ethereum/swarm/network/fetcher.go:114 +0x12f
FAIL	github.com/ethereum/go-ethereum/swarm/network/stream	10.124s
```

The problem is that in swarm/network/stream tests we do not have "stream" capability for nodes, but in RequestFromPeers method check for it. This is not a problem on production since every peer that is in Registry.peers must have "stream" capability, which is guaranteed by the p2p package. So this check can be safely removed.

I was not able to reproduce the issue locally, only on Travis, and with this change, multiple travis runs did not produce any errors.