### PR TITLE
storage: fix LazyChunkReader.join potential deadlock

### DIFF
--- a/storage/chunker.go
+++ b/storage/chunker.go
@@ -540,6 +540,7 @@ func (r *LazyChunkReader) join(ctx context.Context, b []byte, off int64, eoff in
 				case errC <- fmt.Errorf("chunk %v-%v not found; key: %s", off, off+treeSize, fmt.Sprintf("%x", childAddress)):
 				case <-quitC:
 				}
+				wg.Done()
 				return
 			}
 			metrics.GetOrRegisterResettingTimer("lcr.getter.get", nil).UpdateSince(startTime)
@@ -548,6 +549,7 @@ func (r *LazyChunkReader) join(ctx context.Context, b []byte, off int64, eoff in
 				case errC <- fmt.Errorf("chunk %v-%v incomplete; key: %s, data length %v", off, off+treeSize, fmt.Sprintf("%x", childAddress), l):
 				case <-quitC:
 				}
+				wg.Done()
 				return
 			}
 			if soff < off {


### PR DESCRIPTION
A goroutine leak was observed on a node in private cluster. Full [goroutine dump](https://github.com/ethersphere/swarm/files/3502671/goroutine.txt.gz) was attached. The problem was a wait on wait group.

```
goroutine 16761764 [semacquire, 254 minutes]:
sync.runtime_Semacquire(0xc00225a238)
    /usr/local/go/src/runtime/sema.go:56 +0x39
sync.(*WaitGroup).Wait(0xc00225a230)
    /usr/local/go/src/sync/waitgroup.go:130 +0x65
github.com/ethersphere/swarm/storage.(*LazyChunkReader).join(0xc00258b180, 0x126f1a0, 0xc0042e8090, 0xc0045e6000, 0x20000, 0x20000, 0xde0000, 0xe00000, 0x2, 0x80000, ...)
    /swarm/build/_workspace/src/github.com/ethersphere/swarm/storage/chunker.go:559 +0x41f
github.com/ethersphere/swarm/storage.(*LazyChunkReader).join.func1(0xc000cf2090, 0x68, 0x70, 0xc00258b180, 0x126f1a0, 0xc0042e8090, 0xc0026e24e0, 0xde0000, 0xc001f00088, 0xc0026e2120, ...)
    /swarm/build/_workspace/src/github.com/ethersphere/swarm/storage/chunker.go:556 +0x73f
created by github.com/ethersphere/swarm/storage.(*LazyChunkReader).join
    /swarm/build/_workspace/src/github.com/ethersphere/swarm/storage/chunker.go:533 +0x366
```

```
goroutine 17801050 [semacquire, 249 minutes]:
sync.runtime_Semacquire(0xc002dcf7f8)
	/usr/local/go/src/runtime/sema.go:56 +0x39
sync.(*WaitGroup).Wait(0xc002dcf7f0)
	/usr/local/go/src/sync/waitgroup.go:130 +0x65
github.com/ethersphere/swarm/storage.(*LazyChunkReader).ReadAt.func2(0xc002dcf7f0, 0xc002b7e180)
	/swarm/build/_workspace/src/github.com/ethersphere/swarm/storage/chunker.go:470 +0x2b
created by github.com/ethersphere/swarm/storage.(*LazyChunkReader).ReadAt
	/swarm/build/_workspace/src/github.com/ethersphere/swarm/storage/chunker.go:469 +0x47f
```

It is possible that in case of error in LazyChunkReader.join wait group counter is not decremented. This PR adds a simple fix.


