### PR TITLE
storage: fix possible hasherstore deadlock on waitC channel

### DIFF
--- a/storage/hasherstore.go
+++ b/storage/hasherstore.go
@@ -153,6 +153,7 @@ func (h *hasherStore) startWait(ctx context.Context) {
 		// if context is done earlier, just return with the error
 		case <-ctx.Done():
 			h.waitC <- ctx.Err()
+			return
 		// doneC is closed if all chunks have been submitted, from then we just wait until all of them are also stored
 		case <-doneC:
 			done = true
@@ -161,6 +162,7 @@ func (h *hasherStore) startWait(ctx context.Context) {
 		case err := <-h.errC:
 			if err != nil {
 				h.waitC <- err
+				return
 			}
 			nrStoredChunks++
 		}


### PR DESCRIPTION
This is a propsed solution for fixing a possible deadlock on hasherstore. It is possible that multiple errors are sent to the waitC channel, but that channel is red only once. This is causing deadlocks on:

```
goroutine 27052665 [chan send, 93 minutes]:
github.com/ethersphere/swarm/storage.(*hasherStore).startWait(0xc0034480e0, 0x12854c0, 0xc00399e0f0)
        /swarm/build/_workspace/src/github.com/ethersphere/swarm/storage/hasherstore.go:155 +0x23b
created by github.com/ethersphere/swarm/storage.(*hasherStore).Put.func1
        /swarm/build/_workspace/src/github.com/ethersphere/swarm/storage/hasherstore.go:98 +0x50
```

and 

```
goroutine 28380920 [select, 93 minutes]:
github.com/ethersphere/swarm/storage.(*hasherStore).storeChunk.func1(0xc0034480e0, 0x12854c0, 0xc00399e0f0, 0x1285a40, 0xc002f8d340)
        /swarm/build/_workspace/src/github.com/ethersphere/swarm/storage/hasherstore.go:279 +0x187
created by github.com/ethersphere/swarm/storage.(*hasherStore).storeChunk
        /swarm/build/_workspace/src/github.com/ethersphere/swarm/storage/hasherstore.go:270 +0xa5
```

[goroutines.txt.gz](https://github.com/ethersphere/swarm/files/3509038/goroutines.txt.gz)

This change makes only possible to have one send to the waitC. But could it maybe create logical problems that I do not see? Please, review.