### PR TITLE
pss: Modularize crypto and remove Whisper. Step 1 - isolate whisper code

### DIFF
--- a/pss/api.go
+++ b/pss/api.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethersphere/swarm/log"
@@ -118,13 +117,13 @@ func (pssapi *API) BaseAddr() (PssAddress, error) {
 // Retrieves the node's public key in hex form
 func (pssapi *API) GetPublicKey() (keybytes hexutil.Bytes) {
 	key := pssapi.Pss.PublicKey()
-	keybytes = crypto.FromECDSAPub(key)
+	keybytes = pssapi.Pss.Crypto.FromECDSAPub(key)
 	return keybytes
 }
 
 // Set Public key to associate with a particular Pss peer
 func (pssapi *API) SetPeerPublicKey(pubkey hexutil.Bytes, topic Topic, addr PssAddress) error {
-	pk, err := crypto.UnmarshalPubkey(pubkey)
+	pk, err := pssapi.Pss.Crypto.UnmarshalPubkey(pubkey)
 	if err != nil {
 		return fmt.Errorf("Cannot unmarshal pubkey: %x", pubkey)
 	}

--- a/pss/client/client_test.go
+++ b/pss/client/client_test.go
@@ -48,7 +48,7 @@ type protoCtrl struct {
 var (
 	debugdebugflag = flag.Bool("vv", false, "veryverbose")
 	debugflag      = flag.Bool("v", false, "verbose")
-	cryptoBackend  pss.CryptoBackend
+	cryptoUtils    pss.CryptoUtils
 	// custom logging
 	psslogmain   log.Logger
 	pssprotocols map[string]*protoCtrl
@@ -76,7 +76,7 @@ func init() {
 	h := log.CallerFileHandler(hf)
 	log.Root().SetHandler(h)
 
-	cryptoBackend = pss.NewCryptoBackend()
+	cryptoUtils = pss.NewCryptoUtils()
 
 	pssprotocols = make(map[string]*protoCtrl)
 }
@@ -247,11 +247,11 @@ func newServices() adapters.Services {
 		"pss": func(ctx *adapters.ServiceContext) (node.Service, error) {
 			ctxlocal, cancel := context.WithTimeout(context.Background(), time.Second)
 			defer cancel()
-			keys, err := cryptoBackend.NewKeyPair(ctxlocal)
+			keys, err := cryptoUtils.NewKeyPair(ctxlocal)
 			if err != nil {
 				return nil, err
 			}
-			privkey, err := cryptoBackend.GetPrivateKey(keys)
+			privkey, err := cryptoUtils.GetPrivateKey(keys)
 			if err != nil {
 				return nil, err
 			}

--- a/pss/client/client_test.go
+++ b/pss/client/client_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/simulations"
 	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
 	"github.com/ethereum/go-ethereum/rpc"
-	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
 	"github.com/ethersphere/swarm/network"
 	"github.com/ethersphere/swarm/pss"
 	"github.com/ethersphere/swarm/state"
@@ -49,8 +48,7 @@ type protoCtrl struct {
 var (
 	debugdebugflag = flag.Bool("vv", false, "veryverbose")
 	debugflag      = flag.Bool("v", false, "verbose")
-	w              *whisper.Whisper
-	wapi           *whisper.PublicWhisperAPI
+	cryptoBackend  pss.CryptoBackend
 	// custom logging
 	psslogmain   log.Logger
 	pssprotocols map[string]*protoCtrl
@@ -78,8 +76,7 @@ func init() {
 	h := log.CallerFileHandler(hf)
 	log.Root().SetHandler(h)
 
-	w = whisper.New(&whisper.DefaultConfig)
-	wapi = whisper.NewPublicWhisperAPI(w)
+	cryptoBackend = pss.NewCryptoBackend()
 
 	pssprotocols = make(map[string]*protoCtrl)
 }
@@ -250,11 +247,11 @@ func newServices() adapters.Services {
 		"pss": func(ctx *adapters.ServiceContext) (node.Service, error) {
 			ctxlocal, cancel := context.WithTimeout(context.Background(), time.Second)
 			defer cancel()
-			keys, err := wapi.NewKeyPair(ctxlocal)
+			keys, err := cryptoBackend.NewKeyPair(ctxlocal)
 			if err != nil {
 				return nil, err
 			}
-			privkey, err := w.GetPrivateKey(keys)
+			privkey, err := cryptoBackend.GetPrivateKey(keys)
 			if err != nil {
 				return nil, err
 			}

--- a/pss/crypto.go
+++ b/pss/crypto.go
@@ -1,0 +1,64 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+package pss
+
+import (
+	"context"
+	"crypto/ecdsa"
+
+	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
+)
+
+type CryptoBackend interface {
+	GetSymKey(id string) ([]byte, error)
+	GenerateSymKey() (string, error)
+	AddSymKeyDirect(bytes []byte) (string, error)
+	GetPrivateKey(id string) (*ecdsa.PrivateKey, error)
+	NewKeyPair(ctx context.Context) (string, error)
+}
+
+type WhisperCryptoBackend struct {
+	whisper *whisper.Whisper
+	wapi    *whisper.PublicWhisperAPI
+}
+
+func NewCryptoBackend() CryptoBackend {
+	w := whisper.New(&whisper.DefaultConfig)
+	return &WhisperCryptoBackend{
+		whisper: w,
+		wapi:    whisper.NewPublicWhisperAPI(w),
+	}
+}
+
+func (crypto *WhisperCryptoBackend) GetSymKey(id string) ([]byte, error) {
+	return crypto.whisper.GetSymKey(id)
+}
+
+func (crypto *WhisperCryptoBackend) GenerateSymKey() (string, error) {
+	return crypto.whisper.GenerateSymKey()
+}
+
+func (crypto *WhisperCryptoBackend) AddSymKeyDirect(bytes []byte) (string, error) {
+	return crypto.whisper.AddSymKeyDirect(bytes)
+}
+
+func (crypto *WhisperCryptoBackend) GetPrivateKey(id string) (*ecdsa.PrivateKey, error) {
+	return crypto.whisper.GetPrivateKey(id)
+}
+
+func (crypto *WhisperCryptoBackend) NewKeyPair(ctx context.Context) (string, error) {
+	return crypto.wapi.NewKeyPair(ctx)
+}

--- a/pss/crypto.go
+++ b/pss/crypto.go
@@ -1,18 +1,18 @@
-// Copyright 2019 The go-ethereum Authors
-// This file is part of the go-ethereum library.
+// Copyright 2019 The Swarm Authors
+// This file is part of the Swarm library.
 //
-// The go-ethereum library is free software: you can redistribute it and/or modify
+// The Swarm library is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The go-ethereum library is distributed in the hope that it will be useful,
+// The Swarm library is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
 package pss
 
 import (
@@ -30,35 +30,35 @@ type CryptoBackend interface {
 	NewKeyPair(ctx context.Context) (string, error)
 }
 
-type WhisperCryptoBackend struct {
+type whisperCryptoBackend struct {
 	whisper *whisper.Whisper
 	wapi    *whisper.PublicWhisperAPI
 }
 
 func NewCryptoBackend() CryptoBackend {
 	w := whisper.New(&whisper.DefaultConfig)
-	return &WhisperCryptoBackend{
+	return &whisperCryptoBackend{
 		whisper: w,
 		wapi:    whisper.NewPublicWhisperAPI(w),
 	}
 }
 
-func (crypto *WhisperCryptoBackend) GetSymKey(id string) ([]byte, error) {
+func (crypto *whisperCryptoBackend) GetSymKey(id string) ([]byte, error) {
 	return crypto.whisper.GetSymKey(id)
 }
 
-func (crypto *WhisperCryptoBackend) GenerateSymKey() (string, error) {
+func (crypto *whisperCryptoBackend) GenerateSymKey() (string, error) {
 	return crypto.whisper.GenerateSymKey()
 }
 
-func (crypto *WhisperCryptoBackend) AddSymKeyDirect(bytes []byte) (string, error) {
+func (crypto *whisperCryptoBackend) AddSymKeyDirect(bytes []byte) (string, error) {
 	return crypto.whisper.AddSymKeyDirect(bytes)
 }
 
-func (crypto *WhisperCryptoBackend) GetPrivateKey(id string) (*ecdsa.PrivateKey, error) {
+func (crypto *whisperCryptoBackend) GetPrivateKey(id string) (*ecdsa.PrivateKey, error) {
 	return crypto.whisper.GetPrivateKey(id)
 }
 
-func (crypto *WhisperCryptoBackend) NewKeyPair(ctx context.Context) (string, error) {
+func (crypto *whisperCryptoBackend) NewKeyPair(ctx context.Context) (string, error) {
 	return crypto.wapi.NewKeyPair(ctx)
 }

--- a/pss/forwarding_test.go
+++ b/pss/forwarding_test.go
@@ -349,7 +349,7 @@ func newTestMsg(addr []byte) *PssMsg {
 	msg := newPssMsg(&msgParams{})
 	msg.To = addr[:]
 	msg.Expire = uint32(time.Now().Add(time.Second * 60).Unix())
-	msg.Payload = &Envelope{
+	msg.Payload = &envelope{
 		Topic: [4]byte{},
 		Data:  []byte("i have nothing to hide"),
 	}

--- a/pss/forwarding_test.go
+++ b/pss/forwarding_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
-	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
 	"github.com/ethersphere/swarm/network"
 	"github.com/ethersphere/swarm/p2p/protocols"
 	"github.com/ethersphere/swarm/pot"
@@ -350,7 +349,7 @@ func newTestMsg(addr []byte) *PssMsg {
 	msg := newPssMsg(&msgParams{})
 	msg.To = addr[:]
 	msg.Expire = uint32(time.Now().Add(time.Second * 60).Unix())
-	msg.Payload = &whisper.Envelope{
+	msg.Payload = &Envelope{
 		Topic: [4]byte{},
 		Data:  []byte("i have nothing to hide"),
 	}

--- a/pss/forwarding_test.go
+++ b/pss/forwarding_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethersphere/swarm/network"
@@ -26,6 +25,7 @@ type testCase struct {
 }
 
 var testCases []testCase
+var crypto CryptoUtils = NewCryptoUtils()
 
 // the purpose of this test is to see that pss.forward() function correctly
 // selects the peers for message forwarding, depending on the message address

--- a/pss/handshake.go
+++ b/pss/handshake.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -325,7 +324,7 @@ func (ctl *HandshakeController) registerSymKeyUse(symkeyid string) error {
 	}
 	symKey.count++
 
-	receiver := common.ToHex(crypto.FromECDSAPub(ctl.pss.PublicKey()))
+	receiver := common.ToHex(ctl.pss.Crypto.FromECDSAPub(ctl.pss.PublicKey()))
 	log.Trace("increment symkey recv use", "symsymkeyid", symkeyid, "count", symKey.count, "limit", symKey.limit, "receiver", receiver)
 
 	return nil

--- a/pss/keystore.go
+++ b/pss/keystore.go
@@ -167,8 +167,8 @@ func (ks *KeyStore) processSym(envelope *envelope) (*receivedMessage, string, Ps
 		}
 		var from PssAddress
 		ks.mx.RLock()
-		if ks.symKeyPool[*symkeyid][Topic(envelope.Topic)] != nil {
-			from = ks.symKeyPool[*symkeyid][Topic(envelope.Topic)].address
+		if ks.symKeyPool[*symkeyid][envelope.Topic] != nil {
+			from = ks.symKeyPool[*symkeyid][envelope.Topic].address
 		}
 		ks.mx.RUnlock()
 		ks.symKeyDecryptCacheCursor++
@@ -197,8 +197,8 @@ func (ks *Pss) processAsym(envelope *envelope) (*receivedMessage, string, PssAdd
 	pubkeyid := common.ToHex(crypto.FromECDSAPub(recvmsg.Src))
 	var from PssAddress
 	ks.mx.RLock()
-	if ks.pubKeyPool[pubkeyid][Topic(envelope.Topic)] != nil {
-		from = ks.pubKeyPool[pubkeyid][Topic(envelope.Topic)].address
+	if ks.pubKeyPool[pubkeyid][envelope.Topic] != nil {
+		from = ks.pubKeyPool[pubkeyid][envelope.Topic].address
 	}
 	ks.mx.RUnlock()
 	return recvmsg, pubkeyid, from, nil

--- a/pss/message.go
+++ b/pss/message.go
@@ -1,0 +1,168 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Contains all types and code related to messages and envelopes.
+// Currently backed by whisperv6
+package pss
+
+import (
+	"crypto/ecdsa"
+
+	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
+)
+
+func WBytesToTopic(b []byte) (t Topic) {
+	return Topic(whisper.BytesToTopic(b))
+}
+
+type Envelope struct {
+	Topic  Topic
+	Data   []byte
+	Expiry uint32
+}
+
+// == Envelope ==
+
+// NewSentEnvelope creates and initializes a non-signed, non-encrypted Whisper message
+// and then wrap it and encrypt it. It performs what it used to be two function calls:
+// msg, e1 := NewSentMessage and env, e := msg.Wrap
+func NewSentEnvelope(params *MessageParams) (*Envelope, error) {
+	whisperParams := toWhisperParams(params)
+
+	message, e := whisper.NewSentMessage(whisperParams)
+	if e != nil {
+		return nil, e
+	}
+
+	whisperEnvelope, e := message.Wrap(whisperParams)
+	if e != nil {
+		return nil, e
+	}
+
+	return toPssEnvelope(whisperEnvelope), nil
+}
+
+// OpenSymmetric tries to decrypt an envelope, potentially encrypted with a particular key.
+func (e *Envelope) OpenSymmetric(key []byte) (*ReceivedMessage, error) {
+	whisperEnvelope := toWhisperEnvelope(e)
+	whisperMsg, err := whisperEnvelope.OpenSymmetric(key)
+	if err != nil {
+		return nil, err
+	}
+	msg := toReceivedMessage(whisperMsg)
+	return msg, nil
+}
+
+// OpenAsymmetric tries to decrypt an envelope, potentially encrypted with a particular key.
+func (e *Envelope) OpenAsymmetric(key *ecdsa.PrivateKey) (*ReceivedMessage, error) {
+	whisperEnvelope := toWhisperEnvelope(e)
+	whisperMsg, err := whisperEnvelope.OpenAsymmetric(key)
+	if err != nil {
+		return nil, err
+	}
+
+	msg := toReceivedMessage(whisperMsg)
+	return msg, nil
+}
+
+// == Received message ==
+
+// ReceivedMessage represents a data packet to be received
+// and successfully decrypted.
+type ReceivedMessage struct {
+	Payload   []byte
+	Raw       []byte
+	Signature []byte
+	Salt      []byte
+	Padding   []byte
+
+	Src *ecdsa.PublicKey // Message recipient (identity used to decode the message)
+	Dst *ecdsa.PublicKey // Message recipient (identity used to decode the message)
+
+}
+
+// ValidateAndParse checks the message validity and extracts the fields in case of success.
+func (msg *ReceivedMessage) ValidateAndParse() bool {
+	whisperRecvMsg := &whisper.ReceivedMessage{
+		Raw: msg.Raw,
+	}
+
+	success := whisperRecvMsg.ValidateAndParse()
+	if success {
+		msg.Signature = whisperRecvMsg.Signature
+		msg.Src = whisperRecvMsg.Src
+		msg.Payload = whisperRecvMsg.Payload
+		msg.Padding = whisperRecvMsg.Padding
+	}
+	return success
+}
+
+type MessageParams struct {
+	Src     *ecdsa.PrivateKey
+	Dst     *ecdsa.PublicKey
+	KeySym  []byte
+	Topic   Topic
+	Payload []byte
+	Padding []byte
+}
+
+func toReceivedMessage(whisperMsg *whisper.ReceivedMessage) *ReceivedMessage {
+	return &ReceivedMessage{
+		Payload:   whisperMsg.Payload,
+		Raw:       whisperMsg.Raw,
+		Signature: whisperMsg.Signature,
+		Salt:      whisperMsg.Salt,
+		Src:       whisperMsg.Src,
+		Dst:       whisperMsg.Dst,
+	}
+}
+
+// == Conversion functions ==
+
+func toWhisperEnvelope(e *Envelope) *whisper.Envelope {
+	// uint32(time.Now().Add(time.Second * time.Duration(defaultWhisperTTL)).Unix()),
+	whisperEnvelope := &whisper.Envelope{
+		Expiry: e.Expiry,
+		TTL:    defaultWhisperTTL,
+		Topic:  whisper.TopicType(e.Topic),
+		Data:   e.Data,
+		Nonce:  0,
+	}
+	return whisperEnvelope
+}
+
+func toPssEnvelope(whisperEnvelope *whisper.Envelope) *Envelope {
+	return &Envelope{
+		Topic:  Topic(whisperEnvelope.Topic),
+		Data:   whisperEnvelope.Data,
+		Expiry: whisperEnvelope.Expiry,
+	}
+}
+
+func toWhisperParams(params *MessageParams) *whisper.MessageParams {
+	whisperParams := &whisper.MessageParams{
+		TTL:      defaultWhisperTTL,
+		Src:      params.Src,
+		Dst:      params.Dst,
+		KeySym:   params.KeySym,
+		Topic:    whisper.TopicType(params.Topic),
+		WorkTime: defaultWhisperWorkTime,
+		PoW:      defaultWhisperPoW,
+		Payload:  params.Payload,
+		Padding:  params.Padding,
+	}
+	return whisperParams
+}

--- a/pss/notify/notify.go
+++ b/pss/notify/notify.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethersphere/swarm/log"
@@ -139,7 +138,7 @@ func (c *Controller) Subscribe(name string, pubkey *ecdsa.PublicKey, address pss
 	defer c.mu.Unlock()
 	msg := NewMsg(MsgCodeStart, name, c.pss.BaseAddr())
 	c.pss.SetPeerPublicKey(pubkey, controlTopic, address)
-	pubkeyId := hexutil.Encode(crypto.FromECDSAPub(pubkey))
+	pubkeyId := hexutil.Encode(c.pss.Crypto.FromECDSAPub(pubkey))
 	smsg, err := rlp.EncodeToBytes(msg)
 	if err != nil {
 		return err
@@ -290,7 +289,7 @@ func (c *Controller) handleStartMsg(msg *Msg, keyid string) (err error) {
 	if err != nil {
 		return err
 	}
-	pubkey, err := crypto.UnmarshalPubkey(keyidbytes)
+	pubkey, err := c.pss.Crypto.UnmarshalPubkey(keyidbytes)
 	if err != nil {
 		return err
 	}

--- a/pss/notify/notify_test.go
+++ b/pss/notify/notify_test.go
@@ -22,10 +22,10 @@ import (
 )
 
 var (
-	loglevel      = flag.Int("loglevel", 3, "logging verbosity")
-	psses         map[string]*pss.Pss
-	cryptoUtils   pss.CryptoUtils
-	cryptoBackend pss.CryptoBackend
+	loglevel    = flag.Int("loglevel", 3, "logging verbosity")
+	psses       map[string]*pss.Pss
+	cryptoUtils pss.CryptoUtils
+	crypto      pss.CryptoBackend
 )
 
 func init() {
@@ -36,7 +36,7 @@ func init() {
 	log.Root().SetHandler(h)
 
 	cryptoUtils = pss.NewCryptoUtils()
-	cryptoBackend = pss.NewCryptoBackend()
+	crypto = pss.NewCryptoBackend()
 	psses = make(map[string]*pss.Pss)
 }
 
@@ -137,7 +137,7 @@ func TestStart(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	pubkey, err := cryptoBackend.UnmarshalPubkey(pubkeybytes)
+	pubkey, err := crypto.UnmarshalPubkey(pubkeybytes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -246,7 +246,7 @@ func newServices(allowRaw bool) adapters.Services {
 				return nil, err
 			}
 			//psses[common.ToHex(cryptoUtils.FromECDSAPub(&privkey.PublicKey))] = ps
-			psses[hexutil.Encode(cryptoBackend.FromECDSAPub(&privkey.PublicKey))] = ps
+			psses[hexutil.Encode(crypto.FromECDSAPub(&privkey.PublicKey))] = ps
 			return ps, nil
 		},
 		"bzz": func(ctx *adapters.ServiceContext) (node.Service, error) {

--- a/pss/notify/notify_test.go
+++ b/pss/notify/notify_test.go
@@ -16,17 +16,15 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/simulations"
 	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
-	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
 	"github.com/ethersphere/swarm/network"
 	"github.com/ethersphere/swarm/pss"
 	"github.com/ethersphere/swarm/state"
 )
 
 var (
-	loglevel = flag.Int("l", 3, "loglevel")
-	psses    map[string]*pss.Pss
-	w        *whisper.Whisper
-	wapi     *whisper.PublicWhisperAPI
+	loglevel      = flag.Int("l", 3, "loglevel")
+	psses         map[string]*pss.Pss
+	cryptoBackend pss.CryptoBackend
 )
 
 func init() {
@@ -36,8 +34,7 @@ func init() {
 	h := log.CallerFileHandler(hf)
 	log.Root().SetHandler(h)
 
-	w = whisper.New(&whisper.DefaultConfig)
-	wapi = whisper.NewPublicWhisperAPI(w)
+	cryptoBackend = pss.NewCryptoBackend()
 	psses = make(map[string]*pss.Pss)
 }
 
@@ -230,11 +227,11 @@ func newServices(allowRaw bool) adapters.Services {
 		"pss": func(ctx *adapters.ServiceContext) (node.Service, error) {
 			ctxlocal, cancel := context.WithTimeout(context.Background(), time.Second)
 			defer cancel()
-			keys, err := wapi.NewKeyPair(ctxlocal)
+			keys, err := cryptoBackend.NewKeyPair(ctxlocal)
 			if err != nil {
 				return nil, err
 			}
-			privkey, err := w.GetPrivateKey(keys)
+			privkey, err := cryptoBackend.GetPrivateKey(keys)
 			if err != nil {
 				return nil, err
 			}

--- a/pss/notify/notify_test.go
+++ b/pss/notify/notify_test.go
@@ -245,7 +245,6 @@ func newServices(allowRaw bool) adapters.Services {
 			if err != nil {
 				return nil, err
 			}
-			//psses[common.ToHex(cryptoUtils.FromECDSAPub(&privkey.PublicKey))] = ps
 			psses[hexutil.Encode(crypto.FromECDSAPub(&privkey.PublicKey))] = ps
 			return ps, nil
 		},

--- a/pss/prox_test.go
+++ b/pss/prox_test.go
@@ -428,8 +428,8 @@ func newProxServices(td *testData, allowRaw bool, handlerContextFuncs map[Topic]
 			// create keys in whisper and set up the pss object
 			ctxlocal, cancel := context.WithTimeout(context.Background(), time.Second*3)
 			defer cancel()
-			keys, err := wapi.NewKeyPair(ctxlocal)
-			privkey, err := w.GetPrivateKey(keys)
+			keys, err := cryptoBackend.NewKeyPair(ctxlocal)
+			privkey, err := cryptoBackend.GetPrivateKey(keys)
 			pssp := NewParams().WithPrivateKey(privkey)
 			pssp.AllowRaw = allowRaw
 			bzzPrivateKey, err := simulation.BzzPrivateKeyFromConfig(ctx.Config)

--- a/pss/prox_test.go
+++ b/pss/prox_test.go
@@ -425,7 +425,7 @@ func newProxServices(td *testData, allowRaw bool, handlerContextFuncs map[Topic]
 			// execadapter does not exec init()
 			initTest()
 
-			// create keys in whisper and set up the pss object
+			// create keys in crypto backend and set up the pss object
 			ctxlocal, cancel := context.WithTimeout(context.Background(), time.Second*3)
 			defer cancel()
 			keys, err := cryptoBackend.NewKeyPair(ctxlocal)

--- a/pss/prox_test.go
+++ b/pss/prox_test.go
@@ -425,11 +425,11 @@ func newProxServices(td *testData, allowRaw bool, handlerContextFuncs map[Topic]
 			// execadapter does not exec init()
 			initTest()
 
-			// create keys in crypto backend and set up the pss object
+			// create keys in cryptoUtils and set up the pss object
 			ctxlocal, cancel := context.WithTimeout(context.Background(), time.Second*3)
 			defer cancel()
-			keys, err := cryptoBackend.NewKeyPair(ctxlocal)
-			privkey, err := cryptoBackend.GetPrivateKey(keys)
+			keys, err := cryptoUtils.NewKeyPair(ctxlocal)
+			privkey, err := cryptoUtils.GetPrivateKey(keys)
 			pssp := NewParams().WithPrivateKey(privkey)
 			pssp.AllowRaw = allowRaw
 			bzzPrivateKey, err := simulation.BzzPrivateKeyFromConfig(ctx.Config)

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -413,7 +413,7 @@ func (p *Pss) handle(ctx context.Context, msg interface{}) error {
 	}
 	p.addFwdCache(pssmsg)
 
-	psstopic := Topic(pssmsg.Payload.Topic)
+	psstopic := pssmsg.Payload.Topic
 
 	// raw is simplest handler contingency to check, so check that first
 	var isRaw bool
@@ -466,7 +466,7 @@ func (p *Pss) process(pssmsg *PssMsg, raw bool, prox bool) error {
 	var keyFunc func(envelope *envelope) (*receivedMessage, string, PssAddress, error)
 
 	envelope := pssmsg.Payload
-	psstopic := Topic(envelope.Topic)
+	psstopic := envelope.Topic
 
 	if raw {
 		payload = pssmsg.Payload.Data

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -149,7 +148,7 @@ type Pss struct {
 }
 
 func (p *Pss) String() string {
-	return fmt.Sprintf("pss: addr %x, pubkey %v", p.BaseAddr(), common.ToHex(crypto.FromECDSAPub(&p.privateKey.PublicKey)))
+	return fmt.Sprintf("pss: addr %x, pubkey %v", p.BaseAddr(), common.ToHex(p.Crypto.FromECDSAPub(&p.privateKey.PublicKey)))
 }
 
 // Creates a new Pss instance.
@@ -236,7 +235,7 @@ func (p *Pss) Start(srv *p2p.Server) error {
 		}
 	}()
 	log.Info("Started Pss")
-	log.Info("Loaded EC keys", "pubkey", common.ToHex(crypto.FromECDSAPub(p.PublicKey())), "secp256", common.ToHex(crypto.CompressPubkey(p.PublicKey())))
+	log.Info("Loaded EC keys", "pubkey", common.ToHex(p.Crypto.FromECDSAPub(p.PublicKey())), "secp256", common.ToHex(p.Crypto.CompressPubkey(p.PublicKey())))
 	return nil
 }
 
@@ -615,7 +614,7 @@ func (p *Pss) SendSym(symkeyid string, topic Topic, msg []byte) error {
 //
 // Fails if the key id does not match any in of the stored public keys
 func (p *Pss) SendAsym(pubkeyid string, topic Topic, msg []byte) error {
-	if _, err := crypto.UnmarshalPubkey(common.FromHex(pubkeyid)); err != nil {
+	if _, err := p.Crypto.UnmarshalPubkey(common.FromHex(pubkeyid)); err != nil {
 		return fmt.Errorf("Cannot unmarshal pubkey: %x", pubkeyid)
 	}
 	psp, ok := p.getPeerPub(pubkeyid, topic)
@@ -649,7 +648,7 @@ func (p *Pss) send(to []byte, topic Topic, msg []byte, asymmetric bool, key []by
 		Padding: padding,
 	}
 	if asymmetric {
-		pk, err := crypto.UnmarshalPubkey(key)
+		pk, err := p.Crypto.UnmarshalPubkey(key)
 		if err != nil {
 			return fmt.Errorf("Cannot unmarshal pubkey: %x", key)
 		}

--- a/pss/pss_test.go
+++ b/pss/pss_test.go
@@ -166,24 +166,25 @@ func TestCache(t *testing.T) {
 	data := []byte("foo")
 	datatwo := []byte("bar")
 	datathree := []byte("baz")
-	wparams := &MessageParams{
+	mparams := &messageParams{
+		Src:     privkey,
 		Dst:     &privkey.PublicKey,
 		Topic:   PingTopic,
 		Payload: data,
 	}
-	env, err := NewSentEnvelope(wparams)
+	env, err := newSentEnvelope(mparams)
 	msg := &PssMsg{
 		Payload: env,
 		To:      to,
 	}
-	wparams.Payload = datatwo
-	envtwo, err := NewSentEnvelope(wparams)
+	mparams.Payload = datatwo
+	envtwo, err := newSentEnvelope(mparams)
 	msgtwo := &PssMsg{
 		Payload: envtwo,
 		To:      to,
 	}
-	wparams.Payload = datathree
-	envthree, err := NewSentEnvelope(wparams)
+	mparams.Payload = datathree
+	envthree, err := newSentEnvelope(mparams)
 	msgthree := &PssMsg{
 		Payload: envthree,
 		To:      to,
@@ -412,7 +413,7 @@ func TestAddressMatchProx(t *testing.T) {
 		pssMsg := newPssMsg(&msgParams{raw: true})
 		pssMsg.To = remoteAddr
 		pssMsg.Expire = uint32(time.Now().Unix() + 4200)
-		pssMsg.Payload = &Envelope{
+		pssMsg.Payload = &envelope{
 			Topic: topic,
 			Data:  data[:],
 		}
@@ -443,7 +444,7 @@ func TestAddressMatchProx(t *testing.T) {
 		pssMsg := newPssMsg(&msgParams{raw: true})
 		pssMsg.To = remoteAddr
 		pssMsg.Expire = uint32(time.Now().Unix() + 4200)
-		pssMsg.Payload = &Envelope{
+		pssMsg.Payload = &envelope{
 			Topic: topic,
 			Data:  data[:],
 		}
@@ -467,7 +468,7 @@ func TestAddressMatchProx(t *testing.T) {
 		pssMsg := newPssMsg(&msgParams{raw: true})
 		pssMsg.To = remoteAddr
 		pssMsg.Expire = uint32(time.Now().Unix() + 4200)
-		pssMsg.Payload = &Envelope{
+		pssMsg.Payload = &envelope{
 			Topic: topic,
 			Data:  []byte(remotePotAddr.String()),
 		}
@@ -500,7 +501,7 @@ func TestMessageProcessing(t *testing.T) {
 	msg := newPssMsg(&msgParams{})
 	msg.To = addr
 	msg.Expire = uint32(time.Now().Add(time.Second * 60).Unix())
-	msg.Payload = &Envelope{
+	msg.Payload = &envelope{
 		Topic: [4]byte{},
 		Data:  []byte{0x66, 0x6f, 0x6f},
 	}
@@ -780,7 +781,7 @@ func TestPeerCapabilityMismatch(t *testing.T) {
 	pssmsg := &PssMsg{
 		To:      []byte{},
 		Expire:  uint32(time.Now().Add(time.Second).Unix()),
-		Payload: &Envelope{},
+		Payload: &envelope{},
 	}
 	ps := newTestPss(privkey, kad, nil)
 	defer ps.Stop()
@@ -825,7 +826,7 @@ func TestRawAllow(t *testing.T) {
 	})
 	pssMsg.To = baseAddr.OAddr
 	pssMsg.Expire = uint32(time.Now().Unix() + 4200)
-	pssMsg.Payload = &Envelope{
+	pssMsg.Payload = &envelope{
 		Topic: topic,
 	}
 	ps.handle(context.TODO(), pssMsg)
@@ -1633,13 +1634,13 @@ func benchmarkSymkeyBruteforceChangeaddr(b *testing.B) {
 		if err != nil {
 			b.Fatalf("could not retrieve symkey %s: %v", keyid, err)
 		}
-		wparams := &MessageParams{
+		mparams := &messageParams{
 			KeySym:  symkey,
 			Topic:   topic,
 			Payload: []byte("xyzzy"),
 			Padding: []byte("1234567890abcdef"),
 		}
-		env, err := NewSentEnvelope(wparams)
+		env, err := newSentEnvelope(mparams)
 		if err != nil {
 			b.Fatalf("could not generate envelope: %v", err)
 		}
@@ -1711,13 +1712,13 @@ func benchmarkSymkeyBruteforceSameaddr(b *testing.B) {
 	if err != nil {
 		b.Fatalf("could not retrieve symkey %s: %v", keyid, err)
 	}
-	wparams := &MessageParams{
+	mparams := &messageParams{
 		KeySym:  symkey,
 		Topic:   topic,
 		Payload: []byte("xyzzy"),
 		Padding: []byte("1234567890abcdef"),
 	}
-	env, err := NewSentEnvelope(wparams)
+	env, err := newSentEnvelope(mparams)
 	if err != nil {
 		b.Fatalf("could not generate envelope: %v", err)
 	}

--- a/pss/types.go
+++ b/pss/types.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/rlp"
-	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
 	"github.com/ethersphere/swarm/storage"
 )
 
@@ -37,6 +36,7 @@ const (
 const (
 	pssControlSym = 1
 	pssControlRaw = 1 << 1
+	TopicLength   = 4 // in bytes Taken from Whisper
 )
 
 var (
@@ -46,7 +46,7 @@ var (
 )
 
 // Topic is the PSS encapsulation of the Whisper topic type
-type Topic whisper.TopicType
+type Topic [TopicLength]byte
 
 func (t *Topic) String() string {
 	return hexutil.Encode(t[:])
@@ -135,7 +135,7 @@ type PssMsg struct {
 	To      []byte
 	Control []byte
 	Expire  uint32
-	Payload *whisper.Envelope
+	Payload *Envelope
 }
 
 func newPssMsg(param *msgParams) *PssMsg {
@@ -158,7 +158,7 @@ func (msg *PssMsg) isSym() bool {
 func (msg *PssMsg) serialize() []byte {
 	rlpdata, _ := rlp.EncodeToBytes(struct {
 		To      []byte
-		Payload *whisper.Envelope
+		Payload *Envelope
 	}{
 		To:      msg.To,
 		Payload: msg.Payload,
@@ -226,5 +226,5 @@ func BytesToTopic(b []byte) Topic {
 	defer topicHashMutex.Unlock()
 	topicHashFunc.Reset()
 	topicHashFunc.Write(b)
-	return Topic(whisper.BytesToTopic(topicHashFunc.Sum(nil)))
+	return WBytesToTopic(topicHashFunc.Sum(nil))
 }

--- a/pss/types.go
+++ b/pss/types.go
@@ -135,7 +135,7 @@ type PssMsg struct {
 	To      []byte
 	Control []byte
 	Expire  uint32
-	Payload *Envelope
+	Payload *envelope
 }
 
 func newPssMsg(param *msgParams) *PssMsg {
@@ -158,7 +158,7 @@ func (msg *PssMsg) isSym() bool {
 func (msg *PssMsg) serialize() []byte {
 	rlpdata, _ := rlp.EncodeToBytes(struct {
 		To      []byte
-		Payload *Envelope
+		Payload *envelope
 	}{
 		To:      msg.To,
 		Payload: msg.Payload,
@@ -226,5 +226,5 @@ func BytesToTopic(b []byte) Topic {
 	defer topicHashMutex.Unlock()
 	topicHashFunc.Reset()
 	topicHashFunc.Write(b)
-	return WBytesToTopic(topicHashFunc.Sum(nil))
+	return toTopic(topicHashFunc.Sum(nil))
 }


### PR DESCRIPTION
We want to modularize crypto and stop depending on `whisper`. Issue #1655 describe several steps to achive this. The goal of this PR is just a small fraction of that first step.
This PR isolates all usages of whisper into two new files:

- `crypto.go`: contains all the whisper usages related to keys management

- `message.go`: contains the data model related to envelopes and messages that we were using from `whisper`.

This PR is only a refactor of code, we are not changing anything so all the new methods and types are delegating into the old whisper methods and types.

The only minor thing done was removing unused fields from `whisper.ReceivedMessage` and `whisper.Envelope`.

In `crypto.go` we have created and interface of the methods needed by keystore and also created a default implementation delegating to whisper.

We also isolated code calling `github.com/ethereum/go-ethereum/crypto` into `crypto.go`.

There are some crypto utilities used only by tests. Instead of adding those methods to the crypto interface, we created `CryptoUtils.go` and add them there. `CryptoUtils` is intended to be used only in tests.

