### PR TITLE
Dockerfile: add kernel profiler to alltools image

### DIFF
--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -8,6 +8,8 @@ FROM ethereum/client-go:v1.8.27 as geth
 
 FROM alpine:3.9
 RUN apk --no-cache add ca-certificates
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+RUN apk --update add perf
 COPY --from=builder /swarm/build/bin/* /usr/local/bin/
 COPY --from=geth /usr/local/bin/geth /usr/local/bin/
 COPY docker/run-smoke.sh /run-smoke.sh


### PR DESCRIPTION
This PR adds the linux kernel `perf` tool to the `alltools` docker image.