### PR TITLE
swarm/network/stream: use bzzAddr for proximity calculation

### DIFF
--- a/swarm/network/stream/delivery_test.go
+++ b/swarm/network/stream/delivery_test.go
@@ -146,17 +146,19 @@ func TestRequestFromPeers(t *testing.T) {
 	to := network.NewKademlia(addr.OAddr, network.NewKadParams())
 	delivery := NewDelivery(to, nil)
 	protocolsPeer := protocols.NewPeer(p2p.NewPeer(dummyPeerID, "dummy", nil), nil, nil)
-	peer := network.NewPeer(&network.BzzPeer{
+	bzzPeer := &network.BzzPeer{
 		BzzAddr:   network.RandomAddr(),
 		LightNode: false,
 		Peer:      protocolsPeer,
-	}, to)
+	}
+	peer := network.NewPeer(bzzPeer, to)
+
 	to.On(peer)
 	r := NewRegistry(addr.ID(), delivery, nil, nil, nil, nil)
 
 	// an empty priorityQueue has to be created to prevent a goroutine being called after the test has finished
 	sp := &Peer{
-		Peer:     protocolsPeer,
+		bzzPeer:  bzzPeer,
 		pq:       pq.New(int(PriorityQueue), PriorityQueueCap),
 		streamer: r,
 	}
@@ -187,16 +189,17 @@ func TestRequestFromPeersWithLightNode(t *testing.T) {
 
 	protocolsPeer := protocols.NewPeer(p2p.NewPeer(dummyPeerID, "dummy", nil), nil, nil)
 	// setting up a lightnode
-	peer := network.NewPeer(&network.BzzPeer{
+	bzzPeer := &network.BzzPeer{
 		BzzAddr:   network.RandomAddr(),
 		LightNode: true,
 		Peer:      protocolsPeer,
-	}, to)
+	}
+	peer := network.NewPeer(bzzPeer, to)
 	to.On(peer)
 	r := NewRegistry(addr.ID(), delivery, nil, nil, nil, nil)
 	// an empty priorityQueue has to be created to prevent a goroutine being called after the test has finished
 	sp := &Peer{
-		Peer:     protocolsPeer,
+		bzzPeer:  bzzPeer,
 		pq:       pq.New(int(PriorityQueue), PriorityQueueCap),
 		streamer: r,
 	}

--- a/swarm/network/stream/peer.go
+++ b/swarm/network/stream/peer.go
@@ -58,6 +58,7 @@ var ErrMaxPeerServers = errors.New("max peer servers")
 // Peer is the Peer extension for the streaming protocol
 type Peer struct {
 	*protocols.Peer
+	bzzPeer  *network.BzzPeer
 	streamer *Registry
 	pq       *pq.PriorityQueue
 	serverMu sync.RWMutex
@@ -77,9 +78,10 @@ type WrappedPriorityMsg struct {
 }
 
 // NewPeer is the constructor for Peer
-func NewPeer(peer *protocols.Peer, streamer *Registry) *Peer {
+func NewPeer(peer *network.BzzPeer, streamer *Registry) *Peer {
 	p := &Peer{
-		Peer:         peer,
+		Peer:         peer.Peer,
+		bzzPeer:      peer,
 		pq:           pq.New(int(PriorityQueue), PriorityQueueCap),
 		streamer:     streamer,
 		servers:      make(map[Stream]*server),
@@ -440,7 +442,7 @@ func (p *Peer) runUpdateSyncing() {
 	}
 
 	kad := p.streamer.delivery.kad
-	po := chunk.Proximity(network.NewAddr(p.Node()).Over(), kad.BaseAddr())
+	po := chunk.Proximity(p.bzzPeer.Over(), kad.BaseAddr())
 
 	depth := kad.NeighbourhoodDepth()
 

--- a/swarm/network/stream/peer_test.go
+++ b/swarm/network/stream/peer_test.go
@@ -144,6 +144,7 @@ func TestUpdateSyncingSubscriptions(t *testing.T) {
 				r.Close()
 				clean()
 			}
+			bucket.Store("addr", addr)
 			return r, cleanup, nil
 		},
 	})
@@ -166,7 +167,13 @@ func TestUpdateSyncingSubscriptions(t *testing.T) {
 		// nodes proximities from the pivot node
 		nodeProximities := make(map[string]int)
 		for _, id := range ids[1:] {
-			nodeProximities[id.String()] = chunk.Proximity(pivotKademlia.BaseAddr(), id.Bytes())
+			item, ok := sim.NodeItem(id, "addr")
+			if !ok {
+				t.Fatal("No addr")
+			}
+
+			bzzAddr := item.(*network.BzzAddr)
+			nodeProximities[id.String()] = chunk.Proximity(pivotKademlia.BaseAddr(), bzzAddr.Address())
 		}
 		// wait until sync subscriptions are done for all nodes
 		waitForSubscriptions(t, pivotRegistry, ids[1:]...)

--- a/swarm/network/stream/stream.go
+++ b/swarm/network/stream/stream.go
@@ -334,7 +334,7 @@ func (r *Registry) peersCount() (c int) {
 
 // Run protocol run function
 func (r *Registry) Run(p *network.BzzPeer) error {
-	sp := NewPeer(p.Peer, r)
+	sp := NewPeer(p, r)
 	r.setPeer(sp)
 	defer r.deletePeer(sp)
 	defer close(sp.quit)


### PR DESCRIPTION
This PR uses `BzzAddr` instead of `enode.ID` to use `chunk.Proximity()` for `po` calculations between nodes.

This PR currently passes the tests but it is important to understand that it produces errors which do NOT result in the tests failing....check the logs!