### PR TITLE
swarm/network: synchronise peer.close()

### DIFF
--- a/swarm/network/stream/peer.go
+++ b/swarm/network/stream/peer.go
@@ -415,9 +415,14 @@ func (p *Peer) removeClientParams(s Stream) error {
 }
 
 func (p *Peer) close() {
+	p.serverMu.Lock()
+	defer p.serverMu.Unlock()
+
 	for _, s := range p.servers {
 		s.Close()
 	}
+
+	p.servers = nil
 }
 
 // runUpdateSyncing is a long running function that creates the initial


### PR DESCRIPTION
`Peer.close()` does not access `servers` in a safe was, similar to `updateSyncSubscriptions` resulting in panics. Fixes: https://github.com/ethersphere/go-ethereum/issues/1368