### PR TITLE
swarm: replace streamer updateSyncing with peer-based syncing

### DIFF
--- a/swarm/network/kademlia.go
+++ b/swarm/network/kademlia.go
@@ -336,8 +336,9 @@ func (k *Kademlia) On(p *Peer) (uint8, bool) {
 }
 
 func (k *Kademlia) notifyKadChange() {
+	depth := k.NeighbourhoodDepth()
 	k.EachConn(nil, 255, func(p *Peer, po int) bool {
-		go p.NotifyChanged()
+		go p.NotifyChanged(depth)
 		return true
 	})
 }

--- a/swarm/network/kademlia.go
+++ b/swarm/network/kademlia.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/swarm/chunk"
 	"github.com/ethereum/go-ethereum/swarm/log"
 	"github.com/ethereum/go-ethereum/swarm/pot"
 	sv "github.com/ethereum/go-ethereum/swarm/version"
@@ -293,19 +294,8 @@ func (k *Kademlia) SuggestPeer() (suggestedPeer *BzzAddr, saturationDepth int, c
 	return suggestedPeer, 0, false
 }
 
-func (k *Kademlia) PoOfPeer(peer *BzzPeer) (int, error) {
-	peerPo := -1
-	k.EachConn(nil, 255, func(p *Peer, po int) bool {
-		if p.BzzPeer == peer {
-			peerPo = po
-			return false
-		}
-		return true
-	})
-	if peerPo == -1 {
-		return peerPo, fmt.Errorf("peer not in kademlia")
-	}
-	return peerPo, nil
+func (k *Kademlia) PoOfPeer(peer *BzzPeer) int {
+	return chunk.Proximity(k.BaseAddr(), peer.Over())
 }
 
 // On inserts the peer as a kademlia peer into the live peers

--- a/swarm/network/kademlia.go
+++ b/swarm/network/kademlia.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/swarm/chunk"
 	"github.com/ethereum/go-ethereum/swarm/log"
 	"github.com/ethereum/go-ethereum/swarm/pot"
 	sv "github.com/ethereum/go-ethereum/swarm/version"
@@ -292,10 +291,6 @@ func (k *Kademlia) SuggestPeer() (suggestedPeer *BzzAddr, saturationDepth int, c
 		return suggestedPeer, saturationDepth, true
 	}
 	return suggestedPeer, 0, false
-}
-
-func (k *Kademlia) PoOfPeer(peer *BzzPeer) int {
-	return chunk.Proximity(k.BaseAddr(), peer.Over())
 }
 
 // On inserts the peer as a kademlia peer into the live peers

--- a/swarm/network/protocol.go
+++ b/swarm/network/protocol.go
@@ -249,7 +249,7 @@ func (b *Bzz) runBzz(p *p2p.Peer, rw p2p.MsgReadWriter) error {
 type BzzPeer struct {
 	*protocols.Peer // represents the connection for online peers
 	*BzzAddr        // remote address -> implements Addr interface = protocols.Peer
-	ChangeC         chan struct{}
+	ChangeC         chan int
 	lastActive      time.Time // time is updated whenever mutexes are releasing
 	LightNode       bool
 }
@@ -258,12 +258,12 @@ func NewBzzPeer(p *protocols.Peer) *BzzPeer {
 	return &BzzPeer{
 		Peer:    p,
 		BzzAddr: NewAddr(p.Node()),
-		ChangeC: make(chan struct{}, 1),
+		ChangeC: make(chan int, 1),
 	}
 }
 
-func (p *BzzPeer) NotifyChanged() {
-	p.ChangeC <- struct{}{}
+func (p *BzzPeer) NotifyChanged(depth int) {
+	p.ChangeC <- depth
 }
 
 // TODO: call this function from somewhere

--- a/swarm/network/stream/peer.go
+++ b/swarm/network/stream/peer.go
@@ -169,6 +169,7 @@ func (p *Peer) Registrations() error {
 			if err != nil {
 				log.Error(err.Error())
 			}
+		default:
 		}
 	}
 	return nil
@@ -180,10 +181,7 @@ func (p *Peer) doRegistrations() error {
 
 	kad := p.streamer.delivery.kad
 	kadDepth := kad.NeighbourhoodDepth()
-	po, err := kad.PoOfPeer(p.bzzPeer)
-	if err != nil {
-		return err
-	}
+	po := kad.PoOfPeer(p.bzzPeer)
 
 	if po < kadDepth {
 		startPo = po

--- a/swarm/network/stream/peer.go
+++ b/swarm/network/stream/peer.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p/protocols"
+	"github.com/ethereum/go-ethereum/swarm/chunk"
 	"github.com/ethereum/go-ethereum/swarm/log"
 	"github.com/ethereum/go-ethereum/swarm/network"
 	pq "github.com/ethereum/go-ethereum/swarm/network/priorityqueue"
@@ -181,7 +182,7 @@ func (p *Peer) doRegistrations() error {
 
 	kad := p.streamer.delivery.kad
 	kadDepth := kad.NeighbourhoodDepth()
-	po := kad.PoOfPeer(p.bzzPeer)
+	po := chunk.Proximity(kad.BaseAddr(), p.bzzPeer.Over())
 
 	if po < kadDepth {
 		startPo = po

--- a/swarm/network/stream/snapshot_retrieval_test.go
+++ b/swarm/network/stream/snapshot_retrieval_test.go
@@ -16,6 +16,7 @@
 package stream
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"sync"
@@ -25,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
+	"github.com/ethereum/go-ethereum/swarm/chunk"
 	"github.com/ethereum/go-ethereum/swarm/log"
 	"github.com/ethereum/go-ethereum/swarm/network/simulation"
 	"github.com/ethereum/go-ethereum/swarm/state"
@@ -32,17 +34,17 @@ import (
 	"github.com/ethereum/go-ethereum/swarm/testutil"
 )
 
-//constants for random file generation
+// constants for random file generation
 const (
 	minFileSize = 2
 	maxFileSize = 40
 )
 
-//This test is a retrieval test for nodes.
-//A configurable number of nodes can be
-//provided to the test.
-//Files are uploaded to nodes, other nodes try to retrieve the file
-//Number of nodes can be provided via commandline too.
+// This test is a retrieval test for nodes.
+// A configurable number of nodes can be
+// provided to the test.
+// Files are uploaded to nodes, other nodes try to retrieve the file
+// Number of nodes can be provided via commandline too.
 func TestFileRetrieval(t *testing.T) {
 	var nodeCount []int
 
@@ -62,6 +64,44 @@ func TestFileRetrieval(t *testing.T) {
 	for _, nc := range nodeCount {
 		if err := runFileRetrievalTest(nc); err != nil {
 			t.Error(err)
+		}
+	}
+}
+
+// TestPureRetrieval tests pure retrieval without syncing
+// A configurable number of nodes and chunks
+// can be provided to the test.
+// A number of random chunks is generated, then stored directly in
+// each node's localstore according to their address.
+// Each chunk is supposed to end up at certain nodes
+// With retrieval we then make sure that every node can actually retrieve
+// the chunks.
+func TestPureRetrieval(t *testing.T) {
+	var nodeCount []int
+	var chunkCount []int
+
+	if *nodes != 0 && *chunks != 0 {
+		nodeCount = []int{*nodes}
+		chunkCount = []int{*chunks}
+	} else {
+		nodeCount = []int{16}
+		chunkCount = []int{16}
+
+		if *longrunning {
+			nodeCount = append(nodeCount, 32, 64)
+			chunkCount = append(chunkCount, 32, 256)
+		} else if testutil.RaceEnabled {
+			nodeCount = []int{4}
+			chunkCount = []int{4}
+		}
+
+	}
+
+	for _, nc := range nodeCount {
+		for _, c := range chunkCount {
+			if err := runPureRetrievalTest(nc, c); err != nil {
+				t.Error(err)
+			}
 		}
 	}
 }
@@ -119,7 +159,7 @@ var retrievalSimServiceMap = map[string]simulation.ServiceFunc{
 
 		r := NewRegistry(addr.ID(), delivery, netStore, state.NewInmemoryStore(), &RegistryOptions{
 			Retrieval:       RetrievalEnabled,
-			Syncing:         SyncingRegisterOnly,
+			Syncing:         SyncingAutoSubscribe,
 			SyncUpdateDelay: syncUpdateDelay,
 		}, nil)
 
@@ -132,14 +172,149 @@ var retrievalSimServiceMap = map[string]simulation.ServiceFunc{
 	},
 }
 
-/*
-The test loads a snapshot file to construct the swarm network,
-assuming that the snapshot file identifies a healthy
-kademlia network. Nevertheless a health check runs in the
-simulation's `action` function.
+// runPureRetrievalTest by uploading a snapshot,
+// then starting a simulation, distribute chunks to nodes
+// and start retrieval.
+// The snapshot should have 'streamer' in its service list.
+func runPureRetrievalTest(nodeCount int, chunkCount int) error {
+	// the pure retrieval test needs a different service map, as we want
+	// syncing disabled and we don't need to set the syncUpdateDelay
+	sim := simulation.New(map[string]simulation.ServiceFunc{
+		"streamer": func(ctx *adapters.ServiceContext, bucket *sync.Map) (s node.Service, cleanup func(), err error) {
+			addr, netStore, delivery, clean, err := newNetStoreAndDelivery(ctx, bucket)
+			if err != nil {
+				return nil, nil, err
+			}
 
-The snapshot should have 'streamer' in its service list.
-*/
+			r := NewRegistry(addr.ID(), delivery, netStore, state.NewInmemoryStore(), &RegistryOptions{
+				Retrieval: RetrievalEnabled,
+				Syncing:   SyncingDisabled, // disable syncing
+			}, nil)
+
+			cleanup = func() {
+				r.Close()
+				clean()
+			}
+
+			return r, cleanup, nil
+		},
+	},
+	)
+	defer sim.Close()
+
+	log.Info("Initializing test config", "node count", nodeCount)
+
+	conf := &synctestConfig{}
+	//map of discover ID to indexes of chunks expected at that ID
+	conf.idToChunksMap = make(map[enode.ID][]int)
+	//map of overlay address to discover ID
+	conf.addrToIDMap = make(map[string]enode.ID)
+	//array where the generated chunk hashes will be stored
+	conf.hashes = make([]storage.Address, 0)
+
+	ctx, cancelSimRun := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancelSimRun()
+
+	filename := fmt.Sprintf("testing/snapshot_%d.json", nodeCount)
+	err := sim.UploadSnapshot(ctx, filename)
+	if err != nil {
+		return err
+	}
+
+	log.Info("Starting simulation")
+
+	result := sim.Run(ctx, func(ctx context.Context, sim *simulation.Simulation) error {
+		nodeIDs := sim.UpNodeIDs()
+		// first iteration: create addresses
+		for _, n := range nodeIDs {
+			//get the kademlia overlay address from this ID
+			a := n.Bytes()
+			//append it to the array of all overlay addresses
+			conf.addrs = append(conf.addrs, a)
+			//the proximity calculation is on overlay addr,
+			//the p2p/simulations check func triggers on enode.ID,
+			//so we need to know which overlay addr maps to which nodeID
+			conf.addrToIDMap[string(a)] = n
+		}
+
+		// now create random chunks
+		chunks := make([]chunk.Chunk, chunkCount)
+
+		for i := 0; i < chunkCount; i++ {
+			chunks[i] = storage.GenerateRandomChunk(int64(chunkSize))
+			conf.hashes = append(conf.hashes, chunks[i].Address())
+		}
+		log.Debug("random chunks generated, mapping keys to nodes")
+
+		// map addresses to nodes
+		mapKeysToNodes(conf)
+
+		// second iteration: store chunks at the nodes they would be
+		// expected to be
+		log.Debug("storing every chunk at correspondent node store")
+		for _, id := range nodeIDs {
+			// these are the chunks for this node
+			localChunks := conf.idToChunksMap[id]
+			// for every such chunk (which are only indexes)...
+			for _, ch := range localChunks {
+				item, ok := sim.NodeItem(id, bucketKeyStore)
+				if !ok {
+					return fmt.Errorf("Error accessing localstore")
+				}
+				lstore := item.(*storage.LocalStore)
+				// ...get the actual chunk
+				for _, chunk := range chunks {
+					if bytes.Equal(chunk.Address(), conf.hashes[ch]) {
+						// ...and store it in the localstore
+						err = lstore.Put(ctx, chunk)
+					}
+				}
+			}
+		}
+
+		// now try to retrieve every chunk from every node
+		log.Debug("starting retrieval")
+		cnt := 0
+
+	REPEAT:
+		for {
+			for _, id := range nodeIDs {
+				item, ok := sim.NodeItem(id, bucketKeyFileStore)
+				if !ok {
+					return fmt.Errorf("No filestore")
+				}
+				fileStore := item.(*storage.FileStore)
+				for _, chunk := range chunks {
+					reader, _ := fileStore.Retrieve(context.TODO(), chunk.Address())
+					//check that we can read the file size and that it corresponds to the generated file size
+					if s, err := reader.Size(ctx, nil); err != nil || s != int64(chunkSize) {
+						log.Debug("Retrieve error", "err", err, "hash", chunk.Address(), "nodeId", id)
+						time.Sleep(500 * time.Millisecond)
+						// we continue trying if it failed
+						continue REPEAT
+					}
+					log.Debug(fmt.Sprintf("chunk with root hash %x successfully retrieved", chunk.Address()))
+					cnt++
+				}
+			}
+			// we iterate sequentially, one after the other, so at this point we got all chunks
+			break
+		}
+		log.Info("retrieval terminated, chunks retrieved: ", "count", cnt)
+		return nil
+
+	})
+
+	log.Info("Simulation terminated")
+
+	if result.Error != nil {
+		return result.Error
+	}
+	return nil
+}
+
+// The test loads a snapshot file to construct the swarm network.
+// The snapshot should have 'streamer' in its service list.
 func runFileRetrievalTest(nodeCount int) error {
 	sim := simulation.New(retrievalSimServiceMap)
 	defer sim.Close()
@@ -180,9 +355,6 @@ func runFileRetrievalTest(nodeCount int) error {
 
 		//an array for the random files
 		var randomFiles []string
-		//channel to signal when the upload has finished
-		//uploadFinished := make(chan struct{})
-		//channel to trigger new node checks
 
 		conf.hashes, randomFiles, err = uploadFilesToNodes(sim)
 		if err != nil {
@@ -227,16 +399,9 @@ func runFileRetrievalTest(nodeCount int) error {
 	return nil
 }
 
-/*
-The test generates the given number of chunks.
-
-The test loads a snapshot file to construct the swarm network,
-assuming that the snapshot file identifies a healthy
-kademlia network. Nevertheless a health check runs in the
-simulation's `action` function.
-
-The snapshot should have 'streamer' in its service list.
-*/
+// The test generates the given number of chunks.
+// The test loads a snapshot file to construct the swarm network.
+// The snapshot should have 'streamer' in its service list.
 func runRetrievalTest(t *testing.T, chunkCount int, nodeCount int) error {
 	t.Helper()
 	sim := simulation.New(retrievalSimServiceMap)

--- a/swarm/network/stream/snapshot_retrieval_test.go
+++ b/swarm/network/stream/snapshot_retrieval_test.go
@@ -119,7 +119,7 @@ var retrievalSimServiceMap = map[string]simulation.ServiceFunc{
 
 		r := NewRegistry(addr.ID(), delivery, netStore, state.NewInmemoryStore(), &RegistryOptions{
 			Retrieval:       RetrievalEnabled,
-			Syncing:         SyncingAutoSubscribe,
+			Syncing:         SyncingRegisterOnly,
 			SyncUpdateDelay: syncUpdateDelay,
 		}, nil)
 

--- a/swarm/network/stream/stream.go
+++ b/swarm/network/stream/stream.go
@@ -79,23 +79,25 @@ var subscriptionFunc = doRequestSubscription
 
 // Registry registry for outgoing and incoming streamer constructors
 type Registry struct {
-	addr           enode.ID
-	api            *API
-	skipCheck      bool
-	clientMu       sync.RWMutex
-	serverMu       sync.RWMutex
-	peersMu        sync.RWMutex
-	serverFuncs    map[string]func(*Peer, string, bool) (Server, error)
-	clientFuncs    map[string]func(*Peer, string, bool) (Client, error)
-	peers          map[enode.ID]*Peer
-	delivery       *Delivery
-	intervalsStore state.Store
-	autoRetrieval  bool // automatically subscribe to retrieve request stream
-	maxPeerServers int
-	spec           *protocols.Spec   //this protocol's spec
-	balance        protocols.Balance //implements protocols.Balance, for accounting
-	prices         protocols.Prices  //implements protocols.Prices, provides prices to accounting
-	quit           chan struct{}     // terminates registry goroutines
+	addr            enode.ID
+	api             *API
+	skipCheck       bool
+	clientMu        sync.RWMutex
+	serverMu        sync.RWMutex
+	peersMu         sync.RWMutex
+	serverFuncs     map[string]func(*Peer, string, bool) (Server, error)
+	clientFuncs     map[string]func(*Peer, string, bool) (Client, error)
+	peers           map[enode.ID]*Peer
+	delivery        *Delivery
+	intervalsStore  state.Store
+	autoRetrieval   bool // automatically subscribe to retrieve request stream
+	maxPeerServers  int
+	spec            *protocols.Spec   //this protocol's spec
+	balance         protocols.Balance //implements protocols.Balance, for accounting
+	prices          protocols.Prices  //implements protocols.Prices, provides prices to accounting
+	quit            chan struct{}     // terminates registry goroutines
+	syncMode        SyncingOption
+	syncUpdateDelay time.Duration
 }
 
 // RegistryOptions holds optional values for NewRegistry constructor.
@@ -121,17 +123,18 @@ func NewRegistry(localID enode.ID, delivery *Delivery, syncChunkStore storage.Sy
 	quit := make(chan struct{})
 
 	streamer := &Registry{
-		addr:           localID,
-		skipCheck:      options.SkipCheck,
-		serverFuncs:    make(map[string]func(*Peer, string, bool) (Server, error)),
-		clientFuncs:    make(map[string]func(*Peer, string, bool) (Client, error)),
-		peers:          make(map[enode.ID]*Peer),
-		delivery:       delivery,
-		intervalsStore: intervalsStore,
-		autoRetrieval:  retrieval,
-		maxPeerServers: options.MaxPeerServers,
-		balance:        balance,
-		quit:           quit,
+		addr:            localID,
+		skipCheck:       options.SkipCheck,
+		serverFuncs:     make(map[string]func(*Peer, string, bool) (Server, error)),
+		clientFuncs:     make(map[string]func(*Peer, string, bool) (Client, error)),
+		peers:           make(map[enode.ID]*Peer),
+		delivery:        delivery,
+		intervalsStore:  intervalsStore,
+		autoRetrieval:   retrieval,
+		maxPeerServers:  options.MaxPeerServers,
+		balance:         balance,
+		quit:            quit,
+		syncUpdateDelay: options.SyncUpdateDelay,
 	}
 
 	streamer.setupSpec()
@@ -162,102 +165,7 @@ func NewRegistry(localID enode.ID, delivery *Delivery, syncChunkStore storage.Sy
 		RegisterSwarmSyncerClient(streamer, syncChunkStore)
 	}
 
-	// if syncing is set to automatically subscribe to the syncing stream, start the subscription process
-	if options.Syncing == SyncingAutoSubscribe {
-		// latestIntC function ensures that
-		//   - receiving from the in chan is not blocked by processing inside the for loop
-		// 	 - the latest int value is delivered to the loop after the processing is done
-		// In context of NeighbourhoodDepthC:
-		// after the syncing is done updating inside the loop, we do not need to update on the intermediate
-		// depth changes, only to the latest one
-		latestIntC := func(in <-chan int) <-chan int {
-			out := make(chan int, 1)
-
-			go func() {
-				defer close(out)
-
-				for {
-					select {
-					case i, ok := <-in:
-						if !ok {
-							return
-						}
-						select {
-						case <-out:
-						default:
-						}
-						out <- i
-					case <-quit:
-						return
-					}
-				}
-			}()
-
-			return out
-		}
-
-		kad := streamer.delivery.kad
-		// get notification channels from Kademlia before returning
-		// from this function to avoid race with Close method and
-		// the goroutine created below
-		depthC := latestIntC(kad.NeighbourhoodDepthC())
-		addressBookSizeC := latestIntC(kad.AddrCountC())
-
-		go func() {
-			// wait for kademlia table to be healthy
-			// but return if Registry is closed before
-			select {
-			case <-time.After(options.SyncUpdateDelay):
-			case <-quit:
-				return
-			}
-
-			// initial requests for syncing subscription to peers
-			streamer.updateSyncing()
-
-			for depth := range depthC {
-				log.Debug("Kademlia neighbourhood depth change", "depth", depth)
-
-				// Prevent too early sync subscriptions by waiting until there are no
-				// new peers connecting. Sync streams updating will be done after no
-				// peers are connected for at least SyncUpdateDelay period.
-				timer := time.NewTimer(options.SyncUpdateDelay)
-				// Hard limit to sync update delay, preventing long delays
-				// on a very dynamic network
-				maxTimer := time.NewTimer(3 * time.Minute)
-			loop:
-				for {
-					select {
-					case <-maxTimer.C:
-						// force syncing update when a hard timeout is reached
-						log.Trace("Sync subscriptions update on hard timeout")
-						// request for syncing subscription to new peers
-						streamer.updateSyncing()
-						break loop
-					case <-timer.C:
-						// start syncing as no new peers has been added to kademlia
-						// for some time
-						log.Trace("Sync subscriptions update")
-						// request for syncing subscription to new peers
-						streamer.updateSyncing()
-						break loop
-					case size := <-addressBookSizeC:
-						log.Trace("Kademlia address book size changed on depth change", "size", size)
-						// new peers has been added to kademlia,
-						// reset the timer to prevent early sync subscriptions
-						if !timer.Stop() {
-							<-timer.C
-						}
-						timer.Reset(options.SyncUpdateDelay)
-					case <-quit:
-						break loop
-					}
-				}
-				timer.Stop()
-				maxTimer.Stop()
-			}
-		}()
-	}
+	streamer.syncMode = options.Syncing
 
 	return streamer
 }
@@ -439,6 +347,7 @@ func (r *Registry) setPeer(peer *Peer) {
 	r.peersMu.Lock()
 	r.peers[peer.ID()] = peer
 	metrics.GetOrRegisterGauge("registry.peers", nil).Update(int64(len(r.peers)))
+	go peer.Registrations()
 	r.peersMu.Unlock()
 }
 
@@ -458,7 +367,7 @@ func (r *Registry) peersCount() (c int) {
 
 // Run protocol run function
 func (r *Registry) Run(p *network.BzzPeer) error {
-	sp := NewPeer(p.Peer, r)
+	sp := NewPeer(p, r)
 	r.setPeer(sp)
 	defer r.deletePeer(sp)
 	defer close(sp.quit)
@@ -474,116 +383,17 @@ func (r *Registry) Run(p *network.BzzPeer) error {
 	return sp.Run(sp.HandleMsg)
 }
 
-// updateSyncing subscribes to SYNC streams by iterating over the
-// kademlia connections and bins. If there are existing SYNC streams
-// and they are no longer required after iteration, request to Quit
-// them will be send to appropriate peers.
-func (r *Registry) updateSyncing() {
-	kad := r.delivery.kad
-	// map of all SYNC streams for all peers
-	// used at the and of the function to remove servers
-	// that are not needed anymore
-	subs := make(map[enode.ID]map[Stream]struct{})
-	r.peersMu.RLock()
-	for id, peer := range r.peers {
-		peer.serverMu.RLock()
-		for stream := range peer.servers {
-			if stream.Name == "SYNC" {
-				if _, ok := subs[id]; !ok {
-					subs[id] = make(map[Stream]struct{})
-				}
-				subs[id][stream] = struct{}{}
-			}
-		}
-		peer.serverMu.RUnlock()
-	}
-	r.peersMu.RUnlock()
-
-	// start requesting subscriptions from peers
-	r.requestPeerSubscriptions(kad, subs)
-
-	// remove SYNC servers that do not need to be subscribed
-	for id, streams := range subs {
-		if len(streams) == 0 {
-			continue
-		}
-		peer := r.getPeer(id)
-		if peer == nil {
-			continue
-		}
-		for stream := range streams {
-			log.Debug("Remove sync server", "peer", id, "stream", stream)
-			err := r.Quit(peer.ID(), stream)
-			if err != nil && err != p2p.ErrShuttingDown {
-				log.Error("quit", "err", err, "peer", peer.ID(), "stream", stream)
-			}
-		}
-	}
-}
-
-// requestPeerSubscriptions calls on each live peer in the kademlia table
-// and sends a `RequestSubscription` to peers according to their bin
-// and their relationship with kademlia's depth.
-// Also check `TestRequestPeerSubscriptions` in order to understand the
-// expected behavior.
-// The function expects:
-//   * the kademlia
-//   * a map of subscriptions
-//   * the actual function to subscribe
-//     (in case of the test, it doesn't do real subscriptions)
-func (r *Registry) requestPeerSubscriptions(kad *network.Kademlia, subs map[enode.ID]map[Stream]struct{}) {
-
-	var startPo int
-	var endPo int
-	var ok bool
-
-	// kademlia's depth
-	kadDepth := kad.NeighbourhoodDepth()
-	// request subscriptions for all nodes and bins
-	// nil as base takes the node's base; we need to pass 255 as `EachConn` runs
-	// from deepest bins backwards
-	kad.EachConn(nil, 255, func(p *network.Peer, po int) bool {
-		// nodes that do not provide stream protocol
-		// should not be subscribed, e.g. bootnodes
-		if !p.HasCap("stream") {
-			return true
-		}
-		//if the peer's bin is shallower than the kademlia depth,
-		//only the peer's bin should be subscribed
-		if po < kadDepth {
-			startPo = po
-			endPo = po
-		} else {
-			//if the peer's bin is equal or deeper than the kademlia depth,
-			//each bin from the depth up to k.MaxProxDisplay should be subscribed
-			startPo = kadDepth
-			endPo = kad.MaxProxDisplay
-		}
-
-		for bin := startPo; bin <= endPo; bin++ {
-			//do the actual subscription
-			ok = subscriptionFunc(r, p, uint8(bin), subs)
-		}
-		return ok
-	})
-}
-
 // doRequestSubscription sends the actual RequestSubscription to the peer
-func doRequestSubscription(r *Registry, p *network.Peer, bin uint8, subs map[enode.ID]map[Stream]struct{}) bool {
+func doRequestSubscription(r *Registry, p *network.BzzPeer, bin uint8) error {
 	log.Debug("Requesting subscription by registry:", "registry", r.addr, "peer", p.ID(), "bin", bin)
 	// bin is always less then 256 and it is safe to convert it to type uint8
 	stream := NewStream("SYNC", FormatSyncBinKey(bin), true)
-	if streams, ok := subs[p.ID()]; ok {
-		// delete live and history streams from the map, so that it won't be removed with a Quit request
-		delete(streams, stream)
-		delete(streams, getHistoryStream(stream))
-	}
 	err := r.RequestSubscription(p.ID(), stream, NewRange(0, 0), High)
 	if err != nil {
 		log.Debug("Request subscription", "err", err, "peer", p.ID(), "stream", stream)
-		return false
+		return err
 	}
-	return true
+	return nil
 }
 
 func (r *Registry) runProtocol(p *p2p.Peer, rw p2p.MsgReadWriter) error {

--- a/swarm/network/stream/streamer_test.go
+++ b/swarm/network/stream/streamer_test.go
@@ -1189,7 +1189,7 @@ func TestGetSubscriptionsRPC(t *testing.T) {
 	// arbitrarily set to 4
 	nodeCount := 4
 	// set the syncUpdateDelay for sync registrations to start
-	syncUpdateDelay := 200 * time.Millisecond
+	syncUpdateDelay := 1 * time.Second
 	// run with more nodes if `longrunning` flag is set
 	if *longrunning {
 		nodeCount = 64
@@ -1207,12 +1207,7 @@ func TestGetSubscriptionsRPC(t *testing.T) {
 
 	// we use this subscriptionFunc for this test: just increases count and calls the actual subscription
 	subscriptionFunc = func(r *Registry, p *network.BzzPeer, bin uint8) error {
-		// syncing starts after syncUpdateDelay and loops after that Duration; we only want to count at the first iteration
-		// in the first iteration, subs will be empty (no existing subscriptions), thus we can use this check
-		// this avoids flakyness
-		//if len(subs) == 0 {
 		expectedMsgCount.inc()
-		//}
 		doRequestSubscription(r, p, bin)
 		return nil
 	}
@@ -1341,7 +1336,7 @@ func TestGetSubscriptionsRPC(t *testing.T) {
 			log.Debug("All node streams counted", "realCount", realCount)
 		}
 		emc := expectedMsgCount.count()
-		if realCount != emc {
+		if realCount/2 != emc {
 			return fmt.Errorf("Real subscriptions and expected amount don't match; real: %d, expected: %d", realCount/2, emc)
 		}
 		return nil


### PR DESCRIPTION
This PR is an experiment and work in progress.

It is a replacement for udpateSyncing in the Registry to run subscriptions from peers and not globally via the registry.

It is meant as a discussion base to refine the architecture to replace updateSyncing.

Currently there are no removal of subscriptions yet. Some parts may be qualified as bad or even ugly, consequence of quick hacks in order to have first results.

Currently the smoke tests produce a timeout at about 50% rate with this approach. Also, the retrieval tests are very slow (explaining the timeouts)

fixes https://github.com/ethersphere/go-ethereum/issues/1329