### PR TITLE
cmd/swarm-smoke: add paging to trackChunks

### DIFF
--- a/cmd/swarm-smoke/upload_and_sync.go
+++ b/cmd/swarm-smoke/upload_and_sync.go
@@ -178,12 +178,26 @@ func trackChunks(testData []byte, submitMetrics bool) error {
 // getChunksBitVectorFromHost returns a bit vector of presence for a given slice of chunks from a given host
 func getChunksBitVectorFromHost(client *rpc.Client, addrs []storage.Address) (string, error) {
 	var hostChunks string
-
-	err := client.Call(&hostChunks, "bzz_has", addrs)
-	if err != nil {
-		return "", err
+	lastPage := false
+	for {
+		var pageChunks string
+		var page []storage.Address
+		if len(addrs) > 7500 {
+			page = addrs[:7500]
+			addrs = addrs[7500:]
+		} else {
+			page = addrs
+			lastPage = true
+		}
+		err := client.Call(&pageChunks, "bzz_has", page)
+		if err != nil {
+			return "", err
+		}
+		hostChunks += pageChunks
+		if lastPage {
+			break
+		}
 	}
-
 	return hostChunks, nil
 }
 

--- a/cmd/swarm-smoke/upload_and_sync.go
+++ b/cmd/swarm-smoke/upload_and_sync.go
@@ -189,7 +189,7 @@ func getChunksBitVectorFromHost(client *rpc.Client, addrs []storage.Address) (st
 			pagesize = cap(addrs)
 		}
 
-		err := client.Call(&pageChunks, "bzz_has", pagesize)
+		err := client.Call(&pageChunks, "bzz_has", addrs[:pagesize])
 		if err != nil {
 			return "", err
 		}

--- a/cmd/swarm-smoke/upload_and_sync.go
+++ b/cmd/swarm-smoke/upload_and_sync.go
@@ -182,13 +182,14 @@ func getChunksBitVectorFromHost(client *rpc.Client, addrs []storage.Address) (st
 	var hostChunks string
 
 	for len(addrs) > 0 {
+		var pageChunks string
 		// get current page size, so that we avoid a slice out of bounds on the last page
 		pagesize := trackChunksPageSize
 		if cap(addrs) < trackChunksPageSize {
 			pagesize = cap(addrs)
 		}
 
-		err := client.Call(&pageChunks, "bzz_has", page)
+		err := client.Call(&pageChunks, "bzz_has", pagesize)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
this PR adds a needed functionality to track higher number of chunks in smoke tests.
previously it would fail once the batches were over a specific size.
this PR adds paging to get the different batches of addresses on the different nodes, concatenates them and returns it for the rest of the smoke test assertions.