### PR TITLE
network/bitvector: Multibit set/unset + string rep

### DIFF
--- a/network/bitvector/bitvector.go
+++ b/network/bitvector/bitvector.go
@@ -22,15 +22,20 @@ import (
 
 var errInvalidLength = errors.New("invalid length")
 
+// BitVector is a convenience object for manipulating and representing bit vectors
 type BitVector struct {
 	len int
 	b   []byte
 }
 
+// New creates a new bit vector with the given length
 func New(l int) (bv *BitVector, err error) {
 	return NewFromBytes(make([]byte, l/8+1), l)
 }
 
+// NewFromBytes creates a bit vector from the passed byte slice.
+//
+// Leftmost bit in byte slice becomes leftmost bit in bit vector
 func NewFromBytes(b []byte, l int) (bv *BitVector, err error) {
 	if l <= 0 {
 		return nil, errInvalidLength
@@ -44,11 +49,13 @@ func NewFromBytes(b []byte, l int) (bv *BitVector, err error) {
 	}, nil
 }
 
+// Get gets the corresponding bit, counted from left to right
 func (bv *BitVector) Get(i int) bool {
 	bi := i / 8
 	return bv.b[bi]&(0x1<<uint(i%8)) != 0
 }
 
+// Set sets the corresponding bit, counted from left to right, to the corresponding state of v
 func (bv *BitVector) Set(i int, v bool) {
 	bi := i / 8
 	cv := bv.Get(i)
@@ -57,6 +64,9 @@ func (bv *BitVector) Set(i int, v bool) {
 	}
 }
 
+// SetBytes sets all bits in the bitvector that are set in the argument
+//
+// The argument must be the same as the bitvector length
 func (bv *BitVector) SetBytes(bs []byte) error {
 	if len(bs) != bv.len {
 		return errors.New("invalid length")
@@ -70,6 +80,9 @@ func (bv *BitVector) SetBytes(bs []byte) error {
 	return nil
 }
 
+// UnsetBytes UNSETS all bits in the bitvector that are set in the argument
+//
+// The argument must be the same as the bitvector length
 func (bv *BitVector) UnsetBytes(bs []byte) error {
 	if len(bs) != bv.len {
 		return errors.New("invalid length")
@@ -95,6 +108,7 @@ func (bv *BitVector) String() (s string) {
 	return s
 }
 
+// Bytes retrieves the underlying bytes of the bitvector
 func (bv *BitVector) Bytes() []byte {
 	return bv.b
 }

--- a/network/bitvector/bitvector.go
+++ b/network/bitvector/bitvector.go
@@ -57,6 +57,44 @@ func (bv *BitVector) Set(i int, v bool) {
 	}
 }
 
+func (bv *BitVector) SetBytes(bs []byte) error {
+	if len(bs) != bv.len {
+		return errors.New("invalid length")
+	}
+	for i := 0; i < bv.len*8; i++ {
+		bi := i / 8
+		if bs[bi]&(0x01<<uint(i%8)) > 0 {
+			bv.Set(i, true)
+		}
+	}
+	return nil
+}
+
+func (bv *BitVector) UnsetBytes(bs []byte) error {
+	if len(bs) != bv.len {
+		return errors.New("invalid length")
+	}
+	for i := 0; i < bv.len*8; i++ {
+		bi := i / 8
+		if bs[bi]&(0x01<<uint(i%8)) > 0 {
+			bv.Set(i, false)
+		}
+	}
+	return nil
+}
+
+// String implements Stringer interface
+func (bv *BitVector) String() (s string) {
+	for i := 0; i < bv.len*8; i++ {
+		if bv.Get(i) {
+			s += "1"
+		} else {
+			s += "0"
+		}
+	}
+	return s
+}
+
 func (bv *BitVector) Bytes() []byte {
 	return bv.b
 }

--- a/network/bitvector/bitvector.go
+++ b/network/bitvector/bitvector.go
@@ -55,8 +55,8 @@ func (bv *BitVector) Get(i int) bool {
 	return bv.b[bi]&(0x1<<uint(i%8)) != 0
 }
 
-// Set sets the corresponding bit, counted from left to right, to the corresponding state of v
-func (bv *BitVector) Set(i int, v bool) {
+// Set sets the bit corresponding to the index in the bitvector, counted from left to right
+func (bv *BitVector) set(i int, v bool) {
 	bi := i / 8
 	cv := bv.Get(i)
 	if cv != v {
@@ -64,20 +64,43 @@ func (bv *BitVector) Set(i int, v bool) {
 	}
 }
 
-// SetBytes modifies all bits in the bitvector that are set in the argument
-//
-// If v is true, it sets all bits in the bitvector that are set in the argument
-// If v is false, it unsets all bites in the bitvector that are set in the argument
+// Set sets the bit corresponding to the index in the bitvector, counted from left to right
+func (bv *BitVector) Set(i int) {
+	bv.set(i, true)
+}
+
+// Unset UNSETS the corresponding bit, counted from left to right
+func (bv *BitVector) Unset(i int) {
+	bv.set(i, false)
+}
+
+// SetBytes sets all bits in the bitvector that are set in the argument
 //
 // The argument must be the same as the bitvector length
-func (bv *BitVector) SetBytes(bs []byte, v bool) error {
+func (bv *BitVector) SetBytes(bs []byte) error {
 	if len(bs) != bv.len {
 		return errors.New("invalid length")
 	}
 	for i := 0; i < bv.len*8; i++ {
 		bi := i / 8
 		if bs[bi]&(0x01<<uint(i%8)) > 0 {
-			bv.Set(i, v)
+			bv.set(i, true)
+		}
+	}
+	return nil
+}
+
+// UnsetBytes UNSETS all bits in the bitvector that are set in the argument
+//
+// The argument must be the same as the bitvector length
+func (bv *BitVector) UnsetBytes(bs []byte) error {
+	if len(bs) != bv.len {
+		return errors.New("invalid length")
+	}
+	for i := 0; i < bv.len*8; i++ {
+		bi := i / 8
+		if bs[bi]&(0x01<<uint(i%8)) > 0 {
+			bv.set(i, false)
 		}
 	}
 	return nil

--- a/network/bitvector/bitvector.go
+++ b/network/bitvector/bitvector.go
@@ -64,33 +64,20 @@ func (bv *BitVector) Set(i int, v bool) {
 	}
 }
 
-// SetBytes sets all bits in the bitvector that are set in the argument
+// SetBytes modifies all bits in the bitvector that are set in the argument
+//
+// If v is true, it sets all bits in the bitvector that are set in the argument
+// If v is false, it unsets all bites in the bitvector that are set in the argument
 //
 // The argument must be the same as the bitvector length
-func (bv *BitVector) SetBytes(bs []byte) error {
+func (bv *BitVector) SetBytes(bs []byte, v bool) error {
 	if len(bs) != bv.len {
 		return errors.New("invalid length")
 	}
 	for i := 0; i < bv.len*8; i++ {
 		bi := i / 8
 		if bs[bi]&(0x01<<uint(i%8)) > 0 {
-			bv.Set(i, true)
-		}
-	}
-	return nil
-}
-
-// UnsetBytes UNSETS all bits in the bitvector that are set in the argument
-//
-// The argument must be the same as the bitvector length
-func (bv *BitVector) UnsetBytes(bs []byte) error {
-	if len(bs) != bv.len {
-		return errors.New("invalid length")
-	}
-	for i := 0; i < bv.len*8; i++ {
-		bi := i / 8
-		if bs[bi]&(0x01<<uint(i%8)) > 0 {
-			bv.Set(i, false)
+			bv.Set(i, v)
 		}
 	}
 	return nil

--- a/network/bitvector/bitvector_test.go
+++ b/network/bitvector/bitvector_test.go
@@ -73,7 +73,7 @@ func TestBitvectorGetSet(t *testing.T) {
 		}()
 
 		for i := 0; i < length; i++ {
-			bv.Set(i, true)
+			bv.Set(i)
 			for j := 0; j < length; j++ {
 				if j == i {
 					if !bv.Get(j) {
@@ -86,7 +86,7 @@ func TestBitvectorGetSet(t *testing.T) {
 				}
 			}
 
-			bv.Set(i, false)
+			bv.Unset(i)
 
 			if bv.Get(i) {
 				t.Errorf("element on index %v is not set to false", i)
@@ -129,11 +129,11 @@ func TestBitVectorSetBytes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	bv.SetBytes(cb, false)
+	bv.UnsetBytes(cb)
 	if bv.String() != expectUnset {
 		t.Fatalf("bitvector unset bytes fail: got %s, expect %s", bv.String(), expectUnset)
 	}
-	bv.SetBytes(cb, true)
+	bv.SetBytes(cb)
 	if bv.String() != expectReset {
 		t.Fatalf("bitvector reset bytes fail: got %s, expect %s", bv.String(), expectReset)
 	}

--- a/network/bitvector/bitvector_test.go
+++ b/network/bitvector/bitvector_test.go
@@ -18,6 +18,7 @@ package bitvector
 
 import "testing"
 
+// TestBitvectorNew checks that enforcements of argument length works in the constructors
 func TestBitvectorNew(t *testing.T) {
 	_, err := New(0)
 	if err != errInvalidLength {
@@ -40,6 +41,7 @@ func TestBitvectorNew(t *testing.T) {
 	}
 }
 
+// TestBitvectorGetSet tests correctness of individual Set and Get commands
 func TestBitvectorGetSet(t *testing.T) {
 	for _, length := range []int{
 		1,
@@ -93,6 +95,7 @@ func TestBitvectorGetSet(t *testing.T) {
 	}
 }
 
+// TestBitvectorNewFromBytesGet tests that bit vector is initialized correctly from underlying byte slice
 func TestBitvectorNewFromBytesGet(t *testing.T) {
 	bv, err := NewFromBytes([]byte{8}, 8)
 	if err != nil {
@@ -103,6 +106,7 @@ func TestBitvectorNewFromBytesGet(t *testing.T) {
 	}
 }
 
+// TestBitVectorString tests that string representation of bit vector is correct
 func TestBitVectorString(t *testing.T) {
 	b := []byte{0xa5, 0x81}
 	expect := "1010010110000001"
@@ -115,7 +119,8 @@ func TestBitVectorString(t *testing.T) {
 	}
 }
 
-func TestBitVectorSetUnsetBytes(t *testing.T) {
+// TestBitVectorSetUnsetBytes tests that setting and unsetting by byte slice modifies the bit vector correctly
+func TestBitVectorSetBytes(t *testing.T) {
 	b := []byte{0xff, 0xff}
 	cb := []byte{0xa5, 0x81}
 	expectUnset := "0101101001111110"
@@ -124,11 +129,11 @@ func TestBitVectorSetUnsetBytes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	bv.UnsetBytes(cb)
+	bv.SetBytes(cb, false)
 	if bv.String() != expectUnset {
 		t.Fatalf("bitvector unset bytes fail: got %s, expect %s", bv.String(), expectUnset)
 	}
-	bv.SetBytes(cb)
+	bv.SetBytes(cb, true)
 	if bv.String() != expectReset {
 		t.Fatalf("bitvector reset bytes fail: got %s, expect %s", bv.String(), expectReset)
 	}

--- a/network/bitvector/bitvector_test.go
+++ b/network/bitvector/bitvector_test.go
@@ -102,3 +102,34 @@ func TestBitvectorNewFromBytesGet(t *testing.T) {
 		t.Fatalf("element 3 is not set to true: state %08b", bv.b[0])
 	}
 }
+
+func TestBitVectorString(t *testing.T) {
+	b := []byte{0xa5, 0x81}
+	expect := "1010010110000001"
+	bv, err := NewFromBytes(b, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bv.String() != expect {
+		t.Fatalf("bitvector string fail: got %s, expect %s", bv.String(), expect)
+	}
+}
+
+func TestBitVectorSetUnsetBytes(t *testing.T) {
+	b := []byte{0xff, 0xff}
+	cb := []byte{0xa5, 0x81}
+	expectUnset := "0101101001111110"
+	expectReset := "1111111111111111"
+	bv, err := NewFromBytes(b, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bv.UnsetBytes(cb)
+	if bv.String() != expectUnset {
+		t.Fatalf("bitvector unset bytes fail: got %s, expect %s", bv.String(), expectUnset)
+	}
+	bv.SetBytes(cb)
+	if bv.String() != expectReset {
+		t.Fatalf("bitvector reset bytes fail: got %s, expect %s", bv.String(), expectReset)
+	}
+}

--- a/network/stream/messages.go
+++ b/network/stream/messages.go
@@ -231,7 +231,7 @@ func (p *Peer) handleOfferedHashesMsg(ctx context.Context, req *OfferedHashesMsg
 			ctr++
 
 			// set the bit, so create a request
-			want.Set(i/HashSize, true)
+			want.Set(i / HashSize)
 			log.Trace("need data", "ref", fmt.Sprintf("%x", hash), "request", true)
 
 			// measure how long it takes before we mark chunks for retrieval, and actually send the request


### PR DESCRIPTION
Adaptive capabilities' use of bitvectors require setting multiple bits in one command, and also string output for logging. This PR adds this functionality to the bitvector package as a preparatory step.