### PR TITLE
swap: add cashChequeBeneficiary

### DIFF
--- a/swap/peer.go
+++ b/swap/peer.go
@@ -89,11 +89,8 @@ func (sp *Peer) handleEmitChequeMsg(ctx context.Context, msg *EmitChequeMsg) err
 	sp.swap.resetBalance(sp.ID(), 0-int64(cheque.Honey))
 
 	// cash in cheque
-	//TODO: input parameter checks?
 	opts := bind.NewKeyedTransactor(sp.swap.owner.privateKey)
 	opts.Context = ctx
-
-	//TODO: make instanceAt to directly return a swap type
 
 	otherSwap, err := cswap.InstanceAt(cheque.Contract, sp.backend)
 	if err != nil {
@@ -117,7 +114,6 @@ func (sp *Peer) handleEmitChequeMsg(ctx context.Context, msg *EmitChequeMsg) err
 			//TODO: do something with the error
 		}
 		log.Info("cash tx minded", "receipt", receipt)
-		//TODO: cashCheque
 		//TODO: after the cashCheque is done, we have to watch the blockchain for x amount (25) blocks for reorgs
 		//TODO: make sure we make a case where we listen to the possibiliyt of the peer shutting down.
 	}()

--- a/swap/peer.go
+++ b/swap/peer.go
@@ -105,6 +105,7 @@ func (sp *Peer) handleEmitChequeMsg(ctx context.Context, msg *EmitChequeMsg) err
 		if err != nil {
 			log.Error("Got error when calling submitChequeBeneficiary", "err", err)
 			//TODO: do something with the error
+			return
 		}
 		log.Info("submit tx minded", "receipt", receipt)
 
@@ -112,6 +113,7 @@ func (sp *Peer) handleEmitChequeMsg(ctx context.Context, msg *EmitChequeMsg) err
 		if err != nil {
 			log.Error("Got error when calling cashChequeBeneficiary", "err", err)
 			//TODO: do something with the error
+			return
 		}
 		log.Info("cash tx minded", "receipt", receipt)
 		//TODO: after the cashCheque is done, we have to watch the blockchain for x amount (25) blocks for reorgs

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -808,8 +808,13 @@ func TestPeerVerifyChequeAgainstLast(t *testing.T) {
 	newCheque.Serial = oldCheque.Serial + 1
 	newCheque.Amount = oldCheque.Amount + increase
 
-	if err := peer.verifyChequeAgainstLast(newCheque, oldCheque, increase); err != nil {
+	actualAmount, err := peer.verifyChequeAgainstLast(newCheque, oldCheque, increase)
+	if err != nil {
 		t.Fatalf("failed to verify cheque compared to old cheque: %s", err.Error())
+	}
+
+	if actualAmount != increase {
+		t.Fatalf("incr")
 	}
 }
 
@@ -825,7 +830,7 @@ func TestPeerVerifyChequeAgainstLastInvalid(t *testing.T) {
 	newCheque := newTestCheque()
 	newCheque.Amount = oldCheque.Amount + increase
 
-	if err := peer.verifyChequeAgainstLast(newCheque, oldCheque, increase); err == nil {
+	if _, err := peer.verifyChequeAgainstLast(newCheque, oldCheque, increase); err == nil {
 		t.Fatal("accepted a cheque with same serial")
 	}
 
@@ -834,7 +839,7 @@ func TestPeerVerifyChequeAgainstLastInvalid(t *testing.T) {
 	newCheque = newTestCheque()
 	newCheque.Serial = oldCheque.Serial + 1
 
-	if err := peer.verifyChequeAgainstLast(newCheque, oldCheque, increase); err == nil {
+	if _, err := peer.verifyChequeAgainstLast(newCheque, oldCheque, increase); err == nil {
 		t.Fatal("accepted a cheque with same amount")
 	}
 
@@ -844,7 +849,7 @@ func TestPeerVerifyChequeAgainstLastInvalid(t *testing.T) {
 	newCheque.Serial = oldCheque.Serial + 1
 	newCheque.Amount = oldCheque.Amount + increase + 5
 
-	if err := peer.verifyChequeAgainstLast(newCheque, oldCheque, increase); err == nil {
+	if _, err := peer.verifyChequeAgainstLast(newCheque, oldCheque, increase); err == nil {
 		t.Fatal("accepted a cheque with unexpected amount")
 	}
 }
@@ -858,8 +863,13 @@ func TestPeerProcessAndVerifyCheque(t *testing.T) {
 	cheque := newTestCheque()
 	cheque.Sig, _ = swap.signContentWithKey(cheque, ownerKey)
 
-	if err := peer.processAndVerifyCheque(cheque); err != nil {
+	actualAmount, err := peer.processAndVerifyCheque(cheque)
+	if err != nil {
 		t.Fatalf("failed to process cheque: %s", err)
+	}
+
+	if actualAmount != cheque.Amount {
+		t.Fatalf("computed wrong actual amount: was %d, expected: %d", actualAmount, cheque.Amount)
 	}
 
 	// verify that it was indeed saved
@@ -874,7 +884,7 @@ func TestPeerProcessAndVerifyCheque(t *testing.T) {
 	otherCheque.Honey = 10
 	otherCheque.Sig, _ = swap.signContentWithKey(otherCheque, ownerKey)
 
-	if err := peer.processAndVerifyCheque(otherCheque); err != nil {
+	if _, err := peer.processAndVerifyCheque(otherCheque); err != nil {
 		t.Fatalf("failed to process cheque: %s", err)
 	}
 
@@ -898,7 +908,7 @@ func TestPeerProcessAndVerifyChequeInvalid(t *testing.T) {
 	cheque.Beneficiary = ownerAddress
 	cheque.Sig, _ = swap.signContentWithKey(cheque, ownerKey)
 
-	if err := peer.processAndVerifyCheque(cheque); err == nil {
+	if _, err := peer.processAndVerifyCheque(cheque); err == nil {
 		t.Fatal("accecpted an invalid cheque as first cheque")
 	}
 
@@ -907,7 +917,7 @@ func TestPeerProcessAndVerifyChequeInvalid(t *testing.T) {
 	cheque.Serial = 5
 	cheque.Sig, _ = swap.signContentWithKey(cheque, ownerKey)
 
-	if err := peer.processAndVerifyCheque(cheque); err != nil {
+	if _, err := peer.processAndVerifyCheque(cheque); err != nil {
 		t.Fatalf("failed to process cheque: %s", err)
 	}
 
@@ -922,7 +932,7 @@ func TestPeerProcessAndVerifyChequeInvalid(t *testing.T) {
 	otherCheque.Honey = 10
 	otherCheque.Sig, _ = swap.signContentWithKey(otherCheque, ownerKey)
 
-	if err := peer.processAndVerifyCheque(otherCheque); err == nil {
+	if _, err := peer.processAndVerifyCheque(otherCheque); err == nil {
 		t.Fatal("accepted a cheque with lower serial")
 	}
 
@@ -933,7 +943,7 @@ func TestPeerProcessAndVerifyChequeInvalid(t *testing.T) {
 	otherCheque.Honey = 10
 	otherCheque.Sig, _ = swap.signContentWithKey(otherCheque, ownerKey)
 
-	if err := peer.processAndVerifyCheque(otherCheque); err == nil {
+	if _, err := peer.processAndVerifyCheque(otherCheque); err == nil {
 		t.Fatal("accepted a cheque with lower amount")
 	}
 

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -810,11 +810,11 @@ func TestPeerVerifyChequeAgainstLast(t *testing.T) {
 
 	actualAmount, err := peer.verifyChequeAgainstLast(newCheque, oldCheque, increase)
 	if err != nil {
-		t.Fatalf("failed to verify cheque compared to old cheque: %s", err.Error())
+		t.Fatalf("failed to verify cheque compared to old cheque: %v", err)
 	}
 
 	if actualAmount != increase {
-		t.Fatalf("incr")
+		t.Fatalf("wrong actual amount, expected: %d, was: %d", increase, actualAmount)
 	}
 }
 
@@ -950,5 +950,121 @@ func TestPeerProcessAndVerifyChequeInvalid(t *testing.T) {
 	// check that no invalid cheque was saved
 	if peer.loadLastReceivedCheque().Serial != cheque.Serial {
 		t.Fatalf("last received cheque has wrong serial, was: %d, expected: %d", peer.lastReceivedCheque.Serial, cheque.Serial)
+	}
+}
+
+// TestContractIntegrationWrapper tests a end-to-end cheque interaction.
+// Unlike the TestContractIntegration test this uses the swap.contractReference where possible
+// First a simulated backend is created, then we deploy the issuer's swap contract.
+// We issue a test cheque with the beneficiary address and on the issuer's contract,
+// and immediately try to cash-in the cheque
+
+func TestContractIntegrationWrapper(t *testing.T) {
+	issuerSwap, dir := newTestSwap(t)
+	defer os.RemoveAll(dir)
+
+	issuerSwap.owner.address = ownerAddress
+	issuerSwap.owner.privateKey = ownerKey
+
+	backend := issuerSwap.backend.(*backends.SimulatedBackend)
+
+	log.Debug("deploy issuer swap")
+
+	ctx := context.TODO()
+	err := testDeploy(ctx, backend, issuerSwap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend.Commit()
+
+	log.Debug("deployed. signing cheque")
+
+	cheque := newTestCheque()
+	cheque.ChequeParams.Contract = issuerSwap.owner.Contract
+	cheque.Sig, err = issuerSwap.signContent(cheque)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	log.Debug("sending cheque...")
+
+	opts := bind.NewKeyedTransactor(beneficiaryKey)
+	opts.Value = big.NewInt(0)
+	opts.Context = ctx
+
+	// SubmitChequeBeneficiary will block until the tx is mined, therefore we have to schedule a Commit in the future
+	go func() { time.Sleep(10 * time.Millisecond); backend.Commit() }()
+	receipt, err := issuerSwap.contractReference.SubmitChequeBeneficiary(
+		opts,
+		backend,
+		big.NewInt(int64(cheque.Serial)),
+		big.NewInt(int64(cheque.Amount)),
+		big.NewInt(int64(cheque.Timeout)),
+		cheque.Sig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check if success
+	if receipt.Status != 1 {
+		t.Fatalf("Bad status %d", receipt.Status)
+	}
+
+	log.Debug("check cheques state")
+
+	// check state, check that cheque is indeed there
+	result, err := issuerSwap.contractReference.Instance.Cheques(nil, beneficiaryAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Serial.Uint64() != cheque.Serial {
+		t.Fatalf("Wrong serial %d", result.Serial)
+	}
+	if result.Amount.Uint64() != cheque.Amount {
+		t.Fatalf("Wrong amount %d", result.Amount)
+	}
+	log.Debug("cheques result", "result", result)
+
+	// go forward in time
+	backend.AdjustTime(30 * time.Second)
+
+	payoutAmount := int64(20)
+	// test cashing in, for this we need balance in the contract
+	// => send some money
+	log.Debug("send money to contract")
+	depoTx := types.NewTransaction(
+		1,
+		issuerSwap.owner.Contract,
+		big.NewInt(payoutAmount),
+		50000,
+		big.NewInt(int64(0)),
+		[]byte{},
+	)
+	depoTxs, err := types.SignTx(depoTx, types.HomesteadSigner{}, issuerSwap.owner.privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend.SendTransaction(context.TODO(), depoTxs)
+
+	log.Debug("cash-in the cheque")
+	// CashChequeBeneficiary will block until the tx is mined, therefore we have to schedule a Commit in the future
+	go func() { time.Sleep(10 * time.Millisecond); backend.Commit() }()
+	receipt, err = issuerSwap.contractReference.CashChequeBeneficiary(opts, backend, beneficiaryAddress, big.NewInt(payoutAmount))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if receipt.Status != 1 {
+		t.Fatalf("Bad status %d", receipt.Status)
+	}
+
+	// check again the status, check paid out is increase by amount
+	result, err = issuerSwap.contractReference.Instance.Cheques(nil, beneficiaryAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Debug("cheques result", "result", result)
+	if result.PaidOut.Int64() != payoutAmount {
+		t.Fatalf("Expected paid out amount to be %d, but is %d", payoutAmount, result.PaidOut)
 	}
 }


### PR DESCRIPTION
This PR adds the contract call to `CashChequeBeneficary` after a cheque was successfully submitted:
- `CashChequeBeneficary` added to `contracts/Swap`
- call to `CashChequeBeneficary` in `handleEmitCheque`
- `processAndVerifyCheque` now also returns the actual amount of the cheque (since we need it for cashing)

This PR adds no tests as the `contracts/Swap` wait for the tx to be mined and how to properly do this with the `SimulatedBackend` is still an open question. One hacky way is to start a goroutine which runs `.Commit` after a small timeout. However this also won't work when we have a function that has multiple contract calls in sequence (like in `handleEmitCheque`). Another issue is that `bind.WaitMined` only watches the chain once per second, so we get at least one additional second of testing time for every contract interaction.
Another approach I tried was to communicate the receipt with channels and return without waiting, therefore allowing the test to call `.Commit` but all that did was shift complexity into `handleEmitCheque` nor did it help with the multiple calls scenario.