### PR TITLE
api: temporary fix test failing on windows due to access denied

### DIFF
--- a/api/filesystem_test.go
+++ b/api/filesystem_test.go
@@ -29,8 +29,6 @@ import (
 	"github.com/ethersphere/swarm/storage"
 )
 
-var testDownloadDir, _ = ioutil.TempDir(os.TempDir(), "bzz-test")
-
 func testFileSystem(t *testing.T, f func(*FileSystem, bool)) {
 	testAPI(t, func(api *API, _ *chunk.Tags, toEncrypt bool) {
 		f(NewFileSystem(api), toEncrypt)
@@ -70,8 +68,13 @@ func TestApiDirUpload0(t *testing.T) {
 			t.Fatalf("expected error: %v", err)
 		}
 
+		testDownloadDir, err := ioutil.TempDir(os.TempDir(), "bzz-test")
 		downloadDir := filepath.Join(testDownloadDir, "test0")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		defer os.RemoveAll(downloadDir)
+
 		err = fs.Download(bzzhash, downloadDir)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
I haven't really figured out the real reason for this failing... Running it locally in my machine would have a ~ 80% failure rate (flaky) with errors like:

```
mkdir C:\Users\rafael\AppData\Local\Temp\bzz-test578205679\test0: Access is denied.
(string) (len=66) "C:\\Users\\rafael\\AppData\\Local\\Temp\\bzz-test578205679\\test0"
(*os.PathError)(0xc001a570b0)(mkdir C:\Users\rafael\AppData\Local\Temp\bzz-test578205679\test0: Access is denied.)
--- FAIL: TestApiDirUpload0 (0.06s)
    filesystem_test.go:77: unexpected error: mkdir C:\Users\rafael\AppData\Local\Temp\bzz-test578205679\test0: Access is denied.
```

With this fix it's passing all the time but we're not really testing the directory creation that `fs.Download(...)` does... which in any way shouldn't be that important because the function seems to be deprecated.