### PR TITLE
swap: Incentives prices

### DIFF
--- a/network/discovery_test.go
+++ b/network/discovery_test.go
@@ -33,6 +33,7 @@ import (
 	p2ptest "github.com/ethereum/go-ethereum/p2p/testing"
 	"github.com/ethersphere/swarm/p2p/protocols"
 	"github.com/ethersphere/swarm/pot"
+	"github.com/ethersphere/swarm/testutil"
 )
 
 /***
@@ -249,16 +250,7 @@ func newDiscPeer(addr pot.Address) (*Peer, error) {
 	id := nod.ID()
 	p2pPeer := p2p.NewPeer(id, id.String(), nil)
 	return NewPeer(&BzzPeer{
-		Peer:    protocols.NewPeer(p2pPeer, &dummyMsgRW{}, DiscoverySpec),
+		Peer:    protocols.NewPeer(p2pPeer, &testutil.DummyMsgRW{}, DiscoverySpec),
 		BzzAddr: bzzAddr,
 	}, nil), nil
-}
-
-type dummyMsgRW struct{}
-
-func (d *dummyMsgRW) ReadMsg() (p2p.Msg, error) {
-	return p2p.Msg{}, nil
-}
-func (d *dummyMsgRW) WriteMsg(msg p2p.Msg) error {
-	return nil
 }

--- a/network/stream/constants.go
+++ b/network/stream/constants.go
@@ -1,7 +1,0 @@
-package stream
-
-// Placeholder prices
-const (
-	RetrieveRequestMsgPrice        = uint64(1)
-	ChunkDeliveryMsgRetrievalPrice = uint64(1)
-)

--- a/network/stream/stream.go
+++ b/network/stream/stream.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ethersphere/swarm/p2p/protocols"
 	"github.com/ethersphere/swarm/state"
 	"github.com/ethersphere/swarm/storage"
+	"github.com/ethersphere/swarm/swap"
 )
 
 const (
@@ -658,13 +659,13 @@ func (sp *StreamerPrices) Price(msg interface{}) *protocols.Price {
 // Instead of hardcoding the price, get it
 // through a function - it could be quite complex in the future
 func (sp *StreamerPrices) getRetrieveRequestMsgPrice() uint64 {
-	return RetrieveRequestMsgPrice
+	return swap.RetrieveRequestMsgPrice
 }
 
 // Instead of hardcoding the price, get it
 // through a function - it could be quite complex in the future
 func (sp *StreamerPrices) getChunkDeliveryMsgRetrievalPrice() uint64 {
-	return ChunkDeliveryMsgRetrievalPrice
+	return swap.ChunkDeliveryMsgRetrievalPrice
 }
 
 // createPriceOracle sets up a matrix which can be queried to get

--- a/p2p/protocols/accounting.go
+++ b/p2p/protocols/accounting.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The go-ethereum Authors
+// Copyright 2019 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //
 // The go-ethereum library is free software: you can redistribute it and/or modify
@@ -53,10 +53,13 @@ type Prices interface {
 	Price(interface{}) *Price
 }
 
+// Payer is the base type to define who pays in an exchange between peers
 type Payer bool
 
 const (
-	Sender   = Payer(true)
+	// Sender declares that a message needs to be payed by the sender of the message
+	Sender = Payer(true)
+	// Receiver declares that a message needs to be payed by the receiver of the message
 	Receiver = Payer(false)
 )
 
@@ -103,6 +106,7 @@ type Accounting struct {
 	Prices  // interface to prices logic
 }
 
+// NewAccounting creates a new instance of Accounting
 func NewAccounting(balance Balance, po Prices) *Accounting {
 	ah := &Accounting{
 		Prices:  po,

--- a/swap/defaults.go
+++ b/swap/defaults.go
@@ -16,9 +16,25 @@
 
 package swap
 
+import "time"
+
 // These are currently arbitrary values which have not been verified nor tested
 // Need experimentation to arrive to values which make sense
 const (
+	// Thresholds which trigger payment or disconnection. The unit is in honey (internal accounting unit)
 	DefaultPaymentThreshold    = 1000000
 	DefaultDisconnectThreshold = 1500000
+	// DefaultInitialDepositAmount is the default amount to send to the contract when initially deploying
+	// TODO: deliberate value for now; needs experimentation
+	DefaultInitialDepositAmount = 0
+
+	deployRetries = 5
+	// delay between retries
+	deployDelay = 1 * time.Second
+	// Default timeout until cashing in cheques is possible - TODO: deliberate value, experiment
+	// Should be non-zero once we implement waivers
+	defaultCashInDelay = uint64(0)
+	// This is the amount of time in seconds which an issuer has to wait to decrease the harddeposit of a beneficiary.
+	// The smart-contract allows for setting this variable differently per beneficiary
+	defaultHarddepositTimeoutDuration = 24 * time.Hour
 )

--- a/swap/defaults.go
+++ b/swap/defaults.go
@@ -1,6 +1,23 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
 package swap
 
-// Uknown for now, placeholder values
+// These are currently arbitrary values which have not been verified nor tested
+// Need experimentation to arrive to values which make sense
 const (
 	DefaultPaymentThreshold    = 1000000
 	DefaultDisconnectThreshold = 1500000

--- a/swap/oracle.go
+++ b/swap/oracle.go
@@ -1,0 +1,65 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package swap
+
+import "time"
+
+const (
+	// maximum validity of the honey price
+	maxPriceAge       = 1 * time.Hour // TODO: this is currently an arbitrary value - currently irrelevant as prices are fixed
+	defaultHoneyPrice = uint64(1)     // default convertion of honey into output currency - currently ETH
+)
+
+// Currency represents a string identifier for currencies
+type Currency string
+
+// PriceOracle is the interface through which Oracles will deliver prices
+type PriceOracle interface {
+	GetPrice(honey int64) (int64, error)
+}
+
+// NewPriceOracle returns the actual oracle to be used for discovering the price
+// TODO: Add a config flag so that this can be configured via command line
+// For now it will return a default one
+func NewPriceOracle() PriceOracle {
+	cpo := &ConfigurablePriceOracle{
+		honeyPrice: defaultHoneyPrice,
+	}
+	cpo.refreshRate()
+	return cpo
+}
+
+// ConfigurablePriceOracle is a price oracle which can be customized.
+// It is the default price oracle used as a placeholder for this iteration of the implementation.
+// In production this should probably be some on-chain oracle called remotely
+type ConfigurablePriceOracle struct {
+	honeyPrice  uint64
+	lastUpdated time.Time
+}
+
+// GetPrice returns the actual price for honey
+func (cpo *ConfigurablePriceOracle) GetPrice(honey int64) (int64, error) {
+	if time.Now().After(cpo.lastUpdated.Add(maxPriceAge)) {
+		cpo.refreshRate()
+	}
+	return honey * int64(cpo.honeyPrice), nil
+}
+
+// refreshRate refreshes the honey to output unit price (currently ETH)
+func (cpo *ConfigurablePriceOracle) refreshRate() (uint64, error) {
+	return cpo.honeyPrice, nil
+}

--- a/swap/oracle.go
+++ b/swap/oracle.go
@@ -29,7 +29,7 @@ type Currency string
 
 // PriceOracle is the interface through which Oracles will deliver prices
 type PriceOracle interface {
-	GetPrice(honey int64) (int64, error)
+	GetPrice(honey uint64) (uint64, error)
 }
 
 // NewPriceOracle returns the actual oracle to be used for discovering the price
@@ -52,14 +52,18 @@ type ConfigurablePriceOracle struct {
 }
 
 // GetPrice returns the actual price for honey
-func (cpo *ConfigurablePriceOracle) GetPrice(honey int64) (int64, error) {
+func (cpo *ConfigurablePriceOracle) GetPrice(honey uint64) (uint64, error) {
+	// only request to refresh the rate if the timestamp is old enough
 	if time.Now().After(cpo.lastUpdated.Add(maxPriceAge)) {
 		cpo.refreshRate()
 	}
-	return honey * int64(cpo.honeyPrice), nil
+	// otherwise don't refresh the rate and return the latest price
+	return honey * cpo.honeyPrice, nil
 }
 
 // refreshRate refreshes the honey to output unit price (currently ETH)
 func (cpo *ConfigurablePriceOracle) refreshRate() (uint64, error) {
+	// currently do not do anything.
+	// in the future, this might make a network request to some service, reload a file or whatever
 	return cpo.honeyPrice, nil
 }

--- a/swap/oracle.go
+++ b/swap/oracle.go
@@ -16,17 +16,6 @@
 
 package swap
 
-import "time"
-
-const (
-	// maximum validity of the honey price
-	maxPriceAge       = 1 * time.Hour // TODO: this is currently an arbitrary value - currently irrelevant as prices are fixed
-	defaultHoneyPrice = uint64(1)     // default convertion of honey into output currency - currently ETH
-)
-
-// Currency represents a string identifier for currencies
-type Currency string
-
 // PriceOracle is the interface through which Oracles will deliver prices
 type PriceOracle interface {
 	GetPrice(honey uint64) (uint64, error)
@@ -36,34 +25,21 @@ type PriceOracle interface {
 // TODO: Add a config flag so that this can be configured via command line
 // For now it will return a default one
 func NewPriceOracle() PriceOracle {
-	cpo := &ConfigurablePriceOracle{
+	cpo := &FixedPriceOracle{
 		honeyPrice: defaultHoneyPrice,
 	}
-	cpo.refreshRate()
 	return cpo
 }
 
-// ConfigurablePriceOracle is a price oracle which can be customized.
+// FixedPriceOracle is a price oracle which which returns a fixed price.
 // It is the default price oracle used as a placeholder for this iteration of the implementation.
 // In production this should probably be some on-chain oracle called remotely
-type ConfigurablePriceOracle struct {
-	honeyPrice  uint64
-	lastUpdated time.Time
+type FixedPriceOracle struct {
+	honeyPrice uint64
 }
 
 // GetPrice returns the actual price for honey
-func (cpo *ConfigurablePriceOracle) GetPrice(honey uint64) (uint64, error) {
-	// only request to refresh the rate if the timestamp is old enough
-	if time.Now().After(cpo.lastUpdated.Add(maxPriceAge)) {
-		cpo.refreshRate()
-	}
+func (cpo *FixedPriceOracle) GetPrice(honey uint64) (uint64, error) {
 	// otherwise don't refresh the rate and return the latest price
 	return honey * cpo.honeyPrice, nil
-}
-
-// refreshRate refreshes the honey to output unit price (currently ETH)
-func (cpo *ConfigurablePriceOracle) refreshRate() (uint64, error) {
-	// currently do not do anything.
-	// in the future, this might make a network request to some service, reload a file or whatever
-	return cpo.honeyPrice, nil
 }

--- a/swap/peer.go
+++ b/swap/peer.go
@@ -103,7 +103,10 @@ func (sp *Peer) handleEmitChequeMsg(ctx context.Context, msg *EmitChequeMsg) err
 	// so that updateBalance will calculate balance + amount which result in reducing the peer's balance
 	sp.swap.resetBalance(sp.ID(), 0-int64(cheque.Honey))
 	// send confirmation
-	if err := sp.Send(ctx, &ConfirmMsg{}); err != nil {
+	confMsg := &ConfirmMsg{
+		Cheque: cheque,
+	}
+	if err := sp.Send(ctx, confMsg); err != nil {
 		log.Error("error while sending confirm msg", "peer", sp.ID().String(), "err", err.Error())
 		return err
 	}

--- a/swap/peer.go
+++ b/swap/peer.go
@@ -62,9 +62,10 @@ func (sp *Peer) handleMsg(ctx context.Context, msg interface{}) error {
 
 	case *ErrorMsg:
 		return sp.handleErrorMsg(ctx, msg)
-	}
 
-	return nil
+	default:
+		return fmt.Errorf("unknown message type: %T", msg)
+	}
 }
 
 // handleEmitChequeMsg should be handled by the creditor when it receives

--- a/swap/peer.go
+++ b/swap/peer.go
@@ -103,8 +103,10 @@ func (sp *Peer) handleEmitChequeMsg(ctx context.Context, msg interface{}) error 
 
 	// TODO: check serial and balance are higher
 
-	// reset balance to zero, TODO: fix
-	sp.swap.resetBalance(sp.ID())
+	// reset balance by amount
+	// as this is done by the creditor, receiving the cheque, the amount should be negative,
+	// so that updateBalance will calculate balance + amount which result in reducing the peer's balance
+	sp.swap.resetBalance(sp.ID(), 0-int64(cheque.Amount))
 	// send confirmation
 	if err := sp.Send(ctx, &ConfirmMsg{}); err != nil {
 		log.Error("error while sending confirm msg", "peer", sp.ID().String(), "err", err.Error())

--- a/swap/peer.go
+++ b/swap/peer.go
@@ -62,16 +62,13 @@ func (sp *Peer) handleMsg(ctx context.Context, msg interface{}) error {
 
 	case *ErrorMsg:
 		return sp.handleErrorMsg(ctx, msg)
-
-	case *ConfirmMsg:
-		return sp.handleConfirmMsg(ctx, msg)
 	}
 
 	return nil
 }
 
 // handleEmitChequeMsg should be handled by the creditor when it receives
-// a cheque from a creditor
+// a cheque from a debitor
 // TODO: validate the contract address in the cheque to match the address given at handshake
 // TODO: this should not be blocking
 func (sp *Peer) handleEmitChequeMsg(ctx context.Context, msg *EmitChequeMsg) error {
@@ -102,14 +99,7 @@ func (sp *Peer) handleEmitChequeMsg(ctx context.Context, msg *EmitChequeMsg) err
 	// as this is done by the creditor, receiving the cheque, the amount should be negative,
 	// so that updateBalance will calculate balance + amount which result in reducing the peer's balance
 	sp.swap.resetBalance(sp.ID(), 0-int64(cheque.Honey))
-	// send confirmation
-	confMsg := &ConfirmMsg{
-		Cheque: cheque,
-	}
-	if err := sp.Send(ctx, confMsg); err != nil {
-		log.Error("error while sending confirm msg", "peer", sp.ID().String(), "err", err.Error())
-		return err
-	}
+
 	// cash in cheque
 	//TODO: input parameter checks?
 	opts := bind.NewKeyedTransactor(sp.swap.owner.privateKey)
@@ -144,11 +134,5 @@ func (sp *Peer) handleEmitChequeMsg(ctx context.Context, msg *EmitChequeMsg) err
 func (sp *Peer) handleErrorMsg(ctx context.Context, msg interface{}) error {
 	log.Info("received error msg")
 	// maybe balance disagreement
-	return nil
-}
-
-// handleConfirmMsg is called when a ConfirmMsg is received
-func (sp *Peer) handleConfirmMsg(ctx context.Context, msg interface{}) error {
-	log.Info("received confirm msg")
 	return nil
 }

--- a/swap/peer.go
+++ b/swap/peer.go
@@ -74,15 +74,10 @@ func (sp *Peer) handleMsg(ctx context.Context, msg interface{}) error {
 // a cheque from a creditor
 // TODO: validate the contract address in the cheque to match the address given at handshake
 // TODO: this should not be blocking
-func (sp *Peer) handleEmitChequeMsg(ctx context.Context, msg interface{}) error {
+func (sp *Peer) handleEmitChequeMsg(ctx context.Context, msg *EmitChequeMsg) error {
 	log.Info("received emit cheque message")
 
-	chequeMsg, ok := msg.(*EmitChequeMsg)
-	if !ok {
-		return fmt.Errorf("Invalid message type, %v", msg)
-	}
-
-	cheque := chequeMsg.Cheque
+	cheque := msg.Cheque
 	if cheque.Contract != sp.contractAddress {
 		return fmt.Errorf("wrong cheque parameters: expected contract: %s, was: %s", sp.contractAddress, cheque.Contract)
 	}
@@ -106,7 +101,7 @@ func (sp *Peer) handleEmitChequeMsg(ctx context.Context, msg interface{}) error 
 	// reset balance by amount
 	// as this is done by the creditor, receiving the cheque, the amount should be negative,
 	// so that updateBalance will calculate balance + amount which result in reducing the peer's balance
-	sp.swap.resetBalance(sp.ID(), 0-int64(cheque.Amount))
+	sp.swap.resetBalance(sp.ID(), 0-int64(cheque.Honey))
 	// send confirmation
 	if err := sp.Send(ctx, &ConfirmMsg{}); err != nil {
 		log.Error("error while sending confirm msg", "peer", sp.ID().String(), "err", err.Error())

--- a/swap/prices.go
+++ b/swap/prices.go
@@ -20,11 +20,12 @@ package swap
 This module contains the pricing for message types as constants.
 
 Pricing in Swarm is defined in an internal unit.
-This unit allows to set prices of messages relative to each other
+The name of this internal unit is honey.
+The honey unit allows to set prices of messages relative to each other
 without any dependancy to any currency.
 
 The expectation is then that an external, probably on-chain, **oracle**
-would be queried with the total amount of units for a message,
+would be queried with the total amount of honey for a message,
 for which the oracle would return the price in a given currency.
 
 Currently the expected currency from the oracle would be wei,
@@ -36,4 +37,6 @@ allowing for a multi-currency design.
 const (
 	RetrieveRequestMsgPrice        = uint64(1)
 	ChunkDeliveryMsgRetrievalPrice = uint64(1)
+	// default convertion of honey into output currency - currently ETH
+	defaultHoneyPrice = uint64(1)
 )

--- a/swap/prices.go
+++ b/swap/prices.go
@@ -1,0 +1,39 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package swap
+
+/*
+This module contains the pricing for message types as constants.
+
+Pricing in Swarm is defined in an internal unit.
+This unit allows to set prices of messages relative to each other
+without any dependancy to any currency.
+
+The expectation is then that an external, probably on-chain, **oracle**
+would be queried with the total amount of units for a message,
+for which the oracle would return the price in a given currency.
+
+Currently the expected currency from the oracle would be wei,
+but it could potentially be any currency the oracle and Swarm support,
+allowing for a multi-currency design.
+*/
+
+// Placeholder prices
+const (
+	RetrieveRequestMsgPrice        = uint64(1)
+	ChunkDeliveryMsgRetrievalPrice = uint64(1)
+)

--- a/swap/protocol.go
+++ b/swap/protocol.go
@@ -39,7 +39,6 @@ var Spec = &protocols.Spec{
 		HandshakeMsg{},
 		EmitChequeMsg{},
 		ErrorMsg{},
-		ConfirmMsg{},
 	},
 }
 

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -16,105 +16,81 @@
 
 package swap
 
-// TODO: Update this test.
-// We are no longer sending the cheque request messages, we send the cheques directly now.
+import (
+	"os"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	p2ptest "github.com/ethereum/go-ethereum/p2p/testing"
+)
+
 /*
-TestRequestCheque tests that a peer will respond with a
-`EmitChequeMsg` containing a cheque for an expected amount
-if it sends a `RequestChequeMsg` is sent to it
+TestEmitCheque tests an end-to-end exchange between a debitor peer
+and its creditor. The debitor issues the cheque, the creditor receives it
+and responds with a confirmation
 */
-// func TestRequestCheque(t *testing.T) {
-// 	var err error
+func TestEmitCheque(t *testing.T) {
+	var err error
 
-// 	// setup test swap object
-// 	swap, dir := createTestSwap(t)
-// 	defer os.RemoveAll(dir)
+	// setup test swap object
+	swap, dir := newTestSwap(t)
+	defer os.RemoveAll(dir)
 
-// 	// dummy object so we can run the protocol
-// 	ss := swap
+	// setup the protocolTester, which will allow protocol testing by sending messages
+	protocolTester := p2ptest.NewProtocolTester(swap.owner.privateKey, 2, swap.run)
 
-// 	// setup the protocolTester, which will allow protocol testing by sending messages
-// 	protocolTester := p2ptest.NewProtocolTester(swap.owner.privateKey, 2, ss.run)
+	// shortcut to creditor node
+	debitor := protocolTester.Nodes[0]
+	creditor := protocolTester.Nodes[1]
 
-// 	// shortcut to creditor node
-// 	creditor := protocolTester.Nodes[0]
+	// set balance artifially
+	swap.balances[creditor.ID()] = -42
 
-// 	// set balance artifially
-// 	swap.balances[creditor.ID()] = -42
+	// create the expected cheque to be received
+	cheque := newTestCheque()
 
-// 	// create the expected cheque to be received
-// 	// NOTE: this may be improved, as it is essentially running the same
-// 	// code as in production
-// 	expectedCheque := swap.cheques[creditor.ID()]
-// 	expectedCheque = &Cheque{
-// 		ChequeParams: ChequeParams{
-// 			Serial:      uint64(1),
-// 			Amount:      uint64(42),
-// 			Timeout:     defaultCashInDelay,
-// 			Beneficiary: crypto.PubkeyToAddress(*creditor.Pubkey()),
-// 		},
-// 	}
+	// sign the cheque
+	cheque.Sig, err = swap.signContent(cheque)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	// sign the cheque
-// 	expectedCheque.Sig, err = swap.signContent(expectedCheque)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+	// run the exchange:
+	// trigger a `ChequeRequestMsg`
+	// expect a `EmitChequeMsg` with a valid cheque
+	err = protocolTester.TestExchanges(p2ptest.Exchange{
+		Label: "TestRequestCheque",
+		Triggers: []p2ptest.Trigger{
+			{
+				Code: 1,
+				Msg: &EmitChequeMsg{
+					Cheque: cheque,
+				},
+				Peer: debitor.ID(),
+			},
+		},
+		Expects: []p2ptest.Expect{
+			{
+				Code: 0,
+				Msg: &HandshakeMsg{
+					ContractAddress: common.Address{},
+				},
+				Peer: creditor.ID(),
+			},
+			{
+				Code: 0,
+				Msg: &HandshakeMsg{
+					ContractAddress: common.Address{},
+				},
+				Peer: debitor.ID(),
+			},
+		},
+	})
 
-// 	// run the exchange:
-// 	// trigger a `ChequeRequestMsg`
-// 	// expect a `EmitChequeMsg` with a valid cheque
-// 	err = protocolTester.TestExchanges(p2ptest.Exchange{
-// 		Label: "TestRequestCheque",
-// 		Triggers: []p2ptest.Trigger{
-// 			{
-// 				Code: 0,
-// 				Msg: &ChequeRequestMsg{
-// 					crypto.PubkeyToAddress(*creditor.Pubkey()),
-// 				},
-// 				Peer: creditor.ID(),
-// 			},
-// 		},
-// 		Expects: []p2ptest.Expect{
-// 			{
-// 				Code: 1,
-// 				Msg: &EmitChequeMsg{
-// 					Cheque: expectedCheque,
-// 				},
-// 				Peer: creditor.ID(),
-// 			},
-// 		},
-// 	})
+	// there should be no error at this point
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	// there should be no error at this point
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-
-// 	// now we request a new cheque;
-// 	// the peer though should have already reset the balance,
-// 	// so no new cheque should be issued
-// 	err = protocolTester.TestExchanges(p2ptest.Exchange{
-// 		Label: "TestRequestNoCheque",
-// 		Triggers: []p2ptest.Trigger{
-// 			{
-// 				Code: 0,
-// 				Msg: &ChequeRequestMsg{
-// 					crypto.PubkeyToAddress(*creditor.Pubkey()),
-// 				},
-// 				Peer: creditor.ID(),
-// 			},
-// 		},
-// 	})
-
-// 	//
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-
-// 	// no new cheques should have been emitted
-// 	if len(swap.cheques) != 1 {
-// 		t.Fatalf("Expected unchanged number of cheques, but it changed: %d", len(swap.cheques))
-// 	}
-
-// }
+	// TODO: Test further exchanges
+}

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -17,25 +17,34 @@
 package swap
 
 import (
+	"bytes"
+	"context"
 	"os"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/enode"
 	p2ptest "github.com/ethereum/go-ethereum/p2p/testing"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethersphere/swarm/p2p/protocols"
 )
 
 /*
-TestEmitCheque tests an end-to-end exchange between a debitor peer
-and its creditor. The debitor issues the cheque, the creditor receives it
-and responds with a confirmation
+TestHandshake creates two mock nodes and initiates an exchange;
+it expects a handshake to take place between the two nodes
+(the handshake would fail because we don't actually use real nodes here)
 */
-func TestEmitCheque(t *testing.T) {
+func TestHandshake(t *testing.T) {
 	var err error
 
 	// setup test swap object
 	swap, dir := newTestSwap(t)
 	defer os.RemoveAll(dir)
 
+	ctx := context.Background()
+	testDeploy(ctx, swap.backend, swap)
 	// setup the protocolTester, which will allow protocol testing by sending messages
 	protocolTester := p2ptest.NewProtocolTester(swap.owner.privateKey, 2, swap.run)
 
@@ -73,14 +82,14 @@ func TestEmitCheque(t *testing.T) {
 			{
 				Code: 0,
 				Msg: &HandshakeMsg{
-					ContractAddress: common.Address{},
+					ContractAddress: swap.owner.Contract,
 				},
 				Peer: creditor.ID(),
 			},
 			{
 				Code: 0,
 				Msg: &HandshakeMsg{
-					ContractAddress: common.Address{},
+					ContractAddress: swap.owner.Contract,
 				},
 				Peer: debitor.ID(),
 			},
@@ -91,6 +100,152 @@ func TestEmitCheque(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
 
-	// TODO: Test further exchanges
+// TestEmitCheque is a full round of a cheque exchange between peers via the protocol.
+// We create two swap, for the creditor (beneficiary) and debitor (issuer) each,
+// and deploy them to the simulated backend.
+// We then create Swap protocol peers with a MsgPipe to be able to directly write messages to each other.
+// We have the debitor send a cheque via an `EmitChequeMsg`, then the creditor "reads" (pipe) the message
+// and handles the cheque. We finally also send back a `ConfirmMsg` to the debitor
+// TODO: The ConfirmMsg part is not definitevely specificied.
+func TestEmitCheque(t *testing.T) {
+	log.Debug("set up test swaps")
+	creditorSwap, testDir1 := newTestSwap(t)
+	debitorSwap, testDir2 := newTestSwap(t)
+	defer os.RemoveAll(testDir1)
+	defer os.RemoveAll(testDir2)
+
+	ctx := context.Background()
+
+	log.Debug("deploy to simulated backend")
+	testDeploy(ctx, creditorSwap.backend, creditorSwap)
+	testDeploy(ctx, debitorSwap.backend, debitorSwap)
+	creditorSwap.backend.(*backends.SimulatedBackend).Commit()
+	debitorSwap.backend.(*backends.SimulatedBackend).Commit()
+
+	log.Debug("create peer instances")
+	// create Peer instances
+	// NOTE: remember that these are peer instances representing each **a model of the remote peer** for every local node
+	// so creditor is the model of the remote mode for the debitor! (and vice versa)
+
+	// in order to be able to model as realistically as possible sending and receiving, let's use a MsgPipe
+	// a MsgPipe is a duplex read-write object, write to one end and read from the other
+
+	// create the message pipe
+	crw, drw := p2p.MsgPipe()
+	// create the creditor peer
+	cPtpPeer := p2p.NewPeer(enode.ID{}, "creditor", []p2p.Cap{})
+	cProtoPeer := protocols.NewPeer(cPtpPeer, crw, Spec)
+	// create the debitor peer
+	dPtpPeer := p2p.NewPeer(enode.ID{}, "dreditor", []p2p.Cap{})
+	dProtoPeer := protocols.NewPeer(dPtpPeer, drw, Spec)
+	// create the Swap protocol peers
+	creditor := NewPeer(cProtoPeer, debitorSwap, debitorSwap.backend, creditorSwap.owner.address, debitorSwap.owner.Contract)
+	debitor := NewPeer(dProtoPeer, creditorSwap, creditorSwap.backend, debitorSwap.owner.address, debitorSwap.owner.Contract)
+
+	// a safe check: at this point no cheques should be in the swap
+	if len(creditorSwap.cheques) != 0 {
+		t.Fatalf("Expected no cheques at creditor, but there are %d:", len(creditorSwap.cheques))
+	}
+
+	log.Debug("create a cheque")
+	var err error
+	cheque := &Cheque{
+		ChequeParams: ChequeParams{
+			Contract:    debitorSwap.owner.Contract,
+			Beneficiary: creditorSwap.owner.address,
+			Amount:      42,
+			Timeout:     0,
+		},
+	}
+	cheque.Sig, err = debitorSwap.signContent(cheque)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	emitMsg := &EmitChequeMsg{
+		Cheque: cheque,
+	}
+	log.Debug("send the message with the cheque to the beneficiary")
+	go creditor.Send(ctx, emitMsg)
+
+	log.Debug("read the message on the beneficiary through the pipe")
+	msg, err := drw.ReadMsg()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	log.Debug("convert the message to our message type (simulated p2p.protocols)")
+	var wmsg protocols.WrappedMsg
+	err = msg.Decode(&wmsg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg.Discard()
+
+	val, ok := Spec.NewMsg(msg.Code)
+	if !ok {
+		t.Fatalf("invalid message code: %v", msg.Code)
+	}
+	if err := rlp.DecodeBytes(wmsg.Payload, val); err != nil {
+		t.Fatalf("decode error <= %v: %v", msg, err)
+	}
+
+	log.Debug("trigger reading the message on the beneficiary")
+	// handleMsg is blocking as it sends a synchronous confirmation message back.
+	// Therefore, we need a go-routine in order to check for the test,
+	// and we need to synchronize the go-routines
+
+	errc := make(chan error)
+	// start the go-routine for handling the message
+	go func(t *testing.T) {
+		// this blocks
+		err = debitor.handleMsg(ctx, val)
+		if err != nil {
+			errc <- err
+		}
+		/*
+			TODO: When saving the cheque on creditor side is implemented,
+			we should to re-enable this check
+			if len(creditorSwap.cheques) != 1 {
+				t.Fatalf("Expected exactly one cheque at creditor, but there are %d:", len(creditorSwap.cheques))
+			}
+		*/
+		errc <- nil
+	}(t)
+
+	// handleMsg will block until we read a message
+	log.Debug("read the message on the issuer")
+	msg, err = crw.ReadMsg()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = msg.Decode(&wmsg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	val, ok = Spec.NewMsg(msg.Code)
+	if !ok {
+		t.Fatalf("invalid message code: %v", msg.Code)
+	}
+	if err := rlp.DecodeBytes(wmsg.Payload, val); err != nil {
+		t.Fatalf("decode error <= %v: %v", msg, err)
+	}
+
+	// check that it is indeed a `ConfirmMsg`
+	var conf *ConfirmMsg
+	if conf, ok = val.(*ConfirmMsg); !ok {
+		t.Fatal("Expected ConfirmMsg but it was not")
+	}
+	if bytes.Compare(conf.Cheque.Sig, cheque.Sig) != 0 {
+		t.Fatal("Expected confirmation cheque to be the same, but it is no")
+	}
+
+	// wait until the go routine terminates
+	if err := <-errc; err != nil {
+		t.Fatal(err)
+	}
 }

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -39,15 +39,6 @@ import (
 	"github.com/ethersphere/swarm/state"
 )
 
-const (
-	deployRetries      = 5
-	deployDelay        = 1 * time.Second // delay between retries
-	defaultCashInDelay = uint64(0)       // Default timeout until cashing in cheques is possible - TODO: deliberate value, experiment // should be non-zero once we implement waivers
-	// DefaultInitialDepositAmount is the default amount to send to the contract when initially deploying
-	DefaultInitialDepositAmount       = 0              // TODO: deliberate value for now; needs experimentation
-	defaultHarddepositTimeoutDuration = 24 * time.Hour // this is the amount of time in seconds which an issuer has to wait to decrease the harddeposit of a beneficiary. The smart-contract allows for setting this variable differently per beneficiary
-)
-
 // ErrInvalidChequeSignature indicates the signature on the cheque was invalid
 var ErrInvalidChequeSignature = errors.New("invalid cheque signature")
 

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -144,7 +144,7 @@ func (s *Swap) Add(amount int64, peer *protocols.Peer) (err error) {
 		return
 	}
 
-	// check if balance with peer is over the payment threshold
+	// check if balance with peer crosses the threshold
 	// it is the peer with a negative balance who sends a cheque, thus we check
 	// that the balance is *below* the threshold
 	if newBalance <= -s.paymentThreshold {

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The go-ethereum Authors
+// Copyright 2019 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //
 // The go-ethereum library is free software: you can redistribute it and/or modify
@@ -40,17 +40,18 @@ import (
 )
 
 const (
-	deployRetries                     = 5
-	deployDelay                       = 1 * time.Second // delay between retries
-	defaultCashInDelay                = uint64(0)       // Default timeout until cashing in cheques is possible - TODO: deliberate value, experiment // should be non-zero once we implement waivers
-	DefaultInitialDepositAmount       = 0               // TODO: deliberate value for now; needs experimentation
-	defaultHarddepositTimeoutDuration = 24 * time.Hour  // this is the amount of time in seconds which an issuer has to wait to decrease the harddeposit of a beneficiary. The smart-contract allows for setting this variable differently per beneficiary
+	deployRetries      = 5
+	deployDelay        = 1 * time.Second // delay between retries
+	defaultCashInDelay = uint64(0)       // Default timeout until cashing in cheques is possible - TODO: deliberate value, experiment // should be non-zero once we implement waivers
+	// DefaultInitialDepositAmount is the default amount to send to the contract when initially deploying
+	DefaultInitialDepositAmount       = 0              // TODO: deliberate value for now; needs experimentation
+	defaultHarddepositTimeoutDuration = 24 * time.Hour // this is the amount of time in seconds which an issuer has to wait to decrease the harddeposit of a beneficiary. The smart-contract allows for setting this variable differently per beneficiary
 )
 
 // ErrInvalidChequeSignature indicates the signature on the cheque was invalid
 var ErrInvalidChequeSignature = errors.New("invalid cheque signature")
 
-// SwAP Swarm Accounting Protocol
+// Swap represents the SwAP Swarm Accounting Protocol
 // a peer to peer micropayment system
 // A node maintains an individual balance with every peer
 // Only messages which have a price will be accounted for
@@ -60,13 +61,14 @@ type Swap struct {
 	lock                sync.RWMutex         // lock the balances
 	balances            map[enode.ID]int64   // map of balances for each peer
 	cheques             map[enode.ID]*Cheque // map of balances for each peer
-	peers               map[enode.ID]*Peer
-	backend             cswap.Backend
-	owner               *Owner  // contract access
-	params              *Params // economic and operational parameters
-	contractReference   *swap.Swap
-	paymentThreshold    int64 // balance difference required for requesting cheque
-	disconnectThreshold int64 // balance difference required for dropping peer
+	peers               map[enode.ID]*Peer   // map of all swap Peers
+	backend             cswap.Backend        // the backend (blockchain) used
+	owner               *Owner               // contract access
+	params              *Params              // economic and operational parameters
+	contractReference   *swap.Swap           // reference to the smart contract
+	oracle              PriceOracle          // the oracle providing the ether price for honey
+	paymentThreshold    int64                // balance difference required for requesting cheque
+	disconnectThreshold int64                // balance difference required for dropping peer
 }
 
 // Owner encapsulates information related to accessing the contract
@@ -101,6 +103,7 @@ func New(stateStore state.Store, prvkey *ecdsa.PrivateKey, contract common.Addre
 		paymentThreshold:    DefaultPaymentThreshold,
 		disconnectThreshold: DefaultDisconnectThreshold,
 		contractReference:   nil,
+		oracle:              NewPriceOracle(),
 	}
 	sw.owner = sw.createOwner(prvkey, contract)
 	return sw
@@ -124,7 +127,7 @@ func (s *Swap) DeploySuccess() string {
 
 // Add is the (sole) accounting function
 // Swap implements the protocols.Balance interface
-func (s *Swap) Add(amount int64, peer *protocols.Peer) (err error) {
+func (s *Swap) Add(honey int64, peer *protocols.Peer) (err error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
@@ -143,22 +146,23 @@ func (s *Swap) Add(amount int64, peer *protocols.Peer) (err error) {
 		return errors.New(disconnectMessage)
 	}
 
-	//adjust the balance
-	//if amount is negative, it will decrease, otherwise increase
-	s.balances[peer.ID()] += amount
-
-	//save the new balance to the state store
-	peerBalance := s.balances[peer.ID()]
-	err = s.stateStore.Put(peer.ID().String(), &peerBalance)
+	// convert honey to ETH
+	var amount int64
+	amount, err = s.oracle.GetPrice(honey)
 	if err != nil {
-		log.Error(fmt.Sprintf("error while storing balance for peer %s", peer.ID().String()))
-		return err
+		log.Error("error getting price from oracle", "err", err)
+		return
 	}
 
-	log.Debug(fmt.Sprintf("balance for peer %s after accounting: %s", peer.ID().String(), strconv.FormatInt(peerBalance, 10)))
+	// calculate new balance
+	var newBalance int64
+	newBalance, err = s.updateBalance(peer.ID(), amount)
+	if err != nil {
+		return
+	}
 
 	//check if balance with peer is over the payment threshold
-	if peerBalance <= -s.paymentThreshold {
+	if newBalance <= -s.paymentThreshold {
 		//if so, send cheque
 		log.Warn(fmt.Sprintf("balance for peer %s went over the payment threshold %v, sending cheque", peer.ID().String(), s.paymentThreshold))
 		err = s.sendCheque(peer.ID())
@@ -170,6 +174,20 @@ func (s *Swap) Add(amount int64, peer *protocols.Peer) (err error) {
 	}
 
 	return
+}
+
+func (s *Swap) updateBalance(peer enode.ID, amount int64) (int64, error) {
+	//adjust the balance
+	//if amount is negative, it will decrease, otherwise increase
+	s.balances[peer] += amount
+	//save the new balance to the state store
+	peerBalance := s.balances[peer]
+	err := s.stateStore.Put(peer.String(), &peerBalance)
+	if err != nil {
+		log.Error("error while storing balance for peer", "peer", peer.String())
+	}
+	log.Debug("balance for peer after accounting", "peer", peer.String(), "balance", strconv.FormatInt(peerBalance, 10))
+	return peerBalance, err
 }
 
 // logBalance is a helper function to log the current balance of a peer
@@ -205,12 +223,9 @@ func (s *Swap) sendCheque(peer enode.ID) error {
 		Cheque: cheque,
 	}
 
-	// TODO: reset balance here?
-	// if we don't, then multiple cheques may be sent
-	// If we do, then if something goes wrong and the remote does not reset the balance,
-	// we have issues as well.
-	// For now, reset the balance
-	s.resetBalance(peer)
+	// reset balance;
+	// TODO: if sending fails it should actually be roll backed...
+	s.resetBalance(peer, int64(cheque.Amount))
 
 	err = swapPeer.Send(context.TODO(), emit)
 	return err
@@ -255,22 +270,22 @@ func (s *Swap) createCheque(peer enode.ID) (*Cheque, error) {
 	return cheque, err
 }
 
-//GetPeerBalance returns the balance for a given peer
-func (swap *Swap) GetPeerBalance(peer enode.ID) (int64, error) {
-	swap.lock.RLock()
-	defer swap.lock.RUnlock()
-	if p, ok := swap.balances[peer]; ok {
+// GetPeerBalance returns the balance for a given peer
+func (s *Swap) GetPeerBalance(peer enode.ID) (int64, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	if p, ok := s.balances[peer]; ok {
 		return p, nil
 	}
 	return 0, errors.New("Peer not found")
 }
 
 // GetLastCheque returns the last cheque for a given peer
-func (swap *Swap) GetLastCheque(peer enode.ID) (*Cheque, error) {
-	swap.lock.RLock()
-	defer swap.lock.RUnlock()
+func (s *Swap) GetLastCheque(peer enode.ID) (*Cheque, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
 
-	if lc, ok := swap.cheques[peer]; ok {
+	if lc, ok := s.cheques[peer]; ok {
 		return lc, nil
 	}
 
@@ -278,10 +293,10 @@ func (swap *Swap) GetLastCheque(peer enode.ID) (*Cheque, error) {
 }
 
 //GetAllBalances returns the balances for all known peers
-func (swap *Swap) GetAllBalances() map[enode.ID]int64 {
-	swap.lock.RLock()
-	defer swap.lock.RUnlock()
-	return swap.balances
+func (s *Swap) GetAllBalances() map[enode.ID]int64 {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return s.balances
 }
 
 // loadStates loads balances from the state store (persisted)
@@ -309,19 +324,17 @@ func (s *Swap) loadCheque(peer enode.ID) (err error) {
 	return
 }
 
-//Clean up Swap
-func (swap *Swap) Close() {
-	swap.stateStore.Close()
+// Close cleans up swap
+func (s *Swap) Close() {
+	s.stateStore.Close()
 }
 
 // resetBalance is called:
 // * for the creditor: on cheque receival
 // * for the debitor: on confirmation receival
-func (s *Swap) resetBalance(peerID enode.ID) {
-	//TODO: reset balance based on actual amount
-	//TODO: review the locks
-	log.Info(fmt.Sprintf("resetting balance for peer %s", peerID.String()))
-	s.balances[peerID] = 0
+func (s *Swap) resetBalance(peerID enode.ID, amount int64) {
+	log.Info("resetting balance for peer", "peer", peerID.String(), "amount", amount)
+	s.updateBalance(peerID, amount)
 }
 
 // encodeCheque encodes the cheque in the format used in the signing procedure

--- a/swap/types.go
+++ b/swap/types.go
@@ -52,8 +52,3 @@ type EmitChequeMsg struct {
 
 // ErrorMsg is sent in case of an error TODO: specify error conditions and when this needs to be sent
 type ErrorMsg struct{}
-
-// ConfirmMsg is sent from the creditor to the debitor to confirm cheque reception
-type ConfirmMsg struct {
-	Cheque *Cheque // TODO: probably not needed and if so likely should not include the full cheque
-}

--- a/swap/types.go
+++ b/swap/types.go
@@ -23,22 +23,25 @@ import (
 // TODO: add handshake protocol where we exchange last cheque (this is useful if one node disconnects)
 // FIXME: Check the contract bytecode of the counterparty
 
+// ChequeParams encapsulate all cheque parameters
 type ChequeParams struct {
 	Contract    common.Address // address of chequebook, needed to avoid cross-contract submission
-	Beneficiary common.Address
-	Serial      uint64 // cumulative amount of all funds sent
-	Amount      uint64 // cumulative amount of all funds sent
-	Timeout     uint64
+	Beneficiary common.Address // address of the beneficiary, the contract which will redeem the cheque
+	Serial      uint64         // monotonically increasing serial number
+	Amount      uint64         // cumulative amount of the cheque in currency
+	Honey       uint64         // amount of honey which resulted in the cumulative currency difference
+	Timeout     uint64         // timeout for cashing in
 }
 
+// Cheque encapsulates the parameters and the signature
 // TODO: There should be a request cheque struct that only gives the Serial
-// Cheque encapsulates the cheque information
 type Cheque struct {
 	ChequeParams
 	Sig []byte // signature Sign(Keccak256(contract, beneficiary, amount), prvKey)
 }
 
-type SwapHandshakeMsg struct {
+// HandshakeMsg is exchanged on peer handshake
+type HandshakeMsg struct {
 	ContractAddress common.Address
 }
 
@@ -52,5 +55,5 @@ type ErrorMsg struct{}
 
 // ConfirmMsg is sent from the creditor to the debitor to confirm cheque reception
 type ConfirmMsg struct {
-	Cheque Cheque // TODO: probably not needed and if so likely should not include the full cheque
+	Cheque *Cheque // TODO: probably not needed and if so likely should not include the full cheque
 }

--- a/testutil/dummy.go
+++ b/testutil/dummy.go
@@ -1,0 +1,33 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package testutil
+
+import "github.com/ethereum/go-ethereum/p2p"
+
+// DummyMsgRW implements MessageReader and MessageWriter
+// but doesn't do anything. Useful for dummy message sends
+type DummyMsgRW struct{}
+
+// ReadMsg is from the MessageReader interface
+func (d *DummyMsgRW) ReadMsg() (p2p.Msg, error) {
+	return p2p.Msg{}, nil
+}
+
+// WriteMsg is from the MessageWriter interface
+func (d *DummyMsgRW) WriteMsg(msg p2p.Msg) error {
+	return nil
+}


### PR DESCRIPTION
This PR adds a consistent pricing design to swap.

The idea is that internally, swap uses an own unit of account (`honey`), which is then converted to a currency (e.g. wei, could be any other) when the cheque is being created.

The concept of a price oracle is introduced. In order to minimize handshakes, negotiations etc. we postulate that there would be an oracle which nodes query to get the conversion from `honey` to `wei`.

For the time being this will be a hardcoded conversion of 1:1.
