### PR TITLE
change swap cheque signing to match the contract

### DIFF
--- a/swap/swap.go
+++ b/swap/swap.go
@@ -215,6 +215,7 @@ func (s *Swap) resetBalance(peerID enode.ID) {
 	s.balances[peerID] = 0
 }
 
+// encodeCheque encodes the cheque in the format used in the signing procedure
 func (s *Swap) encodeCheque(cheque *Cheque) []byte {
 	serialBytes := make([]byte, 32)
 	amountBytes := make([]byte, 32)
@@ -234,7 +235,7 @@ func (s *Swap) encodeCheque(cheque *Cheque) []byte {
 	return input
 }
 
-// hashes the cheque using the prefix that would be added by eth_Sign
+// sigHashCheque hashes the cheque using the prefix that would be added by eth_Sign
 func (s *Swap) sigHashCheque(cheque *Cheque) []byte {
 	input := crypto.Keccak256(s.encodeCheque(cheque))
 	withPrefix := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(input), input)

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -246,7 +246,7 @@ func (s *Swap) sigHashCheque(cheque *Cheque) []byte {
 func (s *Swap) signContent(cheque *Cheque) ([]byte, error) {
 	sig, err := crypto.Sign(s.sigHashCheque(cheque), s.owner.privateKey)
 	if err != nil {
-		return sig, err
+		return nil, err
 	}
 	// increase the v value by 27 as crypto.Sign produces 0 or 1 but the contract only accepts 27 or 28
 	// this is to prevent malleable signatures. while not strictly necessary in this case the ECDSA implementation from Openzeppelin expects it.

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -189,19 +189,40 @@ func (s *Swap) resetBalance(peer enode.ID) {
 	s.balances[peer] = 0
 }
 
-// signContent signs the cheque
-func (s *Swap) signContent(cheque *Cheque) ([]byte, error) {
+func (s *Swap) encodeCheque(cheque *Cheque) []byte {
 	serialBytes := make([]byte, 32)
 	amountBytes := make([]byte, 32)
 	timeoutBytes := make([]byte, 32)
-	input := append(cheque.Contract.Bytes(), cheque.Beneficiary.Bytes()...)
-	binary.LittleEndian.PutUint64(serialBytes, cheque.Serial)
-	binary.LittleEndian.PutUint64(amountBytes, cheque.Amount)
-	binary.LittleEndian.PutUint64(timeoutBytes, cheque.Timeout)
+	// we need to write the last 8 bytes as we write a uint64 into a 32-byte array
+	binary.BigEndian.PutUint64(serialBytes[24:], cheque.Serial)
+	binary.BigEndian.PutUint64(amountBytes[24:], cheque.Amount)
+	binary.BigEndian.PutUint64(timeoutBytes[24:], cheque.Timeout)
+	// construct the actual cheque
+	input := cheque.Contract.Bytes()
 	input = append(input, serialBytes[:]...)
+	input = append(input, cheque.Beneficiary.Bytes()...)
 	input = append(input, amountBytes[:]...)
 	input = append(input, timeoutBytes[:]...)
-	return crypto.Sign(crypto.Keccak256(input), s.owner.privateKey)
+
+	return input
+}
+
+// hashes the cheque using the prefix that would be added by eth_Sign
+func (s *Swap) sigHashCheque(cheque *Cheque) []byte {
+	input := crypto.Keccak256(s.encodeCheque(cheque))
+	withPrefix := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(input), input)
+	return crypto.Keccak256([]byte(withPrefix))
+}
+
+// signContent signs the cheque
+func (s *Swap) signContent(cheque *Cheque) ([]byte, error) {
+	sig, err := crypto.Sign(s.sigHashCheque(cheque), s.owner.privateKey)
+	if err != nil {
+		return sig, err
+	}
+	// increase the v value by 27 as crypto.Sign produces 0 or 1 but the contract only accepts 27 or 28
+	sig[len(sig)-1] += 27
+	return sig, nil
 }
 
 // GetParams returns contract parameters (Bin, ABI) from the contract

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -194,6 +194,7 @@ func (s *Swap) encodeCheque(cheque *Cheque) []byte {
 	amountBytes := make([]byte, 32)
 	timeoutBytes := make([]byte, 32)
 	// we need to write the last 8 bytes as we write a uint64 into a 32-byte array
+	// encoded in BigEndian because EVM uses BigEndian encoding
 	binary.BigEndian.PutUint64(serialBytes[24:], cheque.Serial)
 	binary.BigEndian.PutUint64(amountBytes[24:], cheque.Amount)
 	binary.BigEndian.PutUint64(timeoutBytes[24:], cheque.Timeout)
@@ -221,6 +222,7 @@ func (s *Swap) signContent(cheque *Cheque) ([]byte, error) {
 		return sig, err
 	}
 	// increase the v value by 27 as crypto.Sign produces 0 or 1 but the contract only accepts 27 or 28
+	// this is to prevent malleable signatures. while not strictly necessary in this case the ECDSA implementation from Openzeppelin expects it.
 	sig[len(sig)-1] += 27
 	return sig, nil
 }

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -280,8 +280,8 @@ func TestEncodeCheque(t *testing.T) {
 	// expected value (computed through truffle/js)
 	expected := common.Hex2Bytes("4405415b2b8c9f9aa83e151637b8378dd3bcfedd0000000000000000000000000000000000000000000000000000000000000001b8d424e9662fe0837fb1d728f1ac97cebb1085fe000000000000000000000000000000000000000000000000000000000000002a000000000000000000000000000000000000000000000000000000000000000a")
 	if !bytes.Equal(encoded, expected) {
-		t.Fatal(fmt.Sprintf("Unexpected encoding of cheque. Expected encoding: %x, result is: %x",
-			expected, encoded))
+		t.Fatalf("Unexpected encoding of cheque. Expected encoding: %x, result is: %x",
+			expected, encoded)
 	}
 }
 


### PR DESCRIPTION
This PR changes the way signContent signs the cheque to match the signing mechanism expected in the contract.