### PR TITLE
swap: refactor swap API interface

### DIFF
--- a/swap/protocol.go
+++ b/swap/protocol.go
@@ -29,7 +29,6 @@ import (
 	contract "github.com/ethersphere/swarm/contracts/swap"
 	"github.com/ethersphere/swarm/log"
 	"github.com/ethersphere/swarm/p2p/protocols"
-	"github.com/ethersphere/swarm/state"
 )
 
 // ErrEmptyAddressInSignature is used when the empty address is used for the chequebook in the handshake
@@ -148,33 +147,21 @@ func (s *Swap) getPeer(id enode.ID) (*Peer, error) {
 	return peer, err
 }
 
-// NewAPI creates a new PublicAPI instance
-func NewAPI(s *Swap) *PublicAPI {
-	return &PublicAPI{
-		Swap:   s,
-		Params: s.GetParams(),
-	}
+type swapAPI interface {
+	Balance(peer enode.ID) (int64, error)
+	Balances() (map[enode.ID]int64, error)
 }
 
 // PublicAPI would be the public API accessor for protocol methods
 type PublicAPI struct {
-	*Swap
+	swapAPI
 	*contract.Params
 }
 
-// Balance returns the current SWAP balance for a given peer
-func (api *PublicAPI) Balance(peer enode.ID) (int64, error) {
-	peerBalance, err := api.Swap.Balance(peer)
-	if err != nil && err != state.ErrNotFound {
-		return peerBalance, err
+// NewAPI creates a new PublicAPI instance
+func NewAPI(s *Swap) *PublicAPI {
+	return &PublicAPI{
+		swapAPI: s,
+		Params:  s.GetParams(),
 	}
-	// A peer not being found in the balances map is not considered an error at this level
-	// Just a balance of 0
-	return peerBalance, nil
-}
-
-// Balances returns the current SWAP balances for all known peers
-func (api *PublicAPI) Balances() (map[enode.ID]int64, error) {
-	peerBalances, err := api.Swap.Balances()
-	return peerBalances, err
 }


### PR DESCRIPTION
The aim of this PR is to make a small refactor to the SWAP API code, based on a [review comment](https://github.com/ethersphere/swarm/pull/1554/files#r310393224) made in #1554. 

This refactor removes unneeded code and allows us to specify exactly what functions to expose from the `Swap` struct to the SWAP API, through the use of an interface.

### Original review comment
>ok so it seems the API just wants to expose two functions of the embedded Swap.
There is a more elegant way to achieve this:

```golang
type swapAPI interface {
   Balance(peer enode.ID) (int64, error)
   Balances() (map[enode.ID]int64, error)
} 

type PublicAPI struct {
   swapAPI
   *contract.Params
}

// NewAPI creates a new PublicAPI instance
func NewAPI(s *Swap) *PublicAPI {
	return &PublicAPI{
		swapApi:   s,
		Params: s.GetParams(),
	}
}
```

_Originally posted by @zelig in https://github.com/ethersphere/swarm/pull/1554_