### PR TITLE
Incentives instance

### DIFF
--- a/contracts/swap/swap.go
+++ b/contracts/swap/swap.go
@@ -48,8 +48,8 @@ type Backend interface {
 	//TODO: needed? BalanceAt(ctx context.Context, address common.Address, blockNum *big.Int) (*big.Int, error)
 }
 
-// SimpleSwap interface defines the simple swap's exposed methods
-type SimpleSwap interface {
+// Contract interface defines the simple swap's exposed methods
+type Contract interface {
 	Deploy(auth *bind.TransactOpts, backend bind.ContractBackend, owner common.Address, harddepositTimeout *big.Int) (common.Address, *types.Transaction, error)
 	SubmitChequeBeneficiary(opts *bind.TransactOpts, serial *big.Int, amount *big.Int, timeout *big.Int, ownerSig []byte) (*types.Transaction, error)
 	CashChequeBeneficiary(auth *bind.TransactOpts, backend Backend, beneficiary common.Address, requestPayout *big.Int) (*types.Transaction, error)
@@ -58,10 +58,8 @@ type SimpleSwap interface {
 	InstanceAt(address common.Address, backend bind.ContractBackend)
 }
 
-// Swap is a proxy object for Swap contracts.
-type Swap struct {
-	Instance *contract.SimpleSwap
-}
+// Swap is a implementation for SimpleSwap contracts.
+type Swap struct{}
 
 // Params encapsulates some contract parameters (currently mostly informational)
 type Params struct {
@@ -69,14 +67,14 @@ type Params struct {
 }
 
 // New returns a pointer to a new Swap struct
-func New() *Swap {
+func NewContract() Contract {
 	return &Swap{}
 }
 
 // ValidateCode checks that the on-chain code at address matches the expected swap
 // contract code.
 // TODO: have this as a package level function and pass the SimpleSwapBin as argument
-func (s *Swap) ValidateCode(ctx context.Context, b bind.ContractBackend, address common.Address) error {
+func (s *swap) ValidateCode(ctx context.Context, b bind.ContractBackend, address common.Address) error {
 	codeReadFromAddress, err := b.CodeAt(ctx, address, nil)
 	if err != nil {
 		return err

--- a/swap/peer.go
+++ b/swap/peer.go
@@ -25,7 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	cswap "github.com/ethersphere/swarm/contracts/swap"
+	contract "github.com/ethersphere/swarm/contracts/swap"
 	"github.com/ethersphere/swarm/log"
 	"github.com/ethersphere/swarm/p2p/protocols"
 )
@@ -37,14 +37,14 @@ var ErrDontOwe = errors.New("no negative balance")
 type Peer struct {
 	*protocols.Peer
 	swap               *Swap
-	backend            cswap.Backend
+	backend            contract.Backend
 	beneficiary        common.Address
 	contractAddress    common.Address
 	lastReceivedCheque *Cheque
 }
 
 // NewPeer creates a new swap Peer instance
-func NewPeer(p *protocols.Peer, s *Swap, backend cswap.Backend, beneficiary common.Address, contractAddress common.Address) *Peer {
+func NewPeer(p *protocols.Peer, s *Swap, backend contract.Backend, beneficiary common.Address, contractAddress common.Address) *Peer {
 	return &Peer{
 		Peer:            p,
 		swap:            s,
@@ -88,7 +88,7 @@ func (sp *Peer) handleEmitChequeMsg(ctx context.Context, msg *EmitChequeMsg) err
 	opts := bind.NewKeyedTransactor(sp.swap.owner.privateKey)
 	opts.Context = ctx
 
-	otherSwap, err := cswap.InstanceAt(cheque.Contract, sp.backend)
+	otherSwap, err := contract.InstanceAt(cheque.Contract, sp.backend)
 	if err != nil {
 		log.Error("could not get an instance of simpleSwap", "error", err)
 		return err

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -32,7 +32,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethersphere/swarm/contracts/swap"
-	cswap "github.com/ethersphere/swarm/contracts/swap"
+	contract "github.com/ethersphere/swarm/contracts/swap"
 	"github.com/ethersphere/swarm/log"
 	"github.com/ethersphere/swarm/p2p/protocols"
 	"github.com/ethersphere/swarm/state"
@@ -52,10 +52,10 @@ type Swap struct {
 	balances            map[enode.ID]int64   // map of balances for each peer
 	cheques             map[enode.ID]*Cheque // map of cheques for each peer
 	peers               map[enode.ID]*Peer   // map of all swap Peers
-	backend             cswap.Backend        // the backend (blockchain) used
+	backend             contract.Backend     // the backend (blockchain) used
 	owner               *Owner               // contract access
 	params              *Params              // economic and operational parameters
-	swapContract        *swap.Swap           // reference to the smart contract
+	contract            swap.Contract        // reference to the smart contract
 	oracle              PriceOracle          // the oracle providing the ether price for honey
 	paymentThreshold    int64                // balance difference required for sending cheque
 	disconnectThreshold int64                // balance difference required for dropping peer
@@ -82,7 +82,7 @@ func NewParams() *Params {
 }
 
 // New - swap constructor
-func New(stateStore state.Store, prvkey *ecdsa.PrivateKey, contract common.Address, backend cswap.Backend) *Swap {
+func New(stateStore state.Store, prvkey *ecdsa.PrivateKey, contract common.Address, backend contract.Backend) *Swap {
 	sw := &Swap{
 		stateStore:          stateStore,
 		balances:            make(map[enode.ID]int64),
@@ -92,7 +92,6 @@ func New(stateStore state.Store, prvkey *ecdsa.PrivateKey, contract common.Addre
 		params:              NewParams(),
 		paymentThreshold:    DefaultPaymentThreshold,
 		disconnectThreshold: DefaultDisconnectThreshold,
-		swapContract:        nil,
 		oracle:              NewPriceOracle(),
 	}
 	sw.owner = sw.createOwner(prvkey, contract)
@@ -401,7 +400,7 @@ func (s *Swap) signContent(cheque *Cheque) ([]byte, error) {
 
 // GetParams returns contract parameters (Bin, ABI) from the contract
 func (s *Swap) GetParams() *swap.Params {
-	return s.swapContract.ContractParams()
+	return s.contract.ContractParams()
 }
 
 // Deploy deploys a new swap contract
@@ -412,22 +411,17 @@ func (s *Swap) Deploy(ctx context.Context, backend swap.Backend, path string) er
 
 // verifyContract checks if the bytecode found at address matches the expected bytecode
 func (s *Swap) verifyContract(ctx context.Context, address common.Address) error {
-	swap, err := swap.InstanceAt(address, s.backend)
-	if err != nil {
-		return err
-	}
-
-	return swap.ValidateCode(ctx, s.backend, address)
+	return contract.ValidateCode(ctx, s.backend, address)
 }
 
 // getContractOwner retrieve the owner of the chequebook at address from the blockchain
 func (s *Swap) getContractOwner(ctx context.Context, address common.Address) (common.Address, error) {
-	swap, err := swap.InstanceAt(address, s.backend)
+	contr, err := contract.InstanceAt(address, s.backend)
 	if err != nil {
 		return common.Address{}, err
 	}
 
-	return swap.Instance.Issuer(nil)
+	return contr.Issuer(nil)
 }
 
 // deploy deploys the Swap contract
@@ -457,7 +451,7 @@ func (s *Swap) deployLoop(opts *bind.TransactOpts, backend swap.Backend, owner c
 			time.Sleep(deployDelay)
 		}
 
-		if _, s.swapContract, tx, err = swap.Deploy(opts, backend, owner, defaultHarddepositTimeoutDuration); err != nil {
+		if _, s.contract, tx, err = contract.Deploy(opts, backend, owner, defaultHarddepositTimeoutDuration); err != nil {
 			log.Warn("can't send chequebook deploy tx", "try", try, "error", err)
 			continue
 		}

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -647,6 +647,20 @@ func TestVerifyContractWrongContract(t *testing.T) {
 	}
 }
 
+// setupContractTest is a helper function for setting up the
+// blockchain wait function for testing
+func setupContractTest() func() {
+	// we overwrite the waitForTx function with one which the simulated backend
+	// immediately commits
+	currentWaitFunc := cswap.WaitFunc
+	// overwrite only for the duration of the test, so...
+	cswap.WaitFunc = testWaitForTx
+	return func() {
+		// ...we need to set it back to original when done
+		cswap.WaitFunc = currentWaitFunc
+	}
+}
+
 // TestContractIntegration tests a end-to-end cheque interaction.
 // First a simulated backend is created, then we deploy the issuer's swap contract.
 // We issue a test cheque with the beneficiary address and on the issuer's contract,
@@ -683,19 +697,13 @@ func TestContractIntegration(t *testing.T) {
 
 	log.Debug("sending cheque...")
 
+	// setup the wait for mined transaction function for testing
+	cleanup := setupContractTest()
+	defer cleanup()
+
 	opts := bind.NewKeyedTransactor(beneficiaryKey)
 	opts.Value = big.NewInt(0)
 	opts.Context = ctx
-
-	// we overwrite the waitForTx function with one which the simulated backend
-	// immediately commits
-	currentWaitFunc := cswap.WaitFunc
-	// overwrite only for the duration of the test, so...
-	cswap.WaitFunc = testWaitForTx
-	defer func() {
-		// ...we need to set it back to original when done
-		cswap.WaitFunc = currentWaitFunc
-	}()
 
 	receipt, err := issuerSwap.contract.SubmitChequeBeneficiary(
 		opts,
@@ -1045,129 +1053,6 @@ func TestPeerProcessAndVerifyChequeInvalid(t *testing.T) {
 	// check that no invalid cheque was saved
 	if peer.loadLastReceivedCheque().Serial != cheque.Serial {
 		t.Fatalf("last received cheque has wrong serial, was: %d, expected: %d", peer.lastReceivedCheque.Serial, cheque.Serial)
-	}
-}
-
-// TestContractIntegrationWrapper tests a end-to-end cheque interaction.
-// Unlike the TestContractIntegration test this uses the swap.swapContract where possible
-// First a simulated backend is created, then we deploy the issuer's swap contract.
-// We issue a test cheque with the beneficiary address and on the issuer's contract,
-// and immediately try to cash-in the cheque
-func TestContractIntegrationWrapper(t *testing.T) {
-	issuerSwap, dir := newTestSwap(t)
-	defer os.RemoveAll(dir)
-
-	issuerSwap.owner.address = ownerAddress
-	issuerSwap.owner.privateKey = ownerKey
-
-	backend := issuerSwap.backend.(*backends.SimulatedBackend)
-
-	log.Debug("deploy issuer swap")
-
-	ctx := context.TODO()
-	err := testDeploy(ctx, backend, issuerSwap)
-	if err != nil {
-		t.Fatal(err)
-	}
-	backend.Commit()
-
-	log.Debug("deployed. signing cheque")
-
-	cheque := newTestCheque()
-	cheque.ChequeParams.Contract = issuerSwap.owner.Contract
-	cheque.Signature, err = issuerSwap.signContent(cheque)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	log.Debug("sending cheque...")
-
-	opts := bind.NewKeyedTransactor(beneficiaryKey)
-	opts.Value = big.NewInt(0)
-	opts.Context = ctx
-
-	// we overwrite the waitForTx function with one which the simulated backend
-	// immediately commits
-	currentWaitFunc := cswap.WaitFunc
-	// overwrite only for the duration of the test, so...
-	cswap.WaitFunc = testWaitForTx
-	defer func() {
-		// ...we need to set it back to original when done
-		cswap.WaitFunc = currentWaitFunc
-	}()
-
-	// SubmitChequeBeneficiary will block until the tx is mined, therefore we have to schedule a Commit in the future
-	receipt, err := issuerSwap.contract.SubmitChequeBeneficiary(
-		opts,
-		backend,
-		big.NewInt(int64(cheque.Serial)),
-		big.NewInt(int64(cheque.Amount)),
-		big.NewInt(int64(cheque.Timeout)),
-		cheque.Signature)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// check if success
-	if receipt.Status != 1 {
-		t.Fatalf("Bad status %d", receipt.Status)
-	}
-
-	log.Debug("check cheques state")
-
-	// check state, check that cheque is indeed there
-	result, err := issuerSwap.contract.Cheques(nil, beneficiaryAddress)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if result.Serial.Uint64() != cheque.Serial {
-		t.Fatalf("Wrong serial %d", result.Serial)
-	}
-	if result.Amount.Uint64() != cheque.Amount {
-		t.Fatalf("Wrong amount %d", result.Amount)
-	}
-	log.Debug("cheques result", "result", result)
-
-	// go forward in time
-	backend.AdjustTime(30 * time.Second)
-
-	payoutAmount := int64(20)
-	// test cashing in, for this we need balance in the contract
-	// => send some money
-	log.Debug("send money to contract")
-	depoTx := types.NewTransaction(
-		1,
-		issuerSwap.owner.Contract,
-		big.NewInt(payoutAmount),
-		50000,
-		big.NewInt(int64(0)),
-		[]byte{},
-	)
-	depoTxs, err := types.SignTx(depoTx, types.HomesteadSigner{}, issuerSwap.owner.privateKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-	backend.SendTransaction(context.TODO(), depoTxs)
-
-	log.Debug("cash-in the cheque")
-	// CashChequeBeneficiary will block until the tx is mined, therefore we have to schedule a Commit in the future
-	receipt, err = issuerSwap.contract.CashChequeBeneficiary(opts, backend, beneficiaryAddress, big.NewInt(payoutAmount))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if receipt.Status != 1 {
-		t.Fatalf("Bad status %d", receipt.Status)
-	}
-
-	// check again the status, check paid out is increase by amount
-	result, err = issuerSwap.contract.Cheques(nil, beneficiaryAddress)
-	if err != nil {
-		t.Fatal(err)
-	}
-	log.Debug("cheques result", "result", result)
-	if result.PaidOut.Int64() != payoutAmount {
-		t.Fatalf("Expected paid out amount to be %d, but is %d", payoutAmount, result.PaidOut)
 	}
 }
 


### PR DESCRIPTION
This PR is a refactoring of the contract proxy pattern which was the first iteration of the contract abstraction for reuse with different contract implementations.

It now introduces an interface for contracts (`Contract`) and package wide factory functions to create instances of the underlying contract.

It also refactors the way waiting for transactions to be mined works: the wait function is exported and can be overwritten for tests, so that in tests with the simulated backend, no waiting occurs, allowing to use the same interface for tests and production code