### PR TITLE
swarm, state, swap/swap: query peer balances

### DIFF
--- a/state/dbstore.go
+++ b/state/dbstore.go
@@ -106,7 +106,7 @@ func (s *DBStore) Delete(key string) (err error) {
 	return s.db.Delete([]byte(key), nil)
 }
 
-// Keys returns a string slice containing all the store keys
+// Keys returns a list of all the keys in the underlying LevelDB.
 func (s *DBStore) Keys() (keys []string, err error) {
 	iter := s.db.NewIterator(nil, nil)
 	for iter.Next() {

--- a/state/dbstore.go
+++ b/state/dbstore.go
@@ -109,13 +109,15 @@ func (s *DBStore) Delete(key string) (err error) {
 // Keys returns a list of all the keys in the underlying LevelDB.
 func (s *DBStore) Keys() (keys []string, err error) {
 	iter := s.db.NewIterator(nil, nil)
+	defer iter.Release()
 	for iter.Next() {
 		keys = append(keys, string(iter.Key()))
 	}
-	iter.Release()
 	err = iter.Error()
-
-	return keys, err
+	if err != nil {
+		return []string{}, err
+	}
+	return keys, nil
 }
 
 // Close releases the resources used by the underlying LevelDB.

--- a/state/dbstore.go
+++ b/state/dbstore.go
@@ -34,6 +34,7 @@ type Store interface {
 	Get(key string, i interface{}) (err error)
 	Put(key string, i interface{}) (err error)
 	Delete(key string) (err error)
+	Keys() (keys []string, err error)
 	Close() error
 }
 
@@ -103,6 +104,18 @@ func (s *DBStore) Put(key string, i interface{}) (err error) {
 // Delete removes entries stored under a specific key.
 func (s *DBStore) Delete(key string) (err error) {
 	return s.db.Delete([]byte(key), nil)
+}
+
+// Keys returns a string slice containing all the store keys
+func (s *DBStore) Keys() (keys []string, err error) {
+	iter := s.db.NewIterator(nil, nil)
+	for iter.Next() {
+		keys = append(keys, string(iter.Key()))
+	}
+	iter.Release()
+	err = iter.Error()
+
+	return keys, err
 }
 
 // Close releases the resources used by the underlying LevelDB.

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -255,7 +255,7 @@ func (s *Swap) createCheque(peer enode.ID) (*Cheque, error) {
 	return cheque, err
 }
 
-//GetPeerBalance returns the balance for a given peer
+// GetPeerBalance returns the balance for a given peer
 func (s *Swap) GetPeerBalance(peer enode.ID) (int64, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
@@ -271,35 +271,33 @@ func (s *Swap) GetPeerBalance(peer enode.ID) (int64, error) {
 	return peerBalance, err
 }
 
-//GetAllBalances returns the balances for all known peers
+// GetAllBalances returns the balances for all known SWAP peers
 func (s *Swap) GetAllBalances() (map[enode.ID]int64, error) {
 	balances := make(map[enode.ID]int64)
 
-	// load balances from disk
-	peerIDs, err := s.stateStore.Keys()
+	// get list of all known SWAP peers
+	swapPeers, err := s.SwapPeers()
 	if err != nil {
 		return nil, err
 	}
 
-	for _, peerIDString := range peerIDs {
-		peerID := enode.HexID(peerIDString)
-		peerBalance, err := s.GetPeerBalance(peerID)
+	// get balance for list of peers
+	for _, peer := range swapPeers {
+		peerBalance, err := s.GetPeerBalance(peer)
 		if err != nil {
 			return nil, err
 		}
-		balances[peerID] = peerBalance
-	}
-
-	// add balances from memory
-	for peerID, peerBalance := range s.balances {
-		balances[peerID] = peerBalance
+		balances[peer] = peerBalance
 	}
 
 	return balances, nil
 }
 
-// Returns a list of every known peer to have interacted through SWAP
+// SwapPeers returns a list of every peer known through SWAP
 func (s *Swap) SwapPeers() (peers []enode.ID, err error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
 	knownPeers := make(map[enode.ID]bool)
 
 	// get peer IDs from store

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -276,10 +276,10 @@ func (s *Swap) GetAllBalances() map[enode.ID]int64 {
 	balances := make(map[enode.ID]int64)
 
 	// load balances from disk
-	keys, err := s.stateStore.Keys()
+	peerIDs, err := s.stateStore.Keys()
 	if err == nil {
-		for _, key := range keys {
-			peerID := enode.HexID(key)
+		for _, peerIDString := range peerIDs {
+			peerID := enode.HexID(peerIDString)
 			peerBalance, err := s.GetPeerBalance(peerID)
 			if err == nil {
 				balances[peerID] = peerBalance

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -262,7 +262,7 @@ func (s *Swap) GetPeerBalance(peer enode.ID) (int64, error) {
 	var peerBalance int64
 	var err error
 
-	_, keyExists := s.balances[peer]
+	peerBalance, keyExists := s.balances[peer]
 	if !keyExists {
 		err = s.stateStore.Get(peer.String(), &peerBalance)
 	}

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -265,6 +265,13 @@ func (swap *Swap) GetPeerBalance(peer enode.ID) (int64, error) {
 	return 0, errors.New("Peer not found")
 }
 
+//GetAllBalances returns the balances for all known peers
+func (s *Swap) GetAllBalances() map[enode.ID]int64 {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return s.balances
+}
+
 // GetLastCheque returns the last cheque for a given peer
 func (swap *Swap) GetLastCheque(peer enode.ID) (*Cheque, error) {
 	swap.lock.RLock()
@@ -275,13 +282,6 @@ func (swap *Swap) GetLastCheque(peer enode.ID) (*Cheque, error) {
 	}
 
 	return nil, errors.New("Peer not found")
-}
-
-//GetAllBalances returns the balances for all known peers
-func (swap *Swap) GetAllBalances() map[enode.ID]int64 {
-	swap.lock.RLock()
-	defer swap.lock.RUnlock()
-	return swap.balances
 }
 
 // loadStates loads balances from the state store (persisted)

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -272,26 +272,30 @@ func (s *Swap) GetPeerBalance(peer enode.ID) (int64, error) {
 }
 
 //GetAllBalances returns the balances for all known peers
-func (s *Swap) GetAllBalances() map[enode.ID]int64 {
+func (s *Swap) GetAllBalances() (map[enode.ID]int64, error) {
 	balances := make(map[enode.ID]int64)
 
 	// load balances from disk
 	peerIDs, err := s.stateStore.Keys()
-	if err == nil {
-		for _, peerIDString := range peerIDs {
-			peerID := enode.HexID(peerIDString)
-			peerBalance, err := s.GetPeerBalance(peerID)
-			if err == nil {
-				balances[peerID] = peerBalance
-			}
+	if err != nil {
+		return nil, err
+	}
+
+	for _, peerIDString := range peerIDs {
+		peerID := enode.HexID(peerIDString)
+		peerBalance, err := s.GetPeerBalance(peerID)
+		if err != nil {
+			return nil, err
 		}
+		balances[peerID] = peerBalance
 	}
 
 	// add balances from memory
 	for peerID, peerBalance := range s.balances {
 		balances[peerID] = peerBalance
 	}
-	return balances
+
+	return balances, nil
 }
 
 // GetLastCheque returns the last cheque for a given peer

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -271,9 +271,18 @@ func (s *Swap) GetPeerBalance(peer enode.ID) (int64, error) {
 
 //GetAllBalances returns the balances for all known peers
 func (s *Swap) GetAllBalances() map[enode.ID]int64 {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-	return s.balances
+	balances := make(map[enode.ID]int64)
+	keys, err := s.stateStore.Keys()
+	if err == nil {
+		for _, key := range keys {
+			peerID := enode.HexID(key)
+			peerBalance, err := s.GetPeerBalance(peerID)
+			if err == nil {
+				balances[peerID] = peerBalance
+			}
+		}
+	}
+	return balances
 }
 
 // GetLastCheque returns the last cheque for a given peer

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -256,13 +256,17 @@ func (s *Swap) createCheque(peer enode.ID) (*Cheque, error) {
 }
 
 //GetPeerBalance returns the balance for a given peer
-func (swap *Swap) GetPeerBalance(peer enode.ID) (int64, error) {
-	swap.lock.RLock()
-	defer swap.lock.RUnlock()
-	if p, ok := swap.balances[peer]; ok {
-		return p, nil
+func (s *Swap) GetPeerBalance(peer enode.ID) (int64, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	var peerBalance int64
+	var err error
+
+	_, keyExists := s.balances[peer]
+	if !keyExists {
+		err = s.stateStore.Get(peer.String(), &peerBalance)
 	}
-	return 0, errors.New("Peer not found")
+	return peerBalance, err
 }
 
 //GetAllBalances returns the balances for all known peers

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -262,8 +262,10 @@ func (s *Swap) GetPeerBalance(peer enode.ID) (int64, error) {
 	var peerBalance int64
 	var err error
 
+	// load balance from memory
 	peerBalance, keyExists := s.balances[peer]
 	if !keyExists {
+		// if not in memory, try to load balance from disk
 		err = s.stateStore.Get(peer.String(), &peerBalance)
 	}
 	return peerBalance, err
@@ -272,6 +274,8 @@ func (s *Swap) GetPeerBalance(peer enode.ID) (int64, error) {
 //GetAllBalances returns the balances for all known peers
 func (s *Swap) GetAllBalances() map[enode.ID]int64 {
 	balances := make(map[enode.ID]int64)
+
+	// load balances from disk
 	keys, err := s.stateStore.Keys()
 	if err == nil {
 		for _, key := range keys {
@@ -281,6 +285,11 @@ func (s *Swap) GetAllBalances() map[enode.ID]int64 {
 				balances[peerID] = peerBalance
 			}
 		}
+	}
+
+	// add balances from memory
+	for peerID, peerBalance := range s.balances {
+		balances[peerID] = peerBalance
 	}
 	return balances
 }

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -255,8 +255,8 @@ func (s *Swap) createCheque(peer enode.ID) (*Cheque, error) {
 	return cheque, err
 }
 
-// GetPeerBalance returns the balance for a given peer
-func (s *Swap) GetPeerBalance(peer enode.ID) (int64, error) {
+// PeerBalance returns the balance for a given peer
+func (s *Swap) PeerBalance(peer enode.ID) (int64, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	var peerBalance int64
@@ -283,7 +283,7 @@ func (s *Swap) GetAllBalances() (map[enode.ID]int64, error) {
 
 	// get balance for list of peers
 	for _, peer := range swapPeers {
-		peerBalance, err := s.GetPeerBalance(peer)
+		peerBalance, err := s.PeerBalance(peer)
 		if err != nil {
 			return nil, err
 		}

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -271,12 +271,12 @@ func (s *Swap) PeerBalance(peer enode.ID) (int64, error) {
 	return peerBalance, err
 }
 
-// GetAllBalances returns the balances for all known SWAP peers
-func (s *Swap) GetAllBalances() (map[enode.ID]int64, error) {
+// Balances returns the balances for all known SWAP peers
+func (s *Swap) Balances() (map[enode.ID]int64, error) {
 	balances := make(map[enode.ID]int64)
 
 	// get list of all known SWAP peers
-	swapPeers, err := s.SwapPeers()
+	swapPeers, err := s.Peers()
 	if err != nil {
 		return nil, err
 	}
@@ -293,8 +293,8 @@ func (s *Swap) GetAllBalances() (map[enode.ID]int64, error) {
 	return balances, nil
 }
 
-// SwapPeers returns a list of every peer known through SWAP
-func (s *Swap) SwapPeers() (peers []enode.ID, err error) {
+// Peers returns a list of every peer known through SWAP
+func (s *Swap) Peers() (peers []enode.ID, err error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -125,7 +125,7 @@ func TestGetAllBalances(t *testing.T) {
 }
 
 func testBalances(t *testing.T, swap *Swap, expectedBalances map[enode.ID]int64) {
-	balances := swap.GetAllBalances()
+	balances, _ := swap.GetAllBalances()
 	if !reflect.DeepEqual(balances, expectedBalances) {
 		t.Fatalf("Expected node's balances to be %d, but are %d", expectedBalances, balances)
 	}

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -95,7 +95,7 @@ func TestGetPeerBalance(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected call to fail, but it didn't!")
 	}
-	if err.Error() != "ErrorNotFound" {
+	if err != state.ErrNotFound {
 		t.Fatalf("Expected test to fail with %s, but is %s", "ErrorNotFound", err.Error())
 	}
 }

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -95,8 +95,8 @@ func TestGetPeerBalance(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected call to fail, but it didn't!")
 	}
-	if err.Error() != "Peer not found" {
-		t.Fatalf("Expected test to fail with %s, but is %s", "Peer not found", err.Error())
+	if err.Error() != "ErrorNotFound" {
+		t.Fatalf("Expected test to fail with %s, but is %s", "ErrorNotFound", err.Error())
 	}
 }
 

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -125,7 +125,10 @@ func TestGetAllBalances(t *testing.T) {
 }
 
 func testBalances(t *testing.T, swap *Swap, expectedBalances map[enode.ID]int64) {
-	balances, _ := swap.GetAllBalances()
+	balances, err := swap.GetAllBalances()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !reflect.DeepEqual(balances, expectedBalances) {
 		t.Fatalf("Expected node's balances to be %d, but are %d", expectedBalances, balances)
 	}

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -73,7 +73,7 @@ func init() {
 }
 
 // Test getting a peer's balance
-func TestGetPeerBalance(t *testing.T) {
+func TestPeerBalance(t *testing.T) {
 	// create a test swap account
 	swap, testDir := newTestSwap(t)
 	defer os.RemoveAll(testDir)
@@ -81,7 +81,7 @@ func TestGetPeerBalance(t *testing.T) {
 	// test for correct value
 	testPeer := newDummyPeer()
 	swap.balances[testPeer.ID()] = 888
-	b, err := swap.GetPeerBalance(testPeer.ID())
+	b, err := swap.PeerBalance(testPeer.ID())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +91,7 @@ func TestGetPeerBalance(t *testing.T) {
 
 	// test for inexistent node
 	id := adapters.RandomNodeConfig().ID
-	_, err = swap.GetPeerBalance(id)
+	_, err = swap.PeerBalance(id)
 	if err == nil {
 		t.Fatal("Expected call to fail, but it didn't!")
 	}

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -125,7 +125,7 @@ func TestGetAllBalances(t *testing.T) {
 }
 
 func testBalances(t *testing.T, swap *Swap, expectedBalances map[enode.ID]int64) {
-	balances, err := swap.GetAllBalances()
+	balances, err := swap.Balances()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swarm.go
+++ b/swarm.go
@@ -595,5 +595,6 @@ func (s *SwapInfo) Balance(peer enode.ID) int64 {
 }
 
 func (s *SwapInfo) Balances() map[enode.ID]int64 {
-	return s.Swap.GetAllBalances()
+	peerBalances, _ := s.Swap.GetAllBalances()
+	return peerBalances
 }

--- a/swarm.go
+++ b/swarm.go
@@ -506,6 +506,13 @@ func (s *Swarm) Protocols() (protos []p2p.Protocol) {
 // APIs returns the RPC API descriptors the Swarm implementation offers
 func (s *Swarm) APIs() []rpc.API {
 	apis := []rpc.API{
+		// public APIs
+		{
+			Namespace: "bzz",
+			Version:   "3.0",
+			Service:   &Info{s.config},
+			Public:    true,
+		},
 		// admin APIs
 		{
 			Namespace: "bzz",
@@ -535,12 +542,12 @@ func (s *Swarm) APIs() []rpc.API {
 		apis = append(apis, s.ps.APIs()...)
 	}
 
-	var swapService *Info
+	var swapService *SwapInfo
 	if s.config.SwapEnabled {
 		// Swap public API
-		swapService = &Info{s.config, s.swap.GetParams(), s.swap}
+		swapService = &SwapInfo{s.swap.GetParams(), s.swap}
 	} else {
-		swapService = &Info{s.config, nil, nil}
+		swapService = &SwapInfo{nil, nil}
 	}
 
 	swapPublicApi := rpc.API{
@@ -571,19 +578,22 @@ func (s *Swarm) RegisterPssProtocol(topic *pss.Topic, spec *protocols.Spec, targ
 // serialisable info about swarm
 type Info struct {
 	*api.Config
-	*cswap.Params
-	*swap.Swap
 }
 
 func (i *Info) Info() *Info {
 	return i
 }
 
-func (i *Info) Balance(peer enode.ID) int64 {
-	peerBalance, _ := i.Swap.GetPeerBalance(peer)
+type SwapInfo struct {
+	*cswap.Params
+	*swap.Swap
+}
+
+func (s *SwapInfo) Balance(peer enode.ID) int64 {
+	peerBalance, _ := s.Swap.GetPeerBalance(peer)
 	return peerBalance
 }
 
-func (i *Info) Balances() map[enode.ID]int64 {
-	return i.Swap.GetAllBalances()
+func (s *SwapInfo) Balances() map[enode.ID]int64 {
+	return s.Swap.GetAllBalances()
 }

--- a/swarm.go
+++ b/swarm.go
@@ -591,7 +591,7 @@ type SwapInfo struct {
 
 // Balance returns the current SWAP balance for a given peer
 func (s *SwapInfo) Balance(peer enode.ID) (int64, error) {
-	peerBalance, err := s.Swap.GetPeerBalance(peer)
+	peerBalance, err := s.Swap.PeerBalance(peer)
 	return peerBalance, err
 }
 

--- a/swarm.go
+++ b/swarm.go
@@ -579,6 +579,11 @@ func (i *Info) Info() *Info {
 	return i
 }
 
+func (i *Info) Balance(peer enode.ID) int64 {
+	peerBalance, _ := i.Swap.GetPeerBalance(peer)
+	return peerBalance
+}
+
 func (i *Info) Balances() map[enode.ID]int64 {
 	return i.Swap.GetAllBalances()
 }

--- a/swarm.go
+++ b/swarm.go
@@ -597,6 +597,6 @@ func (s *SwapInfo) Balance(peer enode.ID) (int64, error) {
 
 // Balances returns the current SWAP balances for all known peers
 func (s *SwapInfo) Balances() (map[enode.ID]int64, error) {
-	peerBalances, err := s.Swap.GetAllBalances()
+	peerBalances, err := s.Swap.Balances()
 	return peerBalances, err
 }

--- a/swarm.go
+++ b/swarm.go
@@ -544,8 +544,8 @@ func (s *Swarm) APIs() []rpc.API {
 	}
 
 	swapPublicApi := rpc.API{
-		Namespace: "bzz",
-		Version:   "3.0",
+		Namespace: "swap",
+		Version:   "1.0",
 		Service:   swapService,
 		Public:    true,
 	}

--- a/swarm.go
+++ b/swarm.go
@@ -589,12 +589,14 @@ type SwapInfo struct {
 	*swap.Swap
 }
 
-func (s *SwapInfo) Balance(peer enode.ID) int64 {
-	peerBalance, _ := s.Swap.GetPeerBalance(peer)
-	return peerBalance
+// Balance returns the current SWAP balance for a given peer
+func (s *SwapInfo) Balance(peer enode.ID) (int64, error) {
+	peerBalance, err := s.Swap.GetPeerBalance(peer)
+	return peerBalance, err
 }
 
-func (s *SwapInfo) Balances() map[enode.ID]int64 {
-	peerBalances, _ := s.Swap.GetAllBalances()
-	return peerBalances
+// Balances returns the current SWAP balances for all known peers
+func (s *SwapInfo) Balances() (map[enode.ID]int64, error) {
+	peerBalances, err := s.Swap.GetAllBalances()
+	return peerBalances, err
 }


### PR DESCRIPTION
This PR improves the _query balances_ functionality so that:

- Balances with specific nodes can be queried with the `swap_balance` RPC call, provided the `enode.ID` is included in the call as its only parameter.
- Balance queries now check disk data as well. This means that data for nodes that haven't been seen in a while will still be displayed.
  - For this, the `Store` interface was extended with a `Keys` method, which retrieves all keys from the underlying `leveldb` structure. You can then fetch each individual value from disk and merge it with the results in memory.
- Both queries (_single balance_ and _all balances_) have been moved from the `bzz` namespace to the `swap` API namespace. It should probably be `accounting` instead, but to know this for sure we should resolve issue #1591 first.

Related issues: #1447, #1591.