### PR TITLE
use BzzAddr for proximity calculations, instead of enode.ID

### DIFF
--- a/swarm/network/kademlia.go
+++ b/swarm/network/kademlia.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethereum/go-ethereum/p2p/protocols"
 	"github.com/ethereum/go-ethereum/swarm/log"
 	"github.com/ethereum/go-ethereum/swarm/pot"
 	sv "github.com/ethereum/go-ethereum/swarm/version"
@@ -420,6 +421,25 @@ func (k *Kademlia) Off(p *Peer) {
 		})
 		k.setNeighbourhoodDepth()
 	}
+}
+
+func (k *Kademlia) GetBzzAddr(p *protocols.Peer) *BzzAddr {
+	var res *BzzAddr
+
+	k.addrs.Each(func(val pot.Val) bool {
+		e := val.(*entry)
+		if bytes.Equal(e.BzzAddr.ID().Bytes(), p.Node().ID().Bytes()) {
+			res = e.BzzAddr
+			return false
+		}
+		return true
+	})
+
+	if res == nil {
+		panic("i think we should always be able to map a peer's enode.ID to its BzzAddr")
+	}
+
+	return res
 }
 
 func (k *Kademlia) ListKnown() []*BzzAddr {

--- a/swarm/network/stream/delivery.go
+++ b/swarm/network/stream/delivery.go
@@ -145,7 +145,8 @@ func (d *Delivery) handleChunkDeliveryMsg(ctx context.Context, sp *Peer, req int
 	switch r := req.(type) {
 	case *ChunkDeliveryMsgRetrieval:
 		msg = (*ChunkDeliveryMsg)(r)
-		peerPO := chunk.Proximity(sp.ID().Bytes(), msg.Addr)
+		peerBzzAddr := d.kad.GetBzzAddr(sp.Peer)
+		peerPO := chunk.Proximity(peerBzzAddr.Address(), msg.Addr)
 		po := chunk.Proximity(d.kad.BaseAddr(), msg.Addr)
 		depth := d.kad.NeighbourhoodDepth()
 		// chunks within the area of responsibility should always sync

--- a/swarm/network/stream/peer.go
+++ b/swarm/network/stream/peer.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/protocols"
 	"github.com/ethereum/go-ethereum/swarm/chunk"
 	"github.com/ethereum/go-ethereum/swarm/log"
-	"github.com/ethereum/go-ethereum/swarm/network"
 	pq "github.com/ethereum/go-ethereum/swarm/network/priorityqueue"
 	"github.com/ethereum/go-ethereum/swarm/network/stream/intervals"
 	"github.com/ethereum/go-ethereum/swarm/spancontext"
@@ -440,11 +439,15 @@ func (p *Peer) runUpdateSyncing() {
 	}
 
 	kad := p.streamer.delivery.kad
-	po := chunk.Proximity(network.NewAddr(p.Node()).Over(), kad.BaseAddr())
+	ba := kad.GetBzzAddr(p.Peer)
+	bzzAddr := ba.Address()
+	//bzzAddr := network.NewAddr(p.Node()).Over()
+	po := chunk.Proximity(bzzAddr, kad.BaseAddr())
 
 	depth := kad.NeighbourhoodDepth()
 
-	log.Debug("update syncing subscriptions: initial", "peer", p.ID(), "po", po, "depth", depth)
+	//log.Debug("update syncing subscriptions: initial", "peer", p.ID(), "bzzaddr", ba, "po", po, "depth", depth)
+	log.Debug("update syncing subscriptions: initial", "peer", p.ID(), "bzzaddr", fmt.Sprintf("%x", bzzAddr), "po", po, "depth", depth)
 
 	// initial subscriptions
 	p.updateSyncSubscriptions(syncSubscriptionsDiff(po, -1, depth, kad.MaxProxDisplay))


### PR DESCRIPTION
@janos I open this just for discussion, and to highlight where I think we are doing the proximity calculations wrong. We should find a better way to get the `BzzAddr`, but generally I think these are available only in the Kademlia table's `pots` containers, so for now a get method on Kademlia sounds like the place for that.

I personally find all the `peer` structs we have (`network`, `protocols`, `p2p`, `stream`) rather confusing, but maybe we can see how to refactor and simplify them once we understand this problem :)