### PR TITLE
chunk, storage: storage with multi chunk Set method

### DIFF
--- a/chunk/chunk.go
+++ b/chunk/chunk.go
@@ -245,7 +245,7 @@ type Store interface {
 	Get(ctx context.Context, mode ModeGet, addr Address) (ch Chunk, err error)
 	Put(ctx context.Context, mode ModePut, chs ...Chunk) (exist []bool, err error)
 	Has(ctx context.Context, addr Address) (yes bool, err error)
-	Set(ctx context.Context, mode ModeSet, addr Address) (err error)
+	Set(ctx context.Context, mode ModeSet, addrs ...Address) (err error)
 	LastPullSubscriptionBinID(bin uint8) (id uint64, err error)
 	SubscribePull(ctx context.Context, bin uint8, since, until uint64) (c <-chan Descriptor, stop func())
 	Close() (err error)

--- a/storage/common_test.go
+++ b/storage/common_test.go
@@ -257,7 +257,7 @@ func (m *MapChunkStore) Has(ctx context.Context, ref Address) (has bool, err err
 	return has, nil
 }
 
-func (m *MapChunkStore) Set(ctx context.Context, mode chunk.ModeSet, addr chunk.Address) (err error) {
+func (m *MapChunkStore) Set(ctx context.Context, mode chunk.ModeSet, addrs ...chunk.Address) (err error) {
 	return nil
 }
 

--- a/storage/localstore/localstore_test.go
+++ b/storage/localstore/localstore_test.go
@@ -195,6 +195,42 @@ func generateTestRandomChunks(count int) []chunk.Chunk {
 	return chunks
 }
 
+// chunkAddresses return chunk addresses of provided chunks.
+func chunkAddresses(chunks []chunk.Chunk) []chunk.Address {
+	addrs := make([]chunk.Address, len(chunks))
+	for i, ch := range chunks {
+		addrs[i] = ch.Address()
+	}
+	return addrs
+}
+
+// Standard test cases to validate multi chunk operations.
+var multiChunkTestCases = []struct {
+	name  string
+	count int
+}{
+	{
+		name:  "one",
+		count: 1,
+	},
+	{
+		name:  "two",
+		count: 2,
+	},
+	{
+		name:  "eight",
+		count: 8,
+	},
+	{
+		name:  "hundred",
+		count: 100,
+	},
+	{
+		name:  "thousand",
+		count: 1000,
+	},
+}
+
 // TestGenerateTestRandomChunk validates that
 // generateTestRandomChunk returns random data by comparing
 // two generated chunks.

--- a/storage/localstore/mode_put_test.go
+++ b/storage/localstore/mode_put_test.go
@@ -318,32 +318,6 @@ func TestModePut_sameChunk(t *testing.T) {
 	}
 }
 
-var multiChunkTestCases = []struct {
-	name  string
-	count int
-}{
-	{
-		name:  "one",
-		count: 1,
-	},
-	{
-		name:  "two",
-		count: 2,
-	},
-	{
-		name:  "eight",
-		count: 8,
-	},
-	{
-		name:  "hundred",
-		count: 100,
-	},
-	{
-		name:  "thousand",
-		count: 1000,
-	},
-}
-
 // TestPutDuplicateChunks validates the expected behaviour for
 // passing duplicate chunks to the Put method.
 func TestPutDuplicateChunks(t *testing.T) {

--- a/storage/localstore/mode_set.go
+++ b/storage/localstore/mode_set.go
@@ -26,28 +26,28 @@ import (
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
-// Set updates database indexes for a specific
-// chunk represented by the address.
+// Set updates database indexes for
+// chunks represented by provided addresses.
 // Set is required to implement chunk.Store
 // interface.
-func (db *DB) Set(ctx context.Context, mode chunk.ModeSet, addr chunk.Address) (err error) {
+func (db *DB) Set(ctx context.Context, mode chunk.ModeSet, addrs ...chunk.Address) (err error) {
 	metricName := fmt.Sprintf("localstore.Set.%s", mode)
 
 	metrics.GetOrRegisterCounter(metricName, nil).Inc(1)
 	defer totalTimeMetric(metricName, time.Now())
 
-	err = db.set(mode, addr)
+	err = db.set(mode, addrs...)
 	if err != nil {
 		metrics.GetOrRegisterCounter(metricName+".error", nil).Inc(1)
 	}
 	return err
 }
 
-// set updates database indexes for a specific
-// chunk represented by the address.
+// set updates database indexes for
+// chunks represented by provided addresses.
 // It acquires lockAddr to protect two calls
 // of this function for the same address in parallel.
-func (db *DB) set(mode chunk.ModeSet, addr chunk.Address) (err error) {
+func (db *DB) set(mode chunk.ModeSet, addrs ...chunk.Address) (err error) {
 	// protect parallel updates
 	db.batchMu.Lock()
 	defer db.batchMu.Unlock()
@@ -56,167 +56,61 @@ func (db *DB) set(mode chunk.ModeSet, addr chunk.Address) (err error) {
 
 	// variables that provide information for operations
 	// to be done after write batch function successfully executes
-	var gcSizeChange int64   // number to add or subtract from gcSize
-	var triggerPullFeed bool // signal pull feed subscriptions to iterate
-
-	item := addressToItem(addr)
+	var gcSizeChange int64                      // number to add or subtract from gcSize
+	triggerPullFeed := make(map[uint8]struct{}) // signal pull feed subscriptions to iterate
 
 	switch mode {
 	case chunk.ModeSetAccess:
-		// add to pull, insert to gc
-
-		// need to get access timestamp here as it is not
-		// provided by the access function, and it is not
-		// a property of a chunk provided to Accessor.Put.
-
-		i, err := db.retrievalDataIndex.Get(item)
-		switch err {
-		case nil:
-			item.StoreTimestamp = i.StoreTimestamp
-			item.BinID = i.BinID
-		case leveldb.ErrNotFound:
-			db.pushIndex.DeleteInBatch(batch, item)
-			item.StoreTimestamp = now()
-			item.BinID, err = db.binIDs.Inc(uint64(db.po(item.Address)))
+		// A lazy populated map of bin ids to properly set
+		// BinID values for new chunks based on initial value from database
+		// and incrementing them.
+		binIDs := make(map[uint8]uint64)
+		for _, addr := range addrs {
+			po := db.po(addr)
+			c, err := db.setAccess(batch, binIDs, addr, po)
 			if err != nil {
 				return err
 			}
-		default:
-			return err
+			gcSizeChange += c
+			triggerPullFeed[po] = struct{}{}
 		}
-
-		i, err = db.retrievalAccessIndex.Get(item)
-		switch err {
-		case nil:
-			item.AccessTimestamp = i.AccessTimestamp
-			db.gcIndex.DeleteInBatch(batch, item)
-			gcSizeChange--
-		case leveldb.ErrNotFound:
-			// the chunk is not accessed before
-		default:
-			return err
+		for po, id := range binIDs {
+			db.binIDs.PutInBatch(batch, uint64(po), id)
 		}
-		item.AccessTimestamp = now()
-		db.retrievalAccessIndex.PutInBatch(batch, item)
-		db.pullIndex.PutInBatch(batch, item)
-		triggerPullFeed = true
-		db.gcIndex.PutInBatch(batch, item)
-		gcSizeChange++
 
 	case chunk.ModeSetSync:
-		// delete from push, insert to gc
-
-		// need to get access timestamp here as it is not
-		// provided by the access function, and it is not
-		// a property of a chunk provided to Accessor.Put.
-		i, err := db.retrievalDataIndex.Get(item)
-		if err != nil {
-			if err == leveldb.ErrNotFound {
-				// chunk is not found,
-				// no need to update gc index
-				// just delete from the push index
-				// if it is there
-				db.pushIndex.DeleteInBatch(batch, item)
-				return nil
+		for _, addr := range addrs {
+			c, err := db.setSync(batch, addr)
+			if err != nil {
+				return err
 			}
-			return err
+			gcSizeChange += c
 		}
-		item.StoreTimestamp = i.StoreTimestamp
-		item.BinID = i.BinID
 
-		i, err = db.retrievalAccessIndex.Get(item)
-		switch err {
-		case nil:
-			item.AccessTimestamp = i.AccessTimestamp
-			db.gcIndex.DeleteInBatch(batch, item)
-			gcSizeChange--
-		case leveldb.ErrNotFound:
-			// the chunk is not accessed before
-		default:
-			return err
-		}
-		item.AccessTimestamp = now()
-		db.retrievalAccessIndex.PutInBatch(batch, item)
-		db.pushIndex.DeleteInBatch(batch, item)
-
-		// Add in gcIndex only if this chunk is not pinned
-		ok, err := db.pinIndex.Has(item)
-		if err != nil {
-			return err
-		}
-		if !ok {
-			db.gcIndex.PutInBatch(batch, item)
-			gcSizeChange++
-		}
 	case chunk.ModeSetRemove:
-		// delete from retrieve, pull, gc
-
-		// need to get access timestamp here as it is not
-		// provided by the access function, and it is not
-		// a property of a chunk provided to Accessor.Put.
-
-		i, err := db.retrievalAccessIndex.Get(item)
-		switch err {
-		case nil:
-			item.AccessTimestamp = i.AccessTimestamp
-		case leveldb.ErrNotFound:
-		default:
-			return err
-		}
-		i, err = db.retrievalDataIndex.Get(item)
-		if err != nil {
-			return err
-		}
-		item.StoreTimestamp = i.StoreTimestamp
-		item.BinID = i.BinID
-
-		db.retrievalDataIndex.DeleteInBatch(batch, item)
-		db.retrievalAccessIndex.DeleteInBatch(batch, item)
-		db.pullIndex.DeleteInBatch(batch, item)
-		db.gcIndex.DeleteInBatch(batch, item)
-		// a check is needed for decrementing gcSize
-		// as delete is not reporting if the key/value pair
-		// is deleted or not
-		if _, err := db.gcIndex.Get(item); err == nil {
-			gcSizeChange = -1
+		for _, addr := range addrs {
+			c, err := db.setRemove(batch, addr)
+			if err != nil {
+				return err
+			}
+			gcSizeChange += c
 		}
 
 	case chunk.ModeSetPin:
-		// Get the existing pin counter of the chunk
-		existingPinCounter := uint64(0)
-		pinnedChunk, err := db.pinIndex.Get(item)
-		if err != nil {
-			if err == leveldb.ErrNotFound {
-				// If this Address is not present in DB, then its a new entry
-				existingPinCounter = 0
-
-				// Add in gcExcludeIndex of the chunk is not pinned already
-				db.gcExcludeIndex.PutInBatch(batch, item)
-			} else {
+		for _, addr := range addrs {
+			err := db.setPin(batch, addr)
+			if err != nil {
 				return err
 			}
-		} else {
-			existingPinCounter = pinnedChunk.PinCounter
 		}
-
-		// Otherwise increase the existing counter by 1
-		item.PinCounter = existingPinCounter + 1
-		db.pinIndex.PutInBatch(batch, item)
 	case chunk.ModeSetUnpin:
-		// Get the existing pin counter of the chunk
-		pinnedChunk, err := db.pinIndex.Get(item)
-		if err != nil {
-			return err
+		for _, addr := range addrs {
+			err := db.setUnpin(batch, addr)
+			if err != nil {
+				return err
+			}
 		}
 
-		// Decrement the pin counter or
-		// delete it from pin index if the pin counter has reached 0
-		if pinnedChunk.PinCounter > 1 {
-			item.PinCounter = pinnedChunk.PinCounter - 1
-			db.pinIndex.PutInBatch(batch, item)
-		} else {
-			db.pinIndex.DeleteInBatch(batch, item)
-		}
 	default:
 		return ErrInvalidMode
 	}
@@ -230,8 +124,198 @@ func (db *DB) set(mode chunk.ModeSet, addr chunk.Address) (err error) {
 	if err != nil {
 		return err
 	}
-	if triggerPullFeed {
-		db.triggerPullSubscriptions(db.po(item.Address))
+	for po := range triggerPullFeed {
+		db.triggerPullSubscriptions(po)
 	}
+	return nil
+}
+
+// setAccess sets the chunk access time by updating required indexes:
+//  - add to pull, insert to gc
+// Provided batch and binID map are updated.
+func (db *DB) setAccess(batch *leveldb.Batch, binIDs map[uint8]uint64, addr chunk.Address, po uint8) (gcSizeChange int64, err error) {
+
+	item := addressToItem(addr)
+
+	// need to get access timestamp here as it is not
+	// provided by the access function, and it is not
+	// a property of a chunk provided to Accessor.Put.
+	i, err := db.retrievalDataIndex.Get(item)
+	switch err {
+	case nil:
+		item.StoreTimestamp = i.StoreTimestamp
+		item.BinID = i.BinID
+	case leveldb.ErrNotFound:
+		db.pushIndex.DeleteInBatch(batch, item)
+		item.StoreTimestamp = now()
+		item.BinID, err = db.incBinID(binIDs, po)
+		if err != nil {
+			return 0, err
+		}
+	default:
+		return 0, err
+	}
+
+	i, err = db.retrievalAccessIndex.Get(item)
+	switch err {
+	case nil:
+		item.AccessTimestamp = i.AccessTimestamp
+		db.gcIndex.DeleteInBatch(batch, item)
+		gcSizeChange--
+	case leveldb.ErrNotFound:
+		// the chunk is not accessed before
+	default:
+		return 0, err
+	}
+	item.AccessTimestamp = now()
+	db.retrievalAccessIndex.PutInBatch(batch, item)
+	db.pullIndex.PutInBatch(batch, item)
+	db.gcIndex.PutInBatch(batch, item)
+	gcSizeChange++
+
+	return gcSizeChange, nil
+}
+
+// setSync adds the chunk to the garbage collection after syncing by updating indexes:
+//  - delete from push, insert to gc
+// Provided batch is updated.
+func (db *DB) setSync(batch *leveldb.Batch, addr chunk.Address) (gcSizeChange int64, err error) {
+	item := addressToItem(addr)
+
+	// need to get access timestamp here as it is not
+	// provided by the access function, and it is not
+	// a property of a chunk provided to Accessor.Put.
+
+	i, err := db.retrievalDataIndex.Get(item)
+	if err != nil {
+		if err == leveldb.ErrNotFound {
+			// chunk is not found,
+			// no need to update gc index
+			// just delete from the push index
+			// if it is there
+			db.pushIndex.DeleteInBatch(batch, item)
+			return 0, nil
+		}
+		return 0, err
+	}
+	item.StoreTimestamp = i.StoreTimestamp
+	item.BinID = i.BinID
+
+	i, err = db.retrievalAccessIndex.Get(item)
+	switch err {
+	case nil:
+		item.AccessTimestamp = i.AccessTimestamp
+		db.gcIndex.DeleteInBatch(batch, item)
+		gcSizeChange--
+	case leveldb.ErrNotFound:
+		// the chunk is not accessed before
+	default:
+		return 0, err
+	}
+	item.AccessTimestamp = now()
+	db.retrievalAccessIndex.PutInBatch(batch, item)
+	db.pushIndex.DeleteInBatch(batch, item)
+
+	// Add in gcIndex only if this chunk is not pinned
+	ok, err := db.pinIndex.Has(item)
+	if err != nil {
+		return 0, err
+	}
+	if !ok {
+		db.gcIndex.PutInBatch(batch, item)
+		gcSizeChange++
+	}
+
+	return gcSizeChange, nil
+}
+
+// setRemove removes the chunk by updating indexes:
+//  - delete from retrieve, pull, gc
+// Provided batch is updated.
+func (db *DB) setRemove(batch *leveldb.Batch, addr chunk.Address) (gcSizeChange int64, err error) {
+	item := addressToItem(addr)
+
+	// need to get access timestamp here as it is not
+	// provided by the access function, and it is not
+	// a property of a chunk provided to Accessor.Put.
+	i, err := db.retrievalAccessIndex.Get(item)
+	switch err {
+	case nil:
+		item.AccessTimestamp = i.AccessTimestamp
+	case leveldb.ErrNotFound:
+	default:
+		return 0, err
+	}
+	i, err = db.retrievalDataIndex.Get(item)
+	if err != nil {
+		return 0, err
+	}
+	item.StoreTimestamp = i.StoreTimestamp
+	item.BinID = i.BinID
+
+	db.retrievalDataIndex.DeleteInBatch(batch, item)
+	db.retrievalAccessIndex.DeleteInBatch(batch, item)
+	db.pullIndex.DeleteInBatch(batch, item)
+	db.gcIndex.DeleteInBatch(batch, item)
+	// a check is needed for decrementing gcSize
+	// as delete is not reporting if the key/value pair
+	// is deleted or not
+	if _, err := db.gcIndex.Get(item); err == nil {
+		gcSizeChange = -1
+	}
+
+	return gcSizeChange, nil
+}
+
+// setPin increments pin counter for the chunk by updating
+// pin index and sets the chunk to be excluded from garbage collection.
+// Provided batch is updated.
+func (db *DB) setPin(batch *leveldb.Batch, addr chunk.Address) (err error) {
+	item := addressToItem(addr)
+
+	// Get the existing pin counter of the chunk
+	existingPinCounter := uint64(0)
+	pinnedChunk, err := db.pinIndex.Get(item)
+	if err != nil {
+		if err == leveldb.ErrNotFound {
+			// If this Address is not present in DB, then its a new entry
+			existingPinCounter = 0
+
+			// Add in gcExcludeIndex of the chunk is not pinned already
+			db.gcExcludeIndex.PutInBatch(batch, item)
+		} else {
+			return err
+		}
+	} else {
+		existingPinCounter = pinnedChunk.PinCounter
+	}
+
+	// Otherwise increase the existing counter by 1
+	item.PinCounter = existingPinCounter + 1
+	db.pinIndex.PutInBatch(batch, item)
+
+	return nil
+}
+
+// setUnpin decrements pin counter for the chunk by updating pin index.
+// Provided batch is updated.
+func (db *DB) setUnpin(batch *leveldb.Batch, addr chunk.Address) (err error) {
+	item := addressToItem(addr)
+
+	// Get the existing pin counter of the chunk
+	pinnedChunk, err := db.pinIndex.Get(item)
+	if err != nil {
+		return err
+	}
+
+	// Decrement the pin counter or
+	// delete it from pin index if the pin counter has reached 0
+	if pinnedChunk.PinCounter > 1 {
+		item.PinCounter = pinnedChunk.PinCounter - 1
+		db.pinIndex.PutInBatch(batch, item)
+	} else {
+		db.pinIndex.DeleteInBatch(batch, item)
+	}
+
 	return nil
 }

--- a/storage/types.go
+++ b/storage/types.go
@@ -232,7 +232,7 @@ func (f *FakeChunkStore) Get(_ context.Context, _ chunk.ModeGet, ref Address) (C
 	panic("FakeChunkStore doesn't support Get")
 }
 
-func (f *FakeChunkStore) Set(ctx context.Context, mode chunk.ModeSet, addr chunk.Address) (err error) {
+func (f *FakeChunkStore) Set(ctx context.Context, mode chunk.ModeSet, addrs ...chunk.Address) (err error) {
 	panic("FakeChunkStore doesn't support Set")
 }
 


### PR DESCRIPTION
This PR changes chunk.Store Set method to accept multiple chunks. This PR is a followup of https://github.com/ethersphere/swarm/pull/1681. This is a performance improvement by using one leveldb batch for multiple chunks, instead to have a separate batch for every chunk.

All localstore Set tests are changed to validate functionality with multiple chunks.

