### PR TITLE
api/http: remove unnecessary conversion

### DIFF
--- a/api/http/server_test.go
+++ b/api/http/server_test.go
@@ -1470,7 +1470,7 @@ func (t *testResolveValidator) HeaderByNumber(context.Context, *big.Int) (header
 
 func uploadFile(t *testing.T, srv *TestSwarmServer, data []byte) []byte {
 	t.Helper()
-	resp, err := http.Post(fmt.Sprintf("%s/bzz-raw:/", srv.URL), "text/plain", bytes.NewReader([]byte(data)))
+	resp, err := http.Post(fmt.Sprintf("%s/bzz-raw:/", srv.URL), "text/plain", bytes.NewReader(data))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
fixing linter:

```
 go run build/ci.go lint

>>> /home/travis/.gimme/versions/go1.12.8.linux.amd64/bin/go get github.com/golangci/golangci-lint/cmd/golangci-lint

>>> /home/travis/gopath/src/github.com/ethersphere/swarm/build/bin/golangci-lint run --tests --deadline=2m --disable-all --enable=goimports --enable=varcheck --enable=vet --enable=gofmt --enable=misspell --enable=goconst ./...

>>> /home/travis/gopath/src/github.com/ethersphere/swarm/build/bin/golangci-lint run --tests --deadline=10m --disable-all --enable=unconvert ./...

api/http/server_test.go:1473:99: unnecessary conversion (unconvert)

	resp, err := http.Post(fmt.Sprintf("%s/bzz-raw:/", srv.URL), "text/plain", bytes.NewReader([]byte(data)))

	                                                                                                 ^

util.go:45: exit status 1

exit status 1
```