### PR TITLE
swap: fix TestHandshake and TestEmitCheque

### DIFF
--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -72,21 +72,14 @@ func TestHandshake(t *testing.T) {
 		Label: "TestHandshake",
 		Triggers: []p2ptest.Trigger{
 			{
-				Code: 1,
-				Msg: &EmitChequeMsg{
-					Cheque: cheque,
-				},
-				Peer: debitor.ID(),
-			},
-		},
-		Expects: []p2ptest.Expect{
-			{
 				Code: 0,
 				Msg: &HandshakeMsg{
 					ContractAddress: swap.owner.Contract,
 				},
 				Peer: creditor.ID(),
 			},
+		},
+		Expects: []p2ptest.Expect{
 			{
 				Code: 0,
 				Msg: &HandshakeMsg{
@@ -182,16 +175,11 @@ func TestEmitCheque(t *testing.T) {
 	if creditorSwap.balances[debitor.ID()] != 0 {
 		t.Fatalf("Expected debitor balance to have been reset to %d, but it is %d", 0, creditorSwap.balances[debitor.ID()])
 	}
-	/*
-			TODO: This test actually fails now, because the two Swaps create independent backends,
-			thus when handling the cheque, it will actually complain (check ERROR log output)
-			with `error="no contract code at given address"`.
-			Therefore, the `lastReceivedCheque` is not being saved, and this check would fail.
-			So TODO is to find out how to address this (should be by having same backend when creating the Swap)
-		if creditorSwap.loadLastReceivedCheque(debitor.ID()) != cheque {
-			t.Fatalf("Expected exactly one cheque at creditor, but there are %d:", len(creditorSwap.cheques))
-		}
-	*/
+	recvCheque := creditorSwap.loadLastReceivedCheque(debitor)
+	log.Debug("expected cheque", "cheque", recvCheque)
+	if recvCheque != cheque {
+		t.Fatalf("Expected exactly one cheque at creditor, but there are %d:", len(creditorSwap.cheques))
+	}
 }
 
 // TestTriggerPaymentThreshold is to test that the whole cheque protocol is triggered


### PR DESCRIPTION
This PR fixes an inconsistency of `TestHandshake`.

It also fixes an issue left open in `TestEmitCheque`.

Closes https://github.com/ethersphere/swarm/issues/1711