### PR TITLE
add --disable-auto-connect flag

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -72,6 +72,7 @@ type Config struct {
 	MaxStreamPeerServers int
 	LightNodeEnabled     bool
 	BootnodeMode         bool
+	DisableAutoConnect   bool
 	SyncUpdateDelay      time.Duration
 	SwapAPI              string
 	Cors                 string

--- a/cmd/swarm/config.go
+++ b/cmd/swarm/config.go
@@ -266,6 +266,10 @@ func flagsOverride(currentConfig *bzzapi.Config, ctx *cli.Context) *bzzapi.Confi
 		currentConfig.BootnodeMode = ctx.GlobalBool(SwarmBootnodeModeFlag.Name)
 	}
 
+	if ctx.GlobalIsSet(SwarmDisableAutoConnectFlag.Name) {
+		currentConfig.DisableAutoConnect = ctx.GlobalBool(SwarmDisableAutoConnectFlag.Name)
+	}
+
 	if ctx.GlobalIsSet(SwarmGlobalStoreAPIFlag.Name) {
 		currentConfig.GlobalStoreAPI = ctx.GlobalString(SwarmGlobalStoreAPIFlag.Name)
 	}

--- a/cmd/swarm/flags.go
+++ b/cmd/swarm/flags.go
@@ -166,6 +166,10 @@ var (
 		Name:  "bootnode-mode",
 		Usage: "Run Swarm in Bootnode mode",
 	}
+	SwarmDisableAutoConnectFlag = cli.BoolFlag{
+		Name:  "disable-auto-connect",
+		Usage: "Disables the peer discovery mechanism in the hive protocol as well as the auto connect loop (manual peer addition)",
+	}
 	SwarmFeedNameFlag = cli.StringFlag{
 		Name:  "name",
 		Usage: "User-defined name for the new feed, limited to 32 characters. If combined with topic, it will refer to a subtopic with this name",

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -196,6 +196,7 @@ func init() {
 		SwarmUploadMimeType,
 		// bootnode mode
 		SwarmBootnodeModeFlag,
+		SwarmDisableAutoConnectFlag,
 		// storage flags
 		SwarmStorePath,
 		SwarmStoreCapacity,

--- a/network/hive.go
+++ b/network/hive.go
@@ -39,6 +39,7 @@ to suggest peers to bootstrap connectivity
 // HiveParams holds the config options to hive
 type HiveParams struct {
 	Discovery             bool  // if want discovery of not
+	DisableAutoConnect    bool  // this flag disables the auto connect loop
 	PeersBroadcastSetSize uint8 // how many peers to use when relaying
 	MaxPeersPerRequest    uint8 // max size for peer address batches
 	KeepAliveInterval     time.Duration
@@ -97,7 +98,9 @@ func (h *Hive) Start(server *p2p.Server) error {
 	// ticker to keep the hive alive
 	h.ticker = time.NewTicker(h.KeepAliveInterval)
 	// this loop is doing bootstrapping and maintains a healthy table
-	go h.connect()
+	if !h.DisableAutoConnect {
+		go h.connect()
+	}
 	return nil
 }
 

--- a/swarm.go
+++ b/swarm.go
@@ -120,6 +120,10 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 
 	config.HiveParams.Discovery = true
 
+	if config.DisableAutoConnect {
+		config.HiveParams.DisableAutoConnect = true
+	}
+
 	bzzconfig := &network.BzzConfig{
 		NetworkID:    config.NetworkID,
 		OverlayAddr:  common.FromHex(config.BzzKey),


### PR DESCRIPTION
This PR is adding a `--disable-auto-connect` flag, so that we can run Swarm without `hive` discovery and reproduce the same connections between deployments, without relying on the non-deterministic `SuggestPeer` functionality.

Next step would be to add tools to extract and apply connections from running deployments (a very early attempt at https://github.com/ethersphere/swarm/pull/1183) and to generate snapshots out of them so that we can have more determinism in our tests.