### PR TITLE
storage: fix hasherstore seen panic

### DIFF
--- a/storage/hasherstore.go
+++ b/storage/hasherstore.go
@@ -281,7 +281,7 @@ func (h *hasherStore) storeChunk(ctx context.Context, ch Chunk) {
 		}()
 		seen, err := h.store.Put(ctx, chunk.ModePutUpload, ch)
 		h.tag.Inc(chunk.StateStored)
-		if err != nil && seen[0] {
+		if err == nil && seen[0] {
 			h.tag.Inc(chunk.StateSeen)
 		}
 		select {


### PR DESCRIPTION
This PR fixes a panic that happens when the error returned from `netstore.Put` is not `nil`. In that case, the returned `seen` slice is empty, therefore resulting in a panic