### PR TITLE
swap: log-levels

### DIFF
--- a/swap/swap.go
+++ b/swap/swap.go
@@ -392,7 +392,7 @@ func (s *Swap) Close() {
 // * for the creditor: on cheque receival
 // * for the debitor: on confirmation receival
 func (s *Swap) resetBalance(peerID enode.ID, amount int64) {
-	log.Info("resetting balance for peer", "peer", peerID.String(), "amount", amount)
+	log.Debug("resetting balance for peer", "peer", peerID.String(), "amount", amount)
 	s.updateBalance(peerID, amount)
 }
 


### PR DESCRIPTION

Based on: 

```
I generally subscribe to the following convention:

    Trace - Only when I would be "tracing" the code and trying to find one part of a function specifically.
    Debug - Information that is diagnostically helpful to people more than just developers (IT, sysadmins, etc.).
    Info - Generally useful information to log (service start/stop, configuration assumptions, etc). Info I want to always have available but usually don't care about under normal circumstances. This is my out-of-the-box config level.
    Warn - Anything that can potentially cause application oddities, but for which I am automatically recovering. (Such as switching from a primary to backup server, retrying an operation, missing secondary data, etc.)
    Error - Any error which is fatal to the operation, but not the service or application (can't open a required file, missing data, etc.). These errors will force user (administrator, or direct user) intervention. These are usually reserved (in my apps) for incorrect connection strings, missing services, etc.
    Fatal - Any error that is forcing a shutdown of the service or application to prevent data loss (or further data loss). I reserve these only for the most heinous errors and situations where there is guaranteed to have been data corruption or loss.
```

https://stackoverflow.com/questions/2031163/when-to-use-the-different-log-levels

