### PR TITLE
p2p/protocols, swarm/network: fix p2p resource leak

### DIFF
--- a/p2p/protocols/protocol_test.go
+++ b/p2p/protocols/protocol_test.go
@@ -269,6 +269,7 @@ func TestProtocolHook(t *testing.T) {
 		panic(err)
 	}
 	tester := p2ptest.NewProtocolTester(prvkey, 2, runFunc)
+	defer tester.Stop()
 	err = tester.TestExchanges(p2ptest.Exchange{
 		Expects: []p2ptest.Expect{
 			{

--- a/swarm/network/protocol_test.go
+++ b/swarm/network/protocol_test.go
@@ -228,6 +228,7 @@ func TestBzzHandshakeNetworkIDMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer s.Stop()
 	node := s.Nodes[0]
 
 	err = s.testHandshake(
@@ -251,6 +252,7 @@ func TestBzzHandshakeVersionMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer s.Stop()
 	node := s.Nodes[0]
 
 	err = s.testHandshake(
@@ -274,6 +276,7 @@ func TestBzzHandshakeSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer s.Stop()
 	node := s.Nodes[0]
 
 	err = s.testHandshake(
@@ -305,6 +308,7 @@ func TestBzzHandshakeLightNode(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			defer pt.Stop()
 
 			node := pt.Nodes[0]
 			addr := NewAddr(node)


### PR DESCRIPTION
this PR fixes the resource leak due to improper shutdown of p2p server on `p2p/protocoltester`.
we are still leaking keystores but this is a bit more hard to pin down, since the keystore directory is created side-by-side with the node data directory. I think this is done when the geth components get bootstrapped and the keystore gets created automatically.

fixes https://github.com/ethersphere/go-ethereum/issues/1322