### PR TITLE
swarm, swap: extend swap `Stop` function

### DIFF
--- a/swap/protocol.go
+++ b/swap/protocol.go
@@ -83,8 +83,7 @@ func (s *Swap) Start(server *p2p.Server) error {
 // Stop is a node.Service interface method
 func (s *Swap) Stop() error {
 	log.Info("Swap service stopping")
-	s.Close()
-	return nil
+	return s.Close()
 }
 
 // verifyHandshake verifies the chequebook address transmitted in the swap handshake

--- a/swap/protocol.go
+++ b/swap/protocol.go
@@ -83,6 +83,7 @@ func (s *Swap) Start(server *p2p.Server) error {
 // Stop is a node.Service interface method
 func (s *Swap) Stop() error {
 	log.Info("Swap service stopping")
+	s.Close()
 	return nil
 }
 

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -501,8 +501,8 @@ func (s *Swap) saveLastReceivedCheque(p *Peer, cheque *Cheque) error {
 }
 
 // Close cleans up swap
-func (s *Swap) Close() {
-	s.store.Close()
+func (s *Swap) Close() error {
+	return s.store.Close()
 }
 
 // resetBalance is called:

--- a/swarm.go
+++ b/swarm.go
@@ -455,7 +455,7 @@ func (s *Swarm) Stop() error {
 		s.ps.Stop()
 	}
 	if s.swap != nil {
-		s.swap.Close()
+		s.swap.Stop()
 	}
 	if s.accountingMetrics != nil {
 		s.accountingMetrics.Close()


### PR DESCRIPTION
This PR is based on a [review comment](https://github.com/ethersphere/swarm/pull/1554#discussion_r311565303) from PR #1554. 

- The Swap `Stop` method now calls the Swap `Close` method, rather than just logging.
- When shutting down Swarm, `Stop` will be called (instead of `Close` directly).
- `Close` still needs to exists for testing purposes–we need a way to close the Swap store even when not starting it as a service.
- `Stop` no longer returns a hard-coded `nil` error. To achieve this, `Close` was changed to return an `error` as well.
  - This `error` was already available as a result of the `store.Close` call, but was being ignored.  
  - This, in turn, will be the output of `Stop` as well. 
  - Outside of the function, no changes to the code have been made to actually _do something_ with this `error`, but at least we are not suppressing it.