### PR TITLE
HTTP API support for pinning contents

### DIFF
--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -32,11 +32,12 @@ import (
 	"github.com/ethersphere/swarm/storage"
 	"github.com/ethersphere/swarm/storage/feed"
 	"github.com/ethersphere/swarm/storage/feed/lookup"
+	"github.com/ethersphere/swarm/storage/pin"
 	"github.com/ethersphere/swarm/testutil"
 )
 
-func serverFunc(api *api.API) swarmhttp.TestServer {
-	return swarmhttp.NewServer(api, nil, "")
+func serverFunc(api *api.API, pinAPI *pin.API) swarmhttp.TestServer {
+	return swarmhttp.NewServer(api, pinAPI, "")
 }
 
 // TestClientUploadDownloadRaw test uploading and downloading raw data to swarm

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -946,7 +946,6 @@ func (s *Server) HandlePin(w http.ResponseWriter, r *http.Request) {
 	log.Debug("pinned content", "ruid", ruid, "key", fileAddr.Hex())
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprint(w, fmt.Sprintf("Address %s pinned", fileAddr.Hex()))
 }
 
 // HandleUnpin takes a root hash as argument and unpins the file or collection from the local Swarm DB
@@ -973,7 +972,6 @@ func (s *Server) HandleUnpin(w http.ResponseWriter, r *http.Request) {
 	log.Debug("unpinned content", "ruid", ruid, "key", fileAddr.Hex())
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprint(w, fmt.Sprintf("Address %s unpinned", fileAddr.Hex()))
 }
 
 // HandleGetPins return information about all the hashes pinned at this moment

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -980,7 +980,7 @@ func (s *Server) HandleGetPins(w http.ResponseWriter, r *http.Request) {
 	ruid := GetRUID(r.Context())
 	log.Debug("handle.get.pin", "ruid", ruid, "uri", r.RequestURI)
 
-	pinnedFiles, err := s.pinAPI.ListPinFiles()
+	pinnedFiles, err := s.pinAPI.ListPins()
 	if err != nil {
 		getPinFail.Inc(1)
 		respondError(w, r, fmt.Sprintf("error getting pinned files: %s", err), http.StatusInternalServerError)

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -926,7 +926,7 @@ func (s *Server) HandlePin(w http.ResponseWriter, r *http.Request) {
 
 	if fileAddr == nil {
 		postPinFail.Inc(1)
-		respondError(w, r, "missig hash to pin " , http.StatusBadRequest)
+		respondError(w, r, "missig hash to pin ", http.StatusBadRequest)
 		return
 	}
 
@@ -939,7 +939,7 @@ func (s *Server) HandlePin(w http.ResponseWriter, r *http.Request) {
 	err := s.pinAPI.PinFiles(fileAddr, isRaw, "")
 	if err != nil {
 		postPinFail.Inc(1)
-		respondError(w, r, fmt.Sprintf("error pinning file %s: %s", fileAddr.Hex(), err) , http.StatusInternalServerError)
+		respondError(w, r, fmt.Sprintf("error pinning file %s: %s", fileAddr.Hex(), err), http.StatusInternalServerError)
 		return
 	}
 
@@ -959,14 +959,14 @@ func (s *Server) HandleUnpin(w http.ResponseWriter, r *http.Request) {
 
 	if fileAddr == nil {
 		deletePinFail.Inc(1)
-		respondError(w, r, "missig hash to unpin " , http.StatusBadRequest)
+		respondError(w, r, "missig hash to unpin ", http.StatusBadRequest)
 		return
 	}
 
 	err := s.pinAPI.UnpinFiles(fileAddr, "")
 	if err != nil {
 		deletePinFail.Inc(1)
-		respondError(w, r, fmt.Sprintf("error pinning file %s: %s", fileAddr.Hex(), err) , http.StatusInternalServerError)
+		respondError(w, r, fmt.Sprintf("error pinning file %s: %s", fileAddr.Hex(), err), http.StatusInternalServerError)
 		return
 	}
 
@@ -985,7 +985,7 @@ func (s *Server) HandleGetPins(w http.ResponseWriter, r *http.Request) {
 	pinnedFiles, err := s.pinAPI.ListPinFiles()
 	if err != nil {
 		getPinFail.Inc(1)
-		respondError(w, r, fmt.Sprintf("error getting pinned files: %s", err) , http.StatusInternalServerError)
+		respondError(w, r, fmt.Sprintf("error getting pinned files: %s", err), http.StatusInternalServerError)
 		return
 	}
 

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -168,13 +168,6 @@ func NewServer(api *api.API, pinAPI *pin.API, corsString string) *Server {
 			defaultMiddlewares...,
 		),
 	})
-	mux.Handle("/", methodHandler{
-		"GET": Adapt(
-			http.HandlerFunc(server.HandleRootPaths),
-			SetRequestID,
-			InitLoggingResponseWriter,
-		),
-	})
 	mux.Handle("/bzz-pin:/", methodHandler{
 		"GET": Adapt(
 			http.HandlerFunc(server.HandleGetPins),
@@ -187,6 +180,13 @@ func NewServer(api *api.API, pinAPI *pin.API, corsString string) *Server {
 		"DELETE": Adapt(
 			http.HandlerFunc(server.HandleUnpin),
 			defaultMiddlewares...,
+		),
+	})
+	mux.Handle("/", methodHandler{
+		"GET": Adapt(
+			http.HandlerFunc(server.HandleRootPaths),
+			SetRequestID,
+			InitLoggingResponseWriter,
 		),
 	})
 	server.Handler = c.Handler(mux)
@@ -930,10 +930,10 @@ func (s *Server) HandlePin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	isRaw := true
+	isRaw := false
 	isRawString := r.URL.Query().Get("IsRaw")
-	if isRawString == "" || isRawString == "false" {
-		isRaw = false
+	if strings.ToLower(isRawString) == "true" {
+		isRaw = true
 	}
 
 	err := s.pinAPI.PinFiles(fileAddr, isRaw, "")

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -62,6 +62,12 @@ var (
 	getFileFail     = metrics.NewRegisteredCounter("api.http.get.file.fail", nil)
 	getListCount    = metrics.NewRegisteredCounter("api.http.get.list.count", nil)
 	getListFail     = metrics.NewRegisteredCounter("api.http.get.list.fail", nil)
+	getPinCount     = metrics.NewRegisteredCounter("api.http.get.pin.count", nil)
+	getPinFail      = metrics.NewRegisteredCounter("api.http.get.pin.fail", nil)
+	postPinCount    = metrics.NewRegisteredCounter("api.http.post.pin.count", nil)
+	postPinFail     = metrics.NewRegisteredCounter("api.http.post.pin.fail", nil)
+	deletePinCount  = metrics.NewRegisteredCounter("api.http.delete.pin.count", nil)
+	deletePinFail   = metrics.NewRegisteredCounter("api.http.delete.pin.fail", nil)
 )
 
 const (
@@ -162,12 +168,25 @@ func NewServer(api *api.API, pinAPI *pin.API, corsString string) *Server {
 			defaultMiddlewares...,
 		),
 	})
-
 	mux.Handle("/", methodHandler{
 		"GET": Adapt(
 			http.HandlerFunc(server.HandleRootPaths),
 			SetRequestID,
 			InitLoggingResponseWriter,
+		),
+	})
+	mux.Handle("/bzz-pin:/", methodHandler{
+		"GET": Adapt(
+			http.HandlerFunc(server.HandleGetPins),
+			defaultMiddlewares...,
+		),
+		"POST": Adapt(
+			http.HandlerFunc(server.HandlePin),
+			defaultPostMiddlewares...,
+		),
+		"DELETE": Adapt(
+			http.HandlerFunc(server.HandleUnpin),
+			defaultMiddlewares...,
 		),
 	})
 	server.Handler = c.Handler(mux)
@@ -895,6 +914,83 @@ func (s *Server) HandleGetFile(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename=\"%s\"", fileName))
 
 	http.ServeContent(w, r, fileName, time.Now(), newBufferedReadSeeker(reader, getFileBufferSize))
+}
+
+// HandlePin takes a root hash as argument and pins a given file or collection in the local Swarm DB
+func (s *Server) HandlePin(w http.ResponseWriter, r *http.Request) {
+	postPinCount.Inc(1)
+	ruid := GetRUID(r.Context())
+	uri := GetURI(r.Context())
+	fileAddr := uri.Address()
+	log.Debug("handle.post.pin", "ruid", ruid, "uri", r.RequestURI)
+
+	if fileAddr == nil {
+		postPinFail.Inc(1)
+		respondError(w, r, "missig hash to pin " , http.StatusBadRequest)
+		return
+	}
+
+	isRaw := true
+	isRawString := r.URL.Query().Get("IsRaw")
+	if isRawString == "" || isRawString == "false" {
+		isRaw = false
+	}
+
+	err := s.pinAPI.PinFiles(fileAddr, isRaw, "")
+	if err != nil {
+		postPinFail.Inc(1)
+		respondError(w, r, fmt.Sprintf("error pinning file %s: %s", fileAddr.Hex(), err) , http.StatusInternalServerError)
+		return
+	}
+
+	log.Debug("pinned content", "ruid", ruid, "key", fileAddr.Hex())
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, fmt.Sprintf("Address %s pinned", fileAddr.Hex()))
+}
+
+// HandleUnpin takes a root hash as argument and unpins the file or collection from the local Swarm DB
+func (s *Server) HandleUnpin(w http.ResponseWriter, r *http.Request) {
+	deletePinCount.Inc(1)
+	ruid := GetRUID(r.Context())
+	uri := GetURI(r.Context())
+	fileAddr := uri.Address()
+	log.Debug("handle.delete.pin", "ruid", ruid, "uri", r.RequestURI)
+
+	if fileAddr == nil {
+		deletePinFail.Inc(1)
+		respondError(w, r, "missig hash to unpin " , http.StatusBadRequest)
+		return
+	}
+
+	err := s.pinAPI.UnpinFiles(fileAddr, "")
+	if err != nil {
+		deletePinFail.Inc(1)
+		respondError(w, r, fmt.Sprintf("error pinning file %s: %s", fileAddr.Hex(), err) , http.StatusInternalServerError)
+		return
+	}
+
+	log.Debug("unpinned content", "ruid", ruid, "key", fileAddr.Hex())
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, fmt.Sprintf("Address %s unpinned", fileAddr.Hex()))
+}
+
+// HandleGetPins return information about all the hashes pinned at this moment
+func (s *Server) HandleGetPins(w http.ResponseWriter, r *http.Request) {
+	getPinCount.Inc(1)
+	ruid := GetRUID(r.Context())
+	log.Debug("handle.get.pin", "ruid", ruid, "uri", r.RequestURI)
+
+	pinnedFiles, err := s.pinAPI.ListPinFiles()
+	if err != nil {
+		getPinFail.Inc(1)
+		respondError(w, r, fmt.Sprintf("error getting pinned files: %s", err) , http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(&pinnedFiles)
 }
 
 // calculateNumberOfChunks calculates the number of chunks in an arbitrary content length

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -931,7 +931,7 @@ func (s *Server) HandlePin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	isRaw := false
-	isRawString := r.URL.Query().Get("IsRaw")
+	isRawString := r.URL.Query().Get("raw")
 	if strings.ToLower(isRawString) == "true" {
 		isRaw = true
 	}

--- a/api/http/server_test.go
+++ b/api/http/server_test.go
@@ -85,13 +85,7 @@ func TestPinUnpinAPI(t *testing.T) {
 	rootHash := uploadFile(t, srv, data)
 
 	// pin it
-	pinMessage := pinFile(t, srv, rootHash)
-
-	// Check if the return message is valid
-	expectedPinMsg := fmt.Sprintf("Address %s pinned", string(rootHash))
-	if string(pinMessage) != expectedPinMsg {
-		t.Fatalf("pin message mismatch, expected %x, got %x", expectedPinMsg, pinMessage)
-	}
+	pinFile(t, srv, rootHash)
 
 	// get the list of files pinned
 	pinnedInfo := listPinnedFiles(t, srv)
@@ -117,13 +111,7 @@ func TestPinUnpinAPI(t *testing.T) {
 	}
 
 	// unpin it
-	unpinMessage := unpinFile(t, srv, rootHash)
-
-	// Check if the return message is valid
-	expectedunPinMsg := fmt.Sprintf("Address %s unpinned", string(rootHash))
-	if string(unpinMessage) != expectedunPinMsg {
-		t.Fatalf("pin message mismatch, expected %x, got %x", expectedunPinMsg, unpinMessage)
-	}
+	unpinFile(t, srv, rootHash)
 
 	// get the list of files pinned again
 	unpinnedInfo := listPinnedFiles(t, srv)

--- a/api/http/server_test.go
+++ b/api/http/server_test.go
@@ -1487,7 +1487,7 @@ func uploadFile(t *testing.T, srv *TestSwarmServer, data []byte) []byte {
 
 func pinFile(t *testing.T, srv *TestSwarmServer, rootHash []byte) []byte {
 	t.Helper()
-	pinResp, err := http.Post(fmt.Sprintf("%s/bzz-pin:/%s?IsRaw=true", srv.URL, string(rootHash)), "text/plain", bytes.NewReader([]byte("")))
+	pinResp, err := http.Post(fmt.Sprintf("%s/bzz-pin:/%s?raw=true", srv.URL, string(rootHash)), "text/plain", bytes.NewReader([]byte("")))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/http/server_test.go
+++ b/api/http/server_test.go
@@ -89,7 +89,7 @@ func TestPinUnpinAPI(t *testing.T) {
 
 	// get the list of files pinned
 	pinnedInfo := listPinnedFiles(t, srv)
-	listInfos := make([]pin.FileInfo, 0)
+	listInfos := make([]pin.PinInfo, 0)
 	err := json.Unmarshal(pinnedInfo, &listInfos)
 	if err != nil {
 		t.Fatal(err)
@@ -115,7 +115,7 @@ func TestPinUnpinAPI(t *testing.T) {
 
 	// get the list of files pinned again
 	unpinnedInfo := listPinnedFiles(t, srv)
-	listInfosUnpin := make([]pin.FileInfo, 0)
+	listInfosUnpin := make([]pin.PinInfo, 0)
 	err = json.Unmarshal(unpinnedInfo, &listInfosUnpin)
 	if err != nil {
 		t.Fatal(err)

--- a/api/http/server_test.go
+++ b/api/http/server_test.go
@@ -44,9 +44,9 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethersphere/swarm/api"
 	"github.com/ethersphere/swarm/storage"
-	"github.com/ethersphere/swarm/storage/pin"
 	"github.com/ethersphere/swarm/storage/feed"
 	"github.com/ethersphere/swarm/storage/feed/lookup"
+	"github.com/ethersphere/swarm/storage/pin"
 	"github.com/ethersphere/swarm/testutil"
 )
 
@@ -75,7 +75,7 @@ func newTestSigner() (*feed.GenericSigner, error) {
 //    3) list all the files using HTTP API and check if the pinned file is present
 //    4) unpin the pinned file
 //    5) list pinned files and check if the unpinned files is not there anymore
-func TestPinUnpinAPI(t *testing.T){
+func TestPinUnpinAPI(t *testing.T) {
 	// Initialize Swarm test server
 	srv := NewTestSwarmServer(t, serverFunc, nil, nil)
 	defer srv.Close()
@@ -85,17 +85,17 @@ func TestPinUnpinAPI(t *testing.T){
 	rootHash := uploadFile(t, srv, data)
 
 	// pin it
-	pinMessage := pinFile(t,srv, rootHash)
+	pinMessage := pinFile(t, srv, rootHash)
 
 	// Check if the return message is valid
-	expectedPinMsg := fmt.Sprintf("Address %s pinned",string(rootHash))
+	expectedPinMsg := fmt.Sprintf("Address %s pinned", string(rootHash))
 	if string(pinMessage) != expectedPinMsg {
 		t.Fatalf("pin message mismatch, expected %x, got %x", expectedPinMsg, pinMessage)
 	}
 
 	// get the list of files pinned
-	pinnedInfo := listPinnedFiles(t,srv)
-	listInfos := make([]pin.FileInfo,0)
+	pinnedInfo := listPinnedFiles(t, srv)
+	listInfos := make([]pin.FileInfo, 0)
 	err := json.Unmarshal(pinnedInfo, &listInfos)
 	if err != nil {
 		t.Fatal(err)
@@ -103,10 +103,10 @@ func TestPinUnpinAPI(t *testing.T){
 
 	// Check if the pinned file is present in the list pin command
 	fileInfo := listInfos[0]
-	if hex.EncodeToString(fileInfo.Address) !=  string(rootHash) {
+	if hex.EncodeToString(fileInfo.Address) != string(rootHash) {
 		t.Fatalf("roothash not in list of pinned files")
 	}
-	if fileInfo.IsRaw != true {
+	if !fileInfo.IsRaw {
 		t.Fatalf("pinned file is not raw")
 	}
 	if fileInfo.PinCounter != 1 {
@@ -117,10 +117,10 @@ func TestPinUnpinAPI(t *testing.T){
 	}
 
 	// unpin it
-	unpinMessage := unpinFile(t,srv, rootHash)
+	unpinMessage := unpinFile(t, srv, rootHash)
 
 	// Check if the return message is valid
-	expectedunPinMsg := fmt.Sprintf("Address %s unpinned",string(rootHash))
+	expectedunPinMsg := fmt.Sprintf("Address %s unpinned", string(rootHash))
 	if string(unpinMessage) != expectedunPinMsg {
 		t.Fatalf("pin message mismatch, expected %x, got %x", expectedunPinMsg, unpinMessage)
 	}
@@ -1467,8 +1467,7 @@ func (t *testResolveValidator) HeaderByNumber(context.Context, *big.Int) (header
 	return
 }
 
-
-func uploadFile(t *testing.T, srv *TestSwarmServer, data []byte) []byte{
+func uploadFile(t *testing.T, srv *TestSwarmServer, data []byte) []byte {
 	t.Helper()
 	resp, err := http.Post(fmt.Sprintf("%s/bzz-raw:/", srv.URL), "text/plain", bytes.NewReader([]byte(data)))
 	if err != nil {
@@ -1485,7 +1484,7 @@ func uploadFile(t *testing.T, srv *TestSwarmServer, data []byte) []byte{
 	return rootHash
 }
 
-func pinFile(t *testing.T, srv *TestSwarmServer, rootHash []byte) []byte{
+func pinFile(t *testing.T, srv *TestSwarmServer, rootHash []byte) []byte {
 	t.Helper()
 	pinResp, err := http.Post(fmt.Sprintf("%s/bzz-pin:/%s?IsRaw=true", srv.URL, string(rootHash)), "text/plain", bytes.NewReader([]byte("")))
 	if err != nil {

--- a/api/http/server_test.go
+++ b/api/http/server_test.go
@@ -124,6 +124,19 @@ func TestPinUnpinAPI(t *testing.T) {
 	if string(unpinMessage) != expectedunPinMsg {
 		t.Fatalf("pin message mismatch, expected %x, got %x", expectedunPinMsg, unpinMessage)
 	}
+
+	// get the list of files pinned again
+	unpinnedInfo := listPinnedFiles(t, srv)
+	listInfosUnpin := make([]pin.FileInfo, 0)
+	err = json.Unmarshal(unpinnedInfo, &listInfosUnpin)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check if the pinned file is not present in the list pin command
+	if len(listInfosUnpin) != 0 {
+		t.Fatalf("roothash is in list of pinned files")
+	}
 }
 
 // Test the transparent resolving of feed updates with bzz:// scheme

--- a/api/http/test_server.go
+++ b/api/http/test_server.go
@@ -28,9 +28,9 @@ import (
 	"github.com/ethersphere/swarm/chunk"
 	"github.com/ethersphere/swarm/state"
 	"github.com/ethersphere/swarm/storage"
-	"github.com/ethersphere/swarm/storage/pin"
 	"github.com/ethersphere/swarm/storage/feed"
 	"github.com/ethersphere/swarm/storage/localstore"
+	"github.com/ethersphere/swarm/storage/pin"
 )
 
 type TestServer interface {

--- a/api/uri.go
+++ b/api/uri.go
@@ -86,7 +86,7 @@ func Parse(rawuri string) (*URI, error) {
 
 	// check the scheme is valid
 	switch uri.Scheme {
-	case "bzz", "bzz-raw", "bzz-immutable", "bzz-list", "bzz-hash", "bzz-feed":
+	case "bzz", "bzz-raw", "bzz-immutable", "bzz-list", "bzz-hash", "bzz-feed", "bzz-pin":
 	default:
 		return nil, fmt.Errorf("unknown scheme %q", u.Scheme)
 	}
@@ -126,6 +126,10 @@ func (u *URI) List() bool {
 
 func (u *URI) Hash() bool {
 	return u.Scheme == "bzz-hash"
+}
+
+func (u *URI) Pin() bool {
+	return u.Scheme == "bzz-pin"
 }
 
 func (u *URI) String() string {

--- a/cmd/swarm/feeds_test.go
+++ b/cmd/swarm/feeds_test.go
@@ -31,11 +31,12 @@ import (
 	swarmhttp "github.com/ethersphere/swarm/api/http"
 	"github.com/ethersphere/swarm/storage/feed"
 	"github.com/ethersphere/swarm/storage/feed/lookup"
+	"github.com/ethersphere/swarm/storage/pin"
 	"github.com/ethersphere/swarm/testutil"
 )
 
 func TestCLIFeedUpdate(t *testing.T) {
-	srv := swarmhttp.NewTestSwarmServer(t, func(api *api.API) swarmhttp.TestServer {
+	srv := swarmhttp.NewTestSwarmServer(t, func(api *api.API, pinAPI *pin.API) swarmhttp.TestServer {
 		return swarmhttp.NewServer(api, nil, "")
 	}, nil, nil)
 	log.Info("starting a test swarm server")

--- a/cmd/swarm/run_test.go
+++ b/cmd/swarm/run_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/ethersphere/swarm/api"
 	swarmhttp "github.com/ethersphere/swarm/api/http"
 	"github.com/ethersphere/swarm/internal/cmdtest"
+	"github.com/ethersphere/swarm/storage/pin"
 )
 
 var loglevel = flag.Int("loglevel", 3, "verbosity of logs")
@@ -59,8 +60,8 @@ func init() {
 
 const clusterSize = 3
 
-func serverFunc(api *api.API) swarmhttp.TestServer {
-	return swarmhttp.NewServer(api, nil, "")
+func serverFunc(api *api.API, pinAPI *pin.API) swarmhttp.TestServer {
+	return swarmhttp.NewServer(api, pinAPI, "")
 }
 func TestMain(m *testing.M) {
 	// check if we have been reexec'd

--- a/storage/pin/pin.go
+++ b/storage/pin/pin.go
@@ -240,7 +240,7 @@ func (p *API) UnpinFiles(addr []byte, credentials string) error {
 //     2) Size of the pinned file or collection
 //     3) the number of times that particular file or collection is pinned.
 func (p *API) ListPinFiles() ([]FileInfo, error) {
-	pinnedFiles := make([]FileInfo,0)
+	pinnedFiles := make([]FileInfo, 0)
 	iterFunc := func(key []byte, value []byte) {
 		hash := string(key[4:])
 		fileInfo := FileInfo{}

--- a/storage/pin/pin_test.go
+++ b/storage/pin/pin_test.go
@@ -148,7 +148,7 @@ func TestListPinInfo(t *testing.T) {
 	}
 
 	// Check if the uploaded collection is in the list files data structure
-	fileInfo, err :=  getFileInfo(pinInfo, hash)
+	fileInfo, err := getFileInfo(pinInfo, hash)
 	if err != nil {
 		t.Fatalf("uploaded collection not pinned")
 	}
@@ -170,7 +170,7 @@ func TestListPinInfo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error executing ListPinFiles command")
 	}
-	fileInfo, err =  getFileInfo(pinInfo, hash)
+	fileInfo, err = getFileInfo(pinInfo, hash)
 	if err != nil {
 		t.Fatalf("hash not pinned ")
 	}
@@ -189,7 +189,7 @@ func TestListPinInfo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error executing ListPinFiles command")
 	}
-	fileInfo, err =  getFileInfo(pinInfo, hash)
+	fileInfo, err = getFileInfo(pinInfo, hash)
 	if err != nil {
 		t.Fatalf("collection totally unpinned")
 	}
@@ -208,7 +208,7 @@ func TestListPinInfo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error executing ListPinFiles command")
 	}
-	_, err =  getFileInfo(pinInfo, hash)
+	_, err = getFileInfo(pinInfo, hash)
 	if err == nil {
 		t.Fatalf("uploaded collection is still pinned")
 	}
@@ -409,7 +409,7 @@ func failIfNotPinned(t *testing.T, p *API, rootHash []byte, pinCounter uint64, i
 		t.Fatalf("Could not load pin state from state store")
 	}
 
-	fileInfo, err :=  getFileInfo(pinnedFiles, rootHash)
+	fileInfo, err := getFileInfo(pinnedFiles, rootHash)
 	if err != nil {
 		t.Fatalf("Fileinfo not present in state store")
 	}
@@ -543,7 +543,7 @@ func getChunks(t *testing.T, bin uint8, addrs map[string]int, addrLock *sync.RWM
 	}
 }
 
-func getFileInfo(pinInfo []FileInfo, hash storage.Address) (fileInfo FileInfo, err error){
+func getFileInfo(pinInfo []FileInfo, hash storage.Address) (fileInfo FileInfo, err error) {
 	for _, fi := range pinInfo {
 		if bytes.Equal(fi.Address, hash) {
 			return fi, nil

--- a/storage/pin/pin_test.go
+++ b/storage/pin/pin_test.go
@@ -127,7 +127,7 @@ func TestWalker(t *testing.T) {
 	}
 }
 
-// TestListPinInfo tests the ListPinFiles command by pinning and unpinning a collection
+// TestListPinInfo tests the ListPins command by pinning and unpinning a collection
 // twice and check if this gets reflected properly in the data structure
 func TestListPinInfo(t *testing.T) {
 	p, f, closeFunc := getPinApiAndFileStore(t)
@@ -141,21 +141,21 @@ func TestListPinInfo(t *testing.T) {
 		t.Fatalf("Could not pin " + err.Error())
 	}
 
-	// Get the list of pinned files by calling the ListPinFiles command
-	pinInfo, err := p.ListPinFiles()
+	// Get the list of pinned files by calling the ListPins command
+	pinsInfo, err := p.ListPins()
 	if err != nil {
-		t.Fatalf("Error executing ListPinFiles command")
+		t.Fatalf("Error executing ListPins command")
 	}
 
 	// Check if the uploaded collection is in the list files data structure
-	fileInfo, err := getFileInfo(pinInfo, hash)
+	pinInfo, err := getPinInfo(pinsInfo, hash)
 	if err != nil {
 		t.Fatalf("uploaded collection not pinned")
 	}
-	if fileInfo.PinCounter != 1 {
-		t.Fatalf("pincounter expected is 1 got is %d", fileInfo.PinCounter)
+	if pinInfo.PinCounter != 1 {
+		t.Fatalf("pincounter expected is 1 got is %d", pinInfo.PinCounter)
 	}
-	if fileInfo.IsRaw {
+	if pinInfo.IsRaw {
 		t.Fatalf("IsRaw expected is false got is true")
 	}
 
@@ -165,17 +165,17 @@ func TestListPinInfo(t *testing.T) {
 		t.Fatalf("Could not pin " + err.Error())
 	}
 
-	// Get the list of pinned files by calling the ListPinFiles command
-	pinInfo, err = p.ListPinFiles()
+	// Get the list of pinned files by calling the ListPins command
+	pinsInfo, err = p.ListPins()
 	if err != nil {
-		t.Fatalf("Error executing ListPinFiles command")
+		t.Fatalf("Error executing ListPins command")
 	}
-	fileInfo, err = getFileInfo(pinInfo, hash)
+	pinInfo, err = getPinInfo(pinsInfo, hash)
 	if err != nil {
 		t.Fatalf("hash not pinned ")
 	}
-	if fileInfo.PinCounter != 2 {
-		t.Fatalf("pincounter expected is 2 got is %d", fileInfo.PinCounter)
+	if pinInfo.PinCounter != 2 {
+		t.Fatalf("pincounter expected is 2 got is %d", pinInfo.PinCounter)
 	}
 
 	// Unpin it and check if the counter decrements
@@ -184,17 +184,17 @@ func TestListPinInfo(t *testing.T) {
 		t.Fatalf("Could not unpin " + err.Error())
 	}
 
-	// Get the list of pinned files by calling the ListPinFiles command
-	pinInfo, err = p.ListPinFiles()
+	// Get the list of pinned files by calling the ListPins command
+	pinsInfo, err = p.ListPins()
 	if err != nil {
-		t.Fatalf("Error executing ListPinFiles command")
+		t.Fatalf("Error executing ListPins command")
 	}
-	fileInfo, err = getFileInfo(pinInfo, hash)
+	pinInfo, err = getPinInfo(pinsInfo, hash)
 	if err != nil {
 		t.Fatalf("collection totally unpinned")
 	}
-	if fileInfo.PinCounter != 1 {
-		t.Fatalf("pincounter expected is 1 got is %d", fileInfo.PinCounter)
+	if pinInfo.PinCounter != 1 {
+		t.Fatalf("pincounter expected is 1 got is %d", pinInfo.PinCounter)
 	}
 
 	// Unpin it final time and the entry should not be there
@@ -203,12 +203,12 @@ func TestListPinInfo(t *testing.T) {
 		t.Fatalf("Could not unpin " + err.Error())
 	}
 
-	// Get the list of pinned files by calling the ListPinFiles command
-	pinInfo, err = p.ListPinFiles()
+	// Get the list of pinned files by calling the ListPins command
+	pinsInfo, err = p.ListPins()
 	if err != nil {
-		t.Fatalf("Error executing ListPinFiles command")
+		t.Fatalf("Error executing ListPins command")
 	}
-	_, err = getFileInfo(pinInfo, hash)
+	_, err = getPinInfo(pinsInfo, hash)
 	if err == nil {
 		t.Fatalf("uploaded collection is still pinned")
 	}
@@ -404,12 +404,12 @@ func failIfNotPinned(t *testing.T, p *API, rootHash []byte, pinCounter uint64, i
 		}
 	}
 
-	pinnedFiles, err := p.ListPinFiles()
+	pinnedFiles, err := p.ListPins()
 	if err != nil {
 		t.Fatalf("Could not load pin state from state store")
 	}
 
-	fileInfo, err := getFileInfo(pinnedFiles, rootHash)
+	fileInfo, err := getPinInfo(pinnedFiles, rootHash)
 	if err != nil {
 		t.Fatalf("Fileinfo not present in state store")
 	}
@@ -543,11 +543,11 @@ func getChunks(t *testing.T, bin uint8, addrs map[string]int, addrLock *sync.RWM
 	}
 }
 
-func getFileInfo(pinInfo []FileInfo, hash storage.Address) (fileInfo FileInfo, err error) {
+func getPinInfo(pinInfo []PinInfo, hash storage.Address) (PinInfo, error) {
 	for _, fi := range pinInfo {
 		if bytes.Equal(fi.Address, hash) {
 			return fi, nil
 		}
 	}
-	return FileInfo{}, errors.New("Fileinfo not found")
+	return PinInfo{}, errors.New("Pininfo not found")
 }

--- a/swarm.go
+++ b/swarm.go
@@ -531,12 +531,6 @@ func (s *Swarm) APIs() []rpc.API {
 			Service:   protocols.NewAccountingApi(s.accountingMetrics),
 			Public:    false,
 		},
-		{
-			Namespace: "pin",
-			Version:   pin.Version,
-			Service:   s.pinAPI,
-			Public:    false,
-		},
 	}
 
 	apis = append(apis, s.bzz.APIs()...)


### PR DESCRIPTION
Three HTTP API related to pinning is added
1) bzz-pin: POST -  for pinning a file
    bin-pin:/<swarm address>?IsRaw=true  to pin a raw file
     bin-pin:/<swarm address>  to pin a collection
2) bzz-pin: DELETE - for unpinning a file
3) bzz-pin: GET - for listing pinned files

