### PR TITLE
contracts/swap, swap: verify result of submitChequeBeneficiary

### DIFF
--- a/swap/peer.go
+++ b/swap/peer.go
@@ -209,6 +209,7 @@ func (sp *Peer) handleEmitChequeMsg(ctx context.Context, msg interface{}) error 
 	case err := <-err:
 		if err != nil {
 			log.Error("Got error when calling submitChequeBeneficiary: ", err)
+			return err
 		}
 	case r := <-receipt:
 		log.Info("Transaction submitted to the blockchain", r)

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -93,8 +93,8 @@ func New(stateStore state.Store, prvkey *ecdsa.PrivateKey, contract common.Addre
 		params:              NewDefaultParams(),
 		paymentThreshold:    DefaultPaymentThreshold,
 		disconnectThreshold: DefaultDisconnectThreshold,
+		contractReference:   nil,
 	}
-	sw.contractReference = swap.New()
 	sw.owner = sw.createOwner(prvkey, contract)
 	return sw
 }
@@ -314,7 +314,7 @@ func (s *Swap) deployLoop(opts *bind.TransactOpts, backend swap.Backend, owner c
 		if try > 0 {
 			time.Sleep(deployDelay)
 		}
-		if _, tx, err = s.contractReference.Deploy(opts, backend, owner); err != nil {
+		if _, s.contractReference, tx, err = swap.Deploy(opts, backend, owner); err != nil {
 			log.Warn(fmt.Sprintf("can't send chequebook deploy tx (try %d): %v", try, err))
 			continue
 		}


### PR DESCRIPTION
We make the functionality of submitChequeBeneficiary to return a txHash and two channels on which we can listen to a receipt and error. 
This pattern is in line with [web3 PromiEvents](https://web3js.readthedocs.io/en/1.0/callbacks-promises-events.html).

I am aware that there are no tests yet. If possible, I woud like to have help with this.