### PR TITLE
swap: contract integration test with simulated backend

### DIFF
--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -465,8 +465,9 @@ func TestVerifyContractWrongContract(t *testing.T) {
 }
 
 // TestContractIntegration tests a end-to-end cheque interaction.
-// First we deploy both a issuer and a beneficiary contract,
-// we then send a cheque and try to cash this in.
+// First a simulated backend is created, then we deploy the issuer's swap contract.
+// We issue a test cheque with the beneficiary address and on the issuer's contract,
+// and immediately try to cash-in the cheque
 func TestContractIntegration(t *testing.T) {
 
 	log.Debug("creating simulated backend")

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -75,7 +75,7 @@ func init() {
 // Test getting a peer's balance
 func TestGetPeerBalance(t *testing.T) {
 	// create a test swap account
-	swap, testDir := createTestSwap(t)
+	swap, testDir := newTestSwap(t)
 	defer os.RemoveAll(testDir)
 
 	// test for correct value
@@ -102,7 +102,7 @@ func TestGetPeerBalance(t *testing.T) {
 
 func TestGetAllBalances(t *testing.T) {
 	// create a test swap account
-	swap, testDir := createTestSwap(t)
+	swap, testDir := newTestSwap(t)
 	defer os.RemoveAll(testDir)
 
 	if len(swap.balances) != 0 {
@@ -134,7 +134,7 @@ func testBalances(t *testing.T, swap *Swap, expectedBalances map[enode.ID]int64)
 // Test that repeated bookings do correct accounting
 func TestRepeatedBookings(t *testing.T) {
 	// create a test swap account
-	swap, testDir := createTestSwap(t)
+	swap, testDir := newTestSwap(t)
 	defer os.RemoveAll(testDir)
 
 	var bookings []booking
@@ -230,7 +230,7 @@ func calculateExpectedBalances(swap *Swap, bookings []booking) map[enode.ID]int6
 // the balance is still the same
 func TestRestoreBalanceFromStateStore(t *testing.T) {
 	// create a test swap account
-	swap, testDir := createTestSwap(t)
+	swap, testDir := newTestSwap(t)
 	defer os.RemoveAll(testDir)
 
 	testPeer := newDummyPeer()
@@ -259,7 +259,7 @@ func TestRestoreBalanceFromStateStore(t *testing.T) {
 
 // create a test swap account with a backend
 // creates a stateStore for persistence and a Swap account
-func createTestSwapWithBackend(t *testing.T, backend *backends.SimulatedBackend) (*Swap, string) {
+func newTestSwapWithBackend(t *testing.T, backend *backends.SimulatedBackend) (*Swap, string) {
 	dir, err := ioutil.TempDir("", "swap_test_store")
 	if err != nil {
 		t.Fatal(err)
@@ -280,9 +280,11 @@ func createTestSwapWithBackend(t *testing.T, backend *backends.SimulatedBackend)
 // create a test swap account
 // create a default empty backend
 // creates a stateStore for persistence and a Swap account
-func createTestSwap(t *testing.T) (*Swap, string) {
-	defaultBackend := backends.NewSimulatedBackend(core.GenesisAlloc{}, 8000000)
-	return createTestSwapWithBackend(t, defaultBackend)
+func newTestSwap(t *testing.T) (*Swap, string) {
+	defaultBackend := backends.NewSimulatedBackend(core.GenesisAlloc{
+		ownerAddress: {Balance: big.NewInt(1000000000)},
+	}, 8000000)
+	return newTestSwapWithBackend(t, defaultBackend)
 }
 
 type dummyPeer struct {
@@ -320,7 +322,7 @@ func newTestCheque() *Cheque {
 // tests if encodeCheque encodes the cheque as expected
 func TestEncodeCheque(t *testing.T) {
 	// setup test swap object
-	swap, dir := createTestSwap(t)
+	swap, dir := newTestSwap(t)
 	defer os.RemoveAll(dir)
 
 	expectedCheque := newTestCheque()
@@ -338,7 +340,7 @@ func TestEncodeCheque(t *testing.T) {
 // tests if sigHashCheque computes the correct hash to sign
 func TestSigHashCheque(t *testing.T) {
 	// setup test swap object
-	swap, dir := createTestSwap(t)
+	swap, dir := newTestSwap(t)
 	defer os.RemoveAll(dir)
 
 	expectedCheque := newTestCheque()
@@ -356,7 +358,7 @@ func TestSigHashCheque(t *testing.T) {
 // tests if signContent computes the correct signature
 func TestSignContent(t *testing.T) {
 	// setup test swap object
-	swap, dir := createTestSwap(t)
+	swap, dir := newTestSwap(t)
 	defer os.RemoveAll(dir)
 
 	expectedCheque := newTestCheque()
@@ -382,7 +384,7 @@ func TestSignContent(t *testing.T) {
 // tests if verifyChequeSig accepts a correct signature
 func TestVerifyChequeSig(t *testing.T) {
 	// setup test swap object
-	swap, dir := createTestSwap(t)
+	swap, dir := newTestSwap(t)
 	defer os.RemoveAll(dir)
 
 	expectedCheque := newTestCheque()
@@ -396,7 +398,7 @@ func TestVerifyChequeSig(t *testing.T) {
 // tests if verifyChequeSig reject a signature produced by another key
 func TestVerifyChequeSigWrongSigner(t *testing.T) {
 	// setup test swap object
-	swap, dir := createTestSwap(t)
+	swap, dir := newTestSwap(t)
 	defer os.RemoveAll(dir)
 
 	expectedCheque := newTestCheque()
@@ -411,7 +413,7 @@ func TestVerifyChequeSigWrongSigner(t *testing.T) {
 // tests if verifyChequeSig reject an invalid signature
 func TestVerifyChequeInvalidSignature(t *testing.T) {
 	// setup test swap object
-	swap, dir := createTestSwap(t)
+	swap, dir := newTestSwap(t)
 	defer os.RemoveAll(dir)
 
 	expectedCheque := newTestCheque()
@@ -428,7 +430,7 @@ func TestVerifyChequeInvalidSignature(t *testing.T) {
 
 // tests if verifyContract accepts an address with the correct bytecode
 func TestVerifyContract(t *testing.T) {
-	swap, dir := createTestSwap(t)
+	swap, dir := newTestSwap(t)
 	defer os.RemoveAll(dir)
 
 	// deploy a new swap contract
@@ -447,7 +449,7 @@ func TestVerifyContract(t *testing.T) {
 
 // tests if verifyContract rejects an address with different bytecode
 func TestVerifyContractWrongContract(t *testing.T) {
-	swap, dir := createTestSwap(t)
+	swap, dir := newTestSwap(t)
 	defer os.RemoveAll(dir)
 
 	opts := bind.NewKeyedTransactor(ownerKey)
@@ -484,7 +486,7 @@ func TestContractIntegration(t *testing.T) {
 
 	log.Debug("creating test swap")
 
-	issuerSwap, dir := createTestSwapWithBackend(t, backend)
+	issuerSwap, dir := newTestSwapWithBackend(t, backend)
 	defer os.RemoveAll(dir)
 
 	backend.Commit()

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -19,6 +19,7 @@ package swap
 import (
 	"bytes"
 	"context"
+	"crypto/ecdsa"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -41,7 +42,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
 	cswap "github.com/ethersphere/swarm/contracts/swap"
-	contracts "github.com/ethersphere/swarm/contracts/swap/contract"
+	"github.com/ethersphere/swarm/contracts/swap/contract"
 	"github.com/ethersphere/swarm/p2p/protocols"
 	"github.com/ethersphere/swarm/state"
 	colorable "github.com/mattn/go-colorable"
@@ -448,7 +449,7 @@ func TestVerifyContractWrongContract(t *testing.T) {
 	opts := bind.NewKeyedTransactor(ownerKey)
 
 	// we deploy the ECDSA library of OpenZeppelin which has a different bytecode than swap
-	addr, _, _, err := contracts.DeployECDSA(opts, swap.backend)
+	addr, _, _, err := contract.DeployECDSA(opts, swap.backend)
 	if err != nil {
 		t.Fatalf("Error in deploy: %v", err)
 	}
@@ -459,69 +460,66 @@ func TestVerifyContractWrongContract(t *testing.T) {
 	if err = swap.verifyContract(context.TODO(), addr); err != cswap.ErrNotASwapContract {
 		t.Fatalf("Contract verification verified wrong contract: %v", err)
 	}
+}
 
+// TestContractIntegration tests a end-to-end cheque interaction.
+// First we deploy both a issuer and a beneficiary contract,
+// we then send a cheque and try to cash this in.
 func TestContractIntegration(t *testing.T) {
-	// Generate a new random account and a funded backendulator
-	var beneficiaryKey, _ = crypto.GenerateKey()
-	var beneficiaryAddr = crypto.PubkeyToAddress(beneficiaryKey.PublicKey)
 
 	log.Debug("creating test swap")
-	swap, dir := createTestSwap(t)
+
+	issuerSwap, dir := createTestSwap(t)
 	defer os.RemoveAll(dir)
 
-	log.Debug("creating backendulated backend")
+	log.Debug("creating simulated backend")
 
-	gasLimit := uint64(100000000000000000)
+	gasLimit := uint64(10000000)
 	balance := new(big.Int)
-	balance.SetString("1000000000000000000000", 10)
+	balance.SetString("1000000000", 10)
 	backend := backends.NewSimulatedBackend(core.GenesisAlloc{
-		swap.owner.address: {Balance: balance},
-		beneficiaryAddr:    {Balance: balance},
+		issuerSwap.owner.address: {Balance: balance},
+		beneficiaryAddress:       {Balance: balance},
 	}, gasLimit)
 
-	ctx := context.TODO()
-	err := testDeploy(ctx, backend, swap)
+	log.Debug("deploy issuer swap")
+
+	var addr common.Address
+	addr, ss, err := testDeploy(ctx, backend, issuerSwap.owner.privateKey, issuerSwap.owner.address)
 	if err != nil {
 		t.Fatal(err)
 	}
+	issuerSwap.owner.Contract = addr
 
-	log.Debug("deployed.")
+	log.Debug("deployed. signing cheque")
 
-	testAmount := 42
-
-	cheque := &Cheque{
-		ChequeParams: ChequeParams{
-			Serial:      uint64(1),
-			Amount:      uint64(testAmount),
-			Timeout:     defaultCashInDelay,
-			Contract:    swap.owner.Contract,
-			Beneficiary: beneficiaryAddr,
-		},
-	}
-
-	log.Debug("signing cheque")
-
-	cheque.Sig, err = swap.signContent(cheque)
+	cheque := newTestCheque()
+	cheque.ChequeParams.Contract = issuerSwap.owner.Contract
+	cheque.Sig, err = issuerSwap.signContent(cheque)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	opts := bind.NewKeyedTransactor(swap.owner.privateKey)
-	opts.Context = ctx
 
 	log.Debug("sending cheque...")
 
-	tx, err := swap.contractReference.SubmitChequeBeneficiary(
+	ctx := context.TODO()
+	opts := bind.NewKeyedTransactor(beneficiaryKey)
+	opts.Value = big.NewInt(0)
+	opts.Context = ctx
+
+	tx, err := issuerSwap.contractReference.SubmitChequeBeneficiary(
 		opts,
 		big.NewInt(int64(cheque.Serial)),
 		big.NewInt(int64(cheque.Amount)),
 		big.NewInt(int64(cheque.Timeout)),
 		cheque.Sig)
 
-	backend.Commit()
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	backend.Commit()
+	log.Debug("getting receipt")
 
 	receipt, err := backend.TransactionReceipt(context.TODO(), tx.Hash())
 
@@ -529,13 +527,15 @@ func TestContractIntegration(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// check if success
 	if receipt.Status != 1 {
 		t.Fatalf("Wrong status %d", receipt.Status)
 	}
 
-	result, err := swap.contractReference.Instance.Cheques(nil, beneficiaryAddr)
+	// check state, check that cheque is indeed there
+	result, err := issuerSwap.contractReference.Instance.Cheques(nil, beneficiaryAddress)
 
-	fmt.Printf("%v\n", result)
+	log.Debug("cheques result", "result", result)
 
 	if result.Serial.Uint64() != cheque.Serial {
 		t.Fatalf("Wrong serial %d", result.Serial)
@@ -547,25 +547,21 @@ func TestContractIntegration(t *testing.T) {
 
 	backend.AdjustTime(30 * time.Second)
 
+	// test cash in, we need balance in the contract
 	depoTx := types.NewTransaction(
 		1,
-		swap.owner.Contract,
+		issuerSwap.owner.Contract,
 		big.NewInt(int64(20)),
 		50000,
 		big.NewInt(int64(0)),
 		[]byte{},
 	)
 
-	depoTxs, _ := types.SignTx(depoTx, types.HomesteadSigner{}, swap.owner.privateKey)
+	depoTxs, _ := types.SignTx(depoTx, types.HomesteadSigner{}, issuerSwap.owner.privateKey)
 
 	backend.SendTransaction(context.TODO(), depoTxs)
 
-	beneficiaryAgent := common.Address{}
-	requestPayout := big.NewInt(int64(cheque.Amount))
-	beneficiarySig := []byte{}
-	expiry := big.NewInt(int64(0))
-	calleePayout := big.NewInt(int64(cheque.Amount))
-	tx, err = swap.contractReference.Instance.CashCheque(opts, beneficiaryAddr, beneficiaryAgent, requestPayout, beneficiarySig, expiry, calleePayout)
+	tx, err = issuerSwap.contractReference.Instance.CashCheque(opts, beneficiaryAddress)
 
 	backend.Commit()
 
@@ -575,20 +571,21 @@ func TestContractIntegration(t *testing.T) {
 		t.Fatalf("Wrong status %d", receipt.Status)
 	}
 
-	result, err = swap.contractReference.Instance.Cheques(nil, beneficiaryAddr)
+	// check again the status, check paid out is increase by amount
+	result, err = issuerSwap.contractReference.Instance.Cheques(nil, beneficiaryAddress)
 
 	fmt.Printf("%v\n", result)
 
 }
 
-func testDeploy(ctx context.Context, backend *backends.SimulatedBackend, swap *Swap) error {
-	opts := bind.NewKeyedTransactor(swap.owner.privateKey)
+func testDeploy(ctx context.Context, backend *backends.SimulatedBackend, prvKey *ecdsa.PrivateKey, address common.Address) (addr common.Address, ss *contract.SimpleSwap, err error) {
+	opts := bind.NewKeyedTransactor(prvKey)
 	opts.Value = big.NewInt(0)
 	opts.Context = ctx
 
-	if _, _, err := swap.contractReference.Deploy(opts, backend, swap.owner.address); err != nil {
-		return nil
+	if addr, _, ss, err = contract.DeploySimpleSwap(opts, backend, address); err != nil {
+		return common.Address{}, nil, err
 	}
 	backend.Commit()
-	return nil
+	return addr, ss, nil
 }


### PR DESCRIPTION
This PR adds a test to the swap implementation.

The test instantiates a `backends.SimulatedBackend` from `go-ethereum` and then deploys the swarm contract to it.

Next, an imaginary cheque is created and sent to the issuer's contract; finally it redeems (cash-in) the cheque.