### PR TITLE
pss: fixed flaky test TestForwardBasic

### DIFF
--- a/pss/forwarding_test.go
+++ b/pss/forwarding_test.go
@@ -26,13 +26,11 @@ type testCase struct {
 	errors    string
 }
 
-var testCases []testCase
-
 // the purpose of this test is to see that pss.forward() function correctly
 // selects the peers for message forwarding, depending on the message address
 // and kademlia constellation.
 func TestForwardBasic(t *testing.T) {
-	t.Skip("Flaky on macOS on local machines")
+	var testCases []testCase
 	baseAddrBytes := make([]byte, 32)
 	for i := 0; i < len(baseAddrBytes); i++ {
 		baseAddrBytes[i] = 0xFF


### PR DESCRIPTION
This test was using a global variable `testCases` to append test cases to run. When executed several times, newest test cases were appended at the end instead of creating a new slice of test cases.
Previously, executing 
```sh
$> go test -count 2 -run TestForwardBasic
```
...always failed. Now, no matter how many times this test is repeated, it always passes.

fixes #1545