### PR TITLE
swarm-smoke: fix check max prox hosts for pull/push sync modes

### DIFF
--- a/cmd/swarm-smoke/main.go
+++ b/cmd/swarm-smoke/main.go
@@ -37,18 +37,20 @@ var (
 )
 
 var (
-	allhosts   string
-	hosts      []string
-	filesize   int
-	syncDelay  bool
-	inputSeed  int
-	httpPort   int
-	wsPort     int
-	verbosity  int
-	timeout    int
-	single     bool
-	onlyUpload bool
-	debug      bool
+	allhosts      string
+	hosts         []string
+	filesize      int
+	syncDelay     bool
+	pushsyncDelay bool
+	syncMode      string
+	inputSeed     int
+	httpPort      int
+	wsPort        int
+	verbosity     int
+	timeout       int
+	single        bool
+	onlyUpload    bool
+	debug         bool
 )
 
 func main() {
@@ -87,6 +89,12 @@ func main() {
 			Value:       1024,
 			Usage:       "file size for generated random file in KB",
 			Destination: &filesize,
+		},
+		cli.StringFlag{
+			Name:        "sync-mode",
+			Value:       "pullsync",
+			Usage:       "sync mode - pushsync or pullsync or both",
+			Destination: &syncMode,
 		},
 		cli.BoolFlag{
 			Name:        "sync-delay",

--- a/cmd/swarm-smoke/main.go
+++ b/cmd/swarm-smoke/main.go
@@ -54,7 +54,6 @@ var (
 )
 
 func main() {
-
 	app := cli.NewApp()
 	app.Name = "smoke-test"
 	app.Usage = ""
@@ -95,6 +94,11 @@ func main() {
 			Value:       "pullsync",
 			Usage:       "sync mode - pushsync or pullsync or both",
 			Destination: &syncMode,
+		},
+		cli.BoolFlag{
+			Name:        "pushsync-delay",
+			Usage:       "wait for content to be push synced",
+			Destination: &pushsyncDelay,
 		},
 		cli.BoolFlag{
 			Name:        "sync-delay",

--- a/cmd/swarm-smoke/upload_and_sync.go
+++ b/cmd/swarm-smoke/upload_and_sync.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ethersphere/swarm/chunk"
 	"github.com/ethersphere/swarm/storage"
 	"github.com/ethersphere/swarm/testutil"
+	"github.com/pborman/uuid"
 
 	cli "gopkg.in/urfave/cli.v1"
 )
@@ -264,7 +265,7 @@ func checkChunksVsMostProxHosts(addrs []storage.Address, allHostChunks map[strin
 				}
 			}
 
-			// if chunk found at less than 2 hosts
+			// if chunk found at less than 2 hosts, which is actually less that the min size of a NN
 			if foundAt < 2 {
 				log.Error("chunk found at less than two hosts", "foundAt", foundAt, "ref", addrs[i])
 			}
@@ -273,8 +274,7 @@ func checkChunksVsMostProxHosts(addrs []storage.Address, allHostChunks map[strin
 		if syncMode == "pushsync" {
 			var found bool
 			for _, maxProxHost := range maxProxHosts {
-				if allHostChunks[maxProxHost][i] == '0' {
-				} else {
+				if allHostChunks[maxProxHost][i] == '1' {
 					found = true
 					log.Trace("chunk present at max prox host", "ref", addrs[i], "host", maxProxHost, "bzzAddr", bzzAddrs[maxProxHost])
 				}
@@ -309,7 +309,8 @@ func uploadAndSync(c *cli.Context, randomBytes []byte) error {
 	log.Info("uploading to "+httpEndpoint(hosts[0])+" and syncing", "seed", seed)
 
 	t1 := time.Now()
-	hash, err := upload(randomBytes, httpEndpoint(hosts[0]))
+	tag := uuid.New()[:8]
+	hash, err := uploadWithTag(randomBytes, httpEndpoint(hosts[0]), tag)
 	if err != nil {
 		log.Error(err.Error())
 		return err
@@ -324,6 +325,11 @@ func uploadAndSync(c *cli.Context, randomBytes []byte) error {
 	}
 
 	log.Info("uploaded successfully", "hash", hash, "took", t2, "digest", fmt.Sprintf("%x", fhash))
+
+	// wait to push sync sync
+	if pushsyncDelay {
+		waitToPushSynced(tag)
+	}
 
 	// wait to sync and log chunks before fetch attempt, only if syncDelay is set to true
 	if syncDelay {
@@ -363,6 +369,29 @@ func uploadAndSync(c *cli.Context, randomBytes []byte) error {
 	return nil
 }
 
+func isPushSynced(wsHost string, tagname string) (bool, error) {
+	rpcClient, err := rpc.Dial(wsHost)
+	if rpcClient != nil {
+		defer rpcClient.Close()
+	}
+
+	if err != nil {
+		log.Error("error dialing host", "err", err)
+		return false, err
+	}
+
+	var isSynced bool
+	err = rpcClient.Call(&isSynced, "bzz_isPushSynced", tagname)
+	if err != nil {
+		log.Error("error calling host for isPushSynced", "err", err)
+		return false, err
+	}
+
+	log.Debug("isSynced result", "host", wsHost, "isSynced", isSynced)
+
+	return isSynced, nil
+}
+
 func isSyncing(wsHost string) (bool, error) {
 	rpcClient, err := rpc.Dial(wsHost)
 	if rpcClient != nil {
@@ -384,6 +413,20 @@ func isSyncing(wsHost string) (bool, error) {
 	log.Debug("isSyncing result", "host", wsHost, "isSyncing", isSyncing)
 
 	return isSyncing, nil
+}
+
+func waitToPushSynced(tagname string) {
+	for {
+		synced, err := isPushSynced(wsEndpoint(hosts[0]), tagname)
+		if err != nil {
+			log.Error(err.Error())
+		}
+
+		if synced {
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
 }
 
 func waitToSync() {


### PR DESCRIPTION
This PR is adding a flag to specify the kind of smoke test to test for with respect to syncing:
```
--sync-mode=pushsync, pullsync, or both
```

1. When `pullsync` - make sure that all chunks are hosted at all max prox hosts - previously we had a more relaxed version, where we were checking only one of the max prox hosts (if there were multiple)
2. When `pushsync` - make sure that all chunks are found at at least one max prox host - we don't know which node received our chunk, and sent back a receipt, it can be any one of the max prox hosts if there are multiple
3. When `both` - same as 1.

-----

It also adds a flag to specify if we want to wait for `pushsync` or `pullsync` to complete. Uploads attach a `tag`, so that we can monitor the `pushsync` until completion.