### PR TITLE
chunk, storage: chunk.Store multiple chunk Put

### DIFF
--- a/network/stream/common_test.go
+++ b/network/stream/common_test.go
@@ -227,10 +227,10 @@ func (rrs *roundRobinStore) Get(_ context.Context, _ chunk.ModeGet, _ storage.Ad
 	return nil, errors.New("roundRobinStore doesn't support Get")
 }
 
-func (rrs *roundRobinStore) Put(ctx context.Context, mode chunk.ModePut, ch storage.Chunk) (bool, error) {
+func (rrs *roundRobinStore) Put(ctx context.Context, mode chunk.ModePut, chs ...storage.Chunk) ([]bool, error) {
 	i := atomic.AddUint32(&rrs.index, 1)
 	idx := int(i) % len(rrs.stores)
-	return rrs.stores[idx].Put(ctx, mode, ch)
+	return rrs.stores[idx].Put(ctx, mode, chs...)
 }
 
 func (rrs *roundRobinStore) Set(ctx context.Context, mode chunk.ModeSet, addr chunk.Address) (err error) {

--- a/storage/common_test.go
+++ b/storage/common_test.go
@@ -225,12 +225,17 @@ func NewMapChunkStore() *MapChunkStore {
 	}
 }
 
-func (m *MapChunkStore) Put(_ context.Context, _ chunk.ModePut, ch Chunk) (bool, error) {
+func (m *MapChunkStore) Put(_ context.Context, _ chunk.ModePut, chs ...Chunk) ([]bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	_, exists := m.chunks[ch.Address().Hex()]
-	m.chunks[ch.Address().Hex()] = ch
-	return exists, nil
+
+	exist := make([]bool, len(chs))
+	for i, ch := range chs {
+		addr := ch.Address().Hex()
+		_, exist[i] = m.chunks[addr]
+		m.chunks[addr] = ch
+	}
+	return exist, nil
 }
 
 func (m *MapChunkStore) Get(_ context.Context, _ chunk.ModeGet, ref Address) (Chunk, error) {

--- a/storage/hasherstore.go
+++ b/storage/hasherstore.go
@@ -275,7 +275,7 @@ func (h *hasherStore) storeChunk(ctx context.Context, ch Chunk) {
 		}()
 		seen, err := h.store.Put(ctx, chunk.ModePutUpload, ch)
 		h.tag.Inc(chunk.StateStored)
-		if seen {
+		if err != nil && seen[0] {
 			h.tag.Inc(chunk.StateSeen)
 		}
 		select {

--- a/storage/localstore/gc_test.go
+++ b/storage/localstore/gc_test.go
@@ -32,7 +32,7 @@ import (
 // TestDB_collectGarbageWorker tests garbage collection runs
 // by uploading and syncing a number of chunks.
 func TestDB_collectGarbageWorker(t *testing.T) {
-	testDB_collectGarbageWorker(t)
+	testDBCollectGarbageWorker(t)
 }
 
 // TestDB_collectGarbageWorker_multipleBatches tests garbage
@@ -44,13 +44,12 @@ func TestDB_collectGarbageWorker_multipleBatches(t *testing.T) {
 	defer func(s uint64) { gcBatchSize = s }(gcBatchSize)
 	gcBatchSize = 2
 
-	testDB_collectGarbageWorker(t)
+	testDBCollectGarbageWorker(t)
 }
 
-// testDB_collectGarbageWorker is a helper test function to test
+// testDBCollectGarbageWorker is a helper test function to test
 // garbage collection runs by uploading and syncing a number of chunks.
-func testDB_collectGarbageWorker(t *testing.T) {
-	t.Helper()
+func testDBCollectGarbageWorker(t *testing.T) {
 
 	chunkCount := 150
 

--- a/storage/localstore/localstore_test.go
+++ b/storage/localstore/localstore_test.go
@@ -185,6 +185,16 @@ func generateTestRandomChunk() chunk.Chunk {
 	return chunk.NewChunk(key, data)
 }
 
+// generateTestRandomChunks generates a slice of random
+// Chunks by using generateTestRandomChunk function.
+func generateTestRandomChunks(count int) []chunk.Chunk {
+	chunks := make([]chunk.Chunk, count)
+	for i := 0; i < count; i++ {
+		chunks[i] = generateTestRandomChunk()
+	}
+	return chunks
+}
+
 // TestGenerateTestRandomChunk validates that
 // generateTestRandomChunk returns random data by comparing
 // two generated chunks.
@@ -219,6 +229,8 @@ func TestGenerateTestRandomChunk(t *testing.T) {
 // chunk values are in the retrieval indexes.
 func newRetrieveIndexesTest(db *DB, chunk chunk.Chunk, storeTimestamp, accessTimestamp int64) func(t *testing.T) {
 	return func(t *testing.T) {
+		t.Helper()
+
 		item, err := db.retrievalDataIndex.Get(addressToItem(chunk.Address()))
 		if err != nil {
 			t.Fatal(err)
@@ -238,6 +250,8 @@ func newRetrieveIndexesTest(db *DB, chunk chunk.Chunk, storeTimestamp, accessTim
 // chunk values are in the retrieval indexes when access time must be stored.
 func newRetrieveIndexesTestWithAccess(db *DB, ch chunk.Chunk, storeTimestamp, accessTimestamp int64) func(t *testing.T) {
 	return func(t *testing.T) {
+		t.Helper()
+
 		item, err := db.retrievalDataIndex.Get(addressToItem(ch.Address()))
 		if err != nil {
 			t.Fatal(err)
@@ -258,6 +272,8 @@ func newRetrieveIndexesTestWithAccess(db *DB, ch chunk.Chunk, storeTimestamp, ac
 // chunk values are in the pull index.
 func newPullIndexTest(db *DB, ch chunk.Chunk, binID uint64, wantError error) func(t *testing.T) {
 	return func(t *testing.T) {
+		t.Helper()
+
 		item, err := db.pullIndex.Get(shed.Item{
 			Address: ch.Address(),
 			BinID:   binID,
@@ -275,6 +291,8 @@ func newPullIndexTest(db *DB, ch chunk.Chunk, binID uint64, wantError error) fun
 // chunk values are in the push index.
 func newPushIndexTest(db *DB, ch chunk.Chunk, storeTimestamp int64, wantError error) func(t *testing.T) {
 	return func(t *testing.T) {
+		t.Helper()
+
 		item, err := db.pushIndex.Get(shed.Item{
 			Address:        ch.Address(),
 			StoreTimestamp: storeTimestamp,
@@ -292,6 +310,8 @@ func newPushIndexTest(db *DB, ch chunk.Chunk, storeTimestamp int64, wantError er
 // chunk values are in the push index.
 func newGCIndexTest(db *DB, chunk chunk.Chunk, storeTimestamp, accessTimestamp int64, binID uint64) func(t *testing.T) {
 	return func(t *testing.T) {
+		t.Helper()
+
 		item, err := db.gcIndex.Get(shed.Item{
 			Address:         chunk.Address(),
 			BinID:           binID,
@@ -308,6 +328,8 @@ func newGCIndexTest(db *DB, chunk chunk.Chunk, storeTimestamp, accessTimestamp i
 // an index contains expected number of key/value pairs.
 func newItemsCountTest(i shed.Index, want int) func(t *testing.T) {
 	return func(t *testing.T) {
+		t.Helper()
+
 		var c int
 		err := i.Iterate(func(item shed.Item) (stop bool, err error) {
 			c++
@@ -326,6 +348,8 @@ func newItemsCountTest(i shed.Index, want int) func(t *testing.T) {
 // value is the same as the number of items in DB.gcIndex.
 func newIndexGCSizeTest(db *DB) func(t *testing.T) {
 	return func(t *testing.T) {
+		t.Helper()
+
 		var want uint64
 		err := db.gcIndex.Iterate(func(item shed.Item) (stop bool, err error) {
 			want++
@@ -354,6 +378,8 @@ type testIndexChunk struct {
 // testItemsOrder tests the order of chunks in the index. If sortFunc is not nil,
 // chunks will be sorted with it before validation.
 func testItemsOrder(t *testing.T, i shed.Index, chunks []testIndexChunk, sortFunc func(i, j int) (less bool)) {
+	t.Helper()
+
 	newItemsCountTest(i, len(chunks))(t)
 
 	if sortFunc != nil {

--- a/storage/localstore/mode_put.go
+++ b/storage/localstore/mode_put.go
@@ -194,7 +194,7 @@ func (db *DB) putRequest(batch *leveldb.Batch, binIDs map[uint8]uint64, item she
 	return exists, gcSizeChange, nil
 }
 
-// putRequest adds an Item to the batch by updating required indexes:
+// putUpload adds an Item to the batch by updating required indexes:
 //  - put to indexes: retrieve, push, pull
 // The batch can be written to the database.
 // Provided batch and binID map are updated.
@@ -218,7 +218,7 @@ func (db *DB) putUpload(batch *leveldb.Batch, binIDs map[uint8]uint64, item shed
 	return false, nil
 }
 
-// putRequest adds an Item to the batch by updating required indexes:
+// putSync adds an Item to the batch by updating required indexes:
 //  - put to indexes: retrieve, pull
 // The batch can be written to the database.
 // Provided batch and binID map are updated.

--- a/storage/localstore/mode_put.go
+++ b/storage/localstore/mode_put.go
@@ -27,29 +27,29 @@ import (
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
-// Put stores the Chunk to database and depending
+// Put stores Chunks to database and depending
 // on the Putter mode, it updates required indexes.
 // Put is required to implement chunk.Store
 // interface.
-func (db *DB) Put(ctx context.Context, mode chunk.ModePut, ch chunk.Chunk) (exists bool, err error) {
+func (db *DB) Put(ctx context.Context, mode chunk.ModePut, chs ...chunk.Chunk) (exist []bool, err error) {
 	metricName := fmt.Sprintf("localstore.Put.%s", mode)
 
 	metrics.GetOrRegisterCounter(metricName, nil).Inc(1)
 	defer totalTimeMetric(metricName, time.Now())
 
-	exists, err = db.put(mode, chunkToItem(ch))
+	exist, err = db.put(mode, chs...)
 	if err != nil {
 		metrics.GetOrRegisterCounter(metricName+".error", nil).Inc(1)
 	}
-	return exists, err
+	return exist, err
 }
 
-// put stores Item to database and updates other
+// put stores Chunks to database and updates other
 // indexes. It acquires lockAddr to protect two calls
 // of this function for the same address in parallel.
 // Item fields Address and Data must not be
 // with their nil values.
-func (db *DB) put(mode chunk.ModePut, item shed.Item) (exists bool, err error) {
+func (db *DB) put(mode chunk.ModePut, chs ...chunk.Chunk) (exist []bool, err error) {
 	// protect parallel updates
 	db.batchMu.Lock()
 	defer db.batchMu.Unlock()
@@ -58,119 +58,199 @@ func (db *DB) put(mode chunk.ModePut, item shed.Item) (exists bool, err error) {
 
 	// variables that provide information for operations
 	// to be done after write batch function successfully executes
-	var gcSizeChange int64   // number to add or subtract from gcSize
-	var triggerPullFeed bool // signal pull feed subscriptions to iterate
-	var triggerPushFeed bool // signal push feed subscriptions to iterate
+	var gcSizeChange int64                      // number to add or subtract from gcSize
+	var triggerPushFeed bool                    // signal push feed subscriptions to iterate
+	triggerPullFeed := make(map[uint8]struct{}) // signal pull feed subscriptions to iterate
+
+	exist = make([]bool, len(chs))
+
+	// A lazy populated map of bin ids to properly set
+	// BinID values for new chunks based on initial value from database
+	// and incrementing them.
+	// Values from this map are stored with the batch
+	binIDs := make(map[uint8]uint64)
 
 	switch mode {
 	case chunk.ModePutRequest:
-		// put to indexes: retrieve, gc; it does not enter the syncpool
-
-		// check if the chunk already is in the database
-		// as gc index is updated
-		i, err := db.retrievalAccessIndex.Get(item)
-		switch err {
-		case nil:
-			exists = true
-			item.AccessTimestamp = i.AccessTimestamp
-		case leveldb.ErrNotFound:
-			exists = false
-			// no chunk accesses
-		default:
-			return false, err
-		}
-		i, err = db.retrievalDataIndex.Get(item)
-		switch err {
-		case nil:
-			exists = true
-			item.StoreTimestamp = i.StoreTimestamp
-			item.BinID = i.BinID
-		case leveldb.ErrNotFound:
-			// no chunk accesses
-			exists = false
-		default:
-			return false, err
-		}
-		if item.AccessTimestamp != 0 {
-			// delete current entry from the gc index
-			db.gcIndex.DeleteInBatch(batch, item)
-			gcSizeChange--
-		}
-		if item.StoreTimestamp == 0 {
-			item.StoreTimestamp = now()
-		}
-		if item.BinID == 0 {
-			item.BinID, err = db.binIDs.IncInBatch(batch, uint64(db.po(item.Address)))
+		for i, ch := range chs {
+			exists, c, err := db.putRequest(batch, binIDs, chunkToItem(ch))
 			if err != nil {
-				return false, err
+				return nil, err
 			}
+			exist[i] = exists
+			gcSizeChange += c
 		}
-		// update access timestamp
-		item.AccessTimestamp = now()
-		// update retrieve access index
-		db.retrievalAccessIndex.PutInBatch(batch, item)
-		// add new entry to gc index
-		db.gcIndex.PutInBatch(batch, item)
-		gcSizeChange++
-
-		db.retrievalDataIndex.PutInBatch(batch, item)
 
 	case chunk.ModePutUpload:
-		// put to indexes: retrieve, push, pull
-
-		exists, err = db.retrievalDataIndex.Has(item)
-		if err != nil {
-			return false, err
-		}
-		if !exists {
-			item.StoreTimestamp = now()
-			item.BinID, err = db.binIDs.IncInBatch(batch, uint64(db.po(item.Address)))
+		for i, ch := range chs {
+			exists, err := db.putUpload(batch, binIDs, chunkToItem(ch))
 			if err != nil {
-				return false, err
+				return nil, err
 			}
-			db.retrievalDataIndex.PutInBatch(batch, item)
-			db.pullIndex.PutInBatch(batch, item)
-			triggerPullFeed = true
-			db.pushIndex.PutInBatch(batch, item)
-			triggerPushFeed = true
+			exist[i] = exists
+			if !exists {
+				// chunk is new so, trigger subscription feeds
+				// after the batch is successfully written
+				triggerPullFeed[db.po(ch.Address())] = struct{}{}
+				triggerPushFeed = true
+			}
 		}
 
 	case chunk.ModePutSync:
-		// put to indexes: retrieve, pull
-
-		exists, err = db.retrievalDataIndex.Has(item)
-		if err != nil {
-			return exists, err
-		}
-		if !exists {
-			item.StoreTimestamp = now()
-			item.BinID, err = db.binIDs.IncInBatch(batch, uint64(db.po(item.Address)))
+		for i, ch := range chs {
+			exists, err := db.putSync(batch, binIDs, chunkToItem(ch))
 			if err != nil {
-				return false, err
+				return nil, err
 			}
-			db.retrievalDataIndex.PutInBatch(batch, item)
-			db.pullIndex.PutInBatch(batch, item)
-			triggerPullFeed = true
+			exist[i] = exists
+			if !exists {
+				// chunk is new so, trigger pull subscription feed
+				// after the batch is successfully written
+				triggerPullFeed[db.po(ch.Address())] = struct{}{}
+			}
 		}
 
 	default:
-		return false, ErrInvalidMode
+		return nil, ErrInvalidMode
+	}
+
+	for po, id := range binIDs {
+		db.binIDs.PutInBatch(batch, uint64(po), id)
 	}
 
 	err = db.incGCSizeInBatch(batch, gcSizeChange)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 
 	err = db.shed.WriteBatch(batch)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	if triggerPullFeed {
-		db.triggerPullSubscriptions(db.po(item.Address))
+	for po := range triggerPullFeed {
+		db.triggerPullSubscriptions(po)
 	}
 	if triggerPushFeed {
 		db.triggerPushSubscriptions()
 	}
-	return exists, nil
+	return exist, nil
+}
+
+// putRequest adds an Item to the batch by updating required indexes:
+//  - put to indexes: retrieve, gc
+//  - it does not enter the syncpool
+// The batch can be written to the database.
+// Provided batch and binID map are updated.
+func (db *DB) putRequest(batch *leveldb.Batch, binIDs map[uint8]uint64, item shed.Item) (exists bool, gcSizeChange int64, err error) {
+	// check if the chunk already is in the database
+	// as gc index is updated
+	i, err := db.retrievalAccessIndex.Get(item)
+	switch err {
+	case nil:
+		exists = true
+		item.AccessTimestamp = i.AccessTimestamp
+	case leveldb.ErrNotFound:
+		exists = false
+		// no chunk accesses
+	default:
+		return false, 0, err
+	}
+	i, err = db.retrievalDataIndex.Get(item)
+	switch err {
+	case nil:
+		exists = true
+		item.StoreTimestamp = i.StoreTimestamp
+		item.BinID = i.BinID
+	case leveldb.ErrNotFound:
+		// no chunk accesses
+		exists = false
+	default:
+		return false, 0, err
+	}
+	if item.AccessTimestamp != 0 {
+		// delete current entry from the gc index
+		db.gcIndex.DeleteInBatch(batch, item)
+		gcSizeChange--
+	}
+	if item.StoreTimestamp == 0 {
+		item.StoreTimestamp = now()
+	}
+	if item.BinID == 0 {
+		item.BinID, err = db.incBinID(binIDs, db.po(item.Address))
+		if err != nil {
+			return false, 0, err
+		}
+	}
+	// update access timestamp
+	item.AccessTimestamp = now()
+	// update retrieve access index
+	db.retrievalAccessIndex.PutInBatch(batch, item)
+	// add new entry to gc index
+	db.gcIndex.PutInBatch(batch, item)
+	gcSizeChange++
+
+	db.retrievalDataIndex.PutInBatch(batch, item)
+
+	return exists, gcSizeChange, nil
+}
+
+// putRequest adds an Item to the batch by updating required indexes:
+//  - put to indexes: retrieve, push, pull
+// The batch can be written to the database.
+// Provided batch and binID map are updated.
+func (db *DB) putUpload(batch *leveldb.Batch, binIDs map[uint8]uint64, item shed.Item) (exists bool, err error) {
+	exists, err = db.retrievalDataIndex.Has(item)
+	if err != nil {
+		return false, err
+	}
+	if exists {
+		return true, nil
+	}
+
+	item.StoreTimestamp = now()
+	item.BinID, err = db.incBinID(binIDs, db.po(item.Address))
+	if err != nil {
+		return false, err
+	}
+	db.retrievalDataIndex.PutInBatch(batch, item)
+	db.pullIndex.PutInBatch(batch, item)
+	db.pushIndex.PutInBatch(batch, item)
+	return false, nil
+}
+
+// putRequest adds an Item to the batch by updating required indexes:
+//  - put to indexes: retrieve, pull
+// The batch can be written to the database.
+// Provided batch and binID map are updated.
+func (db *DB) putSync(batch *leveldb.Batch, binIDs map[uint8]uint64, item shed.Item) (exists bool, err error) {
+	exists, err = db.retrievalDataIndex.Has(item)
+	if err != nil {
+		return false, err
+	}
+	if exists {
+		return true, nil
+	}
+
+	item.StoreTimestamp = now()
+	item.BinID, err = db.incBinID(binIDs, db.po(item.Address))
+	if err != nil {
+		return false, err
+	}
+	db.retrievalDataIndex.PutInBatch(batch, item)
+	db.pullIndex.PutInBatch(batch, item)
+	return false, nil
+}
+
+// incBinID is a helper function for db.put* methods that increments bin id
+// based on the current value in the database. This function must be called under
+// a db.batchMu lock. Provided binID map is updated.
+func (db *DB) incBinID(binIDs map[uint8]uint64, po uint8) (id uint64, err error) {
+	if _, ok := binIDs[po]; !ok {
+		binIDs[po], err = db.binIDs.Get(uint64(po))
+		if err != nil {
+			return 0, err
+		}
+	}
+	binIDs[po]++
+	return binIDs[po], nil
 }

--- a/storage/localstore/mode_put_test.go
+++ b/storage/localstore/mode_put_test.go
@@ -344,6 +344,44 @@ var multiChunkTestCases = []struct {
 	},
 }
 
+// TestPutDuplicateChunks validates the expected behaviour for
+// passing duplicate chunks to the Put method.
+func TestPutDuplicateChunks(t *testing.T) {
+	for _, mode := range []chunk.ModePut{
+		chunk.ModePutUpload,
+		chunk.ModePutRequest,
+		chunk.ModePutSync,
+	} {
+		t.Run(mode.String(), func(t *testing.T) {
+			db, cleanupFunc := newTestDB(t, nil)
+			defer cleanupFunc()
+
+			ch := generateTestRandomChunk()
+
+			exist, err := db.Put(context.Background(), mode, ch, ch)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if exist[0] {
+				t.Error("first chunk should not exist")
+			}
+			if !exist[1] {
+				t.Error("second chunk should exist")
+			}
+
+			newItemsCountTest(db.retrievalDataIndex, 1)(t)
+
+			got, err := db.Get(context.Background(), chunk.ModeGetLookup, ch.Address())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(got.Address(), ch.Address()) {
+				t.Errorf("got chunk address %s, want %s", got.Address().Hex(), ch.Address().Hex())
+			}
+		})
+	}
+}
+
 // BenchmarkPutUpload runs a series of benchmarks that upload
 // a specific number of chunks in parallel.
 //

--- a/storage/netstore.go
+++ b/storage/netstore.go
@@ -103,39 +103,43 @@ func NewNetStore(store chunk.Store, localID enode.ID) *NetStore {
 
 // Put stores a chunk in localstore, and delivers to all requestor peers using the fetcher stored in
 // the fetchers cache
-func (n *NetStore) Put(ctx context.Context, mode chunk.ModePut, ch Chunk) (bool, error) {
+func (n *NetStore) Put(ctx context.Context, mode chunk.ModePut, chs ...Chunk) ([]bool, error) {
 	n.putMu.Lock()
 	defer n.putMu.Unlock()
 
-	log.Trace("netstore.put", "ref", ch.Address().String(), "mode", mode)
+	for i, ch := range chs {
+		log.Trace("netstore.put", "index", i, "ref", ch.Address().String(), "mode", mode)
+	}
 
 	// put the chunk to the localstore, there should be no error
-	exists, err := n.Store.Put(ctx, mode, ch)
+	exist, err := n.Store.Put(ctx, mode, chs...)
 	if err != nil {
-		return exists, err
+		return nil, err
 	}
 
-	// notify RemoteGet (or SwarmSyncerClient) about a chunk delivery and it being stored
-	fi, ok := n.fetchers.Get(ch.Address().String())
-	if ok {
-		// we need SafeClose, because it is possible for a chunk to both be
-		// delivered through syncing and through a retrieve request
-		fii := fi.(*Fetcher)
-		fii.SafeClose()
-		log.Trace("netstore.put chunk delivered and stored", "ref", ch.Address().String())
+	for _, ch := range chs {
+		// notify RemoteGet (or SwarmSyncerClient) about a chunk delivery and it being stored
+		fi, ok := n.fetchers.Get(ch.Address().String())
+		if ok {
+			// we need SafeClose, because it is possible for a chunk to both be
+			// delivered through syncing and through a retrieve request
+			fii := fi.(*Fetcher)
+			fii.SafeClose()
+			log.Trace("netstore.put chunk delivered and stored", "ref", ch.Address().String())
 
-		metrics.GetOrRegisterResettingTimer(fmt.Sprintf("netstore.fetcher.lifetime.%s", fii.CreatedBy), nil).UpdateSince(fii.CreatedAt)
+			metrics.GetOrRegisterResettingTimer(fmt.Sprintf("netstore.fetcher.lifetime.%s", fii.CreatedBy), nil).UpdateSince(fii.CreatedAt)
 
-		// helper snippet to log if a chunk took way to long to be delivered
-		slowChunkDeliveryThreshold := 5 * time.Second
-		if time.Since(fii.CreatedAt) > slowChunkDeliveryThreshold {
-			log.Trace("netstore.put slow chunk delivery", "ref", ch.Address().String())
+			// helper snippet to log if a chunk took way to long to be delivered
+			slowChunkDeliveryThreshold := 5 * time.Second
+			if time.Since(fii.CreatedAt) > slowChunkDeliveryThreshold {
+				log.Trace("netstore.put slow chunk delivery", "ref", ch.Address().String())
+			}
+
+			n.fetchers.Remove(ch.Address().String())
 		}
-
-		n.fetchers.Remove(ch.Address().String())
 	}
 
-	return exists, nil
+	return exist, nil
 }
 
 // Close chunk store

--- a/storage/types.go
+++ b/storage/types.go
@@ -218,8 +218,8 @@ type FakeChunkStore struct {
 }
 
 // Put doesn't store anything it is just here to implement ChunkStore
-func (f *FakeChunkStore) Put(_ context.Context, _ chunk.ModePut, ch Chunk) (bool, error) {
-	return false, nil
+func (f *FakeChunkStore) Put(_ context.Context, _ chunk.ModePut, ch ...Chunk) ([]bool, error) {
+	return make([]bool, len(ch)), nil
 }
 
 // Has doesn't do anything it is just here to implement ChunkStore


### PR DESCRIPTION
This PR adds support for multiple chunks to be Put by localstore. This is a performance improvement by using one leveldb batch for multiple chunks, instead to have a separate batch for every chunk.

All localstore Put tests are changed to validate functionality with multiple chunks.

This PR addresses only the Put method for easier review. If this approach is approved, other methods will be changed in a similar way. This change is targeted for master, but new stream package should use it. This way the diff on new stream PR should not get even larger.