### PR TITLE
Incentives rpc test

### DIFF
--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -310,6 +310,10 @@ func TestTriggerDisconnectThreshold(t *testing.T) {
 // We want this so that we can check the API works
 func TestSwapRPC(t *testing.T) {
 
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+
 	var (
 		ipcPath = ".swap.ipc"
 		err     error
@@ -331,11 +335,7 @@ func TestSwapRPC(t *testing.T) {
 	}()
 
 	// use unique IPC path on windows
-	if runtime.GOOS == "windows" {
-		ipcPath = `\\.\pipe\swap.ipc`
-	} else {
-		ipcPath = filepath.Join(stack.DataDir(), ipcPath)
-	}
+	ipcPath = filepath.Join(stack.DataDir(), ipcPath)
 
 	// connect to the servicenode RPCs
 	rpcclient, err := rpc.Dial(ipcPath)

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -347,11 +347,13 @@ func TestSwapRPC(t *testing.T) {
 	// query a first time, should be zero
 	var balance int64
 	err = rpcclient.Call(&balance, "swap_balance", id1)
-	if err != nil {
-		t.Fatal(err)
+	// at this point no balance should be there:  no peer at address in map...
+	if err == nil {
+		t.Fatal("Expected error but no error received")
 	}
 	log.Debug("servicenode balance", "balance", balance)
 
+	// ...thus balance should be zero
 	if balance != 0 {
 		t.Fatalf("Expected balance to be 0 but it is %d", balance)
 	}

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -344,7 +344,7 @@ func TestSwapRPC(t *testing.T) {
 	fakeBalance1 := int64(234)
 	fakeBalance2 := int64(-100)
 
-	// query a first time, should be zero
+	// query a first time, should give error
 	var balance int64
 	err = rpcclient.Call(&balance, "swap_balance", id1)
 	// at this point no balance should be there:  no peer at address in map...
@@ -395,7 +395,7 @@ func TestSwapRPC(t *testing.T) {
 	}
 
 	fakeSum := fakeBalance1 + fakeBalance2
-	if sum != int64(fakeSum) {
+	if sum != fakeSum {
 		t.Fatalf("Expected total balance to be %d, but it %d", fakeSum, sum)
 	}
 

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 
@@ -310,7 +311,7 @@ func TestTriggerDisconnectThreshold(t *testing.T) {
 func TestSwapRPC(t *testing.T) {
 
 	var (
-		ipcPath = ".swarm.ipc"
+		ipcPath = ".swap.ipc"
 		err     error
 	)
 
@@ -329,8 +330,15 @@ func TestSwapRPC(t *testing.T) {
 		go stack.Stop()
 	}()
 
+	// use unique IPC path on windows
+	if runtime.GOOS == "windows" {
+		ipcPath = `\\.\pipe\swap.ipc`
+	} else {
+		ipcPath = filepath.Join(stack.DataDir(), ipcPath)
+	}
+
 	// connect to the servicenode RPCs
-	rpcclient, err := rpc.Dial(filepath.Join(stack.DataDir(), ipcPath))
+	rpcclient, err := rpc.Dial(ipcPath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -397,7 +397,7 @@ func TestSwapRPC(t *testing.T) {
 		t.Fatalf("Expected total balance to be %d, but it %d", fakeSum, sum)
 	}
 
-	if reflect.DeepEqual(allBalances, swap.balances) {
+	if !reflect.DeepEqual(allBalances, swap.balances) {
 		t.Fatal("Balances are not deep equal")
 	}
 }


### PR DESCRIPTION
This PR adds a test for an API call of swap's balance interface via RPC.

It basically starts a node stack with a Swap Service and then just queries for balances. The test is mainly meant to check that the API works, not for testing the balance maths.