### PR TITLE
swarm: close fileStore in Swarm's Stop() function

### DIFF
--- a/swarm.go
+++ b/swarm.go
@@ -469,6 +469,10 @@ func (s *Swarm) Stop() error {
 		s.stateStore.Close()
 	}
 
+	if s.fileStore != nil {
+		s.fileStore.Close()
+	}
+
 	for _, cleanF := range s.cleanupFuncs {
 		err = cleanF()
 		if err != nil {


### PR DESCRIPTION
Swarm's fileStore is not closed when stopping a Swarm node. Added call to close it.