### PR TITLE
Fix error in SubscribeErrorMsg reference (missing pointer)

### DIFF
--- a/network/stream/messages.go
+++ b/network/stream/messages.go
@@ -79,7 +79,7 @@ func (p *Peer) handleRequestSubscription(ctx context.Context, req *RequestSubscr
 		// and will not be returned as it will prevent any new message
 		// exchange between peers over p2p. Instead, error will be returned
 		// only if there is one from sending subscribe error message.
-		err = p.Send(ctx, SubscribeErrorMsg{
+		err = p.Send(ctx, &SubscribeErrorMsg{
 			Error: err.Error(),
 		})
 	}
@@ -95,7 +95,7 @@ func (p *Peer) handleSubscribeMsg(ctx context.Context, req *SubscribeMsg) (err e
 			// and will not be returned as it will prevent any new message
 			// exchange between peers over p2p. Instead, error will be returned
 			// only if there is one from sending subscribe error message.
-			err = p.Send(context.TODO(), SubscribeErrorMsg{
+			err = p.Send(context.TODO(), &SubscribeErrorMsg{
 				Error: err.Error(),
 			})
 		}


### PR DESCRIPTION
(cherry picked from commit 4058f8031f6d38eb0bdd83c66660fc9a29419ed4)