### PR TITLE
swap: remove lock from `getPeer`

### DIFF
--- a/swap/protocol.go
+++ b/swap/protocol.go
@@ -125,8 +125,6 @@ func (s *Swap) addPeer(p *Peer) {
 }
 
 func (s *Swap) getPeer(id enode.ID) *Peer {
-	s.lock.Lock()
-	defer s.lock.Unlock()
 	return s.peers[id]
 }
 


### PR DESCRIPTION
This removes the locking from the `getPeer` function. The lock is already held when called, therefore this led to a deadlock.