### PR TITLE
extract network topology and create simulations JSON snapshot

### DIFF
--- a/cmd/swarm/extract_network_topology/main.go
+++ b/cmd/swarm/extract_network_topology/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"os/exec"
 
@@ -19,11 +20,20 @@ import (
 // echo '{"jsonrpc":"2.0","method":"admin_peers","id":1}' | websocat ws://localhost:8001/api/v1/namespaces/<<namespace>>/pods/http:<<deploymentName>>-<<index>>:8546/proxy/ --origin localhost
 // echo '{"jsonrpc":"2.0","method":"admin_peers","id":1}' | websocat ws://localhost:8001/api/v1/namespaces/gluk256/pods/http:swarm-3:8546/proxy/ --origin localhost | jq ".[]" | tail -n+3 | jq ".[] | .id"
 
+var (
+	nodes          int
+	namespace      string
+	deploymentName string
+)
+
+func init() {
+	flag.IntVar(&nodes, "nodes", 3, "number of nodes in the deployment")
+	flag.StringVar(&namespace, "namespace", "staging", "kubernetes namespace of the deployment")
+	flag.StringVar(&deploymentName, "deploymentName", "swarm-private", "deployment name")
+}
+
 func main() {
-	// TODO: get from command-line arguments / golang flags
-	namespace := "staging"
-	nodes := 3
-	deploymentName := "swarm-private"
+	flag.Parse()
 
 	privateKeys := []string{}
 	names := []string{}

--- a/cmd/swarm/extract_network_topology/main.go
+++ b/cmd/swarm/extract_network_topology/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+func main() {
+	cmd := exec.Command("kubectl", "exec", "-n", "staging", "-ti", "swarm-public-0", "--", "cat", "/root/.ethereum/swarm/nodekey")
+	res, err := cmd.Output()
+	fmt.Println(string(res))
+}

--- a/cmd/swarm/extract_network_topology/main.go
+++ b/cmd/swarm/extract_network_topology/main.go
@@ -1,12 +1,69 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os/exec"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/p2p/simulations"
+	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
 )
 
+// TODO: set correct node ids
+// TODO: set correct node services
+// echo '{"jsonrpc":"2.0","method":"admin_nodeInfo","id":1}' | websocat ws://localhost:8001/api/v1/namespaces/<<namespace>>/pods/http:<<deploymentName>>-<<index>>:8546/proxy/ --origin localhost
+
+// TODO: init correctly Snap.Conns
+// echo '{"jsonrpc":"2.0","method":"admin_peers","id":1}' | websocat ws://localhost:8001/api/v1/namespaces/gluk256/pods/http:swarm-3:8546/proxy/ --origin localhost | jq ".[]" | tail -n+3 | jq ".[] | .enode"
+// echo '{"jsonrpc":"2.0","method":"admin_peers","id":1}' | websocat ws://localhost:8001/api/v1/namespaces/<<namespace>>/pods/http:<<deploymentName>>-<<index>>:8546/proxy/ --origin localhost
+// echo '{"jsonrpc":"2.0","method":"admin_peers","id":1}' | websocat ws://localhost:8001/api/v1/namespaces/gluk256/pods/http:swarm-3:8546/proxy/ --origin localhost | jq ".[]" | tail -n+3 | jq ".[] | .id"
+
 func main() {
-	cmd := exec.Command("kubectl", "exec", "-n", "staging", "-ti", "swarm-public-0", "--", "cat", "/root/.ethereum/swarm/nodekey")
-	res, err := cmd.Output()
-	fmt.Println(string(res))
+	// TODO: get from command-line arguments / golang flags
+	namespace := "staging"
+	nodes := 3
+	deploymentName := "swarm-private"
+
+	privateKeys := []string{}
+	names := []string{}
+
+	// get private keys
+	for i := 0; i < nodes; i++ {
+		cmd := exec.Command("kubectl", "exec", "-n", namespace, "-ti", fmt.Sprintf("%s-%d", deploymentName, i), "--", "cat", "/root/.ethereum/swarm/nodekey")
+		res, err := cmd.Output()
+		if err != nil {
+			panic(err)
+		}
+
+		names = append(names, fmt.Sprintf("%s-%d", deploymentName, i))
+		privateKeys = append(privateKeys, string(res))
+	}
+
+	snap := simulations.Snapshot{}
+	// generate snapshot
+	for i := 0; i < nodes; i++ {
+		prvkey, err := crypto.HexToECDSA(privateKeys[i])
+		if err != nil {
+			panic(err)
+		}
+
+		n := simulations.Node{
+			Config: &adapters.NodeConfig{
+				Name:            names[i],
+				PrivateKey:      prvkey,
+				EnableMsgEvents: true,
+			},
+			Up: true,
+		}
+
+		snap.Nodes = append(snap.Nodes, simulations.NodeSnapshot{Node: n})
+	}
+
+	js, err := json.MarshalIndent(snap, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(string(js))
 }


### PR DESCRIPTION
This PR is adding a tool `extract_network_topology`, which when run from a machine with access to a given Kubernetes deployment, extracts all the information about the network and creates a snapshot to be used in tests and simulations.