### PR TITLE
cmd/swarm: allow using a network interface by name for nat purposes

### DIFF
--- a/cmd/swarm/config.go
+++ b/cmd/swarm/config.go
@@ -81,6 +81,7 @@ const (
 	SwarmEnvStoreCapacity        = "SWARM_STORE_CAPACITY"
 	SwarmEnvStoreCacheCapacity   = "SWARM_STORE_CACHE_CAPACITY"
 	SwarmEnvBootnodeMode         = "SWARM_BOOTNODE_MODE"
+	SwarmEnvNATInterface         = "SWARM_NAT_INTERFACE"
 	SwarmAccessPassword          = "SWARM_ACCESS_PASSWORD"
 	SwarmAutoDefaultPath         = "SWARM_AUTO_DEFAULTPATH"
 	SwarmGlobalstoreAPI          = "SWARM_GLOBALSTORE_API"

--- a/cmd/swarm/flags.go
+++ b/cmd/swarm/flags.go
@@ -45,6 +45,11 @@ var (
 		Usage:  "Swarm local http api port",
 		EnvVar: SwarmEnvPort,
 	}
+	SwarmNATInterfaceFlag = cli.StringFlag{
+		Name:   "natif",
+		Usage:  "Announce the IP address of a given network interface (e.g. eth0)",
+		EnvVar: SwarmEnvNATInterface,
+	}
 	SwarmNetworkIdFlag = cli.IntFlag{
 		Name:   "bzznetworkid",
 		Usage:  "Network identifier (integer, default 3=swarm testnet)",


### PR DESCRIPTION
I didn't want to change the behaviour of the current `--nat` flag. Therefore I added a `--natif` flag.

E.g. `swarm --natif eth0` will announce you with the IP address that is on the `eth0` network interface.

This is specially useful when running multiple swarm nodes within docker because it will pickup the IP address of the interface during runtime. Previously I always had to wrap swarm around some shell script to magically get the IP address... which is not nice. 