### PR TITLE
Balance rework (iterate through state store)

### DIFF
--- a/state/dbstore.go
+++ b/state/dbstore.go
@@ -114,7 +114,7 @@ func (s *DBStore) Delete(key string) (err error) {
 // propagated to the called iterator method on Iterate.
 type iterFunction func([]byte, []byte) (stop bool, err error)
 
-// Iterate entries which has a specific prefix
+// Iterate entries (key/value pair) which have keys matching the given prefix
 func (s *DBStore) Iterate(prefix string, iterFunc iterFunction) (err error) {
 	iter := s.db.NewIterator(util.BytesPrefix([]byte(prefix)), nil)
 	defer iter.Release()

--- a/state/dbstore.go
+++ b/state/dbstore.go
@@ -35,7 +35,6 @@ type Store interface {
 	Get(key string, i interface{}) (err error)
 	Put(key string, i interface{}) (err error)
 	Delete(key string) (err error)
-	Keys(prefix string) (keys []string, err error)
 	Iterate(prefix string, iterFunc iterFunction) (err error)
 	Close() error
 }
@@ -106,20 +105,6 @@ func (s *DBStore) Put(key string, i interface{}) (err error) {
 // Delete removes entries stored under a specific key.
 func (s *DBStore) Delete(key string) (err error) {
 	return s.db.Delete([]byte(key), nil)
-}
-
-// Keys returns a list of all the keys in the underlying LevelDB which match the `prefix` param
-func (s *DBStore) Keys(prefix string) (keys []string, err error) {
-	iter := s.db.NewIterator(util.BytesPrefix([]byte(prefix)), nil)
-	defer iter.Release()
-	for iter.Next() {
-		keys = append(keys, string(iter.Key()))
-	}
-	err = iter.Error()
-	if err != nil {
-		return []string{}, err
-	}
-	return keys, nil
 }
 
 // iterFunction is a function called on every key/value pair obtained

--- a/state/dbstore.go
+++ b/state/dbstore.go
@@ -36,6 +36,7 @@ type Store interface {
 	Put(key string, i interface{}) (err error)
 	Delete(key string) (err error)
 	Keys(prefix string) (keys []string, err error)
+	Iterate(prefix string, iterFunc func([]byte, []byte)) (err error)
 	Close() error
 }
 
@@ -119,6 +120,16 @@ func (s *DBStore) Keys(prefix string) (keys []string, err error) {
 		return []string{}, err
 	}
 	return keys, nil
+}
+
+// Iterate entries which has a specific prefix
+func (s *DBStore) Iterate(prefix string, iterFunc func([]byte, []byte)) (err error) {
+	iter := s.db.NewIterator(util.BytesPrefix([]byte(prefix)), nil)
+	for iter.Next() {
+		iterFunc(iter.Key(), iter.Value())
+	}
+	iter.Release()
+	return iter.Error()
 }
 
 // Close releases the resources used by the underlying LevelDB.

--- a/state/dbstore_test.go
+++ b/state/dbstore_test.go
@@ -77,9 +77,18 @@ func TestDBStore(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer persistedStore.Close()
 
 	testPersistedStore(t, persistedStore)
+
+	persistedStore.Close()
+
+	iteratedStore, err := NewDBStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer iteratedStore.Close()
+
+	testStoreIterator(t, iteratedStore)
 }
 
 func testStore(t *testing.T, store Store) {
@@ -122,4 +131,8 @@ func testPersistedStore(t *testing.T, store Store) {
 	if as[0] != "a" || as[1] != "b" || as[2] != "c" {
 		t.Fatalf("elements serialized did not match expected values")
 	}
+}
+
+func testStoreIterator(t *testing.T, store Store) {
+
 }

--- a/state/dbstore_test.go
+++ b/state/dbstore_test.go
@@ -73,8 +73,6 @@ func TestDBStore(t *testing.T) {
 
 	testStore(t, store)
 
-	store.Close()
-
 	persistedStore, err := NewDBStore(dir)
 	if err != nil {
 		t.Fatal(err)
@@ -82,18 +80,17 @@ func TestDBStore(t *testing.T) {
 
 	testPersistedStore(t, persistedStore)
 
-	persistedStore.Close()
-
 	iteratedStore, err := NewDBStore(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer iteratedStore.Close()
 
 	testStoreIterator(t, iteratedStore)
 }
 
 func testStore(t *testing.T, store Store) {
+	defer store.Close()
+
 	ser := &SerializingType{key: "key1", value: "value1"}
 	jsonify := []string{"a", "b", "c"}
 
@@ -110,8 +107,9 @@ func testStore(t *testing.T, store Store) {
 }
 
 func testPersistedStore(t *testing.T, store Store) {
-	ser := &SerializingType{}
+	defer store.Close()
 
+	ser := &SerializingType{}
 	err := store.Get("key1", ser)
 	if err != nil {
 		t.Fatal(err)
@@ -136,8 +134,9 @@ func testPersistedStore(t *testing.T, store Store) {
 }
 
 func testStoreIterator(t *testing.T, store Store) {
-	storePrefix := "test_"
+	defer store.Close()
 
+	storePrefix := "test_"
 	err := store.Put(storePrefix+"key1", "value1")
 	if err != nil {
 		t.Fatal(err)

--- a/state/dbstore_test.go
+++ b/state/dbstore_test.go
@@ -134,5 +134,27 @@ func testPersistedStore(t *testing.T, store Store) {
 }
 
 func testStoreIterator(t *testing.T, store Store) {
+	storePrefix := "test"
 
+	err := store.Put("key1", "value1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = store.Put("key2", "value2")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entries := make(map[string]string)
+
+	// add store balances, if peer was not already added
+	entriesIterFunction := func(key []byte, value []byte) (stop bool, err error) {
+		entries[string(key)] = string(value)
+		return stop, err
+	}
+	err = store.Iterate(storePrefix, entriesIterFunction)
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -313,11 +313,14 @@ func (s *Swap) NewBalances() (map[enode.ID]int64, error) {
 		balances[peerID] = peerBalance
 	}
 
-	balanceIterFunction := func(key []byte, value []byte) {
+	balanceIterFunction := func(key []byte, value []byte) (stop bool, err error) {
 		peerID := keyToID(string(key), balancePrefix)
 		var peerBalance int64
-		json.Unmarshal(value, &peerBalance)
-		balances[peerID] = peerBalance
+		err = json.Unmarshal(value, &peerBalance)
+		if err == nil {
+			balances[peerID] = peerBalance
+		}
+		return stop, err
 	}
 	err := s.stateStore.Iterate(balancePrefix, balanceIterFunction)
 	if err != nil {

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -304,6 +304,17 @@ func (s *Swap) Balance(peer enode.ID) (int64, error) {
 	return peerBalance, err
 }
 
+func (s *Swap) NewBalances() (map[enode.ID]int64, error) {
+	balances := make(map[enode.ID]int64)
+
+	// add in-memory balance peers
+	for peerID, peerBalance := range s.balances {
+		balances[peerID] = peerBalance
+	}
+
+	return balances, nil
+}
+
 // Balances returns the balances for all known SWAP peers
 func (s *Swap) Balances() (map[enode.ID]int64, error) {
 	balances := make(map[enode.ID]int64)

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -19,6 +19,7 @@ package swap
 import (
 	"context"
 	"crypto/ecdsa"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -315,7 +316,7 @@ func (s *Swap) NewBalances() (map[enode.ID]int64, error) {
 	balanceIterFunction := func(key []byte, value []byte) {
 		peerID := keyToID(string(key), balancePrefix)
 		var peerBalance int64
-		_ = s.stateStore.Get(string(key), &peerBalance)
+		json.Unmarshal(value, &peerBalance)
 		balances[peerID] = peerBalance
 	}
 	err := s.stateStore.Iterate(balancePrefix, balanceIterFunction)

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -19,6 +19,7 @@ package swap
 import (
 	"context"
 	"crypto/ecdsa"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math/big"
@@ -312,6 +313,15 @@ func (s *Swap) NewBalances() (map[enode.ID]int64, error) {
 		balances[peerID] = peerBalance
 	}
 
+	balanceIterFunction := func(key []byte, value []byte) {
+		peerID := enode.HexID(string(key))
+		peerBalance := binary.BigEndian.Uint64(value)
+		balances[peerID] = int64(peerBalance)
+	}
+	err := s.stateStore.Iterate(balancePrefix, balanceIterFunction)
+	if err != nil {
+		return nil, err
+	}
 	return balances, nil
 }
 

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -19,7 +19,6 @@ package swap
 import (
 	"context"
 	"crypto/ecdsa"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"math/big"
@@ -314,9 +313,10 @@ func (s *Swap) NewBalances() (map[enode.ID]int64, error) {
 	}
 
 	balanceIterFunction := func(key []byte, value []byte) {
-		peerID := enode.HexID(string(key))
-		peerBalance := binary.BigEndian.Uint64(value)
-		balances[peerID] = int64(peerBalance)
+		peerID := keyToID(string(key), balancePrefix)
+		var peerBalance int64
+		_ = s.stateStore.Get(string(key), &peerBalance)
+		balances[peerID] = peerBalance
 	}
 	err := s.stateStore.Iterate(balancePrefix, balanceIterFunction)
 	if err != nil {

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -305,7 +305,8 @@ func (s *Swap) Balance(peer enode.ID) (int64, error) {
 	return peerBalance, err
 }
 
-func (s *Swap) NewBalances() (map[enode.ID]int64, error) {
+// Balances returns the balances for all known SWAP peers
+func (s *Swap) Balances() (map[enode.ID]int64, error) {
 	balances := make(map[enode.ID]int64)
 
 	// add in-memory balances
@@ -331,56 +332,6 @@ func (s *Swap) NewBalances() (map[enode.ID]int64, error) {
 	}
 
 	return balances, nil
-}
-
-// Balances returns the balances for all known SWAP peers
-func (s *Swap) Balances() (map[enode.ID]int64, error) {
-	balances := make(map[enode.ID]int64)
-
-	// get list of all known SWAP peers to have a balance
-	swapPeers, err := s.BalancePeers()
-	if err != nil {
-		return nil, err
-	}
-
-	// get balance for list of peers
-	for _, peer := range swapPeers {
-		peerBalance, err := s.Balance(peer)
-		if err != nil {
-			return nil, err
-		}
-		balances[peer] = peerBalance
-	}
-
-	return balances, nil
-}
-
-// BalancePeers returns a list of every peer known to have a balance set through SWAP
-func (s *Swap) BalancePeers() (peers []enode.ID, err error) {
-	knownPeers := make(map[enode.ID]bool)
-
-	// add in-memory balance peers and mark as present
-	for peerID := range s.balances {
-		peers = append(peers, peerID)
-		knownPeers[peerID] = true
-	}
-
-	// get balance keys from store
-	storeBalancePeers, err := s.stateStore.Keys(balancePrefix)
-	if err != nil {
-		return nil, err
-	}
-
-	// add balance peer to result if not present in memory
-	for _, storeBalancePeer := range storeBalancePeers {
-		// take balance key and turn into node ID
-		peerID := keyToID(storeBalancePeer, balancePrefix)
-		if _, peerExists := knownPeers[peerID]; !peerExists {
-			peers = append(peers, peerID)
-		}
-	}
-
-	return peers, nil
 }
 
 // loadLastSentCheque loads the last cheque for a peer from the state store (persisted)

--- a/swarm.go
+++ b/swarm.go
@@ -599,3 +599,9 @@ func (s *SwapInfo) Balances() (map[enode.ID]int64, error) {
 	peerBalances, err := s.Swap.Balances()
 	return peerBalances, err
 }
+
+// Balances returns the current SWAP balances for all known peers
+func (s *SwapInfo) NewBalances() (map[enode.ID]int64, error) {
+	peerBalances, err := s.Swap.NewBalances()
+	return peerBalances, err
+}

--- a/swarm.go
+++ b/swarm.go
@@ -599,9 +599,3 @@ func (s *SwapInfo) Balances() (map[enode.ID]int64, error) {
 	peerBalances, err := s.Swap.Balances()
 	return peerBalances, err
 }
-
-// Balances returns the current SWAP balances for all known peers
-func (s *SwapInfo) NewBalances() (map[enode.ID]int64, error) {
-	peerBalances, err := s.Swap.NewBalances()
-	return peerBalances, err
-}


### PR DESCRIPTION
This PR is a rework of the `Balances` functionality–that is, getting the list of balances for all known SWAP peers for the running node. This method is also exposed through `jsonrpc`.

Since the balances are not only in memory but in disk as well, the state store (i.e. the underlying `leveldb` structure) must be queried.

The concern was that we the original implementation was handling all balance store keys at the same time, and this number can be expected to grow very quickly. 

To fix this, this PR retires the `Keys` method in favor of an `Iterate` method, which takes one key/value pair at a time from the store, as long as they match the given prefix (in this case, the balance entries prefix).

The code was modeled after @jmozah's work on pinning (see [here](https://github.com/ethersphere/swarm/commit/e21368824e2f1f8d2c8949cf2e8ab05059be5102#diff-3c14fdca2493fecfde225ecc83eeb5e8R211)).

This, in turn, also simplified the implementation of the `Balances` functionality, since previously keys were queried first, then values. For this reason, some tests have been simplified as well. 