### PR TITLE
swarm, swap: SWAP network whitelist

### DIFF
--- a/swap/defaults.go
+++ b/swap/defaults.go
@@ -37,4 +37,7 @@ const (
 	// This is the amount of time in seconds which an issuer has to wait to decrease the harddeposit of a beneficiary.
 	// The smart-contract allows for setting this variable differently per beneficiary
 	defaultHarddepositTimeoutDuration = 24 * time.Hour
+
+	// While Swap is unstable, it's only allowed to be run under a specific network ID
+	AllowedNetworkID = 5
 )

--- a/swarm.go
+++ b/swarm.go
@@ -111,6 +111,10 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 
 	// Swap initialization
 	if config.SwapEnabled {
+		// for now, Swap can only be enabled in a whitelisted network
+		if self.config.NetworkID != swap.AllowedNetworkID {
+			return nil, fmt.Errorf("Swap can only be enabled under Network ID %d, found Network ID %d instead.", swap.AllowedNetworkID, self.config.NetworkID)
+		}
 		// if Swap is enabled, we MUST have a contract API
 		if self.config.SwapAPI == "" {
 			return nil, fmt.Errorf("Swap enabled but no contract address given; fatal error condition, aborting.")

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -28,6 +28,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethersphere/swarm/network"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -218,6 +220,19 @@ func TestNewSwarmFailure(t *testing.T) {
 				config.SwapAPI = ""
 				config.SwapEnabled = true
 				config.NetworkID = swap.AllowedNetworkID
+			},
+			check: func(t *testing.T, s *Swarm, _ *api.Config) {
+				if s != nil {
+					t.Error("swarm struct is not nil")
+				}
+			},
+		},
+		{
+			name: "with swap enabled and default network ID",
+			configure: func(config *api.Config) {
+				config.SwapAPI = ""
+				config.SwapEnabled = true
+				config.NetworkID = network.DefaultNetworkID
 			},
 			check: func(t *testing.T, s *Swarm, _ *api.Config) {
 				if s != nil {

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -230,7 +230,7 @@ func TestNewSwarmFailure(t *testing.T) {
 		{
 			name: "with swap enabled and default network ID",
 			configure: func(config *api.Config) {
-				config.SwapAPI = ""
+				config.SwapAPI = ipcEndpoint
 				config.SwapEnabled = true
 				config.NetworkID = network.DefaultNetworkID
 			},

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethersphere/swarm/api"
 	"github.com/ethersphere/swarm/sctx"
+	"github.com/ethersphere/swarm/swap"
 )
 
 // TestNewSwarm validates Swarm fields in repsect to the provided configuration.
@@ -111,6 +112,7 @@ func TestNewSwarm(t *testing.T) {
 			configure: func(config *api.Config) {
 				config.SwapAPI = ipcEndpoint
 				config.SwapEnabled = true
+				config.NetworkID = swap.AllowedNetworkID
 			},
 			check: func(t *testing.T, s *Swarm, _ *api.Config) {
 				if s.backend == nil {
@@ -215,6 +217,7 @@ func TestNewSwarmFailure(t *testing.T) {
 			configure: func(config *api.Config) {
 				config.SwapAPI = ""
 				config.SwapEnabled = true
+				config.NetworkID = swap.AllowedNetworkID
 			},
 			check: func(t *testing.T, s *Swarm, _ *api.Config) {
 				if s != nil {


### PR DESCRIPTION
#1550 dictates that Swarm can run with SWAP enabled only under a whitelisted network.

For this purpose, I've set `5` to be the allowed Network ID (`4` is the default).

This parameter can be specified with the `--bzznetworkid` flag when starting up Swarm.