### PR TITLE
Swarm rather stable: fix data races in TestInitialPeersMsg test:

### DIFF
--- a/p2p/testing/protocoltester.go
+++ b/p2p/testing/protocoltester.go
@@ -110,6 +110,7 @@ func NewProtocolTester(prvkey *ecdsa.PrivateKey, nodeCount int, run func(*p2p.Pe
 // Stop stops the p2p server
 func (t *ProtocolTester) Stop() {
 	t.Server.Stop()
+	t.network.Shutdown()
 }
 
 // Connect brings up the remote peer node and connects it using the

--- a/swarm/network/discovery_test.go
+++ b/swarm/network/discovery_test.go
@@ -174,9 +174,7 @@ func testInitialPeersMsg(t *testing.T, peerPO, peerDepth int) {
 	}
 
 	// pivotDepth is the advertised depth of the pivot node we expect in the outgoing subPeersMsg
-	hive.Kademlia.lock.RLock() // protect Kademlia.conns that are read in Kademlia.saturation()
-	pivotDepth := hive.saturation()
-	hive.Kademlia.lock.RUnlock()
+	pivotDepth := hive.Saturation()
 	// the test exchange is as follows:
 	// 1. pivot sends to the control peer a `subPeersMsg` advertising its depth (ignored)
 	// 2. peer sends to pivot a `subPeersMsg` advertising its own depth (arbitrarily chosen)

--- a/swarm/network/discovery_test.go
+++ b/swarm/network/discovery_test.go
@@ -160,7 +160,10 @@ func testInitialPeersMsg(t *testing.T, peerPO, peerDepth int) {
 	// block until control peer is found among hive peers
 	found := false
 	for attempts := 0; attempts < 20; attempts++ {
-		if _, found = hive.peers[peerID]; found {
+		hive.lock.Lock()
+		_, found = hive.peers[peerID]
+		hive.lock.Unlock()
+		if found {
 			break
 		}
 		time.Sleep(1 * time.Millisecond)
@@ -171,7 +174,9 @@ func testInitialPeersMsg(t *testing.T, peerPO, peerDepth int) {
 	}
 
 	// pivotDepth is the advertised depth of the pivot node we expect in the outgoing subPeersMsg
+	hive.Kademlia.lock.RLock() // protect Kademlia.conns that are read in Kademlia.saturation()
 	pivotDepth := hive.saturation()
+	hive.Kademlia.lock.RUnlock()
 	// the test exchange is as follows:
 	// 1. pivot sends to the control peer a `subPeersMsg` advertising its depth (ignored)
 	// 2. peer sends to pivot a `subPeersMsg` advertising its own depth (arbitrarily chosen)

--- a/swarm/network/discovery_test.go
+++ b/swarm/network/discovery_test.go
@@ -154,6 +154,7 @@ func testInitialPeersMsg(t *testing.T, peerPO, peerDepth int) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer s.Stop()
 
 	// peerID to use in the protocol tester testExchange expect/trigger
 	peerID := s.Nodes[0].ID()

--- a/swarm/network/discovery_test.go
+++ b/swarm/network/discovery_test.go
@@ -160,7 +160,7 @@ func testInitialPeersMsg(t *testing.T, peerPO, peerDepth int) {
 	peerID := s.Nodes[0].ID()
 	// block until control peer is found among hive peers
 	found := false
-	for attempts := 0; attempts < 20; attempts++ {
+	for attempts := 0; attempts < 2000; attempts++ {
 		found = hive.Peer(peerID) != nil
 		if found {
 			break

--- a/swarm/network/discovery_test.go
+++ b/swarm/network/discovery_test.go
@@ -160,9 +160,7 @@ func testInitialPeersMsg(t *testing.T, peerPO, peerDepth int) {
 	// block until control peer is found among hive peers
 	found := false
 	for attempts := 0; attempts < 20; attempts++ {
-		hive.lock.Lock()
-		_, found = hive.peers[peerID]
-		hive.lock.Unlock()
+		found = hive.Peer(peerID) != nil
 		if found {
 			break
 		}

--- a/swarm/network/hive.go
+++ b/swarm/network/hive.go
@@ -209,6 +209,15 @@ func (h *Hive) PeerInfo(id enode.ID) interface{} {
 	}
 }
 
+// Peer returns a bzz peer from the Hive. If there is no peer
+// with the provided enode id, a nil value is returned.
+func (h *Hive) Peer(id enode.ID) *BzzPeer {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	return h.peers[id]
+}
+
 // loadPeers, savePeer implement persistence callback/
 func (h *Hive) loadPeers() error {
 	var as []*BzzAddr

--- a/swarm/network/hive.go
+++ b/swarm/network/hive.go
@@ -192,9 +192,7 @@ func (h *Hive) NodeInfo() interface{} {
 // PeerInfo function is used by the p2p.server RPC interface to display
 // protocol specific information any connected peer referred to by their NodeID
 func (h *Hive) PeerInfo(id enode.ID) interface{} {
-	h.lock.Lock()
-	p := h.peers[id]
-	h.lock.Unlock()
+	p := h.Peer(id)
 
 	if p == nil {
 		return nil

--- a/swarm/network/kademlia.go
+++ b/swarm/network/kademlia.go
@@ -751,9 +751,6 @@ func (k *Kademlia) Saturation() int {
 	return k.saturation()
 }
 
-// saturation returns the smallest po value in which the node has less than MinBinSize peers
-// if the iterator reaches neighbourhood radius, then the last bin + 1 is returned.
-// This function is safe to use in Kademlia methods that use the lock.
 func (k *Kademlia) saturation() int {
 	prev := -1
 	radius := neighbourhoodRadiusForPot(k.conns, k.NeighbourhoodSize, k.base)

--- a/swarm/network/kademlia.go
+++ b/swarm/network/kademlia.go
@@ -742,8 +742,18 @@ func NewPeerPotMap(neighbourhoodSize int, addrs [][]byte) map[string]*PeerPot {
 	return ppmap
 }
 
-// saturation returns the smallest po value in which the node has less than MinBinSize peers
+// Saturation returns the smallest po value in which the node has less than MinBinSize peers
 // if the iterator reaches neighbourhood radius, then the last bin + 1 is returned
+func (k *Kademlia) Saturation() int {
+	k.lock.RLock()
+	defer k.lock.RUnlock()
+
+	return k.saturation()
+}
+
+// saturation returns the smallest po value in which the node has less than MinBinSize peers
+// if the iterator reaches neighbourhood radius, then the last bin + 1 is returned.
+// This function is safe to use in Kademlia methods that use the lock.
 func (k *Kademlia) saturation() int {
 	prev := -1
 	radius := neighbourhoodRadiusForPot(k.conns, k.NeighbourhoodSize, k.base)

--- a/swarm/network/protocol_test.go
+++ b/swarm/network/protocol_test.go
@@ -102,8 +102,8 @@ func newBzzBaseTesterWithAddrs(prvkey *ecdsa.PrivateKey, addrs [][]byte, spec *p
 	nodeToAddr := make(map[enode.ID][]byte)
 	protocol := func(p *p2p.Peer, rw p2p.MsgReadWriter) error {
 		mu.Lock()
-		defer mu.Unlock()
 		nodeToAddr[p.ID()] = addrs[0]
+		mu.Unlock()
 		bzzAddr := &BzzAddr{addrs[0], []byte(p.Node().String())}
 		addrs = addrs[1:]
 		return srv(&BzzPeer{Peer: protocols.NewPeer(p, rw, spec), BzzAddr: bzzAddr})

--- a/swarm/network/protocol_test.go
+++ b/swarm/network/protocol_test.go
@@ -131,9 +131,11 @@ func newBzzBaseTesterWithAddrs(prvkey *ecdsa.PrivateKey, addrs [][]byte, spec *p
 		ProtocolTester: s,
 		cs:             cs,
 	}
+	mu.Lock()
 	for _, n := range pt.Nodes {
 		nodeAddrs = append(nodeAddrs, nodeToAddr[n.ID()])
 	}
+	mu.Unlock()
 
 	return pt, nodeAddrs, nil
 }


### PR DESCRIPTION
This PR fixes data races in TestInitialPeersMsg described in https://github.com/ethersphere/go-ethereum/issues/1331.

This PR contains a cherry-picked commits from https://github.com/ethersphere/go-ethereum/pull/1338.