### PR TITLE
pss: Port tests to `network/simulation`

### DIFF
--- a/pss/handshake_test.go
+++ b/pss/handshake_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/ethersphere/swarm/log"
-	"github.com/ethersphere/swarm/network/simulation"
 )
 
 // asymmetrical key exchange between two directly connected peers
@@ -44,14 +43,13 @@ func testHandshake(t *testing.T) {
 	addrsizestring := strings.Split(t.Name(), "/")
 	addrsize, _ = strconv.ParseInt(addrsizestring[1], 10, 0)
 
-	sim := simulation.NewInProc(newServices(false))
-	defer sim.Close()
 	// set up two nodes directly connected
 	// (we are not testing pss routing here)
-	clients, err := setupNetwork(sim, 2)
+	clients, closeSimFunc, err := setupNetwork(2, true)
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer closeSimFunc()
 
 	var topic string
 	err = clients[0].Call(&topic, "pss_stringToTopic", "foo:42")

--- a/pss/handshake_test.go
+++ b/pss/handshake_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/ethersphere/swarm/log"
+	"github.com/ethersphere/swarm/network/simulation"
 )
 
 // asymmetrical key exchange between two directly connected peers
@@ -43,9 +44,11 @@ func testHandshake(t *testing.T) {
 	addrsizestring := strings.Split(t.Name(), "/")
 	addrsize, _ = strconv.ParseInt(addrsizestring[1], 10, 0)
 
+	sim := simulation.NewInProc(newServices(false))
+	defer sim.Close()
 	// set up two nodes directly connected
 	// (we are not testing pss routing here)
-	clients, err := setupNetwork(2, true)
+	clients, err := setupNetwork(sim, 2)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pss/protocol_test.go
+++ b/pss/protocol_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethersphere/swarm/log"
-	"github.com/ethersphere/swarm/network/simulation"
 )
 
 type protoCtrl struct {
@@ -55,13 +54,12 @@ func testProtocol(t *testing.T) {
 
 	topic := PingTopic.String()
 
-	sim := simulation.NewInProc(newServices(false))
-	defer sim.Close()
-
-	clients, err := setupNetwork(sim, 2)
+	clients, closeSimFunc, err := setupNetwork(2, false)
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer closeSimFunc()
+
 	var loaddrhex string
 	err = clients[0].Call(&loaddrhex, "pss_baseAddr")
 	if err != nil {

--- a/pss/protocol_test.go
+++ b/pss/protocol_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethersphere/swarm/log"
+	"github.com/ethersphere/swarm/network/simulation"
 )
 
 type protoCtrl struct {
@@ -54,7 +55,10 @@ func testProtocol(t *testing.T) {
 
 	topic := PingTopic.String()
 
-	clients, err := setupNetwork(2, false)
+	sim := simulation.NewInProc(newServices(false))
+	defer sim.Close()
+
+	clients, err := setupNetwork(sim, 2)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pss/pss_test.go
+++ b/pss/pss_test.go
@@ -877,8 +877,8 @@ func TestRawAllow(t *testing.T) {
 // tests that the API layer can handle edge case values
 func TestApi(t *testing.T) {
 	sim := simulation.NewInProc(newServices(true))
-
 	defer sim.Close()
+
 	clients, err := setupNetwork(sim, 2)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Because handshake_test.go and protocol_test.go both use a function from pss_test.go that has been  modified, both files have some minor changes

There is still a dependency with p2p/simulations/adapters in pss_test.go  through the use of the type adapters.serviceContext , this is only used as the type of a function parameter, maybe we could extract this type into network/simulations and refactor its uses 

Also, there are more dependencies with p2p/simulations in pss/client and pss/notify, this could be refactored in a future PR

References issue #1652 