### PR TITLE
swap: refactor lastReceivedCheque, lastSentCheque, balances to peer

### DIFF
--- a/swap/peer.go
+++ b/swap/peer.go
@@ -159,8 +159,6 @@ func (p *Peer) sendCheque() error {
 		return fmt.Errorf("error while creating cheque: %v", err)
 	}
 
-	log.Info("sending cheque", "honey", cheque.Honey, "cumulativePayout", cheque.ChequeParams.CumulativePayout, "beneficiary", cheque.Beneficiary, "contract", cheque.Contract)
-
 	if err := p.setLastSentCheque(cheque); err != nil {
 		return fmt.Errorf("error while storing the last cheque: %v", err)
 	}
@@ -168,6 +166,8 @@ func (p *Peer) sendCheque() error {
 	if err := p.updateBalance(int64(cheque.Honey)); err != nil {
 		return err
 	}
+
+	log.Info("sending cheque", "honey", cheque.Honey, "cumulativePayout", cheque.ChequeParams.CumulativePayout, "beneficiary", cheque.Beneficiary, "contract", cheque.Contract)
 
 	return p.Send(context.Background(), &EmitChequeMsg{
 		Cheque: cheque,

--- a/swap/peer.go
+++ b/swap/peer.go
@@ -18,6 +18,7 @@ package swap
 
 import (
 	"errors"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -30,18 +31,51 @@ var ErrDontOwe = errors.New("no negative balance")
 // Peer is a devp2p peer for the Swap protocol
 type Peer struct {
 	*protocols.Peer
+	lock               sync.RWMutex
 	swap               *Swap
 	beneficiary        common.Address
 	contractAddress    common.Address
 	lastReceivedCheque *Cheque
+	lastSentCheque     *Cheque
 }
 
 // NewPeer creates a new swap Peer instance
 func NewPeer(p *protocols.Peer, s *Swap, beneficiary common.Address, contractAddress common.Address) *Peer {
-	return &Peer{
+	peer := &Peer{
 		Peer:            p,
 		swap:            s,
 		beneficiary:     beneficiary,
 		contractAddress: contractAddress,
 	}
+
+	peer.lastReceivedCheque, _ = s.loadLastReceivedCheque(p.ID())
+	peer.lastSentCheque, _ = s.loadLastSentCheque(p.ID())
+
+	return peer
+}
+
+func (p *Peer) getLastReceivedCheque() *Cheque {
+	return p.lastReceivedCheque
+}
+
+func (p *Peer) getLastSentCheque() *Cheque {
+	return p.lastSentCheque
+}
+
+func (p *Peer) setLastReceivedCheque(cheque *Cheque) error {
+	p.lastReceivedCheque = cheque
+	return p.swap.saveLastReceivedCheque(p, cheque)
+}
+
+func (p *Peer) setLastSentCheque(cheque *Cheque) error {
+	p.lastSentCheque = cheque
+	return p.swap.saveLastSentCheque(p, cheque)
+}
+
+func (p *Peer) getLastChequeValues() (total uint64, err error) {
+	lastCheque := p.getLastReceivedCheque()
+	if lastCheque != nil {
+		total = lastCheque.CumulativePayout
+	}
+	return
 }

--- a/swap/peer.go
+++ b/swap/peer.go
@@ -44,7 +44,7 @@ type Peer struct {
 }
 
 // NewPeer creates a new swap Peer instance
-func NewPeer(p *protocols.Peer, s *Swap, beneficiary common.Address, contractAddress common.Address) *Peer {
+func NewPeer(p *protocols.Peer, s *Swap, beneficiary common.Address, contractAddress common.Address) (*Peer, error) {
 	peer := &Peer{
 		Peer:            p,
 		swap:            s,
@@ -52,11 +52,19 @@ func NewPeer(p *protocols.Peer, s *Swap, beneficiary common.Address, contractAdd
 		contractAddress: contractAddress,
 	}
 
-	peer.lastReceivedCheque, _ = s.loadLastReceivedCheque(p.ID())
-	peer.lastSentCheque, _ = s.loadLastSentCheque(p.ID())
-	peer.balance, _ = s.loadBalance(p.ID())
+	var err error
+	if peer.lastReceivedCheque, err = s.loadLastReceivedCheque(p.ID()); err != nil {
+		return nil, err
+	}
 
-	return peer
+	if peer.lastSentCheque, err = s.loadLastSentCheque(p.ID()); err != nil {
+		return nil, err
+	}
+
+	if peer.balance, err = s.loadBalance(p.ID()); err != nil {
+		return nil, err
+	}
+	return peer, nil
 }
 
 func (p *Peer) getLastReceivedCheque() *Cheque {

--- a/swap/peer.go
+++ b/swap/peer.go
@@ -44,15 +44,14 @@ type Peer struct {
 }
 
 // NewPeer creates a new swap Peer instance
-func NewPeer(p *protocols.Peer, s *Swap, beneficiary common.Address, contractAddress common.Address) (*Peer, error) {
-	peer := &Peer{
+func NewPeer(p *protocols.Peer, s *Swap, beneficiary common.Address, contractAddress common.Address) (peer *Peer, err error) {
+	peer = &Peer{
 		Peer:            p,
 		swap:            s,
 		beneficiary:     beneficiary,
 		contractAddress: contractAddress,
 	}
 
-	var err error
 	if peer.lastReceivedCheque, err = s.loadLastReceivedCheque(p.ID()); err != nil {
 		return nil, err
 	}
@@ -129,7 +128,6 @@ func (p *Peer) createCheque() (*Cheque, error) {
 	// the balance should be negative here, we take the absolute value:
 	honey := uint64(-p.getBalance())
 
-	// TODO: this must probably be locked
 	amount, err := p.swap.oracle.GetPrice(honey)
 	if err != nil {
 		return nil, fmt.Errorf("error getting price from oracle: %v", err)

--- a/swap/protocol.go
+++ b/swap/protocol.go
@@ -121,7 +121,10 @@ func (s *Swap) run(p *p2p.Peer, rw p2p.MsgReadWriter) error {
 		return err
 	}
 
-	swapPeer := s.addPeer(protoPeer, beneficiary, response.ContractAddress)
+	swapPeer, err := s.addPeer(protoPeer, beneficiary, response.ContractAddress)
+	if err != nil {
+		return err
+	}
 	defer s.removePeer(swapPeer)
 
 	return swapPeer.Run(s.handleMsg(swapPeer))
@@ -133,12 +136,15 @@ func (s *Swap) removePeer(p *Peer) {
 	delete(s.peers, p.ID())
 }
 
-func (s *Swap) addPeer(protoPeer *protocols.Peer, beneficiary common.Address, contractAddress common.Address) *Peer {
+func (s *Swap) addPeer(protoPeer *protocols.Peer, beneficiary common.Address, contractAddress common.Address) (*Peer, error) {
 	s.peersLock.Lock()
 	defer s.peersLock.Unlock()
-	p := NewPeer(protoPeer, s, beneficiary, contractAddress)
+	p, err := NewPeer(protoPeer, s, beneficiary, contractAddress)
+	if err != nil {
+		return nil, err
+	}
 	s.peers[p.ID()] = p
-	return p
+	return p, nil
 }
 
 func (s *Swap) getPeer(id enode.ID) *Peer {

--- a/swap/protocol.go
+++ b/swap/protocol.go
@@ -121,8 +121,7 @@ func (s *Swap) run(p *p2p.Peer, rw p2p.MsgReadWriter) error {
 		return err
 	}
 
-	swapPeer := NewPeer(protoPeer, s, beneficiary, response.ContractAddress)
-	s.addPeer(swapPeer)
+	swapPeer := s.newPeer(protoPeer, beneficiary, response.ContractAddress)
 	defer s.removePeer(swapPeer)
 
 	return swapPeer.Run(s.handleMsg(swapPeer))
@@ -145,6 +144,12 @@ func (s *Swap) getPeer(id enode.ID) (*Peer, bool) {
 	defer s.peersLock.RUnlock()
 	peer, ok := s.peers[id]
 	return peer, ok
+}
+
+func (s *Swap) newPeer(protoPeer *protocols.Peer, beneficiary common.Address, contractAddress common.Address) *Peer {
+	peer := NewPeer(protoPeer, s, beneficiary, contractAddress)
+	s.addPeer(peer)
+	return peer
 }
 
 type swapAPI interface {

--- a/swap/protocol.go
+++ b/swap/protocol.go
@@ -121,7 +121,7 @@ func (s *Swap) run(p *p2p.Peer, rw p2p.MsgReadWriter) error {
 		return err
 	}
 
-	swapPeer := s.newPeer(protoPeer, beneficiary, response.ContractAddress)
+	swapPeer := s.addPeer(protoPeer, beneficiary, response.ContractAddress)
 	defer s.removePeer(swapPeer)
 
 	return swapPeer.Run(s.handleMsg(swapPeer))
@@ -133,22 +133,18 @@ func (s *Swap) removePeer(p *Peer) {
 	delete(s.peers, p.ID())
 }
 
-func (s *Swap) addPeer(p *Peer) {
+func (s *Swap) addPeer(protoPeer *protocols.Peer, beneficiary common.Address, contractAddress common.Address) *Peer {
 	s.peersLock.Lock()
 	defer s.peersLock.Unlock()
+	p := NewPeer(protoPeer, s, beneficiary, contractAddress)
 	s.peers[p.ID()] = p
+	return p
 }
 
-func (s *Swap) getPeer(id enode.ID) (*Peer, bool) {
+func (s *Swap) getPeer(id enode.ID) *Peer {
 	s.peersLock.RLock()
 	defer s.peersLock.RUnlock()
-	peer, ok := s.peers[id]
-	return peer, ok
-}
-
-func (s *Swap) newPeer(protoPeer *protocols.Peer, beneficiary common.Address, contractAddress common.Address) *Peer {
-	peer := NewPeer(protoPeer, s, beneficiary, contractAddress)
-	s.addPeer(peer)
+	peer := s.peers[id]
 	return peer
 }
 

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -126,7 +126,7 @@ func TestEmitCheque(t *testing.T) {
 	// create the debitor peer
 	dPtpPeer := p2p.NewPeer(enode.ID{}, "debitor", []p2p.Cap{})
 	dProtoPeer := protocols.NewPeer(dPtpPeer, nil, Spec)
-	debitor := creditorSwap.newPeer(dProtoPeer, debitorSwap.owner.address, debitorSwap.owner.Contract)
+	debitor := creditorSwap.addPeer(dProtoPeer, debitorSwap.owner.address, debitorSwap.owner.Contract)
 
 	// set balance artificially
 	debitor.setBalance(42)
@@ -196,7 +196,7 @@ func TestTriggerPaymentThreshold(t *testing.T) {
 
 	// create a dummy pper
 	cPeer := newDummyPeerWithSpec(Spec)
-	creditor := debitorSwap.newPeer(cPeer.Peer, common.Address{}, common.Address{})
+	creditor := debitorSwap.addPeer(cPeer.Peer, common.Address{}, common.Address{})
 
 	// set the balance to manually be at PaymentThreshold
 	overDraft := 42
@@ -248,7 +248,7 @@ func TestTriggerDisconnectThreshold(t *testing.T) {
 
 	// create a dummy pper
 	cPeer := newDummyPeerWithSpec(Spec)
-	debitor := creditorSwap.newPeer(cPeer.Peer, common.Address{}, common.Address{})
+	debitor := creditorSwap.addPeer(cPeer.Peer, common.Address{}, common.Address{})
 
 	// set the balance to manually be at DisconnectThreshold
 	overDraft := 42

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -126,7 +126,10 @@ func TestEmitCheque(t *testing.T) {
 	// create the debitor peer
 	dPtpPeer := p2p.NewPeer(enode.ID{}, "debitor", []p2p.Cap{})
 	dProtoPeer := protocols.NewPeer(dPtpPeer, nil, Spec)
-	debitor := creditorSwap.addPeer(dProtoPeer, debitorSwap.owner.address, debitorSwap.owner.Contract)
+	debitor, err := creditorSwap.addPeer(dProtoPeer, debitorSwap.owner.address, debitorSwap.owner.Contract)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// set balance artificially
 	debitor.setBalance(42)
@@ -196,7 +199,10 @@ func TestTriggerPaymentThreshold(t *testing.T) {
 
 	// create a dummy pper
 	cPeer := newDummyPeerWithSpec(Spec)
-	creditor := debitorSwap.addPeer(cPeer.Peer, common.Address{}, common.Address{})
+	creditor, err := debitorSwap.addPeer(cPeer.Peer, common.Address{}, common.Address{})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// set the balance to manually be at PaymentThreshold
 	overDraft := 42
@@ -207,7 +213,7 @@ func TestTriggerPaymentThreshold(t *testing.T) {
 		t.Fatalf("Expected no cheques yet, but there is %v:", creditor.getLastSentCheque())
 	}
 	// do some accounting, no error expected, just a WARN
-	err := debitorSwap.Add(int64(-overDraft), creditor.Peer)
+	err = debitorSwap.Add(int64(-overDraft), creditor.Peer)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -248,7 +254,10 @@ func TestTriggerDisconnectThreshold(t *testing.T) {
 
 	// create a dummy pper
 	cPeer := newDummyPeerWithSpec(Spec)
-	debitor := creditorSwap.addPeer(cPeer.Peer, common.Address{}, common.Address{})
+	debitor, err := creditorSwap.addPeer(cPeer.Peer, common.Address{}, common.Address{})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// set the balance to manually be at DisconnectThreshold
 	overDraft := 42
@@ -260,7 +269,7 @@ func TestTriggerDisconnectThreshold(t *testing.T) {
 		t.Fatalf("Expected no cheques yet, but there is %v", debitor.getLastSentCheque())
 	}
 	// now do some accounting
-	err := creditorSwap.Add(int64(overDraft), debitor.Peer)
+	err = creditorSwap.Add(int64(overDraft), debitor.Peer)
 	// it should fail due to overdraft
 	if err == nil {
 		t.Fatal("Expected an error due to overdraft, but did not get any")

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"strconv"
 	"sync"
 	"time"
 
@@ -51,8 +50,6 @@ type Swap struct {
 	store               state.Store        // store is needed in order to keep balances and cheques across sessions
 	accountingLock      sync.RWMutex       // lock for data consistency in accounting-related functions
 	storeLock           sync.RWMutex       // lock for store access
-	balances            map[enode.ID]int64 // map of balances for each peer
-	balancesLock        sync.RWMutex       // lock for balances map
 	peers               map[enode.ID]*Peer // map of all swap Peers
 	peersLock           sync.RWMutex       // lock for peers map
 	backend             contract.Backend   // the backend (blockchain) used
@@ -88,7 +85,6 @@ func NewParams() *Params {
 func New(stateStore state.Store, prvkey *ecdsa.PrivateKey, backend contract.Backend) *Swap {
 	return &Swap{
 		store:               stateStore,
-		balances:            make(map[enode.ID]int64),
 		peers:               make(map[enode.ID]*Peer),
 		backend:             backend,
 		owner:               createOwner(prvkey),
@@ -144,55 +140,35 @@ func (s *Swap) DeploySuccess() string {
 func (s *Swap) Add(amount int64, peer *protocols.Peer) (err error) {
 	s.accountingLock.Lock()
 	defer s.accountingLock.Unlock()
-
-	err = s.loadBalance(peer.ID())
-	if err != nil && err != state.ErrNotFound {
-		return fmt.Errorf("error while loading balance for peer %s", peer.ID().String())
+	swapPeer, ok := s.getPeer(peer.ID())
+	if !ok {
+		return fmt.Errorf("peer %s not a swap enabled peer", peer.ID().String())
 	}
+	swapPeer.lock.Lock()
+	defer swapPeer.lock.Unlock()
 
 	// Check if balance with peer is over the disconnect threshold
-	balance, exists := s.getBalance(peer.ID())
-	if !exists {
-		return fmt.Errorf("peer %v does not exist", peer.ID())
-	}
+	balance := swapPeer.getBalance()
 	if balance >= s.disconnectThreshold {
 		return fmt.Errorf("balance for peer %s is over the disconnect threshold %d, disconnecting", peer.ID().String(), s.disconnectThreshold)
 	}
 
-	var newBalance int64
-	newBalance, err = s.updateBalance(peer.ID(), amount)
-	if err != nil {
+	if err = swapPeer.updateBalance(amount); err != nil {
 		return err
 	}
 
 	// Check if balance with peer crosses the payment threshold
 	// It is the peer with a negative balance who sends a cheque, thus we check
 	// that the balance is *below* the threshold
-	if newBalance <= -s.paymentThreshold {
+	if swapPeer.getBalance() <= -s.paymentThreshold {
 		log.Warn("balance for peer went over the payment threshold, sending cheque", "peer", peer.ID().String(), "payment threshold", s.paymentThreshold)
-		swapPeer, ok := s.getPeer(peer.ID())
 		if !ok {
 			return fmt.Errorf("peer %s not found", peer)
 		}
-		swapPeer.lock.Lock()
-		defer swapPeer.lock.Unlock()
 		return s.sendCheque(swapPeer)
 	}
 
 	return nil
-}
-
-func (s *Swap) getBalance(id enode.ID) (int64, bool) {
-	s.balancesLock.RLock()
-	defer s.balancesLock.RUnlock()
-	peerBalance, exists := s.balances[id]
-	return peerBalance, exists
-}
-
-func (s *Swap) setBalance(id enode.ID, balance int64) {
-	s.balancesLock.Lock()
-	defer s.balancesLock.Unlock()
-	s.balances[id] = balance
 }
 
 // handleMsg is for handling messages when receiving messages
@@ -211,6 +187,9 @@ var defaultCashCheque = cashCheque
 // handleEmitChequeMsg should be handled by the creditor when it receives
 // a cheque from a debitor
 func (s *Swap) handleEmitChequeMsg(ctx context.Context, p *Peer, msg *EmitChequeMsg) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
 	cheque := msg.Cheque
 	log.Info("received cheque from peer", "peer", p.ID().String(), "honey", cheque.Honey)
 	_, err := s.processAndVerifyCheque(cheque, p)
@@ -223,9 +202,7 @@ func (s *Swap) handleEmitChequeMsg(ctx context.Context, p *Peer, msg *EmitCheque
 	// reset balance by amount
 	// as this is done by the creditor, receiving the cheque, the amount should be negative,
 	// so that updateBalance will calculate balance + amount which result in reducing the peer's balance
-	s.accountingLock.Lock()
-	err = s.resetBalance(p.ID(), 0-int64(cheque.Honey))
-	s.accountingLock.Unlock()
+	p.updateBalance(-int64(cheque.Honey))
 	if err != nil {
 		return err
 	}
@@ -293,43 +270,10 @@ func (s *Swap) processAndVerifyCheque(cheque *Cheque, p *Peer) (uint64, error) {
 	return actualAmount, nil
 }
 
-// To be called with mutex already held
-// Caller must be careful that the same balance isn't concurrently read and written by multiple routines
-func (s *Swap) updateBalance(peer enode.ID, amount int64) (int64, error) {
-	//adjust the balance
-	//if amount is negative, it will decrease, otherwise increase
-	balance, exists := s.getBalance(peer)
-	if !exists {
-		return 0, fmt.Errorf("peer %v does not exist", peer)
-	}
-	newBalance := balance + amount
-	s.setBalance(peer, newBalance)
-	//save the new balance to the state store
-	err := s.store.Put(balanceKey(peer), &newBalance)
-	if err != nil {
-		return 0, err
-	}
-	log.Debug("balance for peer after accounting", "peer", peer.String(), "balance", strconv.FormatInt(newBalance, 10))
-	return newBalance, err
-}
-
-// loadBalance loads balances from the state store (persisted)
-// To be called with mutex already held
-// Caller must be careful that the same balance isn't concurrently read and written by multiple routines
-func (s *Swap) loadBalance(peer enode.ID) (err error) {
-	var peerBalance int64
-	if _, ok := s.getBalance(peer); !ok {
-		err = s.store.Get(balanceKey(peer), &peerBalance)
-		s.setBalance(peer, peerBalance)
-	}
-	return
-}
-
 // sendCheque sends a cheque to peer
 // To be called with mutex already held
 // Caller must be careful that the same resources aren't concurrently read and written by multiple routines
 func (s *Swap) sendCheque(swapPeer *Peer) error {
-	peer := swapPeer.ID()
 	cheque, err := s.createCheque(swapPeer)
 	if err != nil {
 		return fmt.Errorf("error while creating cheque: %s", err.Error())
@@ -345,9 +289,7 @@ func (s *Swap) sendCheque(swapPeer *Peer) error {
 		Cheque: cheque,
 	}
 
-	// reset balance;
-	err = s.resetBalance(peer, int64(cheque.Honey))
-	if err != nil {
+	if err := swapPeer.updateBalance(int64(cheque.Honey)); err != nil {
 		return err
 	}
 
@@ -363,16 +305,10 @@ func (s *Swap) createCheque(swapPeer *Peer) (*Cheque, error) {
 	var cheque *Cheque
 	var err error
 
-	peer := swapPeer.ID()
 	beneficiary := swapPeer.beneficiary
-
-	peerBalance, exists := s.getBalance(peer)
-	if !exists {
-		return nil, fmt.Errorf("peer not found %v: ", peer)
-	}
+	peerBalance := swapPeer.getBalance()
 	// the balance should be negative here, we take the absolute value:
 	honey := uint64(-peerBalance)
-
 	var amount uint64
 	amount, err = s.oracle.GetPrice(honey)
 	if err != nil {
@@ -401,23 +337,24 @@ func (s *Swap) createCheque(swapPeer *Peer) (*Cheque, error) {
 
 // Balance returns the balance for a given peer
 func (s *Swap) Balance(peer enode.ID) (int64, error) {
-	var err error
-	peerBalance, ok := s.getBalance(peer)
+	swapPeer, ok := s.peers[peer]
 	if !ok {
-		err = s.store.Get(balanceKey(peer), &peerBalance)
+		return 0, state.ErrNotFound
 	}
-	return peerBalance, err
+	return swapPeer.getBalance(), nil
 }
 
 // Balances returns the balances for all known SWAP peers
 func (s *Swap) Balances() (map[enode.ID]int64, error) {
 	balances := make(map[enode.ID]int64)
 
-	s.balancesLock.RLock()
-	for peer, peerBalance := range s.balances {
-		balances[peer] = peerBalance
+	s.peersLock.Lock()
+	for peer, swapPeer := range s.peers {
+		swapPeer.lock.Lock()
+		balances[peer] = swapPeer.getBalance()
+		swapPeer.lock.Unlock()
 	}
-	s.balancesLock.RUnlock()
+	s.peersLock.Unlock()
 
 	// add store balances, if peer was not already added
 	balanceIterFunction := func(key []byte, value []byte) (stop bool, err error) {
@@ -457,32 +394,39 @@ func (s *Swap) loadLastSentCheque(p enode.ID) (*Cheque, error) {
 	return cheque, error
 }
 
-// saveLastReceivedCheque saves cheque as the last received cheque for peer
-func (s *Swap) saveLastReceivedCheque(p *Peer, cheque *Cheque) error {
+// loadBalance loads the current balance for the peer from the store
+func (s *Swap) loadBalance(p enode.ID) (int64, error) {
 	s.storeLock.Lock()
 	defer s.storeLock.Unlock()
-	return s.store.Put(receivedChequeKey(p.ID()), cheque)
+	var balance int64
+	error := s.store.Get(balanceKey(p), &balance)
+	return balance, error
+}
+
+// saveLastReceivedCheque saves cheque as the last received cheque for peer
+func (s *Swap) saveLastReceivedCheque(p enode.ID, cheque *Cheque) error {
+	s.storeLock.Lock()
+	defer s.storeLock.Unlock()
+	return s.store.Put(receivedChequeKey(p), cheque)
 }
 
 // saveLastSentCheque saves cheque as the last received cheque for peer
-func (s *Swap) saveLastSentCheque(p *Peer, cheque *Cheque) error {
+func (s *Swap) saveLastSentCheque(p enode.ID, cheque *Cheque) error {
 	s.storeLock.Lock()
 	defer s.storeLock.Unlock()
-	return s.store.Put(sentChequeKey(p.ID()), cheque)
+	return s.store.Put(sentChequeKey(p), cheque)
+}
+
+// saveBalance saves balance as the current balance for peer
+func (s *Swap) saveBalance(p enode.ID, balance int64) error {
+	s.storeLock.Lock()
+	defer s.storeLock.Unlock()
+	return s.store.Put(balanceKey(p), balance)
 }
 
 // Close cleans up swap
 func (s *Swap) Close() error {
 	return s.store.Close()
-}
-
-// resetBalance is called:
-// * for the creditor: upon receiving the cheque
-// * for the debitor: after sending the cheque
-func (s *Swap) resetBalance(peer enode.ID, amount int64) error {
-	log.Debug("resetting balance for peer", "peer", peer.String(), "amount", amount)
-	_, err := s.updateBalance(peer, amount)
-	return err
 }
 
 // GetParams returns contract parameters (Bin, ABI) from the contract

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -48,7 +48,6 @@ var ErrInvalidChequeSignature = errors.New("invalid cheque signature")
 type Swap struct {
 	api                 API
 	store               state.Store        // store is needed in order to keep balances and cheques across sessions
-	accountingLock      sync.RWMutex       // lock for data consistency in accounting-related functions
 	peers               map[enode.ID]*Peer // map of all swap Peers
 	peersLock           sync.RWMutex       // lock for peers map
 	backend             contract.Backend   // the backend (blockchain) used
@@ -137,8 +136,6 @@ func (s *Swap) DeploySuccess() string {
 // Add is the (sole) accounting function
 // Swap implements the protocols.Balance interface
 func (s *Swap) Add(amount int64, peer *protocols.Peer) (err error) {
-	s.accountingLock.Lock()
-	defer s.accountingLock.Unlock()
 	swapPeer := s.getPeer(peer.ID())
 	if swapPeer == nil {
 		return fmt.Errorf("peer %s not a swap enabled peer", peer.ID().String())

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -243,7 +243,6 @@ func (s *Swap) processAndVerifyCheque(cheque *Cheque, p *Peer) (uint64, error) {
 
 	lastCheque := p.getLastReceivedCheque()
 
-	// TODO: there should probably be a lock here?
 	expectedAmount, err := s.oracle.GetPrice(cheque.Honey)
 	if err != nil {
 		return 0, err
@@ -304,33 +303,33 @@ func (s *Swap) Balances() (map[enode.ID]int64, error) {
 }
 
 // loadLastReceivedCheque loads the last received cheque for the peer from the store
-func (s *Swap) loadLastReceivedCheque(p enode.ID) (*Cheque, error) {
-	var cheque *Cheque
-	error := s.store.Get(receivedChequeKey(p), &cheque)
-	if error == state.ErrNotFound {
+// and returns nil when there never was a cheque saved
+func (s *Swap) loadLastReceivedCheque(p enode.ID) (cheque *Cheque, err error) {
+	err = s.store.Get(receivedChequeKey(p), &cheque)
+	if err == state.ErrNotFound {
 		return nil, nil
 	}
-	return cheque, error
+	return cheque, err
 }
 
 // loadLastSentCheque loads the last sent cheque for the peer from the store
-func (s *Swap) loadLastSentCheque(p enode.ID) (*Cheque, error) {
-	var cheque *Cheque
-	error := s.store.Get(sentChequeKey(p), &cheque)
-	if error == state.ErrNotFound {
+// and returns nil when there never was a cheque saved
+func (s *Swap) loadLastSentCheque(p enode.ID) (cheque *Cheque, err error) {
+	err = s.store.Get(sentChequeKey(p), &cheque)
+	if err == state.ErrNotFound {
 		return nil, nil
 	}
-	return cheque, error
+	return cheque, err
 }
 
 // loadBalance loads the current balance for the peer from the store
-func (s *Swap) loadBalance(p enode.ID) (int64, error) {
-	var balance int64
-	error := s.store.Get(balanceKey(p), &balance)
-	if error == state.ErrNotFound {
+// and returns 0 if there was no prior balance saved
+func (s *Swap) loadBalance(p enode.ID) (balance int64, err error) {
+	err = s.store.Get(balanceKey(p), &balance)
+	if err == state.ErrNotFound {
 		return 0, nil
 	}
-	return balance, error
+	return balance, err
 }
 
 // saveLastReceivedCheque saves cheque as the last received cheque for peer

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -48,7 +48,6 @@ var ErrInvalidChequeSignature = errors.New("invalid cheque signature")
 type Swap struct {
 	api                 API
 	store               state.Store        // store is needed in order to keep balances and cheques across sessions
-	storeLock           sync.RWMutex       // lock for store access
 	accountingLock      sync.RWMutex       // lock for data consistency in accounting-related functions
 	peers               map[enode.ID]*Peer // map of all swap Peers
 	peersLock           sync.RWMutex       // lock for peers map
@@ -309,8 +308,6 @@ func (s *Swap) Balances() (map[enode.ID]int64, error) {
 
 // loadLastReceivedCheque loads the last received cheque for the peer from the store
 func (s *Swap) loadLastReceivedCheque(p enode.ID) (*Cheque, error) {
-	s.storeLock.Lock()
-	defer s.storeLock.Unlock()
 	var cheque *Cheque
 	error := s.store.Get(receivedChequeKey(p), &cheque)
 	return cheque, error
@@ -318,8 +315,6 @@ func (s *Swap) loadLastReceivedCheque(p enode.ID) (*Cheque, error) {
 
 // loadLastSentCheque loads the last sent cheque for the peer from the store
 func (s *Swap) loadLastSentCheque(p enode.ID) (*Cheque, error) {
-	s.storeLock.Lock()
-	defer s.storeLock.Unlock()
 	var cheque *Cheque
 	error := s.store.Get(sentChequeKey(p), &cheque)
 	return cheque, error
@@ -327,8 +322,6 @@ func (s *Swap) loadLastSentCheque(p enode.ID) (*Cheque, error) {
 
 // loadBalance loads the current balance for the peer from the store
 func (s *Swap) loadBalance(p enode.ID) (int64, error) {
-	s.storeLock.Lock()
-	defer s.storeLock.Unlock()
 	var balance int64
 	error := s.store.Get(balanceKey(p), &balance)
 	return balance, error
@@ -336,22 +329,16 @@ func (s *Swap) loadBalance(p enode.ID) (int64, error) {
 
 // saveLastReceivedCheque saves cheque as the last received cheque for peer
 func (s *Swap) saveLastReceivedCheque(p enode.ID, cheque *Cheque) error {
-	s.storeLock.Lock()
-	defer s.storeLock.Unlock()
 	return s.store.Put(receivedChequeKey(p), cheque)
 }
 
 // saveLastSentCheque saves cheque as the last received cheque for peer
 func (s *Swap) saveLastSentCheque(p enode.ID, cheque *Cheque) error {
-	s.storeLock.Lock()
-	defer s.storeLock.Unlock()
 	return s.store.Put(sentChequeKey(p), cheque)
 }
 
 // saveBalance saves balance as the current balance for peer
 func (s *Swap) saveBalance(p enode.ID, balance int64) error {
-	s.storeLock.Lock()
-	defer s.storeLock.Unlock()
 	return s.store.Put(balanceKey(p), balance)
 }
 

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -48,21 +48,20 @@ var ErrInvalidChequeSignature = errors.New("invalid cheque signature")
 // Only messages which have a price will be accounted for
 type Swap struct {
 	api                 API
-	store               state.Store          // store is needed in order to keep balances and cheques across sessions
-	accountingLock      sync.RWMutex         // lock for data consistency in accounting-related functions
-	balances            map[enode.ID]int64   // map of balances for each peer
-	balancesLock        sync.RWMutex         // lock for balances map
-	cheques             map[enode.ID]*Cheque // map of cheques for each peer
-	chequesLock         sync.RWMutex         // lock for cheques map
-	peers               map[enode.ID]*Peer   // map of all swap Peers
-	peersLock           sync.RWMutex         // lock for peers map
-	backend             contract.Backend     // the backend (blockchain) used
-	owner               *Owner               // contract access
-	params              *Params              // economic and operational parameters
-	contract            swap.Contract        // reference to the smart contract
-	oracle              PriceOracle          // the oracle providing the ether price for honey
-	paymentThreshold    int64                // balance difference required for sending cheque
-	disconnectThreshold int64                // balance difference required for dropping peer
+	store               state.Store        // store is needed in order to keep balances and cheques across sessions
+	accountingLock      sync.RWMutex       // lock for data consistency in accounting-related functions
+	storeLock           sync.RWMutex       // lock for store access
+	balances            map[enode.ID]int64 // map of balances for each peer
+	balancesLock        sync.RWMutex       // lock for balances map
+	peers               map[enode.ID]*Peer // map of all swap Peers
+	peersLock           sync.RWMutex       // lock for peers map
+	backend             contract.Backend   // the backend (blockchain) used
+	owner               *Owner             // contract access
+	params              *Params            // economic and operational parameters
+	contract            swap.Contract      // reference to the smart contract
+	oracle              PriceOracle        // the oracle providing the ether price for honey
+	paymentThreshold    int64              // balance difference required for sending cheque
+	disconnectThreshold int64              // balance difference required for dropping peer
 }
 
 // Owner encapsulates information related to accessing the contract
@@ -90,7 +89,6 @@ func New(stateStore state.Store, prvkey *ecdsa.PrivateKey, backend contract.Back
 	return &Swap{
 		store:               stateStore,
 		balances:            make(map[enode.ID]int64),
-		cheques:             make(map[enode.ID]*Cheque),
 		peers:               make(map[enode.ID]*Peer),
 		backend:             backend,
 		owner:               createOwner(prvkey),
@@ -176,6 +174,8 @@ func (s *Swap) Add(amount int64, peer *protocols.Peer) (err error) {
 		if !ok {
 			return fmt.Errorf("peer %s not found", peer)
 		}
+		swapPeer.lock.Lock()
+		defer swapPeer.lock.Unlock()
 		return s.sendCheque(swapPeer)
 	}
 
@@ -193,19 +193,6 @@ func (s *Swap) setBalance(id enode.ID, balance int64) {
 	s.balancesLock.Lock()
 	defer s.balancesLock.Unlock()
 	s.balances[id] = balance
-}
-
-func (s *Swap) getCheque(id enode.ID) (*Cheque, bool) {
-	s.chequesLock.RLock()
-	defer s.chequesLock.RUnlock()
-	peerCheque, exists := s.cheques[id]
-	return peerCheque, exists
-}
-
-func (s *Swap) setCheque(id enode.ID, cheque *Cheque) {
-	s.chequesLock.Lock()
-	defer s.chequesLock.Unlock()
-	s.cheques[id] = cheque
 }
 
 // handleMsg is for handling messages when receiving messages
@@ -285,7 +272,7 @@ func (s *Swap) processAndVerifyCheque(cheque *Cheque, p *Peer) (uint64, error) {
 		return 0, err
 	}
 
-	lastCheque := s.loadLastReceivedCheque(p)
+	lastCheque := p.getLastReceivedCheque()
 
 	// TODO: there should probably be a lock here?
 	expectedAmount, err := s.oracle.GetPrice(cheque.Honey)
@@ -298,7 +285,7 @@ func (s *Swap) processAndVerifyCheque(cheque *Cheque, p *Peer) (uint64, error) {
 		return 0, err
 	}
 
-	if err := s.saveLastReceivedCheque(p, cheque); err != nil {
+	if err := p.setLastReceivedCheque(cheque); err != nil {
 		log.Error("error while saving last received cheque", "peer", p.ID().String(), "err", err.Error())
 		// TODO: what do we do here? Related issue: https://github.com/ethersphere/swarm/issues/1515
 	}
@@ -349,10 +336,8 @@ func (s *Swap) sendCheque(swapPeer *Peer) error {
 	}
 
 	log.Info("sending cheque", "honey", cheque.Honey, "cumulativePayout", cheque.ChequeParams.CumulativePayout, "beneficiary", cheque.Beneficiary, "contract", cheque.Contract)
-	s.setCheque(peer, cheque)
 
-	err = s.store.Put(sentChequeKey(peer), &cheque)
-	if err != nil {
+	if err := swapPeer.setLastSentCheque(cheque); err != nil {
 		return fmt.Errorf("error while storing the last cheque: %s", err.Error())
 	}
 
@@ -396,7 +381,7 @@ func (s *Swap) createCheque(swapPeer *Peer) (*Cheque, error) {
 
 	// if there is no existing cheque when loading from the store, it means it's the first interaction
 	// this is a valid scenario
-	total, err := s.getLastChequeValues(peer)
+	total, err := swapPeer.getLastChequeValues()
 	if err != nil && err != state.ErrNotFound {
 		return nil, err
 	}
@@ -412,18 +397,6 @@ func (s *Swap) createCheque(swapPeer *Peer) (*Cheque, error) {
 	cheque.Signature, err = cheque.Sign(s.owner.privateKey)
 
 	return cheque, err
-}
-
-func (s *Swap) getLastChequeValues(peer enode.ID) (total uint64, err error) {
-	err = s.loadLastSentCheque(peer)
-	if err != nil {
-		return
-	}
-	lastCheque, exists := s.getCheque(peer)
-	if exists {
-		total = lastCheque.CumulativePayout
-	}
-	return
 }
 
 // Balance returns the balance for a given peer
@@ -466,40 +439,36 @@ func (s *Swap) Balances() (map[enode.ID]int64, error) {
 	return balances, nil
 }
 
-// loadLastSentCheque loads the last cheque for a peer from the state store (persisted)
-// To be called with mutex already held
-// Caller must be careful that the same cheque isn't concurrently read and written by multiple routines
-func (s *Swap) loadLastSentCheque(peer enode.ID) (err error) {
-	//only load if the current instance doesn't already have this peer's
-	//last cheque in memory
+// loadLastReceivedCheque loads the last received cheque for the peer from the store
+func (s *Swap) loadLastReceivedCheque(p enode.ID) (*Cheque, error) {
+	s.storeLock.Lock()
+	defer s.storeLock.Unlock()
 	var cheque *Cheque
-	if _, ok := s.getCheque(peer); !ok {
-		err = s.store.Get(sentChequeKey(peer), &cheque)
-		if err == nil {
-			s.setCheque(peer, cheque)
-		}
-	}
-	return err
+	error := s.store.Get(receivedChequeKey(p), &cheque)
+	return cheque, error
 }
 
-// loadLastReceivedCheque gets the last received cheque for the peer
-// cheque gets loaded from database if not already in memory
-func (s *Swap) loadLastReceivedCheque(p *Peer) (cheque *Cheque) {
-	s.accountingLock.Lock()
-	defer s.accountingLock.Unlock()
-	if p.lastReceivedCheque != nil {
-		return p.lastReceivedCheque
-	}
-	s.store.Get(receivedChequeKey(p.ID()), &cheque)
-	return
+// loadLastSentCheque loads the last sent cheque for the peer from the store
+func (s *Swap) loadLastSentCheque(p enode.ID) (*Cheque, error) {
+	s.storeLock.Lock()
+	defer s.storeLock.Unlock()
+	var cheque *Cheque
+	error := s.store.Get(sentChequeKey(p), &cheque)
+	return cheque, error
 }
 
 // saveLastReceivedCheque saves cheque as the last received cheque for peer
 func (s *Swap) saveLastReceivedCheque(p *Peer, cheque *Cheque) error {
-	s.accountingLock.Lock()
-	defer s.accountingLock.Unlock()
-	p.lastReceivedCheque = cheque
+	s.storeLock.Lock()
+	defer s.storeLock.Unlock()
 	return s.store.Put(receivedChequeKey(p.ID()), cheque)
+}
+
+// saveLastSentCheque saves cheque as the last received cheque for peer
+func (s *Swap) saveLastSentCheque(p *Peer, cheque *Cheque) error {
+	s.storeLock.Lock()
+	defer s.storeLock.Unlock()
+	return s.store.Put(sentChequeKey(p.ID()), cheque)
 }
 
 // Close cleans up swap

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -310,6 +310,9 @@ func (s *Swap) Balances() (map[enode.ID]int64, error) {
 func (s *Swap) loadLastReceivedCheque(p enode.ID) (*Cheque, error) {
 	var cheque *Cheque
 	error := s.store.Get(receivedChequeKey(p), &cheque)
+	if error == state.ErrNotFound {
+		return nil, nil
+	}
 	return cheque, error
 }
 
@@ -317,6 +320,9 @@ func (s *Swap) loadLastReceivedCheque(p enode.ID) (*Cheque, error) {
 func (s *Swap) loadLastSentCheque(p enode.ID) (*Cheque, error) {
 	var cheque *Cheque
 	error := s.store.Get(sentChequeKey(p), &cheque)
+	if error == state.ErrNotFound {
+		return nil, nil
+	}
 	return cheque, error
 }
 
@@ -324,6 +330,9 @@ func (s *Swap) loadLastSentCheque(p enode.ID) (*Cheque, error) {
 func (s *Swap) loadBalance(p enode.ID) (int64, error) {
 	var balance int64
 	error := s.store.Get(balanceKey(p), &balance)
+	if error == state.ErrNotFound {
+		return 0, nil
+	}
 	return balance, error
 }
 

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -329,7 +329,7 @@ func TestResetBalance(t *testing.T) {
 	defer cleanup()
 
 	// now simulate sending the cheque to the creditor from the debitor
-	debitorSwap.sendCheque(creditor)
+	creditor.sendCheque()
 	// the debitor should have already reset its balance
 	if creditor.getBalance() != 0 {
 		t.Fatalf("unexpected balance to be 0, but it is %d", creditor.getBalance())

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -142,12 +142,18 @@ func TestAllBalances(t *testing.T) {
 	}
 
 	// test balance addition for peer
-	testPeer := swap.addPeer(newDummyPeer().Peer, common.Address{}, common.Address{})
+	testPeer, err := swap.addPeer(newDummyPeer().Peer, common.Address{}, common.Address{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	testPeer.setBalance(808)
 	testBalances(t, swap, map[enode.ID]int64{testPeer.ID(): 808})
 
 	// test successive balance addition for peer
-	testPeer2 := swap.addPeer(newDummyPeer().Peer, common.Address{}, common.Address{})
+	testPeer2, err := swap.addPeer(newDummyPeer().Peer, common.Address{}, common.Address{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	testPeer2.setBalance(909)
 	testBalances(t, swap, map[enode.ID]int64{testPeer.ID(): 808, testPeer2.ID(): 909})
 
@@ -224,7 +230,10 @@ func TestStoreBalances(t *testing.T) {
 	defer clean()
 
 	// modify balances both in memory and in store
-	testPeer := s.addPeer(newDummyPeer().Peer, common.Address{}, common.Address{})
+	testPeer, err := s.addPeer(newDummyPeer().Peer, common.Address{}, common.Address{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	testPeerID := testPeer.ID()
 	peerBalance := int64(29)
 	if err := testPeer.setBalance(peerBalance); err != nil {
@@ -234,7 +243,10 @@ func TestStoreBalances(t *testing.T) {
 	comparePeerBalance(t, s, testPeerID, peerBalance)
 
 	// update balances for second peer
-	testPeer2 := s.addPeer(newDummyPeer().Peer, common.Address{}, common.Address{})
+	testPeer2, err := s.addPeer(newDummyPeer().Peer, common.Address{}, common.Address{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	testPeer2ID := testPeer2.ID()
 	peer2Balance := int64(-76)
 
@@ -267,13 +279,19 @@ func TestRepeatedBookings(t *testing.T) {
 	var bookings []booking
 
 	// credits to peer 1
-	testPeer := swap.addPeer(newDummyPeer().Peer, common.Address{}, common.Address{})
+	testPeer, err := swap.addPeer(newDummyPeer().Peer, common.Address{}, common.Address{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	bookingAmount := int64(mrand.Intn(100))
 	bookingQuantity := 1 + mrand.Intn(10)
 	testPeerBookings(t, swap, &bookings, bookingAmount, bookingQuantity, testPeer.Peer)
 
 	// debits to peer 2
-	testPeer2 := swap.addPeer(newDummyPeer().Peer, common.Address{}, common.Address{})
+	testPeer2, err := swap.addPeer(newDummyPeer().Peer, common.Address{}, common.Address{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	bookingAmount = 0 - int64(mrand.Intn(100))
 	bookingQuantity = 1 + mrand.Intn(10)
 	testPeerBookings(t, swap, &bookings, bookingAmount, bookingQuantity, testPeer2.Peer)
@@ -320,8 +338,14 @@ func TestResetBalance(t *testing.T) {
 	// so creditor is the model of the remote mode for the debitor! (and vice versa)
 	cPeer := newDummyPeerWithSpec(Spec)
 	dPeer := newDummyPeerWithSpec(Spec)
-	creditor := debitorSwap.addPeer(cPeer.Peer, creditorSwap.owner.address, debitorSwap.owner.Contract)
-	debitor := creditorSwap.addPeer(dPeer.Peer, debitorSwap.owner.address, debitorSwap.owner.Contract)
+	creditor, err := debitorSwap.addPeer(cPeer.Peer, creditorSwap.owner.address, debitorSwap.owner.Contract)
+	if err != nil {
+		t.Fatal(err)
+	}
+	debitor, err := creditorSwap.addPeer(dPeer.Peer, debitorSwap.owner.address, debitorSwap.owner.Contract)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// set balances arbitrarily
 	testAmount := int64(DefaultPaymentThreshold + 42)
@@ -446,13 +470,16 @@ func TestRestoreBalanceFromStateStore(t *testing.T) {
 	swap, testDir := newBaseTestSwap(t, ownerKey)
 	defer os.RemoveAll(testDir)
 
-	testPeer := swap.addPeer(newDummyPeer().Peer, common.Address{}, common.Address{})
+	testPeer, err := swap.addPeer(newDummyPeer().Peer, common.Address{}, common.Address{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	testPeer.setBalance(-8888)
 
 	tmpBalance := testPeer.getBalance()
 	swap.store.Put(testPeer.ID().String(), &tmpBalance)
 
-	err := swap.store.Close()
+	err = swap.store.Close()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -837,7 +864,10 @@ func newTestSwapAndPeer(t *testing.T, key *ecdsa.PrivateKey) (*Swap, *Peer, func
 	swap, clean := newTestSwap(t, key)
 	// owner address is the beneficiary (counterparty) for the peer
 	// that's because we expect cheques we receive to be signed by the address we would issue cheques to
-	peer := swap.addPeer(newDummyPeer().Peer, ownerAddress, testChequeContract)
+	peer, err := swap.addPeer(newDummyPeer().Peer, ownerAddress, testChequeContract)
+	if err != nil {
+		t.Fatal(err)
+	}
 	// we need to adjust the owner address on swap because we will issue cheques to beneficiaryAddress
 	swap.owner.address = beneficiaryAddress
 	return swap, peer, clean
@@ -864,7 +894,10 @@ func TestPeerSetAndGetLastReceivedCheque(t *testing.T) {
 	}
 
 	// create a new swap peer for the same underlying peer to force a database load
-	samePeer := swap.addPeer(peer.Peer, common.Address{}, common.Address{})
+	samePeer, err := swap.addPeer(peer.Peer, common.Address{}, common.Address{})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	returnedCheque = samePeer.getLastReceivedCheque()
 	if returnedCheque == nil {


### PR DESCRIPTION
This PR
* moves `lastSentCheque` to `Peer`
* moves `balances` to `Peer`
* loads cheques and `balance` when the `Peer` is created
* always adds a peer to `peers` when it is created
* introduces a lock per peer and removes the `balanceLock`, `chequesLock ` and `accountingLock`
* moves `sendCheque` and `createCheque` to `Peer`

closes #1604 