### PR TITLE
network/stream: terminate runUpdateSyncing on peer quit

### DIFF
--- a/network/stream/peer.go
+++ b/network/stream/peer.go
@@ -451,6 +451,8 @@ func (p *Peer) runUpdateSyncing() {
 			prevDepth = depth
 		case <-p.streamer.quit:
 			return
+		case <-p.quit:
+			return
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes a goroutine leak in stream package when runUpdateSyncing goroutine is not terminated when peer quits.