### PR TITLE
swarm-smoke: add debug flag

### DIFF
--- a/cmd/swarm-smoke/main.go
+++ b/cmd/swarm-smoke/main.go
@@ -48,6 +48,7 @@ var (
 	timeout    int
 	single     bool
 	onlyUpload bool
+	debug      bool
 )
 
 func main() {
@@ -113,6 +114,11 @@ func main() {
 			Name:        "only-upload",
 			Usage:       "whether to only upload content to a single node without fetching",
 			Destination: &onlyUpload,
+		},
+		cli.BoolFlag{
+			Name:        "debug",
+			Usage:       "whether to call debug APIs as part of the smoke test",
+			Destination: &debug,
 		},
 	}
 

--- a/cmd/swarm-smoke/upload_and_sync.go
+++ b/cmd/swarm-smoke/upload_and_sync.go
@@ -65,10 +65,12 @@ func uploadAndSyncCmd(ctx *cli.Context) error {
 		err = fmt.Errorf("timeout after %v sec", timeout)
 	}
 
-	// trigger debug functionality on randomBytes
-	e := trackChunks(randomBytes[:], true)
-	if e != nil {
-		log.Error(e.Error())
+	if debug {
+		// trigger debug functionality on randomBytes
+		e := trackChunks(randomBytes[:], true)
+		if e != nil {
+			log.Error(e.Error())
+		}
 	}
 
 	return err
@@ -291,9 +293,11 @@ func uploadAndSync(c *cli.Context, randomBytes []byte) error {
 
 		log.Debug("chunks before fetch attempt", "hash", hash)
 
-		err = trackChunks(randomBytes, false)
-		if err != nil {
-			log.Error(err.Error())
+		if debug {
+			err = trackChunks(randomBytes, false)
+			if err != nil {
+				log.Error(err.Error())
+			}
 		}
 	}
 


### PR DESCRIPTION
Our `debug` functionality fails when uploading larger files, due to the increased number of chunk ref that we need to check on every node.

If we increase the chunk size, it would still work.

We have to see about fixing our APIs so that they don't crash when we want to inspect a high number of chunks, but until we do that, we should not be holding back the smoke tests for larger files, such as 100MB, 200MB, and beyond.