### PR TITLE
p2p/protocol: measure different p2p messages

### DIFF
--- a/p2p/protocols/protocol.go
+++ b/p2p/protocols/protocol.go
@@ -254,6 +254,7 @@ func (p *Peer) Drop() {
 func (p *Peer) Send(ctx context.Context, msg interface{}) error {
 	defer metrics.GetOrRegisterResettingTimer("peer.send_t", nil).UpdateSince(time.Now())
 	metrics.GetOrRegisterCounter("peer.send", nil).Inc(1)
+	metrics.GetOrRegisterCounter(fmt.Sprintf("peer.send.%T", msg), nil).Inc(1)
 
 	var b bytes.Buffer
 	if tracing.Enabled {


### PR DESCRIPTION
I've already added a dashboard with the all currently exchanged p2p messages.

We should be monitoring how many of each type we send, just so that we have an intuition about how our protocols are used.