### PR TITLE
CI race detector for Swarm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -214,3 +214,12 @@ matrix:
         submodules: false # avoid cloning ethereum/tests
       script:
         - go run build/ci.go purge -store gethstore/builds -days 14
+
+    - name: Race Detector for Swarm
+      if: repo = ethersphere/go-ethereum AND type = cron
+      os: linux
+      dist: trusty
+      go: 1.11.x
+      git:
+        submodules: false # avoid cloning ethereum/tests
+      script: ./build/travis_keepalive.sh go test -v -timeout 20m -race ./swarm...

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ matrix:
         - go run build/ci.go lint
 
     # This builder does the Ubuntu PPA upload
-    - if: type = push
+    - if: repo = ethereum/go-ethereum AND type = push
       os: linux
       dist: trusty
       go: 1.11.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -216,7 +216,7 @@ matrix:
         - go run build/ci.go purge -store gethstore/builds -days 14
 
     - name: Race Detector for Swarm
-      if: repo = ethersphere/go-ethereum AND type = cron
+      if: repo = ethersphere/go-ethereum
       os: linux
       dist: trusty
       go: 1.11.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ matrix:
         - go run build/ci.go debsrc -upload ethereum/ethereum -sftp-user geth-ci -signer "Go Ethereum Linux Builder <geth-ci@ethereum.org>"
 
     # This builder does the Linux Azure uploads
-    - if: type = push
+    - if: repo = ethereum/go-ethereum AND type = push
       os: linux
       dist: trusty
       sudo: required
@@ -109,7 +109,7 @@ matrix:
         - go run build/ci.go archive -arch arm64 -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
 
     # This builder does the Linux Azure MIPS xgo uploads
-    - if: type = push
+    - if: repo = ethereum/go-ethereum AND type = push
       os: linux
       dist: trusty
       services:
@@ -137,7 +137,7 @@ matrix:
         - go run build/ci.go archive -arch mips64le -type tar -signer LINUX_SIGNING_KEY -upload gethstore/builds
 
     # This builder does the Android Maven and Azure uploads
-    - if: type = push
+    - if: repo = ethereum/go-ethereum AND type = push
       os: linux
       dist: trusty
       addons:
@@ -175,7 +175,7 @@ matrix:
         - go run build/ci.go aar -signer ANDROID_SIGNING_KEY -deploy https://oss.sonatype.org -upload gethstore/builds
 
     # This builder does the OSX Azure, iOS CocoaPods and iOS Azure uploads
-    - if: type = push
+    - if: repo = ethereum/go-ethereum AND type = push
       os: osx
       go: 1.11.x
       env:
@@ -204,7 +204,7 @@ matrix:
         - go run build/ci.go xcode -signer IOS_SIGNING_KEY -deploy trunk -upload gethstore/builds
 
     # This builder does the Azure archive purges to avoid accumulating junk
-    - if: type = cron
+    - if: repo = ethereum/go-ethereum AND type = cron
       os: linux
       dist: trusty
       go: 1.11.x

--- a/build/travis_keepalive.sh
+++ b/build/travis_keepalive.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# travis_keepalive runs the given command and preserves its return value,
+# while it forks a child process what periodically produces a log line,
+# so that Travis won't abort the build after 10 minutes.
+
+# Why?
+# `t.Log()` in Go holds the buffer until the test does not pass or fail,
+# and `-race` can increase the execution time by 2-20x.
+
+set -euo pipefail
+
+readonly KEEPALIVE_INTERVAL=300 # seconds => 5m
+
+main() {
+  keepalive
+  $@
+}
+
+# Keepalive produces a log line in each KEEPALIVE_INTERVAL.
+keepalive() {
+  local child_pid
+  # Note: We fork here!
+  repeat "keepalive" &
+  child_pid=$!
+  ensureChildOnEXIT "${child_pid}"
+}
+
+repeat() {
+  local this="$1"
+  while true; do
+    echo "${this}"
+    sleep "${KEEPALIVE_INTERVAL}"
+  done
+}
+
+# Ensures that the child gets killed on normal program exit.
+ensureChildOnEXIT() {
+  # Note: SIGINT and SIGTERM are forwarded to the child process by Bash
+  # automatically, so we don't have to deal with signals.
+
+  local child_pid="$1"
+  trap "kill ${child_pid}" EXIT
+}
+
+main "$@"


### PR DESCRIPTION
We had more than a dozen of Data Races in our code base. Go has a nice builtin race detector tool. So we should have a CI job that at least notifies us timely if we introduce a new race.

~1st let's just have a daily CRON job triggered on ethersphere/go-ethereum. Later as the job gets stable, we can start using it for ethersphere PRs.~

resolves: #741

-----

# Known Issues

- [x] There are still some data races around `Node.Up` - #1146 also solves
- [x] swarm/network/stream often fails, gets stuck or produces a data race - #1208
- [x] Travis out of memory problems - #1226