### PR TITLE
swap: cheque functions refactor

### DIFF
--- a/swap/swap.go
+++ b/swap/swap.go
@@ -440,19 +440,19 @@ func (s *Swap) Balances() (map[enode.ID]int64, error) {
 	balances := make(map[enode.ID]int64)
 
 	s.balancesLock.RLock()
-	for peerID, peerBalance := range s.balances {
-		balances[peerID] = peerBalance
+	for peer, peerBalance := range s.balances {
+		balances[peer] = peerBalance
 	}
 	s.balancesLock.RUnlock()
 
 	// add store balances, if peer was not already added
 	balanceIterFunction := func(key []byte, value []byte) (stop bool, err error) {
-		peerID := keyToID(string(key), balancePrefix)
-		if _, peerHasBalance := balances[peerID]; !peerHasBalance {
+		peer := keyToID(string(key), balancePrefix)
+		if _, peerHasBalance := balances[peer]; !peerHasBalance {
 			var peerBalance int64
 			err = json.Unmarshal(value, &peerBalance)
 			if err == nil {
-				balances[peerID] = peerBalance
+				balances[peer] = peerBalance
 			}
 		}
 		return stop, err
@@ -509,9 +509,9 @@ func (s *Swap) Close() error {
 // resetBalance is called:
 // * for the creditor: upon receiving the cheque
 // * for the debitor: after sending the cheque
-func (s *Swap) resetBalance(peerID enode.ID, amount int64) error {
-	log.Debug("resetting balance for peer", "peer", peerID.String(), "amount", amount)
-	_, err := s.updateBalance(peerID, amount)
+func (s *Swap) resetBalance(peer enode.ID, amount int64) error {
+	log.Debug("resetting balance for peer", "peer", peer.String(), "amount", amount)
+	_, err := s.updateBalance(peer, amount)
 	return err
 }
 

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -175,7 +175,7 @@ func (s *Swap) Add(amount int64, peer *protocols.Peer) (err error) {
 		log.Warn("balance for peer went over the payment threshold, sending cheque", "peer", peer.ID().String(), "payment threshold", s.paymentThreshold)
 		swapPeer, ok := s.getPeer(peer.ID())
 		if !ok {
-			return fmt.Errorf("error while getting peer: %s", peer)
+			return fmt.Errorf("peer %s not found", peer)
 		}
 		return s.sendCheque(swapPeer)
 	}
@@ -339,7 +339,7 @@ func (s *Swap) loadBalance(peer enode.ID) (err error) {
 // To be called with mutex already held
 // Caller must be careful that the same resources aren't concurrently read and written by multiple routines
 func (s *Swap) sendCheque(swapPeer *Peer) error {
-	peer := swapPeer.Peer.ID()
+	peer := swapPeer.ID()
 	cheque, err := s.createCheque(swapPeer)
 	if err != nil {
 		return fmt.Errorf("error while creating cheque: %s", err.Error())
@@ -375,7 +375,7 @@ func (s *Swap) createCheque(swapPeer *Peer) (*Cheque, error) {
 	var cheque *Cheque
 	var err error
 
-	peer := swapPeer.Peer.ID()
+	peer := swapPeer.ID()
 	beneficiary := swapPeer.beneficiary
 
 	peerBalance, exists := s.getBalance(peer)

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -309,7 +309,7 @@ func TestResetBalance(t *testing.T) {
 	debitorSwap.peers[creditor.ID()] = creditor
 
 	// now simulate sending the cheque to the creditor from the debitor
-	debitorSwap.sendCheque(creditor.ID())
+	debitorSwap.sendCheque(creditor)
 	// the debitor should have already reset its balance
 	if debitorSwap.balances[creditor.ID()] != 0 {
 		t.Fatalf("unexpected balance to be 0, but it is %d", debitorSwap.balances[creditor.ID()])


### PR DESCRIPTION
This PR addresses the comments [originally posted](https://github.com/ethersphere/swarm/pull/1554#discussion_r314605046) by @zelig in PR #1554: 

>this lookup is performed in `createCheque` too. Unnecessary, just pass the swapPeer to createCheque,  not the id.

and

>the argument should be swapPeer not id, see above

Also, for `swap.go`, I am renaming ID-typed variables called `peerID` to `peer` for nomenclature consistency.