### PR TITLE
swarm-smoke: add syncDelay flag

### DIFF
--- a/cmd/swarm/swarm-smoke/main.go
+++ b/cmd/swarm/swarm-smoke/main.go
@@ -40,7 +40,7 @@ var (
 	allhosts   string
 	hosts      []string
 	filesize   int
-	syncDelay  int
+	syncDelay  bool
 	inputSeed  int
 	httpPort   int
 	wsPort     int
@@ -87,10 +87,9 @@ func main() {
 			Usage:       "file size for generated random file in KB",
 			Destination: &filesize,
 		},
-		cli.IntFlag{
+		cli.BoolFlag{
 			Name:        "sync-delay",
-			Value:       5,
-			Usage:       "duration of delay in seconds to wait for content to be synced",
+			Usage:       "wait for content to be synced",
 			Destination: &syncDelay,
 		},
 		cli.IntFlag{

--- a/cmd/swarm/swarm-smoke/sliding_window.go
+++ b/cmd/swarm/swarm-smoke/sliding_window.go
@@ -81,9 +81,13 @@ outer:
 			return err
 		}
 
-		log.Info("uploaded successfully", "hash", hash, "digest", fmt.Sprintf("%x", fhash), "sleeping", syncDelay)
+		log.Info("uploaded successfully", "hash", hash, "digest", fmt.Sprintf("%x", fhash), "wait for sync", syncDelay)
 		hashes = append(hashes, uploadResult{hash: hash, digest: fhash})
-		time.Sleep(time.Duration(syncDelay) * time.Second)
+
+		if syncDelay {
+			waitToSync()
+		}
+
 		uploadedBytes += filesize * 1000
 		q := make(chan struct{}, 1)
 		d := make(chan struct{})

--- a/cmd/swarm/swarm-smoke/upload_and_sync.go
+++ b/cmd/swarm/swarm-smoke/upload_and_sync.go
@@ -197,7 +197,8 @@ func getBzzAddrFromHost(client *rpc.Client) (string, error) {
 	// we make an ugly assumption about the output format of the hive.String() method
 	// ideally we should replace this with an API call that returns the bzz addr for a given host,
 	// but this also works for now (provided we don't change the hive.String() method, which we haven't in some time
-	return strings.Split(strings.Split(hive, "\n")[3], " ")[10], nil
+	ss := strings.Split(strings.Split(hive, "\n")[3], " ")
+	return ss[len(ss)-1], nil
 }
 
 // checkChunksVsMostProxHosts is checking:
@@ -284,13 +285,16 @@ func uploadAndSync(c *cli.Context, randomBytes []byte) error {
 
 	log.Info("uploaded successfully", "hash", hash, "took", t2, "digest", fmt.Sprintf("%x", fhash))
 
-	waitToSync()
+	// wait to sync and log chunks before fetch attempt, only if syncDelay is set to true
+	if syncDelay {
+		waitToSync()
 
-	log.Debug("chunks before fetch attempt", "hash", hash)
+		log.Debug("chunks before fetch attempt", "hash", hash)
 
-	err = trackChunks(randomBytes, false)
-	if err != nil {
-		log.Error(err.Error())
+		err = trackChunks(randomBytes, false)
+		if err != nil {
+			log.Error(err.Error())
+		}
 	}
 
 	if onlyUpload {


### PR DESCRIPTION
We spoke about this last week during standup:

We need to have a wait for the smoke tests to not have to wait for syncing to be complete, before they fire retrieve requests.