### PR TITLE
swarm/network/master: protect SetNextBatch iterator after close

### DIFF
--- a/swarm/network/stream/stream.go
+++ b/swarm/network/stream/stream.go
@@ -597,6 +597,16 @@ func (r *Registry) runProtocol(p *p2p.Peer, rw p2p.MsgReadWriter) error {
 
 // HandleMsg is the message handler that delegates incoming messages
 func (p *Peer) HandleMsg(ctx context.Context, msg interface{}) error {
+	select {
+	case <-p.streamer.quit:
+		log.Trace("message received after the streamer is closed", "peer", p.ID())
+		// return without an error since streamer is closed and
+		// no messages should be handled as other subcomponents like
+		// storage leveldb may be closed
+		return nil
+	default:
+	}
+
 	switch msg := msg.(type) {
 
 	case *SubscribeMsg:

--- a/swarm/network/stream/syncer.go
+++ b/swarm/network/stream/syncer.go
@@ -107,6 +107,11 @@ func (s *SwarmSyncerServer) SetNextBatch(from, to uint64) ([]byte, uint64, uint6
 
 		metrics.GetOrRegisterCounter("syncer.setnextbatch.iterator", nil).Inc(1)
 		err := s.store.Iterator(from, to, s.po, func(key storage.Address, idx uint64) bool {
+			select {
+			case <-s.quit:
+				return false
+			default:
+			}
 			batch = append(batch, key[:]...)
 			i++
 			to = idx


### PR DESCRIPTION
This PR addresses issue described in https://github.com/ethersphere/go-ethereum/issues/1242 where a panic is raised when leveldb database is closed while iterator is active.

This changes do not fix the issue completely but make it much less possible. Preventing handling messages after stream Registry is closed reduces the possibility of this case drastically. The second change addresses the termination of iterator when the database is closed. It is still possible that the panic will raise but much less likely.

The complete way to prevent this panics is to wait for all messages to be handled inside Registry Close method. But, this would require a wait group which can not be used correctly only inside the stream package. There is a data race between waitgroup Wait and Add methods if they are called from a different goroutines, which can not be ensured only in the stream, but would require changes in p2p layer where this goroutines are created. The problem is that messages are handled in sequence, not concurrently for every peer. Potential wait group would need to be incremented and decremented per peer, not per message, and peers are disconnected after the registry is closed in tests (when the network is shut down). This synchronization would require additional features in p2p layer. Alternatively, dropping peers in Registry Close is not safe for production.