### PR TITLE
swarm/network/stream: fix a goroutine leak in Registry

### DIFF
--- a/swarm/network/kademlia.go
+++ b/swarm/network/kademlia.go
@@ -333,6 +333,18 @@ func (k *Kademlia) NeighbourhoodDepthC() <-chan int {
 	return k.nDepthC
 }
 
+// CloseNeighbourhoodDepthC closes the channel returned by
+// NeighbourhoodDepthC and stops sending neighbourhood change.
+func (k *Kademlia) CloseNeighbourhoodDepthC() {
+	k.lock.Lock()
+	defer k.lock.Unlock()
+
+	if k.nDepthC != nil {
+		close(k.nDepthC)
+		k.nDepthC = nil
+	}
+}
+
 // sendNeighbourhoodDepthChange sends new neighbourhood depth to k.nDepth channel
 // if it is initialized.
 func (k *Kademlia) sendNeighbourhoodDepthChange() {
@@ -360,6 +372,18 @@ func (k *Kademlia) AddrCountC() <-chan int {
 		k.addrCountC = make(chan int)
 	}
 	return k.addrCountC
+}
+
+// CloseAddrCountC closes the channel returned by
+// AddrCountC and stops sending address count change.
+func (k *Kademlia) CloseAddrCountC() {
+	k.lock.Lock()
+	defer k.lock.Unlock()
+
+	if k.addrCountC != nil {
+		close(k.addrCountC)
+		k.addrCountC = nil
+	}
 }
 
 // Off removes a peer from among live peers

--- a/swarm/network/stream/stream.go
+++ b/swarm/network/stream/stream.go
@@ -409,6 +409,10 @@ func (r *Registry) Quit(peerId enode.ID, s Stream) error {
 }
 
 func (r *Registry) Close() error {
+	// Stop sending neighborhood depth change and address count
+	// change from Kademlia that were initiated in NewRegistry constructor.
+	r.delivery.kad.CloseNeighbourhoodDepthC()
+	r.delivery.kad.CloseAddrCountC()
 	close(r.close)
 	return r.intervalsStore.Close()
 }


### PR DESCRIPTION
This PR fixes a leak discovered in https://github.com/ethersphere/go-ethereum/issues/1233. The reason is not terminated goroutines from the stream NewRegistry function. This change handles their termination.

To verify the fix: `time go test -v -race -run TestGetSubscriptionsRPC -count 1000 github.com/ethereum/go-ethereum/swarm/network/stream`

fixes #1233 