### PR TITLE
swarm, cmd: fix migration link, change loglevel severity

### DIFF
--- a/cmd/swarm/db.go
+++ b/cmd/swarm/db.go
@@ -217,7 +217,7 @@ func exportLegacy(path string, basekey []byte, out io.Writer) (int64, error) {
 		datakey := getDataKey(index.Idx, po)
 		data, err := db.Get(datakey, nil)
 		if err != nil {
-			log.Crit(fmt.Sprintf("Chunk %x found but could not be accessed: %v, %x", key, err, datakey))
+			log.Warn(fmt.Sprintf("Chunk %x found but could not be accessed: %v, %x", key, err, datakey))
 			continue
 		}
 

--- a/swarm.go
+++ b/swarm.go
@@ -153,7 +153,7 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 	isLegacy := localstore.IsLegacyDatabase(config.ChunkDbPath)
 
 	if isLegacy {
-		return nil, errors.New("Legacy database format detected! Please read the migration announcement at: https://github.com/ethersphere/go-ethereum/wiki/Swarm-v0.4-local-store-migration")
+		return nil, errors.New("Legacy database format detected! Please read the migration announcement at: https://github.com/ethersphere/swarm/blob/master/docs/Migration-v0.3-to-v0.4.md")
 	}
 
 	var feedsHandler *feed.Handler


### PR DESCRIPTION
This PR changes the log level when a chunk is not accessible when doing the `0.4` database migration from `Crit` to `Warn`. This is not a fatal error and the migration should continue after not being able to access the chunk.
The PR also changes the migration notes link to be in the `docs/` folder instead of the wiki.