### PR TITLE
swap: createCheque refactor

### DIFF
--- a/swap/cheque.go
+++ b/swap/cheque.go
@@ -83,7 +83,7 @@ func (cheque *Cheque) VerifySig(expectedSigner common.Address) error {
 	return nil
 }
 
-// Sign signs the cheque with supplied private key
+// Sign returns a signature for the cheque with supplied private key
 func (cheque *Cheque) Sign(prv *ecdsa.PrivateKey) ([]byte, error) {
 	sig, err := crypto.Sign(cheque.sigHash(), prv)
 	if err != nil {

--- a/swap/cheque.go
+++ b/swap/cheque.go
@@ -83,7 +83,7 @@ func (cheque *Cheque) VerifySig(expectedSigner common.Address) error {
 	return nil
 }
 
-// Sign returns a signature for the cheque with supplied private key
+// Sign returns the cheque's signature with supplied private key
 func (cheque *Cheque) Sign(prv *ecdsa.PrivateKey) ([]byte, error) {
 	sig, err := crypto.Sign(cheque.sigHash(), prv)
 	if err != nil {

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -417,6 +417,9 @@ func (s *Swap) createCheque(peer enode.ID) (*Cheque, error) {
 
 func (s *Swap) getLastChequeValues(peer enode.ID) (serial, total uint64, err error) {
 	err = s.loadLastSentCheque(peer)
+	if err != nil {
+		return
+	}
 	lastCheque, exists := s.getCheque(peer)
 	if exists {
 		serial = lastCheque.Serial

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -395,32 +395,21 @@ func (s *Swap) createCheque(peer enode.ID) (*Cheque, error) {
 
 	// if there is no existing cheque when loading from the store, it means it's the first interaction
 	// this is a valid scenario
-	err = s.loadLastSentCheque(peer)
+	serial, total, err := s.getLastChequeValues(peer)
 	if err != nil && err != state.ErrNotFound {
 		return nil, err
 	}
-	lastCheque, exists := s.getCheque(peer)
 
-	serial := uint64(1)
-	if exists {
-		cheque = &Cheque{
-			ChequeParams: ChequeParams{
-				Serial: lastCheque.Serial + serial,
-				Amount: lastCheque.Amount + amount,
-			},
-		}
-	} else {
-		cheque = &Cheque{
-			ChequeParams: ChequeParams{
-				Serial: serial,
-				Amount: amount,
-			},
-		}
+	cheque = &Cheque{
+		ChequeParams: ChequeParams{
+			Serial:      serial + 1,
+			Amount:      total + amount,
+			Timeout:     defaultCashInDelay,
+			Contract:    s.owner.Contract,
+			Honey:       honey,
+			Beneficiary: beneficiary,
+		},
 	}
-	cheque.ChequeParams.Timeout = defaultCashInDelay
-	cheque.ChequeParams.Contract = s.owner.Contract
-	cheque.ChequeParams.Honey = honey
-	cheque.Beneficiary = beneficiary
 
 	cheque.Signature, err = cheque.Sign(s.owner.privateKey)
 

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -427,6 +427,21 @@ func (s *Swap) createCheque(peer enode.ID) (*Cheque, error) {
 	return cheque, err
 }
 
+func (s *Swap) getLastChequeValues(peer enode.ID) (uint64, uint64, error) {
+	// if there is no existing cheque when loading from the store, it means it's the first interaction
+	// this is a valid scenario
+	err := s.loadLastSentCheque(peer)
+	if err != nil && err != state.ErrNotFound {
+		return 0, 0, err
+	}
+
+	lastCheque, exists := s.getCheque(peer)
+	if exists {
+		return lastCheque.Serial, lastCheque.Amount, nil
+	}
+	return 1, 0, nil
+}
+
 // Balance returns the balance for a given peer
 func (s *Swap) Balance(peer enode.ID) (int64, error) {
 	var err error

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -427,19 +427,14 @@ func (s *Swap) createCheque(peer enode.ID) (*Cheque, error) {
 	return cheque, err
 }
 
-func (s *Swap) getLastChequeValues(peer enode.ID) (uint64, uint64, error) {
-	// if there is no existing cheque when loading from the store, it means it's the first interaction
-	// this is a valid scenario
-	err := s.loadLastSentCheque(peer)
-	if err != nil && err != state.ErrNotFound {
-		return 0, 0, err
-	}
-
+func (s *Swap) getLastChequeValues(peer enode.ID) (serial, total uint64, err error) {
+	err = s.loadLastSentCheque(peer)
 	lastCheque, exists := s.getCheque(peer)
 	if exists {
-		return lastCheque.Serial, lastCheque.Amount, nil
+		serial = lastCheque.Serial
+		total = lastCheque.Amount
 	}
-	return 1, 0, nil
+	return
 }
 
 // Balance returns the balance for a given peer

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -410,7 +410,6 @@ func (s *Swap) createCheque(peer enode.ID) (*Cheque, error) {
 			Beneficiary: beneficiary,
 		},
 	}
-
 	cheque.Signature, err = cheque.Sign(s.owner.privateKey)
 
 	return cheque, err


### PR DESCRIPTION
This PR addresses the comment [originally posted](https://github.com/ethersphere/swarm/pull/1554#discussion_r314603091) by @zelig in PR #1554: 

>this is massively redundant and too complex.
>
>`loadLastSentCheque` should be part of `getCheque` and here you only need the last values for serial number and cumulative amount.
>
>So something like this:
>
```golang
serial, total, err := p.getLastChequeValues() // this simply returns 0, 0 if first cheque for peer
if err != nil {
   return nil, err
}
cheque := &Cheque{
   Params: &Params{
      Serial: serial + 1,
      Amount: total + amount,
      Timeout: defaultCashInDelay,
      Contract:  s.owner.Contract,
      Honey:  honey,
    },
    Beneficiary: beneficiary,
}
return cheque.Sign(s.owner.PrivateKey)
```