### PR TITLE
swarm/storage: remove traces for put/get/set

### DIFF
--- a/swarm/storage/localstore/mode_get.go
+++ b/swarm/storage/localstore/mode_get.go
@@ -25,8 +25,6 @@ import (
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/swarm/chunk"
 	"github.com/ethereum/go-ethereum/swarm/shed"
-	"github.com/ethereum/go-ethereum/swarm/spancontext"
-	olog "github.com/opentracing/opentracing-go/log"
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
@@ -37,10 +35,6 @@ import (
 // interface.
 func (db *DB) Get(ctx context.Context, mode chunk.ModeGet, addr chunk.Address) (ch chunk.Chunk, err error) {
 	metricName := fmt.Sprintf("localstore.Get.%s", mode)
-
-	ctx, sp := spancontext.StartSpan(ctx, metricName)
-	defer sp.Finish()
-	sp.LogFields(olog.String("ref", addr.String()), olog.String("mode-get", mode.String()))
 
 	metrics.GetOrRegisterCounter(metricName, nil).Inc(1)
 	defer totalTimeMetric(metricName, time.Now())

--- a/swarm/storage/localstore/mode_has.go
+++ b/swarm/storage/localstore/mode_has.go
@@ -22,17 +22,11 @@ import (
 
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/swarm/chunk"
-	"github.com/ethereum/go-ethereum/swarm/spancontext"
-	olog "github.com/opentracing/opentracing-go/log"
 )
 
 // Has returns true if the chunk is stored in database.
 func (db *DB) Has(ctx context.Context, addr chunk.Address) (bool, error) {
 	metricName := "localstore.Has"
-
-	ctx, sp := spancontext.StartSpan(ctx, metricName)
-	defer sp.Finish()
-	sp.LogFields(olog.String("ref", addr.String()))
 
 	metrics.GetOrRegisterCounter(metricName, nil).Inc(1)
 	defer totalTimeMetric(metricName, time.Now())

--- a/swarm/storage/localstore/mode_put.go
+++ b/swarm/storage/localstore/mode_put.go
@@ -24,8 +24,6 @@ import (
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/swarm/chunk"
 	"github.com/ethereum/go-ethereum/swarm/shed"
-	"github.com/ethereum/go-ethereum/swarm/spancontext"
-	olog "github.com/opentracing/opentracing-go/log"
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
@@ -35,10 +33,6 @@ import (
 // interface.
 func (db *DB) Put(ctx context.Context, mode chunk.ModePut, ch chunk.Chunk) (exists bool, err error) {
 	metricName := fmt.Sprintf("localstore.Put.%s", mode)
-
-	ctx, sp := spancontext.StartSpan(ctx, metricName)
-	defer sp.Finish()
-	sp.LogFields(olog.String("ref", ch.Address().String()), olog.String("mode-put", mode.String()))
 
 	metrics.GetOrRegisterCounter(metricName, nil).Inc(1)
 	defer totalTimeMetric(metricName, time.Now())

--- a/swarm/storage/localstore/mode_set.go
+++ b/swarm/storage/localstore/mode_set.go
@@ -23,8 +23,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/swarm/chunk"
-	"github.com/ethereum/go-ethereum/swarm/spancontext"
-	olog "github.com/opentracing/opentracing-go/log"
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
@@ -34,10 +32,6 @@ import (
 // interface.
 func (db *DB) Set(ctx context.Context, mode chunk.ModeSet, addr chunk.Address) (err error) {
 	metricName := fmt.Sprintf("localstore.Set.%s", mode)
-
-	ctx, sp := spancontext.StartSpan(ctx, metricName)
-	defer sp.Finish()
-	sp.LogFields(olog.String("ref", addr.String()), olog.String("mode-set", mode.String()))
 
 	metrics.GetOrRegisterCounter(metricName, nil).Inc(1)
 	defer totalTimeMetric(metricName, time.Now())


### PR DESCRIPTION
As anticipated and mentioned in the PR when we merged this, these traces are not really useful and are quite spammy.

I think for now it is enough to have instrumentation only in terms of counters and timers in the LocalStore, I don't really see the need for individual traces for every single Get/Set/Put.

We already have a lot of spans in a trace (see screenshot), we should try to limit them.

![Screenshot from 2019-05-09 19-25-40](https://user-images.githubusercontent.com/50459/57473599-74af1880-7290-11e9-87e6-29408e6dbe62.png)
