### PR TITLE
swarm/network: Keep span across roundtrip

### DIFF
--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -533,7 +533,12 @@ func DefaultConfigDir() string {
 		if runtime.GOOS == "darwin" {
 			return filepath.Join(home, "Library", "Signer")
 		} else if runtime.GOOS == "windows" {
-			return filepath.Join(home, "AppData", "Roaming", "Signer")
+			appdata := os.Getenv("APPDATA")
+			if appdata != "" {
+				return filepath.Join(appdata, "Signer")
+			} else {
+				return filepath.Join(home, "AppData", "Roaming", "Signer")
+			}
 		} else {
 			return filepath.Join(home, ".clef")
 		}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -456,7 +456,7 @@ func (bc *BlockChain) repair(head **types.Block) error {
 		if block == nil {
 			return fmt.Errorf("missing block %d [%x]", (*head).NumberU64()-1, (*head).ParentHash())
 		}
-		(*head) = block
+		*head = block
 	}
 }
 

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -1412,7 +1412,7 @@ func benchmarkLargeNumberOfValueToNonexisting(b *testing.B, numTxs, numBlocks in
 		}
 		b.StopTimer()
 		if got := chain.CurrentBlock().Transactions().Len(); got != numTxs*numBlocks {
-			b.Fatalf("Transactions were not included, expected %d, got %d", (numTxs * numBlocks), got)
+			b.Fatalf("Transactions were not included, expected %d, got %d", numTxs*numBlocks, got)
 
 		}
 	}

--- a/core/vm/gas.go
+++ b/core/vm/gas.go
@@ -30,10 +30,6 @@ const (
 	GasMidStep     uint64 = 8
 	GasSlowStep    uint64 = 10
 	GasExtStep     uint64 = 20
-
-	GasReturn       uint64 = 0
-	GasStop         uint64 = 0
-	GasContractByte uint64 = 200
 )
 
 // calcGas returns the actual gas cost of the call.

--- a/crypto/signature_cgo.go
+++ b/crypto/signature_cgo.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build !nacl,!js,!nocgo
+// +build !nacl,!js,cgo
 
 package crypto
 

--- a/crypto/signature_nocgo.go
+++ b/crypto/signature_nocgo.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// +build nacl js nocgo
+// +build nacl js !cgo
 
 package crypto
 

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -526,13 +526,7 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, block *types.Block, config *StdTraceConfig) ([]string, error) {
 	// If we're tracing a single transaction, make sure it's present
 	if config != nil && config.TxHash != (common.Hash{}) {
-		var exists bool
-		for _, tx := range block.Transactions() {
-			if exists = (tx.Hash() == config.TxHash); exists {
-				break
-			}
-		}
-		if !exists {
+		if !containsTx(block, config.TxHash) {
 			return nil, fmt.Errorf("transaction %#x not found in block", config.TxHash)
 		}
 	}
@@ -623,6 +617,17 @@ func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, block 
 		}
 	}
 	return dumps, nil
+}
+
+// containsTx reports whether the transaction with a certain hash
+// is contained within the specified block.
+func containsTx(block *types.Block, hash common.Hash) bool {
+	for _, tx := range block.Transactions() {
+		if tx.Hash() == hash {
+			return true
+		}
+	}
+	return false
 }
 
 // computeStateDB retrieves the state database associated with a certain block.

--- a/eth/config.go
+++ b/eth/config.go
@@ -68,8 +68,15 @@ func init() {
 			home = user.HomeDir
 		}
 	}
-	if runtime.GOOS == "windows" {
-		DefaultConfig.Ethash.DatasetDir = filepath.Join(home, "AppData", "Ethash")
+	if runtime.GOOS == "darwin" {
+		DefaultConfig.Ethash.DatasetDir = filepath.Join(home, "Library", "Ethash")
+	} else if runtime.GOOS == "windows" {
+		localappdata := os.Getenv("LOCALAPPDATA")
+		if localappdata != "" {
+			DefaultConfig.Ethash.DatasetDir = filepath.Join(localappdata, "Ethash")
+		} else {
+			DefaultConfig.Ethash.DatasetDir = filepath.Join(home, "AppData", "Local", "Ethash")
+		}
 	} else {
 		DefaultConfig.Ethash.DatasetDir = filepath.Join(home, ".ethash")
 	}

--- a/p2p/simulations/network_test.go
+++ b/p2p/simulations/network_test.go
@@ -193,7 +193,7 @@ OUTER:
 
 	connEventCount = nodeCount
 
-OUTER_TWO:
+OuterTwo:
 	for {
 		select {
 		case <-ctx.Done():
@@ -211,7 +211,7 @@ OUTER_TWO:
 				connEventCount--
 				log.Debug("ev", "count", connEventCount)
 				if connEventCount == 0 {
-					break OUTER_TWO
+					break OuterTwo
 				}
 			}
 		}

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -124,6 +124,13 @@ func wsHandshakeValidator(allowedOrigins []string) func(*websocket.Config, *http
 	log.Debug(fmt.Sprintf("Allowed origin(s) for WS RPC interface %v", origins.ToSlice()))
 
 	f := func(cfg *websocket.Config, req *http.Request) error {
+		// Skip origin verification if no Origin header is present. The origin check
+		// is supposed to protect against browser based attacks. Browsers always set
+		// Origin. Non-browser software can put anything in origin and checking it doesn't
+		// provide additional security.
+		if _, ok := req.Header["Origin"]; !ok {
+			return
+		}
 		// Verify origin against whitelist.
 		origin := strings.ToLower(req.Header.Get("Origin"))
 		if allowAllOrigins || origins.Contains(origin) {

--- a/rpc/websocket.go
+++ b/rpc/websocket.go
@@ -129,7 +129,7 @@ func wsHandshakeValidator(allowedOrigins []string) func(*websocket.Config, *http
 		// Origin. Non-browser software can put anything in origin and checking it doesn't
 		// provide additional security.
 		if _, ok := req.Header["Origin"]; !ok {
-			return
+			return nil
 		}
 		// Verify origin against whitelist.
 		origin := strings.ToLower(req.Header.Get("Origin"))

--- a/swarm/network/stream/delivery.go
+++ b/swarm/network/stream/delivery.go
@@ -275,8 +275,8 @@ func (d *Delivery) RequestFromPeers(ctx context.Context, req *network.Request) (
 
 	// setting this value in the context creates a new span that can persist across the sendpriority queue and the network roundtrip
 	// this span will finish only when delivery is handled (or times out)
-	ctx = context.WithValue(ctx, "stream_send_tag", "stream.send.request")
-	ctx = context.WithValue(ctx, "stream_send_meta", fmt.Sprintf("%v.%v", sp.ID(), req.Addr))
+	ctx = context.WithValue(ctx, tracing.StoreLabelId, "stream.send.request")
+	ctx = context.WithValue(ctx, tracing.StoreLabelMeta, fmt.Sprintf("%v.%v", sp.ID(), req.Addr))
 	err := sp.SendPriority(ctx, &RetrieveRequestMsg{
 		Addr:      req.Addr,
 		SkipCheck: req.SkipCheck,

--- a/swarm/network/stream/delivery.go
+++ b/swarm/network/stream/delivery.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/swarm/network"
 	"github.com/ethereum/go-ethereum/swarm/spancontext"
 	"github.com/ethereum/go-ethereum/swarm/storage"
+	"github.com/ethereum/go-ethereum/swarm/tracing"
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
@@ -214,11 +215,10 @@ func (d *Delivery) handleChunkDeliveryMsg(ctx context.Context, sp *Peer, req *Ch
 
 	// retrieve the span for the originating retrieverequest
 	spanId := fmt.Sprintf("stream.send.request.%v.%v", sp.ID(), req.Addr)
-	span, spanOk := sp.spans.Load(spanId)
-	sp.spans.Delete(spanId)
+	span := tracing.ShiftSpanByKey(spanId)
 
 	go func() {
-		if spanOk {
+		if span != nil {
 			defer span.(opentracing.Span).Finish()
 		}
 

--- a/swarm/network/stream/messages.go
+++ b/swarm/network/stream/messages.go
@@ -300,7 +300,7 @@ func (p *Peer) handleOfferedHashesMsg(ctx context.Context, req *OfferedHashesMsg
 			return
 		}
 		log.Trace("sending want batch", "peer", p.ID(), "stream", msg.Stream, "from", msg.From, "to", msg.To)
-		err := p.SendPriority(ctx, msg, c.priority, "")
+		err := p.SendPriority(ctx, msg, c.priority)
 		if err != nil {
 			log.Warn("SendPriority error", "err", err)
 		}

--- a/swarm/network/stream/peer.go
+++ b/swarm/network/stream/peer.go
@@ -88,11 +88,11 @@ func NewPeer(peer *protocols.Peer, streamer *Registry) *Peer {
 	ctx, cancel := context.WithCancel(context.Background())
 	go p.pq.Run(ctx, func(i interface{}) {
 		wmsg := i.(WrappedPriorityMsg)
-		defer p.spans.Delete(wmsg.Context)
-		sp, ok := p.spans.Load(wmsg.Context)
-		if ok {
-			defer sp.(opentracing.Span).Finish()
-		}
+		//		defer p.spans.Delete(wmsg.Context)
+		//		sp, ok := p.spans.Load(wmsg.Context)
+		//		if ok {
+		//			defer sp.(opentracing.Span).Finish()
+		//		}
 		err := p.Send(wmsg.Context, wmsg.Msg)
 		if err != nil {
 			log.Error("Message send error, dropping peer", "peer", p.ID(), "err", err)
@@ -158,7 +158,8 @@ func (p *Peer) Deliver(ctx context.Context, chunk storage.Chunk, priority uint8,
 		spanName += ".retrieval"
 	}
 
-	return p.SendPriority(ctx, msg, priority, spanName)
+	//return p.SendPriority(ctx, msg, priority, spanName)
+	return p.SendPriority(ctx, msg, priority, "")
 }
 
 // SendPriority sends message to the peer using the outgoing priority queue
@@ -171,7 +172,7 @@ func (p *Peer) SendPriority(ctx context.Context, msg interface{}, priority uint8
 			ctx,
 			traceId,
 		)
-		p.spans.Store(ctx, sp)
+		p.spans.Store(traceId, sp)
 	}
 	wmsg := WrappedPriorityMsg{
 		Context: ctx,
@@ -190,7 +191,8 @@ func (p *Peer) SendOfferedHashes(s *server, f, t uint64) error {
 	var sp opentracing.Span
 	ctx, sp := spancontext.StartSpan(
 		context.TODO(),
-		"send.offered.hashes")
+		"",
+	)
 	defer sp.Finish()
 
 	hashes, from, to, proof, err := s.setNextBatch(f, t)

--- a/swarm/network/stream/peer.go
+++ b/swarm/network/stream/peer.go
@@ -66,7 +66,6 @@ type Peer struct {
 	// on creating a new client in offered hashes handler.
 	clientParams map[Stream]*clientParams
 	quit         chan struct{}
-	spans        sync.Map
 }
 
 type WrappedPriorityMsg struct {
@@ -84,7 +83,6 @@ func NewPeer(peer *protocols.Peer, streamer *Registry) *Peer {
 		clients:      make(map[Stream]*client),
 		clientParams: make(map[Stream]*clientParams),
 		quit:         make(chan struct{}),
-		//spans:        sync.Map{},
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	go p.pq.Run(ctx, func(i interface{}) {

--- a/swarm/network/stream/peer.go
+++ b/swarm/network/stream/peer.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/swarm/spancontext"
 	"github.com/ethereum/go-ethereum/swarm/state"
 	"github.com/ethereum/go-ethereum/swarm/storage"
+	"github.com/ethereum/go-ethereum/swarm/tracing"
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
@@ -83,16 +84,11 @@ func NewPeer(peer *protocols.Peer, streamer *Registry) *Peer {
 		clients:      make(map[Stream]*client),
 		clientParams: make(map[Stream]*clientParams),
 		quit:         make(chan struct{}),
-		spans:        sync.Map{},
+		//spans:        sync.Map{},
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	go p.pq.Run(ctx, func(i interface{}) {
 		wmsg := i.(WrappedPriorityMsg)
-		//		defer p.spans.Delete(wmsg.Context)
-		//		sp, ok := p.spans.Load(wmsg.Context)
-		//		if ok {
-		//			defer sp.(opentracing.Span).Finish()
-		//		}
 		err := p.Send(wmsg.Context, wmsg.Msg)
 		if err != nil {
 			log.Error("Message send error, dropping peer", "peer", p.ID(), "err", err)
@@ -129,6 +125,7 @@ func NewPeer(peer *protocols.Peer, streamer *Registry) *Peer {
 
 	go func() {
 		<-p.quit
+
 		cancel()
 	}()
 	return p
@@ -165,21 +162,8 @@ func (p *Peer) Deliver(ctx context.Context, chunk storage.Chunk, priority uint8,
 // SendPriority sends message to the peer using the outgoing priority queue
 func (p *Peer) SendPriority(ctx context.Context, msg interface{}, priority uint8) error {
 	defer metrics.GetOrRegisterResettingTimer(fmt.Sprintf("peer.sendpriority_t.%d", priority), nil).UpdateSince(time.Now())
+	tracing.StartSaveSpan(ctx)
 	metrics.GetOrRegisterCounter(fmt.Sprintf("peer.sendpriority.%d", priority), nil).Inc(1)
-	traceId := ctx.Value("stream_send_tag")
-	if traceId != nil {
-		traceStr := traceId.(string)
-		var sp opentracing.Span
-		ctx, sp = spancontext.StartSpan(
-			ctx,
-			traceStr,
-		)
-		traceMeta := ctx.Value("stream_send_meta")
-		if traceMeta != nil {
-			traceStr = traceStr + "." + traceMeta.(string)
-		}
-		p.spans.Store(traceId, sp)
-	}
 	wmsg := WrappedPriorityMsg{
 		Context: ctx,
 		Msg:     msg,
@@ -197,7 +181,7 @@ func (p *Peer) SendOfferedHashes(s *server, f, t uint64) error {
 	var sp opentracing.Span
 	ctx, sp := spancontext.StartSpan(
 		context.TODO(),
-		"",
+		"send.offered.hashes",
 	)
 	defer sp.Finish()
 

--- a/swarm/network/stream/stream.go
+++ b/swarm/network/stream/stream.go
@@ -359,7 +359,7 @@ func (r *Registry) Subscribe(peerId enode.ID, s Stream, h *Range, priority uint8
 	}
 	log.Debug("Subscribe ", "peer", peerId, "stream", s, "history", h)
 
-	return peer.SendPriority(context.TODO(), msg, priority, "")
+	return peer.SendPriority(context.TODO(), msg, priority)
 }
 
 func (r *Registry) Unsubscribe(peerId enode.ID, s Stream) error {
@@ -730,7 +730,7 @@ func (c *client) batchDone(p *Peer, req *OfferedHashesMsg, hashes []byte) error 
 			return err
 		}
 
-		if err := p.SendPriority(context.TODO(), tp, c.priority, ""); err != nil {
+		if err := p.SendPriority(context.TODO(), tp, c.priority); err != nil {
 			return err
 		}
 		if c.to > 0 && tp.Takeover.End >= c.to {

--- a/swarm/network/stream/stream.go
+++ b/swarm/network/stream/stream.go
@@ -35,8 +35,6 @@ import (
 	"github.com/ethereum/go-ethereum/swarm/network/stream/intervals"
 	"github.com/ethereum/go-ethereum/swarm/state"
 	"github.com/ethereum/go-ethereum/swarm/storage"
-
-	opentracing "github.com/opentracing/opentracing-go"
 )
 
 const (
@@ -97,7 +95,6 @@ type Registry struct {
 	spec           *protocols.Spec   //this protocol's spec
 	balance        protocols.Balance //implements protocols.Balance, for accounting
 	prices         protocols.Prices  //implements protocols.Prices, provides prices to accounting
-	spans          sync.Map
 }
 
 // RegistryOptions holds optional values for NewRegistry constructor.
@@ -887,10 +884,6 @@ func (r *Registry) Start(server *p2p.Server) error {
 }
 
 func (r *Registry) Stop() error {
-	r.spans.Range(func(k, v interface{}) bool {
-		v.(opentracing.Span).Finish()
-		return true
-	})
 	return nil
 }
 

--- a/swarm/network/stream/stream.go
+++ b/swarm/network/stream/stream.go
@@ -35,6 +35,8 @@ import (
 	"github.com/ethereum/go-ethereum/swarm/network/stream/intervals"
 	"github.com/ethereum/go-ethereum/swarm/state"
 	"github.com/ethereum/go-ethereum/swarm/storage"
+
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 const (
@@ -95,6 +97,7 @@ type Registry struct {
 	spec           *protocols.Spec   //this protocol's spec
 	balance        protocols.Balance //implements protocols.Balance, for accounting
 	prices         protocols.Prices  //implements protocols.Prices, provides prices to accounting
+	spans          sync.Map
 }
 
 // RegistryOptions holds optional values for NewRegistry constructor.
@@ -884,6 +887,10 @@ func (r *Registry) Start(server *p2p.Server) error {
 }
 
 func (r *Registry) Stop() error {
+	r.spans.Range(func(k, v interface{}) bool {
+		v.(opentracing.Span).Finish()
+		return true
+	})
 	return nil
 }
 

--- a/swarm/storage/filestore_test.go
+++ b/swarm/storage/filestore_test.go
@@ -177,7 +177,6 @@ func testFileStoreCapacity(toEncrypt bool, t *testing.T) {
 // TestGetAllReferences only tests that GetAllReferences returns an expected
 // number of references for a given file
 func TestGetAllReferences(t *testing.T) {
-	t.Skip("sometimes fails with chunk count 247 instead of 248")
 	tdb, cleanup, err := newTestDbStore(false, false)
 	defer cleanup()
 	if err != nil {

--- a/swarm/storage/filestore_test.go
+++ b/swarm/storage/filestore_test.go
@@ -177,6 +177,7 @@ func testFileStoreCapacity(toEncrypt bool, t *testing.T) {
 // TestGetAllReferences only tests that GetAllReferences returns an expected
 // number of references for a given file
 func TestGetAllReferences(t *testing.T) {
+	t.Skip("sometimes fails with chunk count 247 instead of 248")
 	tdb, cleanup, err := newTestDbStore(false, false)
 	defer cleanup()
 	if err != nil {

--- a/swarm/storage/netstore.go
+++ b/swarm/storage/netstore.go
@@ -1,4 +1,4 @@
-//// Copyright 2016 The go-ethereum Authors
+// Copyright 2016 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //
 // The go-ethereum library is free software: you can redistribute it and/or modify

--- a/swarm/storage/netstore.go
+++ b/swarm/storage/netstore.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The go-ethereum Authors
+//// Copyright 2016 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //
 // The go-ethereum library is free software: you can redistribute it and/or modify
@@ -26,6 +26,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/swarm/log"
+	"github.com/ethereum/go-ethereum/swarm/spancontext"
+	"github.com/opentracing/opentracing-go"
+
 	lru "github.com/hashicorp/golang-lru"
 )
 
@@ -208,7 +211,11 @@ func (n *NetStore) getOrCreateFetcher(ctx context.Context, ref Address) *fetcher
 	// the peers which requested the chunk should not be requested to deliver it.
 	peers := &sync.Map{}
 
-	fetcher := newFetcher(ref, n.NewNetFetcherFunc(cctx, ref, peers), destroy, peers, n.closeC)
+	cctx, sp := spancontext.StartSpan(
+		cctx,
+		"netstore.fetcher",
+	)
+	fetcher := newFetcher(sp, ref, n.NewNetFetcherFunc(cctx, ref, peers), destroy, peers, n.closeC)
 	n.fetchers.Add(key, fetcher)
 
 	return fetcher
@@ -233,15 +240,16 @@ func (n *NetStore) RequestsCacheLen() int {
 // One fetcher object is responsible to fetch one chunk for one address, and keep track of all the
 // peers who have requested it and did not receive it yet.
 type fetcher struct {
-	addr        Address       // address of chunk
-	chunk       Chunk         // fetcher can set the chunk on the fetcher
-	deliveredC  chan struct{} // chan signalling chunk delivery to requests
-	cancelledC  chan struct{} // chan signalling the fetcher has been cancelled (removed from fetchers in NetStore)
-	netFetcher  NetFetcher    // remote fetch function to be called with a request source taken from the context
-	cancel      func()        // cleanup function for the remote fetcher to call when all upstream contexts are called
-	peers       *sync.Map     // the peers which asked for the chunk
-	requestCnt  int32         // number of requests on this chunk. If all the requests are done (delivered or context is done) the cancel function is called
-	deliverOnce *sync.Once    // guarantees that we only close deliveredC once
+	addr        Address          // address of chunk
+	chunk       Chunk            // fetcher can set the chunk on the fetcher
+	deliveredC  chan struct{}    // chan signalling chunk delivery to requests
+	cancelledC  chan struct{}    // chan signalling the fetcher has been cancelled (removed from fetchers in NetStore)
+	netFetcher  NetFetcher       // remote fetch function to be called with a request source taken from the context
+	cancel      func()           // cleanup function for the remote fetcher to call when all upstream contexts are called
+	peers       *sync.Map        // the peers which asked for the chunk
+	requestCnt  int32            // number of requests on this chunk. If all the requests are done (delivered or context is done) the cancel function is called
+	deliverOnce *sync.Once       // guarantees that we only close deliveredC once
+	span        opentracing.Span // measure retrieve time per chunk
 }
 
 // newFetcher creates a new fetcher object for the fiven addr. fetch is the function which actually
@@ -250,7 +258,7 @@ type fetcher struct {
 //     1. when the chunk has been fetched all peers have been either notified or their context has been done
 //     2. the chunk has not been fetched but all context from all the requests has been done
 // The peers map stores all the peers which have requested chunk.
-func newFetcher(addr Address, nf NetFetcher, cancel func(), peers *sync.Map, closeC chan struct{}) *fetcher {
+func newFetcher(span opentracing.Span, addr Address, nf NetFetcher, cancel func(), peers *sync.Map, closeC chan struct{}) *fetcher {
 	cancelOnce := &sync.Once{} // cancel should only be called once
 	return &fetcher{
 		addr:        addr,
@@ -264,6 +272,7 @@ func newFetcher(addr Address, nf NetFetcher, cancel func(), peers *sync.Map, clo
 			})
 		},
 		peers: peers,
+		span:  span,
 	}
 }
 
@@ -276,6 +285,7 @@ func (f *fetcher) Fetch(rctx context.Context) (Chunk, error) {
 		if atomic.AddInt32(&f.requestCnt, -1) == 0 {
 			f.cancel()
 		}
+		f.span.Finish()
 	}()
 
 	// The peer asking for the chunk. Store in the shared peers map, but delete after the request

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -426,6 +426,7 @@ func (s *Swarm) Start(srv *p2p.Server) error {
 func (s *Swarm) Stop() error {
 	if s.tracerClose != nil {
 		err := s.tracerClose.Close()
+		tracing.FinishSpans()
 		if err != nil {
 			return err
 		}

--- a/swarm/tracing/tracing.go
+++ b/swarm/tracing/tracing.go
@@ -166,7 +166,7 @@ func ShiftSpanByKey(k string) opentracing.Span {
 // FinishSpans calls `Finish()` on all stored spans
 // It should be called on instance shutdown
 func FinishSpans() {
-	store.spans.Range(func(k, v interface{}) bool {
+	store.spans.Range(func(_, v interface{}) bool {
 		v.(opentracing.Span).Finish()
 		return true
 	})

--- a/swarm/tracing/tracing.go
+++ b/swarm/tracing/tracing.go
@@ -23,7 +23,11 @@ var (
 )
 
 // TracingEnabledFlag is the CLI flag name to use to enable trace collections.
-const TracingEnabledFlag = "tracing"
+const (
+	TracingEnabledFlag = "tracing"
+	StoreLabelId       = "span_save_id"
+	StoreLabelMeta     = "span_save_meta"
+)
 
 var (
 	Closer io.Closer
@@ -117,7 +121,8 @@ func StartSaveSpan(ctx context.Context) context.Context {
 	if !Enabled {
 		return ctx
 	}
-	traceId := ctx.Value("span_save_id")
+	traceId := ctx.Value(StoreLabelId)
+
 	if traceId != nil {
 		traceStr := traceId.(string)
 		var sp opentracing.Span
@@ -125,11 +130,11 @@ func StartSaveSpan(ctx context.Context) context.Context {
 			ctx,
 			traceStr,
 		)
-		traceMeta := ctx.Value("span_save_meta")
+		traceMeta := ctx.Value(StoreLabelMeta)
 		if traceMeta != nil {
 			traceStr = traceStr + "." + traceMeta.(string)
 		}
-		store.spans.Store(traceId, sp)
+		store.spans.Store(traceStr, sp)
 	}
 	return ctx
 }

--- a/swarm/tracing/tracing.go
+++ b/swarm/tracing/tracing.go
@@ -18,6 +18,7 @@ import (
 )
 
 var (
+	// Enabled turns tracing on for the current swarm instance
 	Enabled bool = false
 	store        = spanStore{}
 )
@@ -26,8 +27,11 @@ const (
 	// TracingEnabledFlag is the CLI flag name to use to enable trace collections.
 	TracingEnabledFlag = "tracing"
 
-	// StoreLabels are used to pass span information through context instances to the span store
-	StoreLabelId   = "span_save_id"
+	// StoreLabelId is the context value key of the name of the span to be saved
+	StoreLabelId = "span_save_id"
+
+	// StoreLabelMeta is the context value key that together with StoreLabelId constitutes the retrieval key for saved spans in the span store
+	// StartSaveSpan and ShiftSpanByKey
 	StoreLabelMeta = "span_save_meta"
 )
 

--- a/trie/database.go
+++ b/trie/database.go
@@ -809,7 +809,7 @@ func (db *Database) verifyIntegrity() {
 		db.accumulate(child, reachable)
 	}
 	// Find any unreachable but cached nodes
-	unreachable := []string{}
+	var unreachable []string
 	for hash, node := range db.dirties {
 		if _, ok := reachable[hash]; !ok {
 			unreachable = append(unreachable, fmt.Sprintf("%x: {Node: %v, Parents: %d, Prev: %x, Next: %x}",

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -37,7 +37,7 @@ import (
 func (t *Trie) Prove(key []byte, fromLevel uint, proofDb ethdb.Putter) error {
 	// Collect all nodes on the path to key.
 	key = keybytesToHex(key)
-	nodes := []node{}
+	var nodes []node
 	tn := t.root
 	for len(key) > 0 && tn != nil {
 		switch n := tn.(type) {

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -157,7 +157,7 @@ func (s *Sync) AddRawEntry(hash common.Hash, depth int, parent common.Hash) {
 
 // Missing retrieves the known missing nodes from the trie for retrieval.
 func (s *Sync) Missing(max int) []common.Hash {
-	requests := []common.Hash{}
+	var requests []common.Hash
 	for !s.queue.Empty() && (max == 0 || len(requests) < max) {
 		requests = append(requests, s.queue.PopItem().(common.Hash))
 	}
@@ -254,7 +254,7 @@ func (s *Sync) children(req *request, object node) ([]*request, error) {
 		node  node
 		depth int
 	}
-	children := []child{}
+	var children []child
 
 	switch node := (object).(type) {
 	case *shortNode:

--- a/trie/sync_test.go
+++ b/trie/sync_test.go
@@ -313,7 +313,7 @@ func TestIncompleteSync(t *testing.T) {
 	triedb := NewDatabase(diskdb)
 	sched := NewSync(srcTrie.Hash(), diskdb, nil)
 
-	added := []common.Hash{}
+	var added []common.Hash
 	queue := append([]common.Hash{}, sched.Missing(1)...)
 	for len(queue) > 0 {
 		// Fetch a batch of trie nodes


### PR DESCRIPTION
This PR addresses https://github.com/ethersphere/go-ethereum/issues/1209 (see copy of description below) which is an incremental part of https://github.com/ethersphere/go-ethereum/issues/1181

Until now, the spans are only valid within internal peer contexts, but we may want to trace durations from _node makes request_ to _node received delivery_. 

According to `opentracing` support, if a `Span` is to persist across asynchronous operations, it's the requester's responsibility to _remember_ the `Span` and `Finish()` it accordingly. In other words, a `Span` cannot be recalled after passing through the `tracer.Inject()`/`tracer.Extract()` serialization, only _new_ spans (`ChildOf()`, `FollowFrom()`) can be created from the `SpanContext` that's passed on.

To this end, I've introduced a "store" for spans to be remembered. This "store" is a singleton per swarm instance. It seems to me to belong in the `swarm/tracing` package, so I put it there.

----

Unlike `LazyChunkReader.Read`, we don't know how long a single `Retrieve Request` took. We should update the spans to record the full duration of a retrieve request, until it is actually delivered on the requestor node.

Good
![screen shot 2019-02-08 at 15 26 04](https://user-images.githubusercontent.com/50459/52484160-f15d2880-2bb5-11e9-85f9-4f3faf7e7b8c.png)

Bad
![screen shot 2019-02-08 at 15 26 21](https://user-images.githubusercontent.com/50459/52484164-f4f0af80-2bb5-11e9-9ccd-ab654b5db861.png)
