### PR TITLE
refactor `swarm-smoke` to accept `hosts` list

### DIFF
--- a/cmd/swarm/swarm-smoke/feed_upload_and_sync.go
+++ b/cmd/swarm/swarm-smoke/feed_upload_and_sync.go
@@ -256,7 +256,7 @@ func feedUploadAndSync(c *cli.Context) error {
 			ruid := uuid.New()[:8]
 			go func(url string, endpoint string, ruid string) {
 				for {
-					err := fetch(url, endpoint, fileHash, ruid)
+					err := fetch(url, endpoint, fileHash, ruid, "")
 					if err != nil {
 						continue
 					}

--- a/cmd/swarm/swarm-smoke/main.go
+++ b/cmd/swarm/swarm-smoke/main.go
@@ -37,18 +37,15 @@ var (
 )
 
 var (
-	endpoints        []string
-	includeLocalhost bool
-	cluster          string
-	appName          string
-	scheme           string
-	filesize         int
-	syncDelay        int
-	from             int
-	to               int
-	verbosity        int
-	timeout          int
-	single           bool
+	allhosts  string
+	hosts     []string
+	filesize  int
+	syncDelay int
+	httpPort  int
+	wsPort    int
+	verbosity int
+	timeout   int
+	single    bool
 )
 
 func main() {
@@ -59,39 +56,22 @@ func main() {
 
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
-			Name:        "cluster-endpoint",
-			Value:       "prod",
-			Usage:       "cluster to point to (prod or a given namespace)",
-			Destination: &cluster,
-		},
-		cli.StringFlag{
-			Name:        "app",
-			Value:       "swarm",
-			Usage:       "application to point to (swarm or swarm-private)",
-			Destination: &appName,
+			Name:        "hosts",
+			Value:       "",
+			Usage:       "comma-separated list of swarm hosts",
+			Destination: &allhosts,
 		},
 		cli.IntFlag{
-			Name:        "cluster-from",
-			Value:       8501,
-			Usage:       "swarm node (from)",
-			Destination: &from,
+			Name:        "http-port",
+			Value:       80,
+			Usage:       "http port",
+			Destination: &httpPort,
 		},
 		cli.IntFlag{
-			Name:        "cluster-to",
-			Value:       8512,
-			Usage:       "swarm node (to)",
-			Destination: &to,
-		},
-		cli.StringFlag{
-			Name:        "cluster-scheme",
-			Value:       "http",
-			Usage:       "http or https",
-			Destination: &scheme,
-		},
-		cli.BoolFlag{
-			Name:        "include-localhost",
-			Usage:       "whether to include localhost:8500 as an endpoint",
-			Destination: &includeLocalhost,
+			Name:        "ws-port",
+			Value:       8546,
+			Usage:       "ws port",
+			Destination: &wsPort,
 		},
 		cli.IntFlag{
 			Name:        "filesize",

--- a/cmd/swarm/swarm-smoke/sliding_window.go
+++ b/cmd/swarm/swarm-smoke/sliding_window.go
@@ -90,7 +90,7 @@ outer:
 					idx := 1 + rand.Intn(len(hosts)-1)
 					ruid := uuid.New()[:8]
 					start := time.Now()
-					err := fetch(v.hash, httpEndpoint(hosts[idx]), v.digest, ruid)
+					err := fetch(v.hash, httpEndpoint(hosts[idx]), v.digest, ruid, "")
 					if err != nil {
 						continue inner
 					}

--- a/cmd/swarm/swarm-smoke/upload_speed.go
+++ b/cmd/swarm/swarm-smoke/upload_speed.go
@@ -30,15 +30,18 @@ import (
 )
 
 func uploadSpeed(c *cli.Context) error {
-	endpoint := generateEndpoint(scheme, cluster, appName, from)
+	if len(hosts) < 2 {
+		log.Crit("less than 2 hosts")
+	}
+
 	seed := int(time.Now().UnixNano() / 1e6)
-	log.Info("uploading to "+endpoint, "seed", seed)
+	log.Info("uploading to "+hosts[0], "seed", seed)
 
 	h := md5.New()
 	r := io.TeeReader(io.LimitReader(crand.Reader, int64(filesize*1000)), h)
 
 	t1 := time.Now()
-	hash, err := upload(r, filesize*1000, endpoint)
+	hash, err := upload(r, filesize*1000, hosts[0])
 	if err != nil {
 		log.Error(err.Error())
 		return err

--- a/cmd/swarm/swarm-smoke/util.go
+++ b/cmd/swarm/swarm-smoke/util.go
@@ -154,11 +154,11 @@ func fetchFeed(topic string, user string, endpoint string, original []byte, ruid
 }
 
 // fetch is getting the requested `hash` from the `endpoint` and compares it with the `original` file
-func fetch(hash string, endpoint string, original []byte, ruid string) error {
+func fetch(hash string, endpoint string, original []byte, ruid string, tuid string) error {
 	ctx, sp := spancontext.StartSpan(context.Background(), "upload-and-sync.fetch")
 	defer sp.Finish()
 
-	log.Trace("http get request", "ruid", ruid, "api", endpoint, "hash", hash)
+	log.Info("http get request", "tuid", tuid, "ruid", ruid, "endpoint", endpoint, "hash", hash)
 
 	var tn time.Time
 	reqUri := endpoint + "/bzz:/" + hash + "/"
@@ -182,7 +182,7 @@ func fetch(hash string, endpoint string, original []byte, ruid string) error {
 		log.Error(err.Error(), "ruid", ruid)
 		return err
 	}
-	log.Trace("http get response", "ruid", ruid, "api", endpoint, "hash", hash, "code", res.StatusCode, "len", res.ContentLength)
+	log.Info("http get response", "tuid", tuid, "ruid", ruid, "endpoint", endpoint, "hash", hash, "code", res.StatusCode, "len", res.ContentLength)
 
 	if res.StatusCode != 200 {
 		err := fmt.Errorf("expected status code %d, got %v", 200, res.StatusCode)


### PR DESCRIPTION
This PR is removing the `generateEndpoints` methods, and just uses the `hosts` provided to the command. Then we can target easily `http` or `ws` or any other endpoint, depending on what command we run.