### PR TITLE
network: bump bzz stream hive

### DIFF
--- a/network/protocol.go
+++ b/network/protocol.go
@@ -43,7 +43,7 @@ var DefaultTestNetworkID = rand.Uint64()
 // BzzSpec is the spec of the generic swarm handshake
 var BzzSpec = &protocols.Spec{
 	Name:       "bzz",
-	Version:    10,
+	Version:    11,
 	MaxMsgSize: 10 * 1024 * 1024,
 	Messages: []interface{}{
 		HandshakeMsg{},
@@ -53,7 +53,7 @@ var BzzSpec = &protocols.Spec{
 // DiscoverySpec is the spec for the bzz discovery subprotocols
 var DiscoverySpec = &protocols.Spec{
 	Name:       "hive",
-	Version:    9,
+	Version:    10,
 	MaxMsgSize: 10 * 1024 * 1024,
 	Messages: []interface{}{
 		peersMsg{},

--- a/network/protocol_test.go
+++ b/network/protocol_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	TestProtocolVersion = 10
+	TestProtocolVersion = 11
 )
 
 var TestProtocolNetworkID = DefaultTestNetworkID

--- a/network/stream/stream.go
+++ b/network/stream/stream.go
@@ -623,7 +623,7 @@ func (r *Registry) createSpec() {
 	// Spec is the spec of the streamer protocol
 	var spec = &protocols.Spec{
 		Name:       "stream",
-		Version:    9,
+		Version:    10,
 		MaxMsgSize: 10 * 1024 * 1024,
 		Messages: []interface{}{
 			UnsubscribeMsg{},


### PR DESCRIPTION
We need to merge this prior to release, due to changes in the `RetrieveRequestMsg` protocol message.