### PR TITLE
Enable golangci-lint and fix reported errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,13 @@
+linters-settings:
+  goconst:
+    # minimal length of string constant, 3 by default
+    min-len: 3
+    # minimal occurrences count to trigger, 3 by default
+    min-occurrences: 5
+
+issues:
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -96,7 +96,7 @@ func checkResponse(t *testing.T, resp *testResponse, exp *Response) {
 	}
 	if resp.Content != exp.Content {
 		// if !bytes.Equal(resp.Content, exp.Content)
-		t.Errorf("incorrect content. expected '%s...', got '%s...'", string(exp.Content), string(resp.Content))
+		t.Errorf("incorrect content. expected '%s...', got '%s...'", exp.Content, resp.Content)
 	}
 }
 

--- a/api/http/middleware.go
+++ b/api/http/middleware.go
@@ -113,7 +113,7 @@ func InitUploadTag(h http.Handler, tags *chunk.Tags) http.Handler {
 			uri := GetURI(r.Context())
 			if uri != nil {
 				log.Debug("got uri from context")
-				if uri.Addr == "encrypt" {
+				if uri.Addr == encryptAddr {
 					estimatedTotal = calculateNumberOfChunks(r.ContentLength, true)
 				} else {
 					estimatedTotal = calculateNumberOfChunks(r.ContentLength, false)
@@ -138,7 +138,7 @@ func InitUploadTag(h http.Handler, tags *chunk.Tags) http.Handler {
 func InstrumentOpenTracing(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		uri := GetURI(r.Context())
-		if uri == nil || r.Method == "" || (uri != nil && uri.Scheme == "") {
+		if uri == nil || r.Method == "" || uri.Scheme == "" {
 			h.ServeHTTP(w, r) // soft fail
 			return
 		}

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -63,7 +63,12 @@ var (
 	getListFail     = metrics.NewRegisteredCounter("api.http.get.list.fail", nil)
 )
 
-const SwarmTagHeaderName = "x-swarm-tag"
+const (
+	SwarmTagHeaderName = "x-swarm-tag"
+
+	encryptAddr    = "encrypt"
+	tarContentType = "application/x-tar"
+)
 
 type methodHandler map[string]http.Handler
 
@@ -188,7 +193,7 @@ type Server struct {
 
 func (s *Server) HandleBzzGet(w http.ResponseWriter, r *http.Request) {
 	log.Debug("handleBzzGet", "ruid", GetRUID(r.Context()), "uri", r.RequestURI)
-	if r.Header.Get("Accept") == "application/x-tar" {
+	if r.Header.Get("Accept") == tarContentType {
 		uri := GetURI(r.Context())
 		_, credentials, _ := r.BasicAuth()
 		reader, err := s.api.GetDirectoryTar(r.Context(), s.api.Decryptor(r.Context(), credentials), uri)
@@ -203,7 +208,7 @@ func (s *Server) HandleBzzGet(w http.ResponseWriter, r *http.Request) {
 		}
 		defer reader.Close()
 
-		w.Header().Set("Content-Type", "application/x-tar")
+		w.Header().Set("Content-Type", tarContentType)
 
 		fileName := uri.Addr
 		if found := path.Base(uri.Path); found != "" && found != "." && found != "/" {
@@ -251,7 +256,7 @@ func (s *Server) HandlePostRaw(w http.ResponseWriter, r *http.Request) {
 
 	toEncrypt := false
 	uri := GetURI(r.Context())
-	if uri.Addr == "encrypt" {
+	if uri.Addr == encryptAddr {
 		toEncrypt = true
 	}
 
@@ -261,7 +266,7 @@ func (s *Server) HandlePostRaw(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if uri.Addr != "" && uri.Addr != "encrypt" {
+	if uri.Addr != "" && uri.Addr != encryptAddr {
 		postRawFail.Inc(1)
 		respondError(w, r, "raw POST request addr can only be empty or \"encrypt\"", http.StatusBadRequest)
 		return
@@ -309,12 +314,12 @@ func (s *Server) HandlePostFiles(w http.ResponseWriter, r *http.Request) {
 
 	toEncrypt := false
 	uri := GetURI(r.Context())
-	if uri.Addr == "encrypt" {
+	if uri.Addr == encryptAddr {
 		toEncrypt = true
 	}
 
 	var addr storage.Address
-	if uri.Addr != "" && uri.Addr != "encrypt" {
+	if uri.Addr != "" && uri.Addr != encryptAddr {
 		addr, err = s.api.Resolve(r.Context(), uri.Addr)
 		if err != nil {
 			postFilesFail.Inc(1)
@@ -333,7 +338,7 @@ func (s *Server) HandlePostFiles(w http.ResponseWriter, r *http.Request) {
 	}
 	newAddr, err := s.api.UpdateManifest(r.Context(), addr, func(mw *api.ManifestWriter) error {
 		switch contentType {
-		case "application/x-tar":
+		case tarContentType:
 			_, err := s.handleTarUpload(r, mw)
 			if err != nil {
 				respondError(w, r, fmt.Sprintf("error uploading tarball: %v", err), http.StatusInternalServerError)

--- a/api/http/server_test.go
+++ b/api/http/server_test.go
@@ -102,7 +102,7 @@ func TestBzzWithFeed(t *testing.T) {
 	`)
 
 	// POST data to bzz and get back a content-addressed **manifest hash** pointing to it.
-	resp, err := http.Post(fmt.Sprintf("%s/bzz:/", srv.URL), "text/plain", bytes.NewReader([]byte(dataBytes)))
+	resp, err := http.Post(fmt.Sprintf("%s/bzz:/", srv.URL), "text/plain", bytes.NewReader(dataBytes))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -189,7 +189,7 @@ func TestBzzWithFeed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Equal(retrievedData, []byte(dataBytes)) {
+	if !bytes.Equal(retrievedData, dataBytes) {
 		t.Fatalf("retrieved data mismatch, expected %x, got %x", dataBytes, retrievedData)
 	}
 }
@@ -747,7 +747,7 @@ func testBzzTar(encrypted bool, t *testing.T) {
 	//post tar stream
 	url := srv.URL + "/bzz:/"
 	if encrypted {
-		url = url + "encrypt"
+		url = url + encryptAddr
 	}
 	req, err := http.NewRequest("POST", url, buf)
 	if err != nil {
@@ -864,7 +864,7 @@ func TestBzzCorrectTagEstimate(t *testing.T) {
 		defer cancel()
 		addr := ""
 		if v.toEncrypt {
-			addr = "encrypt"
+			addr = encryptAddr
 		}
 		req, err := http.NewRequest("POST", srv.URL+"/bzz:/"+addr, pr)
 		if err != nil {

--- a/build/ci.go
+++ b/build/ci.go
@@ -304,16 +304,16 @@ func doLint(cmdline []string) {
 		"--disable-all",
 		"--enable=goimports",
 		"--enable=varcheck",
-		//"--enable=vet", // TODO: fix issues and enable
+		"--enable=vet",
 		"--enable=gofmt",
-		// "--enable=misspell", // TODO: fix issues and enable
-		// "--enable=goconst", // TODO: fix issues and enable
+		"--enable=misspell",
+		"--enable=goconst",
 	}
 	build.MustRunCommand(filepath.Join(GOBIN, "golangci-lint"), append(configs, packages...)...)
 
 	// Run slow linters one by one
 	for _, linter := range []string{
-		//"unconvert",// TODO: fix issues and enable
+		"unconvert",
 		"gosimple",
 	} {
 		configs = []string{"run", "--tests", "--deadline=10m", "--disable-all", "--enable=" + linter}

--- a/cmd/swarm-smoke/util.go
+++ b/cmd/swarm-smoke/util.go
@@ -212,7 +212,7 @@ func uploadWithTag(data []byte, endpoint string, tag string) (string, error) {
 		Tag: tag,
 	}
 
-	return swarm.TarUpload("", &client.FileUploader{f}, "", false)
+	return swarm.TarUpload("", &client.FileUploader{File: f}, "", false)
 }
 
 func digest(r io.Reader) ([]byte, error) {

--- a/cmd/swarm-snapshot/create_test.go
+++ b/cmd/swarm-snapshot/create_test.go
@@ -127,8 +127,8 @@ func TestSnapshotCreate(t *testing.T) {
 			// as strings to every node sorted services
 			sort.Strings(wantServices)
 
-			for i, n := range snap.Nodes {
-				gotServices := n.Node.Config.Services
+			for i := 0; i < len(snap.Nodes); i++ {
+				gotServices := snap.Nodes[i].Node.Config.Services
 				sort.Strings(gotServices)
 				if fmt.Sprint(gotServices) != fmt.Sprint(wantServices) {
 					t.Errorf("got services %v for node %v, want %v", gotServices, i, wantServices)

--- a/cmd/swarm/access_test.go
+++ b/cmd/swarm/access_test.go
@@ -43,12 +43,14 @@ import (
 const (
 	hashRegexp = `[a-f\d]{128}`
 	data       = "notsorandomdata"
+
+	goosWindows = "windows"
 )
 
 var DefaultCurve = crypto.S256()
 
 func TestACT(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == goosWindows {
 		t.Skip()
 	}
 

--- a/cmd/swarm/export_test.go
+++ b/cmd/swarm/export_test.go
@@ -53,7 +53,7 @@ const (
 // 5. imports the exported datastore
 // 6. fetches the uploaded random file from the second node
 func TestCLISwarmExportImport(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == goosWindows {
 		t.Skip()
 	}
 	cluster := newTestCluster(t, 1)
@@ -123,7 +123,7 @@ func TestCLISwarmExportImport(t *testing.T) {
 // 5. import the dump
 // 6. file should be accessible
 func TestExportLegacyToNew(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == goosWindows {
 		t.Skip() // this should be reenabled once the appveyor tests underlying issue is fixed
 	}
 	/*

--- a/cmd/swarm/manifest_test.go
+++ b/cmd/swarm/manifest_test.go
@@ -32,7 +32,7 @@ import (
 // TestManifestChange tests manifest add, update and remove
 // cli commands without encryption.
 func TestManifestChange(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == goosWindows {
 		t.Skip()
 	}
 
@@ -42,7 +42,7 @@ func TestManifestChange(t *testing.T) {
 // TestManifestChange tests manifest add, update and remove
 // cli commands with encryption enabled.
 func TestManifestChangeEncrypted(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == goosWindows {
 		t.Skip()
 	}
 
@@ -410,7 +410,7 @@ func testManifestChange(t *testing.T, encrypt bool) {
 // TestNestedDefaultEntryUpdate tests if the default entry is updated
 // if the file in nested manifest used for it is also updated.
 func TestNestedDefaultEntryUpdate(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == goosWindows {
 		t.Skip()
 	}
 
@@ -421,7 +421,7 @@ func TestNestedDefaultEntryUpdate(t *testing.T) {
 // of encrypted upload is updated if the file in nested manifest
 // used for it is also updated.
 func TestNestedDefaultEntryUpdateEncrypted(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == goosWindows {
 		t.Skip()
 	}
 

--- a/cmd/swarm/run_test.go
+++ b/cmd/swarm/run_test.go
@@ -246,7 +246,7 @@ func getTestAccount(t *testing.T, dir string) (conf *node.Config, account accoun
 	}
 
 	// use a unique IPCPath when running tests on Windows
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == goosWindows {
 		conf.IPCPath = fmt.Sprintf("bzzd-%s.ipc", account.Address.String())
 	}
 
@@ -258,7 +258,7 @@ func existingTestNode(t *testing.T, dir string, bzzaccount string) *testNode {
 	node := &testNode{Dir: dir}
 
 	// use a unique IPCPath when running tests on Windows
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == goosWindows {
 		conf.IPCPath = fmt.Sprintf("bzzd-%s.ipc", bzzaccount)
 	}
 

--- a/cmd/swarm/upload_test.go
+++ b/cmd/swarm/upload_test.go
@@ -42,7 +42,7 @@ func init() {
 }
 
 func TestSwarmUp(t *testing.T) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == goosWindows {
 		t.Skip()
 	}
 
@@ -173,7 +173,7 @@ func testDefault(t *testing.T, cluster *testCluster, toEncrypt bool) {
 		}
 	}
 
-	timeout := time.Duration(2 * time.Second)
+	timeout := 2 * time.Second
 	httpClient := http.Client{
 		Timeout: timeout,
 	}

--- a/contracts/chequebook/cheque.go
+++ b/contracts/chequebook/cheque.go
@@ -596,11 +596,9 @@ func (ch *Cheque) Verify(signerKey *ecdsa.PublicKey, contract, beneficiary commo
 	}
 
 	amount := new(big.Int).Set(ch.Amount)
-	if sum != nil {
-		amount.Sub(amount, sum)
-		if amount.Sign() <= 0 {
-			return nil, fmt.Errorf("incorrect amount: %v <= 0", amount)
-		}
+	amount.Sub(amount, sum)
+	if amount.Sign() <= 0 {
+		return nil, fmt.Errorf("incorrect amount: %v <= 0", amount)
 	}
 
 	pubKey, err := crypto.SigToPub(sigHash(ch.Contract, beneficiary, ch.Amount), ch.Sig)

--- a/internal/build/env.go
+++ b/internal/build/env.go
@@ -53,6 +53,7 @@ func (env Environment) String() string {
 // Env returns metadata about the current CI environment, falling back to LocalEnv
 // if not running on CI.
 func Env() Environment {
+	const trueFlag = "True"
 	switch {
 	case os.Getenv("CI") == "true" && os.Getenv("TRAVIS") == "true":
 		commit := os.Getenv("TRAVIS_PULL_REQUEST_SHA")
@@ -70,7 +71,7 @@ func Env() Environment {
 			IsPullRequest: os.Getenv("TRAVIS_PULL_REQUEST") != "false",
 			IsCronJob:     os.Getenv("TRAVIS_EVENT_TYPE") == "cron",
 		}
-	case os.Getenv("CI") == "True" && os.Getenv("APPVEYOR") == "True":
+	case os.Getenv("CI") == trueFlag && os.Getenv("APPVEYOR") == trueFlag:
 		commit := os.Getenv("APPVEYOR_PULL_REQUEST_HEAD_COMMIT")
 		if commit == "" {
 			commit = os.Getenv("APPVEYOR_REPO_COMMIT")
@@ -84,7 +85,7 @@ func Env() Environment {
 			Tag:           os.Getenv("APPVEYOR_REPO_TAG_NAME"),
 			Buildnum:      os.Getenv("APPVEYOR_BUILD_NUMBER"),
 			IsPullRequest: os.Getenv("APPVEYOR_PULL_REQUEST_NUMBER") != "",
-			IsCronJob:     os.Getenv("APPVEYOR_SCHEDULED_BUILD") == "True",
+			IsCronJob:     os.Getenv("APPVEYOR_SCHEDULED_BUILD") == trueFlag,
 		}
 	default:
 		return LocalEnv()

--- a/network/network.go
+++ b/network/network.go
@@ -60,7 +60,7 @@ func RandomAddr() *BzzAddr {
 	return NewAddr(node)
 }
 
-// NewAddr constucts a BzzAddr from a node record.
+// NewAddr constructs a BzzAddr from a node record.
 func NewAddr(node *enode.Node) *BzzAddr {
 	return &BzzAddr{OAddr: node.ID().Bytes(), UAddr: []byte(node.String())}
 }

--- a/network/newstream/peer.go
+++ b/network/newstream/peer.go
@@ -76,7 +76,6 @@ func (p *Peer) HandleMsg(ctx context.Context, msg interface{}) error {
 	default:
 		return fmt.Errorf("unknown message type: %T", msg)
 	}
-	return nil
 }
 
 type offer struct {

--- a/network/newstream/wire.go
+++ b/network/newstream/wire.go
@@ -111,7 +111,7 @@ type GetRange struct {
 	Ruid      uint
 	Stream    ID
 	From      uint64
-	To        uint64 `rlp:nil`
+	To        uint64 `rlp:"nil"`
 	BatchSize uint
 	Roundtrip bool
 }

--- a/network/retrieval/retrieve_test.go
+++ b/network/retrieval/retrieve_test.go
@@ -378,7 +378,7 @@ func getAllRefs(testData []byte) (storage.AddressCollection, error) {
 func getChunks(store chunk.Store) (chunks map[string]struct{}, err error) {
 	chunks = make(map[string]struct{})
 	for po := uint8(0); po <= chunk.MaxPO; po++ {
-		last, err := store.LastPullSubscriptionBinID(uint8(po))
+		last, err := store.LastPullSubscriptionBinID(po)
 		if err != nil {
 			return nil, err
 		}

--- a/network/simulations/discovery/discovery_test.go
+++ b/network/simulations/discovery/discovery_test.go
@@ -320,9 +320,6 @@ func discoveryPersistenceSimulation(nodes, conns int, adapter adapters.NodeAdapt
 		conf := adapters.RandomNodeConfig()
 		node, err := net.NewNodeWithConfig(conf)
 		if err != nil {
-			panic(err)
-		}
-		if err != nil {
 			return nil, fmt.Errorf("error starting node: %s", err)
 		}
 		if err := net.Start(node.ID()); err != nil {

--- a/network/stream/delivery_test.go
+++ b/network/stream/delivery_test.go
@@ -271,10 +271,6 @@ func TestStreamerDownstreamChunkDeliveryMsgExchange(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 	}
 
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-
 	if !bytes.Equal(storedChunk.Data(), chunkData) {
 		t.Fatal("Retrieved chunk has different data than original")
 	}

--- a/network/stream/peer.go
+++ b/network/stream/peer.go
@@ -453,7 +453,6 @@ func (p *Peer) runUpdateSyncing() {
 			return
 		}
 	}
-	log.Debug("update syncing subscriptions: exiting", "peer", p.ID())
 }
 
 // updateSyncSubscriptions accepts two slices of integers, the first one

--- a/p2p/protocols/protocol.go
+++ b/p2p/protocols/protocol.go
@@ -18,7 +18,7 @@
 Package protocols is an extension to p2p. It offers a user friendly simple way to define
 devp2p subprotocols by abstracting away code standardly shared by protocols.
 
-* automate assigments of code indexes to messages
+* automate assignments of code indexes to messages
 * automate RLP decoding/encoding based on reflecting
 * provide the forever loop to read incoming messages
 * standardise error handling related to communication

--- a/pot/address.go
+++ b/pot/address.go
@@ -27,6 +27,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+const nilString = "<nil>"
+
 var (
 	zerosBin = Address{}.Bin()
 )
@@ -198,7 +200,7 @@ func proximityOrder(one, other []byte, pos int) (int, bool) {
 // Label displays the node's key in binary format
 func Label(v Val) string {
 	if v == nil {
-		return "<nil>"
+		return nilString
 	}
 	if s, ok := v.(fmt.Stringer); ok {
 		return s.String()

--- a/pot/pot.go
+++ b/pot/pot.go
@@ -775,7 +775,7 @@ func (t *Pot) String() string {
 
 func (t *Pot) sstring(indent string) string {
 	if t == nil {
-		return "<nil>"
+		return nilString
 	}
 	var s string
 	indent += "  "

--- a/pot/pot_test.go
+++ b/pot/pot_test.go
@@ -179,7 +179,7 @@ func TestPotRemove(t *testing.T) {
 	pof := DefaultPof(8)
 	n := NewPot(newTestAddr("00111100", 0), 0)
 	n, _, _ = Remove(n, newTestAddr("00111100", 0), pof)
-	exp := "<nil>"
+	exp := nilString
 	got := Label(n.Pin())
 	if got != exp {
 		t.Fatalf("incorrect pinned value. Expected %v, got %v", exp, got)

--- a/pss/prox_test.go
+++ b/pss/prox_test.go
@@ -132,7 +132,7 @@ func (td *testData) init(msgCount int) error {
 		td.nodeAddresses[nodeId] = kad.BaseAddr()
 	}
 
-	for i := 0; i < int(msgCount); i++ {
+	for i := 0; i < msgCount; i++ {
 		msgAddr := pot.RandomAddress() // we choose message addresses randomly
 		td.recipientAddresses = append(td.recipientAddresses, msgAddr.Bytes())
 		smallestPo := 256

--- a/pss/pss_test.go
+++ b/pss/pss_test.go
@@ -1880,10 +1880,6 @@ func newServices(allowRaw bool) adapters.Services {
 				Service:   NewAPITest(ps),
 				Public:    false,
 			})
-			if err != nil {
-				log.Error("Couldnt register pss protocol", "err", err)
-				os.Exit(1)
-			}
 			pssprotocols[ctx.Config.ID.String()] = &protoCtrl{
 				C:        ping.OutC,
 				protocol: pp,

--- a/storage/feed/lookup/lookup_test.go
+++ b/storage/feed/lookup/lookup_test.go
@@ -77,7 +77,7 @@ func TestLookup(t *testing.T) {
 
 	var lastData *Data
 	for i := uint64(0); i < 12; i++ {
-		t := uint64(now - Year*3 + i*Month)
+		t := now - Year*3 + i*Month
 		data := Data{
 			Payload: t, //our "payload" will be the timestamp itself.
 			Time:    t,
@@ -415,7 +415,7 @@ func TestHighFreqUpdates(t *testing.T) {
 
 	var lastData *Data
 	for i := uint64(0); i <= 994; i++ {
-		T := uint64(now - 1000 + i)
+		T := now - 1000 + i
 		data := Data{
 			Payload: T, //our "payload" will be the timestamp itself.
 			Time:    T,
@@ -471,7 +471,7 @@ func TestHighFreqUpdates(t *testing.T) {
 			// ### 3.3.- Test multiple lookups at different intervals
 			timeElapsed = stopwatch.Measure(func() {
 				for i := uint64(0); i <= 10; i++ {
-					T := uint64(now - 1000 + i)
+					T := now - 1000 + i
 					value, err := algo.Lookup(context.Background(), T, lookup.NoClue, readFunc)
 					if err != nil {
 						t.Fatal(err)
@@ -509,7 +509,7 @@ func TestSparseUpdates(t *testing.T) {
 	var lastData *Data
 	for i := uint64(0); i < 3; i++ {
 		for j := uint64(0); j < 10; j++ {
-			T := uint64(Year*5*i + j) // write a burst of 10 updates every 5 years 3 times starting in Jan 1st 1970 and then silence
+			T := Year*5*i + j // write a burst of 10 updates every 5 years 3 times starting in Jan 1st 1970 and then silence
 			data := Data{
 				Payload: T, //our "payload" will be the timestamp itself.
 				Time:    T,

--- a/storage/localstore/subscription_pull_test.go
+++ b/storage/localstore/subscription_pull_test.go
@@ -578,7 +578,7 @@ func TestAddressInBin(t *testing.T) {
 
 		got := db.po(addr)
 
-		if got != uint8(po) {
+		if got != po {
 			t.Errorf("got po %v, want %v", got, po)
 		}
 	}


### PR DESCRIPTION
This PR fulfills go-modules PR by enabling linters that are used on master but in updated version report errors on the codebase. While go-modules PR does not make changes to the swarm application, only tooling, this one does and for easier review it is split into a separate changeset.

In go-modules PR, a deprecated gometalinter.v2 is replaced by golangci-lint as the older one does not play well with modules.

Goangci-lint configuration is added mainly for goconst linter to be more permissive on min-occurrences, as some of the changes required with default configuration are not required by my opinion. Even some strings are repeated multiple times, it does not mean that their semantics is the same justifying additional constant. This is debatable and open for discussion.

Running the complete set of goglanci-lint linters produce a very high number of errors and I am suggesting to address some of them in the future and standardize linting.