### PR TITLE
api, chunk: rename Tag.New to Tag.Create

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -152,7 +152,7 @@ func TestApiTagLarge(t *testing.T) {
 	const contentLength = 4096 * 4095
 	testAPI(t, func(api *API, tags *chunk.Tags, toEncrypt bool) {
 		randomContentReader := io.LimitReader(crand.Reader, int64(contentLength))
-		tag, err := api.Tags.New("unnamed-tag", 0)
+		tag, err := api.Tags.Create("unnamed-tag", 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -551,7 +551,7 @@ func TestDetectContentType(t *testing.T) {
 // putString provides singleton manifest creation on top of api.API
 func putString(ctx context.Context, a *API, content string, contentType string, toEncrypt bool) (k storage.Address, wait func(context.Context) error, err error) {
 	r := strings.NewReader(content)
-	tag, err := a.Tags.New("unnamed-tag", 0)
+	tag, err := a.Tags.Create("unnamed-tag", 0)
 
 	log.Trace("created new tag", "uid", tag.Uid)
 

--- a/api/http/middleware.go
+++ b/api/http/middleware.go
@@ -123,7 +123,7 @@ func InitUploadTag(h http.Handler, tags *chunk.Tags) http.Handler {
 
 		log.Trace("creating tag", "tagName", tagName, "estimatedTotal", estimatedTotal)
 
-		t, err := tags.New(tagName, estimatedTotal)
+		t, err := tags.Create(tagName, estimatedTotal)
 		if err != nil {
 			log.Error("error creating tag", "err", err, "tagName", tagName)
 		}

--- a/chunk/tag_test.go
+++ b/chunk/tag_test.go
@@ -142,7 +142,7 @@ func TestTagsMultipleConcurrentIncrementsSyncMap(t *testing.T) {
 	wg.Add(10 * 5 * n)
 	for i := 0; i < 10; i++ {
 		s := string([]byte{uint8(i)})
-		tag, err := ts.New(s, int64(n))
+		tag, err := ts.Create(s, int64(n))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/chunk/tags.go
+++ b/chunk/tags.go
@@ -40,9 +40,9 @@ func NewTags() *Tags {
 	}
 }
 
-// New creates a new tag, stores it by the name and returns it
+// Create creates a new tag, stores it by the name and returns it
 // it returns an error if the tag with this name already exists
-func (ts *Tags) New(s string, total int64) (*Tag, error) {
+func (ts *Tags) Create(s string, total int64) (*Tag, error) {
 	t := &Tag{
 		Uid:       ts.rng.Uint32(),
 		Name:      s,

--- a/chunk/tags_test.go
+++ b/chunk/tags_test.go
@@ -21,8 +21,8 @@ import "testing"
 func TestAll(t *testing.T) {
 	ts := NewTags()
 
-	ts.New("1", 1)
-	ts.New("2", 1)
+	ts.Create("1", 1)
+	ts.Create("2", 1)
 
 	all := ts.All()
 
@@ -38,7 +38,7 @@ func TestAll(t *testing.T) {
 		t.Fatalf("expected tag 1 total to be 1 got %d", n)
 	}
 
-	ts.New("3", 1)
+	ts.Create("3", 1)
 	all = ts.All()
 
 	if len(all) != 3 {

--- a/network_test.go
+++ b/network_test.go
@@ -536,7 +536,7 @@ func retrieve(
 // putString provides singleton manifest creation on top of api.API
 func putString(ctx context.Context, a *api.API, content string, contentType string, toEncrypt bool) (k storage.Address, wait func(context.Context) error, err error) {
 	r := strings.NewReader(content)
-	tag, err := a.Tags.New("unnamed-tag", 0)
+	tag, err := a.Tags.Create("unnamed-tag", 0)
 
 	log.Trace("created new tag", "uid", tag.Uid)
 

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -353,7 +353,7 @@ func testLocalStoreAndRetrieve(t *testing.T, swarm *Swarm, n int, randomData boo
 		rand.Read(slice)
 	}
 	dataPut := string(slice)
-	tag, err := swarm.api.Tags.New("test-local-store-and-retrieve", 0)
+	tag, err := swarm.api.Tags.Create("test-local-store-and-retrieve", 0)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR is renaming `Tag.New` to `Tag.Create`. Generally `New` is used as a constructor in Go and other languages, whereas this function is also running a `LoadAndStore`.

I think it'd be nice if the name conveys that we are not just creating a value.