### PR TITLE
api, network: count chunk deliveries per peer

### DIFF
--- a/api/inspector.go
+++ b/api/inspector.go
@@ -63,6 +63,22 @@ func (inspector *Inspector) IsSyncing() bool {
 	return lrct.After(time.Now().Add(-15 * time.Second))
 }
 
+func (inspector *Inspector) DeliveriesPerPeer() map[string]int64 {
+	res := map[string]int64{}
+
+	// iterate connection in kademlia
+	inspector.hive.Kademlia.EachConn(nil, 255, func(p *network.Peer, po int) bool {
+		// get how many chunks we receive for retrieve requests per peer
+		peermetric := fmt.Sprintf("chunk.delivery.%x", p.Over()[:16])
+
+		res[fmt.Sprintf("%x", p.Over()[:16])] = metrics.GetOrRegisterCounter(peermetric, nil).Count()
+
+		return true
+	})
+
+	return res
+}
+
 // Has checks whether each chunk address is present in the underlying datastore,
 // the bool in the returned structs indicates if the underlying datastore has
 // the chunk stored with the given address (true), or not (false)

--- a/network/stream/delivery.go
+++ b/network/stream/delivery.go
@@ -131,6 +131,10 @@ func (d *Delivery) handleChunkDeliveryMsg(ctx context.Context, sp *Peer, req int
 	var mode chunk.ModePut
 	switch r := req.(type) {
 	case *ChunkDeliveryMsgRetrieval:
+		// count how many chunks we receive for retrieve requests per peer
+		peermetric := fmt.Sprintf("chunk.delivery.%x", sp.BzzAddr.Over()[:16])
+		metrics.GetOrRegisterCounter(peermetric, nil).Inc(1)
+
 		msg = (*ChunkDeliveryMsg)(r)
 		peerPO := chunk.Proximity(sp.BzzAddr.Over(), msg.Addr)
 		po := chunk.Proximity(d.kad.BaseAddr(), msg.Addr)


### PR DESCRIPTION
This PR is adding a debug API that will allow us to measure how many chunk are delivered by which peers of a given node, during retrieve requests.

I am open to suggestions on alternative ways to implement this if you have better ideas, but I think we need such feedback from nodes, so that we see which of our peers we are actually utilising during retrieve requests (it should be all our peers in my opinion).

Related: https://github.com/ethersphere/swarm/issues/1533

Open questions:
- [ ] Are we ok with using the metrics library for such diagnostics APIs? I am not sure, maybe we want to explicitly have APIs that return these values and have proper tests for them, if we use them for other purposes? For a quick hack, this is good enough, question is whether we foresee this as necessary for other purposes.