### PR TITLE
swarm/pss: Disable failing test

### DIFF
--- a/swarm/pss/handshake_test.go
+++ b/swarm/pss/handshake_test.go
@@ -28,6 +28,7 @@ import (
 // asymmetrical key exchange between two directly connected peers
 // full address, partial address (8 bytes) and empty address
 func TestHandshake(t *testing.T) {
+	t.Skip("Handshakes have not been maintained for a longer period, and have started to fail. They should be reviewed and possible removed.")
 	t.Run("32", testHandshake)
 	t.Run("8", testHandshake)
 	t.Run("0", testHandshake)


### PR DESCRIPTION
`pss` tests have been regularly failing. Judging from the logs, the test in question is the one in `handshake_test.go` that was previously disabled because the code has not been maintained for quite a while, and perhaps should be removed because the implementation might not meet the standards we should have for the `pss` package.