### PR TITLE
storage: fix alignement panics on 32 bit arch

### DIFF
--- a/storage/hasherstore.go
+++ b/storage/hasherstore.go
@@ -27,6 +27,10 @@ import (
 )
 
 type hasherStore struct {
+	// nrChunks is used with atomic functions
+	// it is required to be at the start of the struct to ensure 64bit alignment for ARM, x86-32, and 32-bit MIPS architectures
+	// see: https://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	nrChunks  uint64 // number of chunks to store
 	store     ChunkStore
 	tag       *chunk.Tag
 	toEncrypt bool
@@ -36,10 +40,6 @@ type hasherStore struct {
 	errC      chan error    // global error channel
 	doneC     chan struct{} // closed by Close() call to indicate that count is the final number of chunks
 	quitC     chan struct{} // closed to quit unterminated routines
-	// nrChunks is used with atomic functions
-	// it is required to be at the end of the struct to ensure 64bit alignment for arm architecture
-	// see: https://golang.org/pkg/sync/atomic/#pkg-note-BUG
-	nrChunks uint64 // number of chunks to store
 }
 
 // NewHasherStore creates a hasherStore object, which implements Putter and Getter interfaces.


### PR DESCRIPTION
Attempt on fixing the following panic which is happening on the 32 bit test runs on windows:

e.g.: https://ci.appveyor.com/project/ethersphere/swarm/builds/25220636/job/ueh5r89mvapmfq48 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x4028cc]
goroutine 498 [running]:
runtime/internal/atomic.Xadd64(0x13bfc62c, 0x1, 0x0, 0x4b, 0x1008)
	C:/go/src/runtime/internal/atomic/asm_386.s:105 +0xc
github.com/ethersphere/swarm/storage.(*hasherStore).storeChunk(0x13bfc600, 0xef55a0, 0x1393f240, 0xef0210, 0x1393f440)
	C:/gopath/src/github.com/ethersphere/swarm/storage/hasherstore.go:245 +0x36
github.com/ethersphere/swarm/storage.(*hasherStore).Put(0x13bfc600, 0xef55a0, 0x1393f240, 0x1c44f300, 0x4b, 0x1008, 0x13bfc6c0, 0xa, 0x10, 0x1eb, ...)
	C:/gopath/src/github.com/ethersphere/swarm/storage/hasherstore.go:84 +0x89
github.com/ethersphere/swarm/storage.(*PyramidChunker).processChunk(0x13468fc0, 0xef55a0, 0x1393f240, 0x1, 0x0, 0x1393f2c0)
	C:/gopath/src/github.com/ethersphere/swarm/storage/pyramid.go:286 +0x6d
github.com/ethersphere/swarm/storage.(*PyramidChunker).processor(0x13468fc0, 0xef55a0, 0x1393f240, 0x1, 0x0)
	C:/gopath/src/github.com/ethersphere/swarm/storage/pyramid.go:277 +0x71
created by github.com/ethersphere/swarm/storage.(*PyramidChunker).prepareChunks
	C:/gopath/src/github.com/ethersphere/swarm/storage/pyramid.go:392 +0xb9
FAIL	github.com/ethersphere/swarm	0.684s
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x4028cc]
```

> On ARM, x86-32, and 32-bit MIPS, it is the caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically. The first word in a variable or in an allocated struct, array, or slice can be relied upon to be 64-bit aligned. 

https://golang.org/pkg/sync/atomic/#pkg-note-BUG


