### PR TITLE
docker: include git commit hash in swarm version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,1 @@
 .github
-.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 ## v0.4.2 (Unreleased)
 
+### Notes
+
 ### Features
 
 ### Improvements
 
 ### Bug fixes
+* [#1488](https://github.com/ethersphere/swarm/pull/1488): docker: include git commit hash in swarm version
 
-### Notes
+
 
 ## v0.4.1 (June 13, 2019)
 


### PR DESCRIPTION
We need the `.git` directory during builds so that we can detect the git commit hash that is important to have.

Previously:

```bash
$ swarm version
Swarm                                                                        
Version: 0.4.2-unstable                                                               
Go Version: go1.12.5                                                                          
OS: linux   
```
Now:

```bash
$ swarm version
Swarm                                                                                                                            
Version: 0.4.2-unstable                                                                                                          
Git Commit: 8b37def9613e6021a865af0cc4ef42c20a66a1fb                                                                             
Go Version: go1.12.5                                                                                                             
OS: linux    
```