### PR TITLE
Swarm rather stable: LocalStore metrics

### DIFF
--- a/swarm/chunk/chunk.go
+++ b/swarm/chunk/chunk.go
@@ -121,7 +121,7 @@ func (m ModeGet) String() string {
 	case ModeGetLookup:
 		return "Lookup"
 	default:
-		return "Unknown Mode Get"
+		return "Unknown"
 	}
 }
 
@@ -147,7 +147,7 @@ func (m ModePut) String() string {
 	case ModePutUpload:
 		return "Upload"
 	default:
-		return "Unknown Mode Put"
+		return "Unknown"
 	}
 }
 
@@ -173,7 +173,7 @@ func (m ModeSet) String() string {
 	case ModeSetRemove:
 		return "Remove"
 	default:
-		return "Unknown Mode Set"
+		return "Unknown"
 	}
 }
 

--- a/swarm/chunk/chunk.go
+++ b/swarm/chunk/chunk.go
@@ -112,6 +112,19 @@ func Proximity(one, other []byte) (ret int) {
 // ModeGet enumerates different Getter modes.
 type ModeGet int
 
+func (m ModeGet) String() string {
+	switch m {
+	case ModeGetRequest:
+		return "Request"
+	case ModeGetSync:
+		return "Sync"
+	case ModeGetLookup:
+		return "Lookup"
+	default:
+		return "Unknown Mode Get"
+	}
+}
+
 // Getter modes.
 const (
 	// ModeGetRequest: when accessed for retrieval
@@ -125,6 +138,19 @@ const (
 // ModePut enumerates different Putter modes.
 type ModePut int
 
+func (m ModePut) String() string {
+	switch m {
+	case ModePutRequest:
+		return "Request"
+	case ModePutSync:
+		return "Sync"
+	case ModePutUpload:
+		return "Upload"
+	default:
+		return "Unknown Mode Put"
+	}
+}
+
 // Putter modes.
 const (
 	// ModePutRequest: when a chunk is received as a result of retrieve request and delivery
@@ -137,6 +163,19 @@ const (
 
 // ModeSet enumerates different Setter modes.
 type ModeSet int
+
+func (m ModeSet) String() string {
+	switch m {
+	case ModeSetAccess:
+		return "Access"
+	case ModeSetSync:
+		return "Sync"
+	case ModeSetRemove:
+		return "Remove"
+	default:
+		return "Unknown Mode Set"
+	}
+}
 
 // Setter modes.
 const (

--- a/swarm/storage/localstore/gc.go
+++ b/swarm/storage/localstore/gc.go
@@ -18,6 +18,7 @@ package localstore
 
 import (
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/swarm/shed"
 	"github.com/syndtr/goleveldb/leveldb"
 )
@@ -75,6 +76,13 @@ func (db *DB) collectGarbageWorker() {
 // the rest of the garbage as the batch size limit is reached.
 // This function is called in collectGarbageWorker.
 func (db *DB) collectGarbage() (collectedCount uint64, done bool, err error) {
+	metrics.GetOrRegisterCounter("localstore.gc", nil).Inc(1)
+	defer func() {
+		if err != nil {
+			metrics.GetOrRegisterCounter("localstore.gc.error", nil).Inc(1)
+		}
+	}()
+
 	batch := new(leveldb.Batch)
 	target := db.gcTarget()
 

--- a/swarm/storage/localstore/gc.go
+++ b/swarm/storage/localstore/gc.go
@@ -17,6 +17,8 @@
 package localstore
 
 import (
+	"time"
+
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/swarm/shed"
@@ -76,10 +78,12 @@ func (db *DB) collectGarbageWorker() {
 // the rest of the garbage as the batch size limit is reached.
 // This function is called in collectGarbageWorker.
 func (db *DB) collectGarbage() (collectedCount uint64, done bool, err error) {
-	metrics.GetOrRegisterCounter("localstore.gc", nil).Inc(1)
+	metricName := "localstore.gc"
+	metrics.GetOrRegisterCounter(metricName, nil).Inc(1)
+	defer totalTimeMetric(metricName, time.Now())
 	defer func() {
 		if err != nil {
-			metrics.GetOrRegisterCounter("localstore.gc.error", nil).Inc(1)
+			metrics.GetOrRegisterCounter(metricName+".error", nil).Inc(1)
 		}
 	}()
 

--- a/swarm/storage/localstore/localstore.go
+++ b/swarm/storage/localstore/localstore.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/swarm/chunk"
 	"github.com/ethereum/go-ethereum/swarm/shed"
 	"github.com/ethereum/go-ethereum/swarm/storage/mock"
@@ -387,4 +388,13 @@ func init() {
 	now = func() (t int64) {
 		return time.Now().UTC().UnixNano()
 	}
+}
+
+// totalTimeMetric logs a message about time between provided start time
+// and the time when the function is called and sends a resetting timer metric
+// with provided name appended with ".total-time".
+func totalTimeMetric(name string, start time.Time) {
+	totalTime := time.Since(start)
+	log.Trace(name+" total time", "time", totalTime)
+	metrics.GetOrRegisterResettingTimer(name+".total-time", nil).Update(totalTime)
 }

--- a/swarm/storage/localstore/mode_has.go
+++ b/swarm/storage/localstore/mode_has.go
@@ -18,6 +18,7 @@ package localstore
 
 import (
 	"context"
+	"time"
 
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/swarm/chunk"
@@ -27,15 +28,18 @@ import (
 
 // Has returns true if the chunk is stored in database.
 func (db *DB) Has(ctx context.Context, addr chunk.Address) (bool, error) {
-	ctx, sp := spancontext.StartSpan(ctx, "localstore.Has")
-	defer sp.Finish()
+	metricName := "localstore.Has"
 
+	ctx, sp := spancontext.StartSpan(ctx, metricName)
+	defer sp.Finish()
 	sp.LogFields(olog.String("ref", addr.String()))
 
-	metrics.GetOrRegisterCounter("localstore.Has.%s", nil).Inc(1)
+	metrics.GetOrRegisterCounter(metricName, nil).Inc(1)
+	defer totalTimeMetric(metricName, time.Now())
+
 	has, err := db.retrievalDataIndex.Has(addressToItem(addr))
 	if err != nil {
-		metrics.GetOrRegisterCounter("localstore.Has.%s.error", nil).Inc(1)
+		metrics.GetOrRegisterCounter(metricName+".error", nil).Inc(1)
 	}
 	return has, err
 }

--- a/swarm/storage/localstore/mode_has.go
+++ b/swarm/storage/localstore/mode_has.go
@@ -19,10 +19,23 @@ package localstore
 import (
 	"context"
 
+	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/swarm/chunk"
+	"github.com/ethereum/go-ethereum/swarm/spancontext"
+	olog "github.com/opentracing/opentracing-go/log"
 )
 
 // Has returns true if the chunk is stored in database.
-func (db *DB) Has(_ context.Context, addr chunk.Address) (bool, error) {
-	return db.retrievalDataIndex.Has(addressToItem(addr))
+func (db *DB) Has(ctx context.Context, addr chunk.Address) (bool, error) {
+	ctx, sp := spancontext.StartSpan(ctx, "localstore.Has")
+	defer sp.Finish()
+
+	sp.LogFields(olog.String("ref", addr.String()))
+
+	metrics.GetOrRegisterCounter("localstore.Has.%s", nil).Inc(1)
+	has, err := db.retrievalDataIndex.Has(addressToItem(addr))
+	if err != nil {
+		metrics.GetOrRegisterCounter("localstore.Has.%s.error", nil).Inc(1)
+	}
+	return has, err
 }

--- a/swarm/storage/localstore/subscription_pull.go
+++ b/swarm/storage/localstore/subscription_pull.go
@@ -19,7 +19,6 @@ package localstore
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
@@ -42,7 +41,7 @@ import (
 // Make sure that you check the second returned parameter from the channel to stop iteration when its value
 // is false.
 func (db *DB) SubscribePull(ctx context.Context, bin uint8, since, until uint64) (c <-chan chunk.Descriptor, stop func()) {
-	metrics.GetOrRegisterCounter(fmt.Sprintf("localstore.SubscribePull.bin%v", bin), nil).Inc(1)
+	metrics.GetOrRegisterCounter("localstore.SubscribePull", nil).Inc(1)
 
 	chunkDescriptors := make(chan chunk.Descriptor)
 	trigger := make(chan struct{}, 1)
@@ -65,7 +64,7 @@ func (db *DB) SubscribePull(ctx context.Context, bin uint8, since, until uint64)
 	var errStopSubscription = errors.New("stop subscription")
 
 	go func() {
-		defer metrics.GetOrRegisterCounter(fmt.Sprintf("localstore.SubscribePull.bin%v.stop", bin), nil).Inc(1)
+		defer metrics.GetOrRegisterCounter("localstore.SubscribePull.stop", nil).Inc(1)
 		// close the returned chunk.Descriptor channel at the end to
 		// signal that the subscription is done
 		defer close(chunkDescriptors)
@@ -86,7 +85,7 @@ func (db *DB) SubscribePull(ctx context.Context, bin uint8, since, until uint64)
 				// - last index Item is reached
 				// - subscription stop is called
 				// - context is done
-				metrics.GetOrRegisterCounter(fmt.Sprintf("localstore.SubscribePull.bin%v.iter", bin), nil).Inc(1)
+				metrics.GetOrRegisterCounter("localstore.SubscribePull.iter", nil).Inc(1)
 
 				ctx, sp := spancontext.StartSpan(ctx, "localstore.SubscribePull.iter")
 				sp.LogFields(olog.Int("bin", int(bin)), olog.Uint64("since", since), olog.Uint64("until", until))
@@ -143,7 +142,7 @@ func (db *DB) SubscribePull(ctx context.Context, bin uint8, since, until uint64)
 						// if until is reached
 						return
 					}
-					metrics.GetOrRegisterCounter(fmt.Sprintf("localstore.SubscribePull.bin%v.iter.error", bin), nil).Inc(1)
+					metrics.GetOrRegisterCounter("localstore.SubscribePull.iter.error", nil).Inc(1)
 					log.Error("localstore pull subscription iteration", "bin", bin, "since", since, "until", until, "err", err)
 					return
 				}
@@ -189,7 +188,7 @@ func (db *DB) SubscribePull(ctx context.Context, bin uint8, since, until uint64)
 // in pull syncing index for a provided bin. If there are no chunks in
 // that bin, 0 value is returned.
 func (db *DB) LastPullSubscriptionBinID(bin uint8) (id uint64, err error) {
-	metrics.GetOrRegisterCounter(fmt.Sprintf("localstore.LastPullSubscriptionBinID.bin%v", bin), nil).Inc(1)
+	metrics.GetOrRegisterCounter("localstore.LastPullSubscriptionBinID", nil).Inc(1)
 
 	item, err := db.pullIndex.Last([]byte{bin})
 	if err != nil {

--- a/swarm/storage/localstore/subscription_push.go
+++ b/swarm/storage/localstore/subscription_push.go
@@ -19,10 +19,15 @@ package localstore
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/swarm/chunk"
 	"github.com/ethereum/go-ethereum/swarm/shed"
+	"github.com/ethereum/go-ethereum/swarm/spancontext"
+	"github.com/opentracing/opentracing-go"
+	olog "github.com/opentracing/opentracing-go/log"
 )
 
 // SubscribePush returns a channel that provides storage chunks with ordering from push syncing index.
@@ -30,6 +35,8 @@ import (
 // the returned channel without any errors. Make sure that you check the second returned parameter
 // from the channel to stop iteration when its value is false.
 func (db *DB) SubscribePush(ctx context.Context) (c <-chan chunk.Chunk, stop func()) {
+	metrics.GetOrRegisterCounter("localstore.SubscribePush", nil).Inc(1)
+
 	chunks := make(chan chunk.Chunk)
 	trigger := make(chan struct{}, 1)
 
@@ -44,6 +51,7 @@ func (db *DB) SubscribePush(ctx context.Context) (c <-chan chunk.Chunk, stop fun
 	var stopChanOnce sync.Once
 
 	go func() {
+		defer metrics.GetOrRegisterCounter("localstore.SubscribePush.done", nil).Inc(1)
 		// close the returned chunkInfo channel at the end to
 		// signal that the subscription is done
 		defer close(chunks)
@@ -57,6 +65,11 @@ func (db *DB) SubscribePush(ctx context.Context) (c <-chan chunk.Chunk, stop fun
 				// - last index Item is reached
 				// - subscription stop is called
 				// - context is done
+				defer metrics.GetOrRegisterCounter("localstore.SubscribePush.iter", nil).Inc(1)
+
+				ctx, sp := spancontext.StartSpan(ctx, "localstore.SubscribePush.iter")
+
+				var count int
 				err := db.pushIndex.Iterate(func(item shed.Item) (stop bool, err error) {
 					// get chunk data
 					dataItem, err := db.retrievalDataIndex.Get(item)
@@ -66,6 +79,7 @@ func (db *DB) SubscribePush(ctx context.Context) (c <-chan chunk.Chunk, stop fun
 
 					select {
 					case chunks <- chunk.NewChunk(dataItem.Address, dataItem.Data):
+						count++
 						// set next iteration start item
 						// when its chunk is successfully sent to channel
 						sinceItem = &item
@@ -87,7 +101,18 @@ func (db *DB) SubscribePush(ctx context.Context) (c <-chan chunk.Chunk, stop fun
 					// iterator call, skip it in this one
 					SkipStartFromItem: true,
 				})
+
+				sp.FinishWithOptions(opentracing.FinishOptions{
+					LogRecords: []opentracing.LogRecord{
+						{
+							Timestamp: time.Now(),
+							Fields:    []olog.Field{olog.Int("count", count)},
+						},
+					},
+				})
+
 				if err != nil {
+					metrics.GetOrRegisterCounter("localstore.SubscribePush.iter.error", nil).Inc(1)
 					log.Error("localstore push subscription iteration", "err", err)
 					return
 				}


### PR DESCRIPTION
This PR adds metrics and traces to the new localstore and removes unneeded metics fields from shed to the scope of meter function.

fixes: https://github.com/ethersphere/go-ethereum/issues/1345