### PR TITLE
swap: move functions for encoding, signing cheques away from Swap object

### DIFF
--- a/swap/cheque.go
+++ b/swap/cheque.go
@@ -1,0 +1,119 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package swap
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// Encode encodes the cheque in the format used in the signing procedure
+func (cheque *Cheque) Encode() []byte {
+	serialBytes := make([]byte, 32)
+	amountBytes := make([]byte, 32)
+	timeoutBytes := make([]byte, 32)
+	// we need to write the last 8 bytes as we write a uint64 into a 32-byte array
+	// encoded in BigEndian because EVM uses BigEndian encoding
+	binary.BigEndian.PutUint64(serialBytes[24:], cheque.Serial)
+	binary.BigEndian.PutUint64(amountBytes[24:], cheque.Amount)
+	binary.BigEndian.PutUint64(timeoutBytes[24:], cheque.Timeout)
+	// construct the actual cheque
+	input := cheque.Contract.Bytes()
+	input = append(input, cheque.Beneficiary.Bytes()...)
+	input = append(input, serialBytes[:]...)
+	input = append(input, amountBytes[:]...)
+	input = append(input, timeoutBytes[:]...)
+
+	return input
+}
+
+// sigHash hashes the cheque using the prefix that would be added by eth_Sign
+func (cheque *Cheque) sigHash() []byte {
+	input := crypto.Keccak256(cheque.Encode())
+	withPrefix := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(input), input)
+	return crypto.Keccak256([]byte(withPrefix))
+}
+
+// VerifySig verifies the signature on the cheque
+func (cheque *Cheque) VerifySig(expectedSigner common.Address) error {
+	sigHash := cheque.sigHash()
+
+	if cheque.Sig == nil {
+		return fmt.Errorf("tried to verify signature on cheque with sig nil")
+	}
+	// copy signature to avoid modifying the original
+	sig := make([]byte, len(cheque.Sig))
+	copy(sig, cheque.Sig)
+	// reduce the v value of the signature by 27 (see signContent)
+	sig[len(sig)-1] -= 27
+	pubKey, err := crypto.SigToPub(sigHash, sig)
+	if err != nil {
+		return err
+	}
+
+	if crypto.PubkeyToAddress(*pubKey) != expectedSigner {
+		return ErrInvalidChequeSignature
+	}
+
+	return nil
+}
+
+// Sign signs the cheque with supplied private key
+func (cheque *Cheque) Sign(prv *ecdsa.PrivateKey) ([]byte, error) {
+	sig, err := crypto.Sign(cheque.sigHash(), prv)
+	if err != nil {
+		return nil, err
+	}
+	// increase the v value by 27 as crypto.Sign produces 0 or 1 but the contract only accepts 27 or 28
+	// this is to prevent malleable signatures. while not strictly necessary in this case the ECDSA implementation from Openzeppelin expects it.
+	sig[len(sig)-1] += 27
+	return sig, nil
+}
+
+// Equal checks if other has the same fields
+func (cheque *Cheque) Equal(other *Cheque) bool {
+	if cheque.Serial != other.Serial {
+		return false
+	}
+
+	if cheque.Beneficiary != other.Beneficiary {
+		return false
+	}
+
+	if cheque.Amount != other.Amount {
+		return false
+	}
+
+	if cheque.Timeout != other.Timeout {
+		return false
+	}
+
+	if cheque.Honey != other.Honey {
+		return false
+	}
+
+	if !bytes.Equal(cheque.Sig, other.Sig) {
+		return false
+	}
+
+	return true
+}

--- a/swap/cheque.go
+++ b/swap/cheque.go
@@ -60,6 +60,10 @@ func (cheque *Cheque) VerifySig(expectedSigner common.Address) error {
 	if cheque.Sig == nil {
 		return fmt.Errorf("tried to verify signature on cheque with sig nil")
 	}
+
+	if len(cheque.Sig) != 65 {
+		return fmt.Errorf("signature has invalid length: %d", len(cheque.Sig))
+	}
 	// copy signature to avoid modifying the original
 	sig := make([]byte, len(cheque.Sig))
 	copy(sig, cheque.Sig)

--- a/swap/peer.go
+++ b/swap/peer.go
@@ -159,7 +159,7 @@ func (sp *Peer) verifyChequeProperties(cheque *Cheque) error {
 	}
 
 	// the beneficiary is the owner of the counterparty swap contract
-	if err := sp.swap.verifyChequeSig(cheque, sp.beneficiary); err != nil {
+	if err := cheque.VerifySig(sp.beneficiary); err != nil {
 		return err
 	}
 

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -19,7 +19,6 @@ package swap
 import (
 	"context"
 	"crypto/ecdsa"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"math/big"
@@ -402,72 +401,9 @@ func (s *Swap) resetBalance(peerID enode.ID, amount int64) {
 	s.updateBalance(peerID, amount)
 }
 
-// encodeCheque encodes the cheque in the format used in the signing procedure
-func (s *Swap) encodeCheque(cheque *Cheque) []byte {
-	serialBytes := make([]byte, 32)
-	amountBytes := make([]byte, 32)
-	timeoutBytes := make([]byte, 32)
-	// we need to write the last 8 bytes as we write a uint64 into a 32-byte array
-	// encoded in BigEndian because EVM uses BigEndian encoding
-	binary.BigEndian.PutUint64(serialBytes[24:], cheque.Serial)
-	binary.BigEndian.PutUint64(amountBytes[24:], cheque.Amount)
-	binary.BigEndian.PutUint64(timeoutBytes[24:], cheque.Timeout)
-	// construct the actual cheque
-	input := cheque.Contract.Bytes()
-	input = append(input, cheque.Beneficiary.Bytes()...)
-	input = append(input, serialBytes[:]...)
-	input = append(input, amountBytes[:]...)
-	input = append(input, timeoutBytes[:]...)
-
-	return input
-}
-
-// sigHashCheque hashes the cheque using the prefix that would be added by eth_Sign
-func (s *Swap) sigHashCheque(cheque *Cheque) []byte {
-	input := crypto.Keccak256(s.encodeCheque(cheque))
-	withPrefix := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(input), input)
-	return crypto.Keccak256([]byte(withPrefix))
-}
-
-// verifyChequeSig verifies the signature on the cheque
-func (s *Swap) verifyChequeSig(cheque *Cheque, expectedSigner common.Address) error {
-	sigHash := s.sigHashCheque(cheque)
-
-	if cheque.Sig == nil {
-		return fmt.Errorf("tried to verify signature on cheque with sig nil")
-	}
-	// copy signature to avoid modifying the original
-	sig := make([]byte, len(cheque.Sig))
-	copy(sig, cheque.Sig)
-	// reduce the v value of the signature by 27 (see signContent)
-	sig[len(sig)-1] -= 27
-	pubKey, err := crypto.SigToPub(sigHash, sig)
-	if err != nil {
-		return err
-	}
-
-	if crypto.PubkeyToAddress(*pubKey) != expectedSigner {
-		return ErrInvalidChequeSignature
-	}
-
-	return nil
-}
-
-// signContent signs the cheque with supplied private key
-func (s *Swap) signContentWithKey(cheque *Cheque, prv *ecdsa.PrivateKey) ([]byte, error) {
-	sig, err := crypto.Sign(s.sigHashCheque(cheque), prv)
-	if err != nil {
-		return nil, err
-	}
-	// increase the v value by 27 as crypto.Sign produces 0 or 1 but the contract only accepts 27 or 28
-	// this is to prevent malleable signatures. while not strictly necessary in this case the ECDSA implementation from Openzeppelin expects it.
-	sig[len(sig)-1] += 27
-	return sig, nil
-}
-
 // signContent signs the cheque with the owners private key
 func (s *Swap) signContent(cheque *Cheque) ([]byte, error) {
-	return s.signContentWithKey(cheque, s.owner.privateKey)
+	return cheque.Sign(s.owner.privateKey)
 }
 
 // GetParams returns contract parameters (Bin, ABI) from the contract

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -694,6 +694,8 @@ func TestSaveAndLoadLastReceivedCheque(t *testing.T) {
 }
 
 // newTestSwapAndPeer is a helper function to create a swap and a peer instance that fit together
+// the owner of this swap is the beneficiaryAddress
+// hence the owner of this swap would sign cheques with beneficiaryKey and receive cheques from ownerKey (or another party) which is NOT the owner of this swap
 func newTestSwapAndPeer(t *testing.T) (*Swap, *Peer, string) {
 	swap, dir := newTestSwap(t)
 	// owner address is the beneficary (counterparty) for the peer


### PR DESCRIPTION
This PR is only refactoring:

- Cheque related functions have moved to `cheque.go` and are no longer called on `Swap` but on `Cheque` directly
- An `Equal` function was introduced for cheques. This is only used for testing
- There are no logic changes