### PR TITLE
pot: Add Distance methods with tests

### DIFF
--- a/network/discovery.go
+++ b/network/discovery.go
@@ -89,7 +89,8 @@ func NotifyPeer(p *BzzAddr, k *Kademlia) {
 // unless already notified during the connection session
 func (d *Peer) NotifyPeer(a *BzzAddr, po uint8) {
 	// immediately return
-	if (po < d.getDepth() && pot.ProxCmp(d.kad.BaseAddr(), d, a) != 1) || d.seen(a) {
+	//if (po < d.getDepth() && pot.ProxCmp(d.kad.BaseAddr(), d, a) != 1) || d.seen(a) {
+	if (po < d.getDepth() && pot.ProxCmp(d.kad.BaseAddr(), d.Address(), a.Address()) != 1) || d.seen(a) {
 		return
 	}
 	resp := &peersMsg{

--- a/network/discovery.go
+++ b/network/discovery.go
@@ -89,7 +89,6 @@ func NotifyPeer(p *BzzAddr, k *Kademlia) {
 // unless already notified during the connection session
 func (d *Peer) NotifyPeer(a *BzzAddr, po uint8) {
 	// immediately return
-	//if (po < d.getDepth() && pot.ProxCmp(d.kad.BaseAddr(), d, a) != 1) || d.seen(a) {
 	if (po < d.getDepth() && pot.ProxCmp(d.kad.BaseAddr(), d.Address(), a.Address()) != 1) || d.seen(a) {
 		return
 	}

--- a/pot/address.go
+++ b/pot/address.go
@@ -79,7 +79,7 @@ func (a Address) Bytes() []byte {
 
 // Distance returns the distance between address a and address b as a big integer using the distance metric defined in the swarm specfication
 // Fails if not all addresses are of equal length
-func Distance(x, y interface{}) (*big.Int, error) { // a Address, b Address) (*big.Int, error){
+func Distance(x, y []byte) (*big.Int, error) { // a Address, b Address) (*big.Int, error){
 	distanceBytes, err := DistanceRaw(x, y)
 	if err != nil {
 		return nil, err
@@ -91,15 +91,13 @@ func Distance(x, y interface{}) (*big.Int, error) { // a Address, b Address) (*b
 
 // DistanceRaw returns the distance between address a and address b in big-endian binary format using the distance metric defined in the swarm specfication
 // Fails if not all addresses are of equal length
-func DistanceRaw(x, y interface{}) ([]byte, error) { // Address, b Address) ([]byte, error) {
-	bx := ToBytes(x)
-	by := ToBytes(y)
-	if len(bx) != len(by) {
+func DistanceRaw(x, y []byte) ([]byte, error) { // Address, b Address) ([]byte, error) {
+	if len(x) != len(y) {
 		return nil, errors.New("address length must match")
 	}
-	c := NewAddressFromBytes(make([]byte, len(bx)))
-	for i, addr := range bx {
-		c[i] = addr ^ by[i]
+	c := NewAddressFromBytes(make([]byte, len(x)))
+	for i, addr := range x {
+		c[i] = addr ^ y[i]
 	}
 	return c.Bytes(), nil
 }
@@ -110,24 +108,18 @@ func DistanceRaw(x, y interface{}) ([]byte, error) { // Address, b Address) ([]b
 // 	0 if subject is equally far apart as object (subject and object are the same address)
 // 	-1 if subject is farther from a than object
 // Fails if not all addresses are of equal length
-func DistanceCmp(a, x, y interface{}) (int, error) { //a Address, subject Address, object Address) (int, error) {
-	ba := ToBytes(a)
-	bx := ToBytes(x)
-	by := ToBytes(y)
-	if len(ba) != len(bx) || len(ba) != len(by) {
+func DistanceCmp(a, x, y []byte) (int, error) { //a Address, subject Address, object Address) (int, error) {
+	if len(a) != len(x) || len(a) != len(y) {
 		return 0, errors.New("address length must match")
 	}
-	return proxCmp(ba, bx, by), nil
+	return ProxCmp(a, x, y), nil
 }
 
 // ProxCmp compares the distances a->target and b->target.
 // Returns -1 if a is closer to target, 1 if b is closer to target
 // and 0 if they are equal.
-func ProxCmp(a, x, y interface{}) int {
-	return proxCmp(ToBytes(a), ToBytes(x), ToBytes(y))
-}
-
-func proxCmp(a, x, y []byte) int {
+//func ProxCmp(a, x, y interface{}) int {
+func ProxCmp(a, x, y []byte) int {
 	for i := range a {
 		dx := x[i] ^ a[i]
 		dy := y[i] ^ a[i]

--- a/pot/address.go
+++ b/pot/address.go
@@ -77,9 +77,9 @@ func (a Address) Bytes() []byte {
 	return a[:]
 }
 
-// Distance returns the distance between address a and address b as a big integer using the distance metric defined in the swarm specfication
+// Distance returns the distance between address x and address y as a (comparable) big integer using the distance metric defined in the swarm specification
 // Fails if not all addresses are of equal length
-func Distance(x, y []byte) (*big.Int, error) { // a Address, b Address) (*big.Int, error){
+func Distance(x, y []byte) (*big.Int, error) {
 	distanceBytes, err := DistanceRaw(x, y)
 	if err != nil {
 		return nil, err
@@ -89,9 +89,9 @@ func Distance(x, y []byte) (*big.Int, error) { // a Address, b Address) (*big.In
 	return r, nil
 }
 
-// DistanceRaw returns the distance between address a and address b in big-endian binary format using the distance metric defined in the swarm specfication
+// DistanceRaw returns the distance between address x and address y in big-endian binary format using the distance metric defined in the swarm specfication
 // Fails if not all addresses are of equal length
-func DistanceRaw(x, y []byte) ([]byte, error) { // Address, b Address) ([]byte, error) {
+func DistanceRaw(x, y []byte) ([]byte, error) {
 	if len(x) != len(y) {
 		return nil, errors.New("address length must match")
 	}
@@ -102,23 +102,22 @@ func DistanceRaw(x, y []byte) ([]byte, error) { // Address, b Address) ([]byte, 
 	return c.Bytes(), nil
 }
 
-// DistanceCmp compares subject and object to receiver in terms of the distance metric defined in the swarm specfication
+// DistanceCmp compares x and y to a in terms of the distance metric defined in the swarm specfication
 // it returns:
-// 	1 if subject is closer to a than object
-// 	0 if subject is equally far apart as object (subject and object are the same address)
-// 	-1 if subject is farther from a than object
+// 	1 if x is closer to a than y
+// 	0 if x and y are equally far apart from (this means that x and y are the same address)
+// 	-1 if x is farther from a than y
 // Fails if not all addresses are of equal length
-func DistanceCmp(a, x, y []byte) (int, error) { //a Address, subject Address, object Address) (int, error) {
+func DistanceCmp(a, x, y []byte) (int, error) {
 	if len(a) != len(x) || len(a) != len(y) {
 		return 0, errors.New("address length must match")
 	}
 	return ProxCmp(a, x, y), nil
 }
 
-// ProxCmp compares the distances a->target and b->target.
-// Returns -1 if a is closer to target, 1 if b is closer to target
+// ProxCmp compares the distances x->a and y->a
+// Returns -1 if x is closer to a, 1 if y is closer to a
 // and 0 if they are equal.
-//func ProxCmp(a, x, y interface{}) int {
 func ProxCmp(a, x, y []byte) int {
 	for i := range a {
 		dx := x[i] ^ a[i]

--- a/pot/address.go
+++ b/pot/address.go
@@ -79,7 +79,6 @@ func (a Address) Bytes() []byte {
 
 // Distance returns the distance between address a and address b as a big integer using the distance metric defined in the swarm specfication
 // Fails if not all addresses are of equal length
-//func Distance(a Address, b Address) (*big.Int, error) {
 func Distance(x, y interface{}) (*big.Int, error) { // a Address, b Address) (*big.Int, error){
 	distanceBytes, err := DistanceRaw(x, y)
 	if err != nil {
@@ -92,7 +91,6 @@ func Distance(x, y interface{}) (*big.Int, error) { // a Address, b Address) (*b
 
 // DistanceRaw returns the distance between address a and address b in big-endian binary format using the distance metric defined in the swarm specfication
 // Fails if not all addresses are of equal length
-//func DistanceRaw(a Address, b Address) ([]byte, error) {
 func DistanceRaw(x, y interface{}) ([]byte, error) { // Address, b Address) ([]byte, error) {
 	bx := ToBytes(x)
 	by := ToBytes(y)

--- a/pot/address_test.go
+++ b/pot/address_test.go
@@ -17,6 +17,8 @@ func (a testAddress) Address() []byte {
 	return []byte(a)
 }
 
+// TestDistance tests the correctness of the distance calculation
+// as well as the comparison method
 func TestDistance(t *testing.T) {
 	a := [32]byte{}
 	b := [32]byte{}

--- a/pot/address_test.go
+++ b/pot/address_test.go
@@ -1,0 +1,64 @@
+package pot
+
+import (
+	"testing"
+)
+
+type testAddress []byte
+
+func newTestAddress(a []byte) testAddress {
+	if a != nil {
+		return testAddress(a)
+	}
+	return testAddress(make([]byte, 32))
+}
+
+func (a testAddress) Address() []byte {
+	return []byte(a)
+}
+
+func TestDistance(t *testing.T) {
+	a := [32]byte{}
+	b := [32]byte{}
+	a[0] = 0x91
+	b[0] = 0x82
+	aa := newTestAddress(a[:]) //NewAddressFromBytes(a[:])
+	ab := newTestAddress(b[:]) //NewAddressFromBytes(b[:])
+	distance, err := Distance(aa, ab)
+	if err != nil {
+		t.Fatal(err)
+	}
+	correctDistance := "8593944123082061379093159043613555660984881674403010612303492563087302590464"
+	if distance.String() != correctDistance {
+		t.Fatalf("Distance calculation mismatch, got %s, expected %s", distance.String(), correctDistance)
+	}
+
+	c := [32]byte{}
+	c[0] = 0x12
+	ac := newTestAddress(c[:])
+	_, err = DistanceCmp(aa, ab, ac[:31])
+	if err == nil {
+		t.Fatal("Expected length mismatch on address to fail")
+	}
+
+	cmp, err := DistanceCmp(aa, ab, ac)
+	if err != nil {
+		t.Fatal(err)
+	} else if cmp != -1 {
+		t.Fatalf("aaab < aaac, expected -1, got %d", cmp)
+	}
+
+	cmp, err = DistanceCmp(aa, ac, ab)
+	if err != nil {
+		t.Fatal(err)
+	} else if cmp != 1 {
+		t.Fatalf("aaab > aaac, expected 1, got %d", cmp)
+	}
+
+	cmp, err = DistanceCmp(aa, ab, ab)
+	if err != nil {
+		t.Fatal(err)
+	} else if cmp != 0 {
+		t.Fatalf("aaab == aaab, expected 0, got %d", cmp)
+	}
+}

--- a/pot/address_test.go
+++ b/pot/address_test.go
@@ -2,65 +2,79 @@ package pot
 
 import (
 	"testing"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethersphere/swarm/log"
 )
 
-type testAddress []byte
+type distanceTest struct {
+	x      []byte
+	y      []byte
+	result string
+}
 
-func newTestAddress(a []byte) testAddress {
-	if a != nil {
-		return testAddress(a)
+type distanceCmpTest struct {
+	x      []byte
+	y      []byte
+	z      []byte
+	result int
+}
+
+var (
+	distanceTests = []distanceTest{
+		{
+			x:      hexutil.MustDecode("0x9100000000000000000000000000000000000000000000000000000000000000"),
+			y:      hexutil.MustDecode("0x8200000000000000000000000000000000000000000000000000000000000000"),
+			result: "8593944123082061379093159043613555660984881674403010612303492563087302590464",
+		},
 	}
-	return testAddress(make([]byte, 32))
-}
 
-func (a testAddress) Address() []byte {
-	return []byte(a)
-}
+	distanceCmpTests = []distanceCmpTest{
+		{
+			x:      hexutil.MustDecode("0x9100000000000000000000000000000000000000000000000000000000000000"),
+			y:      hexutil.MustDecode("0x8200000000000000000000000000000000000000000000000000000000000000"),
+			z:      hexutil.MustDecode("0x1200000000000000000000000000000000000000000000000000000000000000"),
+			result: -1,
+		},
+		{
+			x:      hexutil.MustDecode("0x9100000000000000000000000000000000000000000000000000000000000000"),
+			y:      hexutil.MustDecode("0x1200000000000000000000000000000000000000000000000000000000000000"),
+			z:      hexutil.MustDecode("0x8200000000000000000000000000000000000000000000000000000000000000"),
+			result: 1,
+		},
+		{
+			x:      hexutil.MustDecode("0x9100000000000000000000000000000000000000000000000000000000000000"),
+			y:      hexutil.MustDecode("0x1200000000000000000000000000000000000000000000000000000000000000"),
+			z:      hexutil.MustDecode("0x1200000000000000000000000000000000000000000000000000000000000000"),
+			result: 0,
+		},
+	}
+)
 
 // TestDistance tests the correctness of the distance calculation
-// as well as the comparison method
 func TestDistance(t *testing.T) {
-	a := [32]byte{}
-	b := [32]byte{}
-	a[0] = 0x91
-	b[0] = 0x82
-	aa := newTestAddress(a[:]) //NewAddressFromBytes(a[:])
-	ab := newTestAddress(b[:]) //NewAddressFromBytes(b[:])
-	distance, err := Distance(aa, ab)
-	if err != nil {
-		t.Fatal(err)
+	for i, dt := range distanceTests {
+		log.Debug("Distance test", "i", i, "dt", dt)
+		distance, err := Distance(dt.x, dt.y)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if distance.String() != dt.result {
+			t.Fatalf("incorrect distance, expected %s, got %s (x: %x, y: %x)", dt.result, distance.String(), dt.x, dt.y)
+		}
 	}
-	correctDistance := "8593944123082061379093159043613555660984881674403010612303492563087302590464"
-	if distance.String() != correctDistance {
-		t.Fatalf("Distance calculation mismatch, got %s, expected %s", distance.String(), correctDistance)
-	}
+}
 
-	c := [32]byte{}
-	c[0] = 0x12
-	ac := newTestAddress(c[:])
-	_, err = DistanceCmp(aa, ab, ac[:31])
-	if err == nil {
-		t.Fatal("Expected length mismatch on address to fail")
-	}
-
-	cmp, err := DistanceCmp(aa, ab, ac)
-	if err != nil {
-		t.Fatal(err)
-	} else if cmp != -1 {
-		t.Fatalf("aaab < aaac, expected -1, got %d", cmp)
-	}
-
-	cmp, err = DistanceCmp(aa, ac, ab)
-	if err != nil {
-		t.Fatal(err)
-	} else if cmp != 1 {
-		t.Fatalf("aaab > aaac, expected 1, got %d", cmp)
-	}
-
-	cmp, err = DistanceCmp(aa, ab, ab)
-	if err != nil {
-		t.Fatal(err)
-	} else if cmp != 0 {
-		t.Fatalf("aaab == aaab, expected 0, got %d", cmp)
+// TestDistanceCmp tests the distance comparison method
+func TestDistanceCmp(t *testing.T) {
+	for i, dt := range distanceCmpTests {
+		log.Debug("DistanceCmp test", "i", i, "dt", dt)
+		direction, err := DistanceCmp(dt.x, dt.y, dt.z)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if direction != dt.result {
+			t.Fatalf("incorrect distance compare, expected %d, got %d (x: %x, y: %x, z: %x)", dt.result, direction, dt.x, dt.y, dt.z)
+		}
 	}
 }


### PR DESCRIPTION
Adds methods for calculating distance metric value, as well as comparison.

Comparison of XOR distance requires the addresses to be compared to be the same length.

The change to `proxCmp` is merely a slight bumming.