### PR TITLE
appveyor: remove unused nsis task

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,6 @@ build_script:
 
 after_build:
   - go run build\ci.go archive -type zip -signer WINDOWS_SIGNING_KEY -upload ethswarm/builds
-  - go run build\ci.go nsis -signer WINDOWS_SIGNING_KEY -upload ethswarm/builds
 
 test_script:
   - set CGO_ENABLED=1

--- a/build/ci.go
+++ b/build/ci.go
@@ -29,7 +29,6 @@ Available commands are:
    archive    [ -arch architecture ] [ -type zip|tar ] [ -signer key-envvar ] [ -upload dest ] -- archives build artifacts
    importkeys                                                                                  -- imports signing keys from env
    debsrc     [ -signer key-id ] [ -upload dest ]                                              -- creates a debian source package
-   nsis                                                                                        -- creates a Windows NSIS installer
    xgo        [ -alltools ] [ options ]                                                        -- cross builds according to options
    purge      [ -store blobstore ] [ -days threshold ]                                         -- purges old archives from the blobstore
 


### PR DESCRIPTION
NSIS is used to create windows installers to run applications. We haven't been using this for swarm.