### PR TITLE
Fix node.Node AccountsManager leak

### DIFF
--- a/p2p/simulations/adapters/inproc.go
+++ b/p2p/simulations/adapters/inproc.go
@@ -172,6 +172,12 @@ type SimNode struct {
 	registerOnce sync.Once
 }
 
+// Close closes the underlaying node.Node to release
+// acquired resources.
+func (sn *SimNode) Close() error {
+	return sn.node.Close()
+}
+
 // Addr returns the node's discovery address
 func (sn *SimNode) Addr() []byte {
 	return []byte(sn.Node().String())

--- a/p2p/simulations/network.go
+++ b/p2p/simulations/network.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math/rand"
 	"sync"
 	"time"
@@ -568,6 +569,12 @@ func (net *Network) Shutdown() {
 		log.Debug("Stopping node", "id", node.ID())
 		if err := node.Stop(); err != nil {
 			log.Warn("Can't stop node", "id", node.ID(), "err", err)
+		}
+		// If the node has the close method, call it.
+		if closer, ok := node.Node.(io.Closer); ok {
+			if err := closer.Close(); err != nil {
+				log.Warn("Can't close node", "id", node.ID(), "err", err)
+			}
 		}
 	}
 	close(net.quitc)


### PR DESCRIPTION
This PR is a second take on fixing the AccountsManager leak on node.Node. The first PR was rejected https://github.com/ethereum/go-ethereum/pull/18505.

Fixes: https://github.com/ethersphere/go-ethereum/issues/1142.

While performing the test described in https://github.com/ethersphere/go-ethereum/issues/1142 issue, a large number of gorutines were created and not terminated. Stack trace shows many goroutines:

```
goroutine 3370 [select]:
github.com/ethereum/go-ethereum/accounts.(*Manager).update(0xc0000b7520)
	/Users/janos/go/src/github.com/ethereum/go-ethereum/accounts/manager.go:95 +0x22a
created by github.com/ethereum/go-ethereum/accounts.NewManager
	/Users/janos/go/src/github.com/ethereum/go-ethereum/accounts/manager.go:68 +0x6f2

goroutine 4481 [select]:
github.com/ethereum/go-ethereum/accounts/keystore.(*watcher).loop(0xc0035ac9a0)
	/Users/janos/go/src/github.com/ethereum/go-ethereum/accounts/keystore/watch.go:94 +0x65b
created by github.com/ethereum/go-ethereum/accounts/keystore.(*watcher).start
	/Users/janos/go/src/github.com/ethereum/go-ethereum/accounts/keystore/watch.go:52 +0xb6
```

Accounts manager is created but not closed for node.Node, leaving large number of goroutines alive. This change closes accounts manager on new method Node.Close, moves the cleaning of ephemeral directory from Stop to Close, and handles the closing of the node in p2p/simulations.Network through p2p/simulations/adapters.SimNode.

