### PR TITLE
Incentives first sim

### DIFF
--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -52,8 +52,11 @@ it expects a handshake to take place between the two nodes
 func TestHandshake(t *testing.T) {
 	var err error
 
+	testBackend := newTestBackend()
+	defer testBackend.Close()
+
 	// setup test swap object
-	swap, clean := newTestSwap(t, ownerKey)
+	swap, clean := newTestSwap(t, ownerKey, testBackend)
 	defer clean()
 
 	ctx := context.Background()
@@ -118,9 +121,12 @@ func TestHandshake(t *testing.T) {
 // We have the debitor send a cheque via an `EmitChequeMsg`, then the creditor "reads" (pipe) the message
 // and handles the cheque.
 func TestEmitCheque(t *testing.T) {
+	testBackend := newTestBackend()
+	defer testBackend.Close()
+
 	log.Debug("set up test swaps")
-	creditorSwap, clean1 := newTestSwap(t, beneficiaryKey)
-	debitorSwap, clean2 := newTestSwap(t, ownerKey)
+	creditorSwap, clean1 := newTestSwap(t, beneficiaryKey, testBackend)
+	debitorSwap, clean2 := newTestSwap(t, ownerKey, testBackend)
 	defer clean1()
 	defer clean2()
 
@@ -208,8 +214,11 @@ func TestEmitCheque(t *testing.T) {
 // when we reach the payment threshold
 // It is the debitor who triggers cheques
 func TestTriggerPaymentThreshold(t *testing.T) {
+	testBackend := newTestBackend()
+	defer testBackend.Close()
+
 	log.Debug("create test swap")
-	debitorSwap, clean := newTestSwap(t, ownerKey)
+	debitorSwap, clean := newTestSwap(t, ownerKey, testBackend)
 	defer clean()
 
 	ctx := context.Background()
@@ -272,8 +281,11 @@ func TestTriggerPaymentThreshold(t *testing.T) {
 // when we reach the disconnect threshold
 // It is the creditor who triggers the disconnect from a overdraft creditor
 func TestTriggerDisconnectThreshold(t *testing.T) {
+	testBackend := newTestBackend()
+	defer testBackend.Close()
+
 	log.Debug("create test swap")
-	creditorSwap, clean := newTestSwap(t, beneficiaryKey)
+	creditorSwap, clean := newTestSwap(t, beneficiaryKey, testBackend)
 	defer clean()
 
 	// create a dummy pper
@@ -325,6 +337,8 @@ func TestTriggerDisconnectThreshold(t *testing.T) {
 // TestSwapRPC tests some basic things over RPC
 // We want this so that we can check the API works
 func TestSwapRPC(t *testing.T) {
+	testBackend := newTestBackend()
+	defer testBackend.Close()
 
 	if runtime.GOOS == "windows" {
 		t.Skip()
@@ -335,7 +349,7 @@ func TestSwapRPC(t *testing.T) {
 		err     error
 	)
 
-	swap, clean := newTestSwap(t, ownerKey)
+	swap, clean := newTestSwap(t, ownerKey, testBackend)
 	defer clean()
 
 	// need to have a dummy contract or the call will fail at `GetParams` due to `NewAPI`

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -337,9 +337,6 @@ func TestTriggerDisconnectThreshold(t *testing.T) {
 // TestSwapRPC tests some basic things over RPC
 // We want this so that we can check the API works
 func TestSwapRPC(t *testing.T) {
-	testBackend := newTestBackend()
-	defer testBackend.Close()
-
 	if runtime.GOOS == "windows" {
 		t.Skip()
 	}
@@ -349,7 +346,7 @@ func TestSwapRPC(t *testing.T) {
 		err     error
 	)
 
-	swap, clean := newTestSwap(t, ownerKey, testBackend)
+	swap, clean := newTestSwap(t, ownerKey, nil)
 	defer clean()
 
 	// need to have a dummy contract or the call will fail at `GetParams` due to `NewAPI`

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -1,0 +1,374 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+package swap
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/ethersphere/swarm/network"
+	"github.com/ethersphere/swarm/network/simulation"
+	"github.com/ethersphere/swarm/p2p/protocols"
+	"github.com/ethersphere/swarm/state"
+)
+
+var bucketKeySwap = simulation.BucketKey("swap")
+
+func init() {
+	err := newSharedBackendSwaps(nodeCount)
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+var simServiceMap = map[string]simulation.ServiceFunc{
+	"bzz": func(ctx *adapters.ServiceContext, bucket *sync.Map) (node.Service, func(), error) {
+		addr := network.NewAddr(ctx.Config.Node())
+		hp := network.NewHiveParams()
+		hp.Discovery = false
+		//assign the network ID
+		config := &network.BzzConfig{
+			OverlayAddr:  addr.Over(),
+			UnderlayAddr: addr.Under(),
+			HiveParams:   hp,
+		}
+		kad := network.NewKademlia(addr.Over(), network.NewKadParams())
+		return network.NewBzz(config, kad, nil, nil, nil), nil, nil
+	},
+	"swap": func(ctx *adapters.ServiceContext, bucket *sync.Map) (s node.Service, cleanup func(), err error) {
+
+		ts := newTestService()
+
+		balance := swaps[count]
+		count++
+		prices := &testPrices{}
+		prices.newTestPriceMatrix()
+		ts.spec = newTestSpec()
+		ts.spec.Hook = protocols.NewAccounting(balance, prices)
+		ts.swap = balance
+		testDeploy(context.Background(), balance.backend, balance)
+		balance.backend.(*backends.SimulatedBackend).Commit()
+
+		bucket.Store(bucketKeySwap, ts)
+
+		cleanup = func() {
+			//os.RemoveAll(dirs[count])
+		}
+
+		return ts, cleanup, nil
+	},
+}
+
+var swaps map[int]*Swap
+var dirs map[int]string
+var count int
+
+var nodeCount = 4
+
+func newSharedBackendSwaps(nodeCount int) error {
+	swaps = make(map[int]*Swap)
+	dirs = make(map[int]string)
+	keys := make(map[int]*ecdsa.PrivateKey)
+	addrs := make(map[int]common.Address)
+	alloc := core.GenesisAlloc{}
+	stores := make(map[int]*state.DBStore)
+
+	for i := 0; i < nodeCount; i++ {
+		key, err := crypto.GenerateKey()
+		if err != nil {
+			return err
+		}
+		keys[i] = key
+		addrs[i] = crypto.PubkeyToAddress(key.PublicKey)
+		alloc[addrs[i]] = core.GenesisAccount{Balance: big.NewInt(1000000000)}
+		dir, err := ioutil.TempDir("", fmt.Sprintf("swap_test_store_%d", i))
+		if err != nil {
+			return err
+		}
+		stateStore, err2 := state.NewDBStore(dir)
+		if err2 != nil {
+			return err
+		}
+		dirs[i] = dir
+		stores[i] = stateStore
+	}
+	gasLimit := uint64(8000000)
+	defaultBackend := backends.NewSimulatedBackend(alloc, gasLimit)
+	for i := 0; i < nodeCount; i++ {
+		swaps[i] = New(stores[i], keys[i], common.Address{}, defaultBackend)
+	}
+
+	return nil
+
+}
+
+func TestSimpleSimulation(t *testing.T) {
+
+	sim := simulation.NewInProc(simServiceMap)
+	defer sim.Close()
+
+	log.Info("Initializing")
+
+	ctx, cancelSimRun := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancelSimRun()
+
+	_, err := sim.AddNodesAndConnectFull(nodeCount)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	log.Info("starting simulation...")
+
+	result := sim.Run(ctx, func(ctx context.Context, sim *simulation.Simulation) (err error) {
+		log.Info("simulation running")
+		disconnected := watchDisconnections(ctx, sim)
+		defer func() {
+			if err != nil && disconnected.bool() {
+				err = errors.New("disconnect events received")
+			}
+		}()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		ill, err := sim.WaitTillHealthy(ctx)
+		if err != nil {
+			// inspect the latest detected not healthy kademlias
+			for id, kad := range ill {
+				fmt.Println("Node", id)
+				fmt.Println(kad.String())
+			}
+			// handle error...
+			t.Fatal(err)
+		}
+
+		pivot := sim.UpNodeIDs()[0]
+		item, ok := sim.NodeItem(pivot, bucketKeySwap)
+		if !ok {
+			return errors.New("no store in simulation bucket")
+		}
+		ts := item.(*testService)
+
+		p := sim.UpNodeIDs()[1]
+		tp := ts.peers[p]
+		fmt.Println(ts.swap.peers)
+		for {
+			if ts.swap.balances[p] > -DefaultPaymentThreshold {
+				tp.Send(ctx, &testMsgBySender{})
+			} else {
+				break
+			}
+			fmt.Println(ts.swap.balances[p])
+		}
+
+		return nil
+	})
+	if result.Error != nil {
+		t.Fatal(result.Error)
+	}
+	log.Info("Simulation ended")
+}
+
+type testMsgBySender struct{}
+type testMsgByReceiver struct{}
+
+type testPeer struct {
+	*protocols.Peer
+}
+
+// boolean is used to concurrently set
+// and read a boolean value.
+type boolean struct {
+	v  bool
+	mu sync.RWMutex
+}
+
+// set sets the value.
+func (b *boolean) set(v bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.v = v
+}
+
+// bool reads the value.
+func (b *boolean) bool() bool {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	return b.v
+}
+
+// watchDisconnections receives simulation peer events in a new goroutine and sets atomic value
+// disconnected to true in case of a disconnect event.
+func watchDisconnections(ctx context.Context, sim *simulation.Simulation) (disconnected *boolean) {
+	log.Debug("Watching for disconnections")
+	disconnections := sim.PeerEvents(
+		ctx,
+		sim.NodeIDs(),
+		simulation.NewPeerEventsFilter().Drop(),
+	)
+	disconnected = new(boolean)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case d := <-disconnections:
+				if d.Error != nil {
+					log.Error("peer drop event error", "node", d.NodeID, "peer", d.PeerID, "err", d.Error)
+				} else {
+					log.Error("peer drop", "node", d.NodeID, "peer", d.PeerID)
+				}
+				disconnected.set(true)
+			}
+		}
+	}()
+	return disconnected
+}
+
+func newTestSpec() *protocols.Spec {
+	return &protocols.Spec{
+		Name:       "testSpec",
+		Version:    1,
+		MaxMsgSize: 10 * 1024 * 1024,
+		Messages: []interface{}{
+			testMsgBySender{},
+			testMsgByReceiver{},
+		},
+	}
+}
+
+type testPrices struct {
+	priceMatrix map[reflect.Type]*protocols.Price
+}
+
+func (tp *testPrices) newTestPriceMatrix() {
+	tp.priceMatrix = map[reflect.Type]*protocols.Price{
+		reflect.TypeOf(testMsgBySender{}): {
+			Value:   1000, // arbitrary price for now
+			PerByte: true,
+			Payer:   protocols.Sender,
+		},
+		reflect.TypeOf(testMsgByReceiver{}): {
+			Value:   100, // arbitrary price for now
+			PerByte: false,
+			Payer:   protocols.Receiver,
+		},
+	}
+}
+
+func (tp *testPrices) Price(msg interface{}) *protocols.Price {
+	t := reflect.TypeOf(msg).Elem()
+	return tp.priceMatrix[t]
+}
+
+type testService struct {
+	swap  *Swap
+	spec  *protocols.Spec
+	peers map[enode.ID]*testPeer
+}
+
+func newTestService() *testService {
+	return &testService{
+		peers: make(map[enode.ID]*testPeer),
+	}
+}
+
+func (ts *testService) Protocols() []p2p.Protocol {
+	spec := newTestSpec()
+	return []p2p.Protocol{
+		{
+			Name:    spec.Name,
+			Version: spec.Version,
+			Length:  spec.Length(),
+			Run:     ts.runProtocol,
+		},
+		{
+			Name:    Spec.Name,
+			Version: Spec.Version,
+			Length:  Spec.Length(),
+			Run:     ts.swap.run,
+		},
+	}
+}
+
+// APIs retrieves the list of RPC descriptors the service provides
+func (ts *testService) APIs() []rpc.API {
+	return []rpc.API{
+		{
+			Namespace: "testAccounted",
+			Version:   "1.0",
+			Service:   ts,
+			Public:    false,
+		},
+	}
+}
+
+func (ts *testService) runProtocol(p *p2p.Peer, rw p2p.MsgReadWriter) error {
+	fmt.Println("run protocol")
+	peer := protocols.NewPeer(p, rw, ts.spec)
+	tp := &testPeer{Peer: peer}
+	ts.peers[tp.ID()] = tp
+	peer.Send(context.Background(), &testMsgByReceiver{})
+	return peer.Run(tp.handleMsg)
+}
+
+func (tp *testPeer) handleMsg(ctx context.Context, msg interface{}) error {
+
+	switch msg.(type) {
+
+	case *testMsgBySender:
+		fmt.Println("testMsgBySender")
+		// go tp.Send(context.Background(), &testMsgByReceiver{})
+
+	case *testMsgByReceiver:
+		fmt.Println("testMsgByReceiver")
+		//go tp.Send(context.Background(), &testMsgBySender{})
+	}
+	return nil
+}
+
+// Start is called after all services have been constructed and the networking
+// layer was also initialized to spawn any goroutines required by the service.
+func (ts *testService) Start(server *p2p.Server) error {
+	fmt.Println("starting testService")
+	return nil
+}
+
+// Stop terminates all goroutines belonging to the service, blocking until they
+// are all terminated.
+func (ts *testService) Stop() error {
+	fmt.Println("stopping testService")
+	return nil
+}

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -240,6 +240,7 @@ func newSharedBackendSwaps(nodeCount int) (*swapSimulationParams, error) {
 	for i := 0; i < nodeCount; i++ {
 		params.swaps[i] = New(stores[i], keys[i], testBackend)
 	}
+	testBackend.Commit()
 
 	params.backend = testBackend
 	return params, nil
@@ -463,7 +464,6 @@ func TestMultiChequeSimulation(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			time.Sleep(100 * time.Millisecond)
 		}
 
 		// check balances:

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -355,7 +355,7 @@ func TestPingPongChequeSimulation(t *testing.T) {
 			} else {
 				p1Peer.Send(ctx, &testMsgBigPrice{})
 			}
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(200 * time.Millisecond)
 		}
 
 		log.Debug("waiting for cheque to arrive....")
@@ -477,7 +477,7 @@ func TestMultiChequeSimulation(t *testing.T) {
 			// use a price which will trigger a cheque each time
 			creditorPeer.Send(ctx, &testMsgBigPrice{})
 			// we need to sleep a bit in order to give time for the cheque to be processed
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(200 * time.Millisecond)
 		}
 
 		// we need some synchronization, or tests get flaky, especially on CI (travis)
@@ -500,7 +500,7 @@ func TestMultiChequeSimulation(t *testing.T) {
 				// the peer should have a CumulativePayout correspondent to the amount of cheques emitted
 				if ch.CumulativePayout == uint64(maxCheques*(DefaultPaymentThreshold+1)) {
 					log.Debug("expected payout reached. going to check values now")
-					time.Sleep(100 * time.Millisecond)
+					time.Sleep(200 * time.Millisecond)
 					close(chequesArrived)
 				}
 			}

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -237,7 +237,7 @@ func newSharedBackendSwaps(nodeCount int) (*swapSimulationParams, error) {
 	defaultBackend := backends.NewSimulatedBackend(alloc, gasLimit)
 	// finally, create all Swap instances for each node, which share the same backend
 	for i := 0; i < nodeCount; i++ {
-		params.swaps[i] = New(stores[i], keys[i], common.Address{}, defaultBackend)
+		params.swaps[i] = New(stores[i], keys[i], defaultBackend)
 	}
 
 	params.backend = defaultBackend

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -463,6 +463,7 @@ func TestMultiChequeSimulation(t *testing.T) {
 			if err != nil {
 				return err
 			}
+			time.Sleep(100 * time.Millisecond)
 		}
 
 		// check balances:

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -263,7 +263,7 @@ func TestPingPongChequeSimulation(t *testing.T) {
 	cleanup := setupContractTest()
 	defer cleanup()
 
-	params.backend.cashDone = make(chan struct{})
+	params.backend.cashDone = make(chan struct{}, 1)
 	// initialize the simulation
 	sim := simulation.NewInProc(newSimServiceMap(params))
 	defer sim.Close()
@@ -386,7 +386,7 @@ func TestMultiChequeSimulation(t *testing.T) {
 	cleanup := setupContractTest()
 	defer cleanup()
 
-	params.backend.cashDone = make(chan struct{})
+	params.backend.cashDone = make(chan struct{}, 1)
 	// initialize the simulation
 	sim := simulation.NewInProc(newSimServiceMap(params))
 	defer sim.Close()
@@ -694,7 +694,7 @@ CONNS:
 		// but probably not all processed yet (balances not updated).
 		// without this wait, we still get occasionally failures with imbalances
 		// (travis CI is not terrific in terms of resources)
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(500 * time.Millisecond)
 
 		//now iterate again and check that every node has the same
 		//balance with a peer as that peer with the same node,
@@ -750,7 +750,6 @@ func waitForChequeProcessed(ts *testService, peer enode.ID, expected uint64) err
 	defer cancel()
 
 	backend := ts.swap.backend.(*swapTestBackend)
-	fmt.Println(backend)
 
 	select {
 	case <-ctx.Done():

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -161,7 +161,7 @@ func newSimServiceMap(params *swapSimulationParams) map[string]simulation.Servic
 				HiveParams:   hp,
 			}
 			kad := network.NewKademlia(addr.Over(), network.NewKadParams())
-			return network.NewBzz(config, kad, nil, nil, nil), nil, nil
+			return network.NewBzz(config, kad, nil, nil, nil, nil, nil), nil, nil
 		},
 		// and we also use a swap service
 		"swap": func(ctx *adapters.ServiceContext, bucket *sync.Map) (s node.Service, cleanup func(), err error) {
@@ -304,6 +304,9 @@ func TestPingPongChequeSimulation(t *testing.T) {
 		p2Svc := peerItem.(*testService)
 
 		p2Peer := p1Svc.peers[p2]
+		if p2Peer == nil {
+			return errors.New("peer not found in peer list")
+		}
 		p1Peer := p2Svc.peers[p1]
 
 		// we need to synchronize when we can actually go check that all values are ok

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -316,7 +316,7 @@ func TestPingPongChequeSimulation(t *testing.T) {
 			} else {
 				p1Peer.Send(ctx, &testMsgBigPrice{})
 			}
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(100 * time.Millisecond)
 		}
 
 		ch1, ok := p2Svc.swap.getCheque(p1)
@@ -422,6 +422,8 @@ func TestMultiChequeSimulation(t *testing.T) {
 			// we need to sleep a bit in order to give time for the cheque to be processed
 			time.Sleep(100 * time.Millisecond)
 		}
+
+		time.Sleep(500 * time.Millisecond)
 
 		// check balances:
 		b1, _ := debitorSvc.swap.getBalance(creditor)

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -220,7 +220,7 @@ func newSharedBackendSwaps(nodeCount int) (*swapSimulationParams, error) {
 		}
 		keys[i] = key
 		addrs[i] = crypto.PubkeyToAddress(key.PublicKey)
-		alloc[addrs[i]] = core.GenesisAccount{Balance: big.NewInt(1000000000)}
+		alloc[addrs[i]] = core.GenesisAccount{Balance: big.NewInt(10000000000)}
 		dir, err := ioutil.TempDir("", fmt.Sprintf("swap_test_store_%d", i))
 		if err != nil {
 			return nil, err
@@ -233,7 +233,7 @@ func newSharedBackendSwaps(nodeCount int) (*swapSimulationParams, error) {
 		stores[i] = stateStore
 	}
 	// then create the single SimulatedBackend
-	gasLimit := uint64(80000000000)
+	gasLimit := uint64(8000000000)
 	defaultBackend := backends.NewSimulatedBackend(alloc, gasLimit)
 	// finally, create all Swap instances for each node, which share the same backend
 	for i := 0; i < nodeCount; i++ {
@@ -316,7 +316,7 @@ func TestPingPongChequeSimulation(t *testing.T) {
 			} else {
 				p1Peer.Send(ctx, &testMsgBigPrice{})
 			}
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(200 * time.Millisecond)
 		}
 
 		ch1, ok := p2Svc.swap.getCheque(p1)
@@ -420,10 +420,8 @@ func TestMultiChequeSimulation(t *testing.T) {
 			// use a price which will trigger a cheque each time
 			creditorPeer.Send(ctx, &testMsgBigPrice{})
 			// we need to sleep a bit in order to give time for the cheque to be processed
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(200 * time.Millisecond)
 		}
-
-		time.Sleep(500 * time.Millisecond)
 
 		// check balances:
 		b1, _ := debitorSvc.swap.getBalance(creditor)

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -276,7 +276,7 @@ func TestPingPongChequeSimulation(t *testing.T) {
 			// let's always be nice and allow a time out to be catched
 			select {
 			case <-ctx.Done():
-				t.Fatal("Timed out waiting for all swap peer connections to be established")
+				return errors.New("Timed out waiting for all swap peer connections to be established")
 			default:
 			}
 			// the node has all other peers in its peer list
@@ -404,7 +404,7 @@ func TestMultiChequeSimulation(t *testing.T) {
 			// let's always be nice and allow a time out to be catched
 			select {
 			case <-ctx.Done():
-				t.Fatal("Timed out waiting for all swap peer connections to be established")
+				return errors.New("Timed out waiting for all swap peer connections to be established")
 			default:
 			}
 			// the node has all other peers in its peer list
@@ -573,18 +573,20 @@ CONNS:
 
 	result := sim.Run(ctx, func(ctx context.Context, sim *simulation.Simulation) (err error) {
 		log.Info("simulation running")
-		disconnected := watchDisconnections(ctx, sim)
-		defer func() {
-			if err != nil && disconnected.bool() {
-				err = errors.New("disconnect events received")
-			}
-		}()
+		/*
+			disconnected := watchDisconnections(ctx, sim)
+			defer func() {
+				if err != nil && disconnected.bool() {
+					err = errors.New("disconnect events received")
+				}
+			}()
+		*/
 
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
 		_, err = sim.WaitTillHealthy(ctx)
 		if err != nil {
-			t.Fatal(err)
+			return err
 		}
 
 		nodes := sim.UpNodeIDs()

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -243,7 +243,7 @@ func TestPingPongChequeSimulation(t *testing.T) {
 	ctx, cancelSimRun := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancelSimRun()
 
-	_, err = sim.AddNodesAndConnectChain(nodeCount)
+	_, err = sim.AddNodesAndConnectFull(nodeCount)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -280,7 +280,7 @@ func TestPingPongChequeSimulation(t *testing.T) {
 			default:
 			}
 			// the node has all other peers in its peer list
-			if len(ts1.peers) == 1 && len(ts2.peers) == 1 {
+			if len(ts1.swap.peers) == 1 && len(ts2.swap.peers) == 1 {
 				break
 			}
 			// don't overheat the CPU...
@@ -367,7 +367,7 @@ func TestMultiChequeSimulation(t *testing.T) {
 	ctx, cancelSimRun := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancelSimRun()
 
-	_, err = sim.AddNodesAndConnectChain(nodeCount)
+	_, err = sim.AddNodesAndConnectFull(nodeCount)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -408,7 +408,7 @@ func TestMultiChequeSimulation(t *testing.T) {
 			default:
 			}
 			// the node has all other peers in its peer list
-			if len(debitorSvc.peers) == 1 && len(creditorSvc.peers) == 1 {
+			if len(debitorSvc.swap.peers) == 1 && len(creditorSvc.swap.peers) == 1 {
 				break
 			}
 			// don't overheat the CPU...

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -209,7 +209,6 @@ func newSharedBackendSwaps(nodeCount int) (*swapSimulationParams, error) {
 		owner = createOwner(keys[i])
 		params.swaps[i] = new(stores[i], owner, testBackend, defParams)
 	}
-	testBackend.Commit()
 
 	params.backend = testBackend
 	return params, nil

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -516,17 +517,6 @@ CONNS:
 
 	log.Info("starting simulation...")
 
-	// setup a filter for all received messages
-	// we count all received messages by any peer in order to know when the last
-	// peer has actually received and processed the message
-	msgs := sim.PeerEvents(
-		context.Background(),
-		sim.NodeIDs(),
-		// Watch when testSpec messages 0 and 1 are received.
-		simulation.NewPeerEventsFilter().ReceivedMessages().Protocol("testSpec").MsgCode(0),
-		simulation.NewPeerEventsFilter().ReceivedMessages().Protocol("testSpec").MsgCode(1),
-	)
-
 	// we don't want any cheques to be issued for this test, we only want to test accounting across nodes
 	// for this we define a "global" maximum amount of messages to be sent;
 	// this formula should ensure that we trigger enough messages but not enough to trigger cheques
@@ -535,27 +525,25 @@ CONNS:
 	// need some synchronization to make sure we wait enough before checking all balances:
 	// all messages should have been received, otherwise there may be some imbalances!
 	allMessagesArrived := make(chan struct{})
-	// count all messages received in the simulation
-	recvCount := 0
+
+	metricsReg := metrics.AccountingRegistry
+	cter := metricsReg.Get("account.msg.credit")
+	counter := cter.(metrics.Counter)
 
 	go func() {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-		}
-		for m := range msgs {
-			if m.Error != nil {
-				log.Error("bzz message", "err", m.Error)
-				continue
+		for {
+			maxMsgsInt64 := int64(maxMsgs)
+			select {
+			case <-ctx.Done():
+				return
+			default:
 			}
-			// received a message
-			recvCount++
 			// all messages have been received
-			if recvCount == maxMsgs {
+			if counter.Count() == maxMsgsInt64 {
 				close(allMessagesArrived)
 				return
 			}
+			time.Sleep(10 * time.Millisecond)
 		}
 	}()
 
@@ -591,7 +579,7 @@ CONNS:
 				}
 				ts := item.(*testService)
 				// the node has all other peers in its peer list
-				if len(ts.peers) == nodeCount-1 {
+				if len(ts.swap.peers) == nodeCount-1 {
 					// so let's take the next node
 					continue ALL_SWAP_PEERS
 				}
@@ -643,12 +631,6 @@ CONNS:
 		}
 		log.Debug("all messages arrived")
 
-		// unfortunately we still need some waiting here...messages should all have arrived,
-		// but probably not all processed yet (balances not updated).
-		// without this wait, we still get occasionally failures with imbalances
-		// (travis CI is not terrific in terms of resources)
-		time.Sleep(1 * time.Second)
-
 		//now iterate again and check that every node has the same
 		//balance with a peer as that peer with the same node,
 		//but in inverted signs
@@ -694,7 +676,7 @@ CONNS:
 	if result.Error != nil {
 		t.Fatal(result.Error)
 	}
-
+	counter.Clear()
 	log.Info("Simulation ended")
 }
 

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/simulations"
 	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethersphere/swarm/network"
@@ -89,6 +90,7 @@ func newTestSpec() *protocols.Spec {
 
 // testService encapsulates objects needed for the simulation
 type testService struct {
+	lock  sync.Mutex
 	swap  *Swap
 	spec  *protocols.Spec
 	peers map[enode.ID]*testPeer
@@ -496,24 +498,8 @@ func TestBasicSwapSimulation(t *testing.T) {
 	}
 
 	log.Debug("Wait for all connections to be established")
-	// first check: let's make sure that all nodes have been connected to the others
-	// this is the maximum number of possible connections
-	maxConns := nodeCount * (nodeCount - 1) / 2
-CONNS:
-	for {
-		select {
-		// let's be nice and make sure we catch a timeout
-		case <-ctx.Done():
-			t.Fatal("Timed out waiting for all connections to be established")
-		default:
-			// this should be true when all connections have been established
-			if len(sim.Net.Conns) == maxConns {
-				break CONNS
-			}
-		}
-		// don't overheat the CPU...
-		time.Sleep(5 * time.Millisecond)
-	}
+
+	simulations.VerifyFull(t, sim.Net, sim.NodeIDs())
 
 	log.Info("starting simulation...")
 
@@ -553,10 +539,6 @@ CONNS:
 
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
-		_, err = sim.WaitTillHealthy(ctx)
-		if err != nil {
-			return err
-		}
 
 		nodes := sim.UpNodeIDs()
 		msgCount := 0
@@ -605,7 +587,9 @@ CONNS:
 					}
 					if msgCount < maxMsgs {
 
+						ts.lock.Lock()
 						tp := ts.peers[p]
+						ts.lock.Unlock()
 						if tp == nil {
 							return errors.New("peer is nil")
 						}
@@ -729,7 +713,9 @@ func (ts *testService) APIs() []rpc.API {
 func (ts *testService) runProtocol(p *p2p.Peer, rw p2p.MsgReadWriter) error {
 	peer := protocols.NewPeer(p, rw, ts.spec)
 	tp := &testPeer{Peer: peer}
+	ts.lock.Lock()
 	ts.peers[tp.ID()] = tp
+	ts.lock.Unlock()
 	return peer.Run(tp.handleMsg)
 }
 

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -322,7 +322,7 @@ func TestPingPongChequeSimulation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := uint64(maxCheques / 2 * (DefaultPaymentThreshold + 1))
+	expected := uint64(maxCheques) / 2 * (DefaultPaymentThreshold + 1)
 	if ch1.CumulativePayout != expected {
 		t.Fatalf("expected cumulative payout to be %d, but is %d", expected, ch1.CumulativePayout)
 	}
@@ -446,7 +446,7 @@ func TestMultiChequeSimulation(t *testing.T) {
 	}
 
 	// check also the actual expected amount
-	expectedPayout := uint64(maxCheques * (DefaultPaymentThreshold + 1))
+	expectedPayout := uint64(maxCheques) * (DefaultPaymentThreshold + 1)
 
 	if cheque2.CumulativePayout != expectedPayout {
 		t.Fatalf("Expected %d in cumulative payout, got %d", expectedPayout, cheque1.CumulativePayout)
@@ -487,8 +487,7 @@ func TestBasicSwapSimulation(t *testing.T) {
 
 	// we don't want any cheques to be issued for this test, we only want to test accounting across nodes
 	// for this we define a "global" maximum amount of messages to be sent;
-	// this formula should ensure that we trigger enough messages but not enough to trigger cheques
-	maxMsgs := (DefaultPaymentThreshold / params.maxMsgPrice) * (nodeCount - 1)
+	maxMsgs := 1500
 
 	// need some synchronization to make sure we wait enough before checking all balances:
 	// all messages should have been received, otherwise there may be some imbalances!
@@ -562,7 +561,6 @@ func TestBasicSwapSimulation(t *testing.T) {
 						continue
 					}
 					if msgCount < maxMsgs {
-
 						ts.lock.Lock()
 						tp := ts.peers[p]
 						ts.lock.Unlock()

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -590,33 +590,35 @@ CONNS:
 		nodes := sim.UpNodeIDs()
 		msgCount := 0
 
-		// unfortunately, before running the actual simulation, we need an additional check (...).
-		// If we start sending right away, it can happen that devp2p did **not yet finish connecting swap peers**
-		// (verified through multiple runs). This would then fail the test because on Swap.Add the peer is not (yet) found...
-		// Thus this iteration here makes sure that all swap peers actually have been added on the Swap protocol as well.
-	ALL_SWAP_PEERS:
-		for _, node := range nodes {
-			for {
-				// let's always be nice and allow a time out to be catched
-				select {
-				case <-ctx.Done():
-					t.Fatal("Timed out waiting for all swap peer connections to be established")
-				default:
+		/*
+				// unfortunately, before running the actual simulation, we need an additional check (...).
+				// If we start sending right away, it can happen that devp2p did **not yet finish connecting swap peers**
+				// (verified through multiple runs). This would then fail the test because on Swap.Add the peer is not (yet) found...
+				// Thus this iteration here makes sure that all swap peers actually have been added on the Swap protocol as well.
+			ALL_SWAP_PEERS:
+				for _, node := range nodes {
+					for {
+						// let's always be nice and allow a time out to be catched
+						select {
+						case <-ctx.Done():
+							t.Fatal("Timed out waiting for all swap peer connections to be established")
+						default:
+						}
+						item, ok := sim.NodeItem(node, bucketKeySwap)
+						if !ok {
+							return errors.New("no swap in simulation bucket")
+						}
+						ts := item.(*testService)
+						// the node has all other peers in its peer list
+						if len(ts.peers) == nodeCount-1 {
+							// so let's take the next node
+							continue ALL_SWAP_PEERS
+						}
+						// don't overheat the CPU...
+						time.Sleep(5 * time.Millisecond)
+					}
 				}
-				item, ok := sim.NodeItem(node, bucketKeySwap)
-				if !ok {
-					return errors.New("no swap in simulation bucket")
-				}
-				ts := item.(*testService)
-				// the node has all other peers in its peer list
-				if len(ts.peers) == nodeCount-1 {
-					// so let's take the next node
-					continue ALL_SWAP_PEERS
-				}
-				// don't overheat the CPU...
-				time.Sleep(5 * time.Millisecond)
-			}
-		}
+		*/
 
 		// iterate all nodes, then send each other test messages
 	ITER:

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -468,10 +468,10 @@ func TestMultiChequeSimulation(t *testing.T) {
 	log.Info("Simulation ended")
 }
 
-// TestSimpleSimulation starts 16 nodes, then in a simple round robin fashion sends messages to each other.
+// TestBasicSwapSimulation starts 16 nodes, then in a simple round robin fashion sends messages to each other.
 // Then checks that accounting is ok. It checks the actual amount of balances without any cheques sent,
 // in order to verify that the most basic accounting works.
-func TestSimpleSimulation(t *testing.T) {
+func TestBasicSwapSimulation(t *testing.T) {
 	nodeCount := 16
 	// create the shared backend and params
 	params, err := newSharedBackendSwaps(nodeCount)

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -208,7 +208,7 @@ func newSharedBackendSwaps(nodeCount int) (*swapSimulationParams, error) {
 	defParams := newDefaultParams()
 	for i := 0; i < nodeCount; i++ {
 		owner = createOwner(keys[i])
-		params.swaps[i] = new(stores[i], owner, testBackend, defParams)
+		params.swaps[i] = new(stores[i], owner, testBackend, DefaultDisconnectThreshold, DefaultPaymentThreshold)
 	}
 
 	params.backend = testBackend

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -88,6 +88,30 @@ func newTestSpec() *protocols.Spec {
 	}
 }
 
+func (m *testMsgBySender) Price() *protocols.Price {
+	return &protocols.Price{
+		Value:   1000, // arbitrary price for now
+		PerByte: true,
+		Payer:   protocols.Sender,
+	}
+}
+
+func (m *testMsgByReceiver) Price() *protocols.Price {
+	return &protocols.Price{
+		Value:   100, // arbitrary price for now
+		PerByte: false,
+		Payer:   protocols.Receiver,
+	}
+}
+
+func (m *testMsgBigPrice) Price() *protocols.Price {
+	return &protocols.Price{
+		Value:   DefaultPaymentThreshold + 1,
+		PerByte: false,
+		Payer:   protocols.Sender,
+	}
+}
+
 // testService encapsulates objects needed for the simulation
 type testService struct {
 	lock  sync.Mutex
@@ -142,7 +166,6 @@ func newSimServiceMap(params *swapSimulationParams) map[string]simulation.Servic
 			dir := params.dirs[params.count]
 			// every node is a different instance of a Swap and gets a different entry in the map
 			params.count++
-			// to create the accounting, we also need a `Price` instance
 			ts.spec = newTestSpec()
 			// create the accounting instance and assign to the spec
 			ts.spec.Hook = protocols.NewAccounting(balance)

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -592,35 +592,33 @@ CONNS:
 		nodes := sim.UpNodeIDs()
 		msgCount := 0
 
-		/*
-				// unfortunately, before running the actual simulation, we need an additional check (...).
-				// If we start sending right away, it can happen that devp2p did **not yet finish connecting swap peers**
-				// (verified through multiple runs). This would then fail the test because on Swap.Add the peer is not (yet) found...
-				// Thus this iteration here makes sure that all swap peers actually have been added on the Swap protocol as well.
-			ALL_SWAP_PEERS:
-				for _, node := range nodes {
-					for {
-						// let's always be nice and allow a time out to be catched
-						select {
-						case <-ctx.Done():
-							t.Fatal("Timed out waiting for all swap peer connections to be established")
-						default:
-						}
-						item, ok := sim.NodeItem(node, bucketKeySwap)
-						if !ok {
-							return errors.New("no swap in simulation bucket")
-						}
-						ts := item.(*testService)
-						// the node has all other peers in its peer list
-						if len(ts.peers) == nodeCount-1 {
-							// so let's take the next node
-							continue ALL_SWAP_PEERS
-						}
-						// don't overheat the CPU...
-						time.Sleep(5 * time.Millisecond)
-					}
+		// unfortunately, before running the actual simulation, we need an additional check (...).
+		// If we start sending right away, it can happen that devp2p did **not yet finish connecting swap peers**
+		// (verified through multiple runs). This would then fail the test because on Swap.Add the peer is not (yet) found...
+		// Thus this iteration here makes sure that all swap peers actually have been added on the Swap protocol as well.
+	ALL_SWAP_PEERS:
+		for _, node := range nodes {
+			for {
+				// let's always be nice and allow a time out to be catched
+				select {
+				case <-ctx.Done():
+					return errors.New("Timed out waiting for all swap peer connections to be established")
+				default:
 				}
-		*/
+				item, ok := sim.NodeItem(node, bucketKeySwap)
+				if !ok {
+					return errors.New("no swap in simulation bucket")
+				}
+				ts := item.(*testService)
+				// the node has all other peers in its peer list
+				if len(ts.peers) == nodeCount-1 {
+					// so let's take the next node
+					continue ALL_SWAP_PEERS
+				}
+				// don't overheat the CPU...
+				time.Sleep(5 * time.Millisecond)
+			}
+		}
 
 		// iterate all nodes, then send each other test messages
 	ITER:

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -233,7 +233,7 @@ func newSharedBackendSwaps(nodeCount int) (*swapSimulationParams, error) {
 	defParams := newDefaultParams()
 	for i := 0; i < nodeCount; i++ {
 		owner = createOwner(keys[i])
-		params.swaps[i] = new(stores[i], owner, testBackend, DefaultDisconnectThreshold, DefaultPaymentThreshold)
+		params.swaps[i] = new(stores[i], owner, testBackend, defParams)
 	}
 
 	params.backend = testBackend

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -529,6 +529,7 @@ CONNS:
 	metricsReg := metrics.AccountingRegistry
 	cter := metricsReg.Get("account.msg.credit")
 	counter := cter.(metrics.Counter)
+	counter.Clear()
 
 	go func() {
 		for {

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -136,6 +136,7 @@ func newSimServiceMap(params *swapSimulationParams) map[string]simulation.Servic
 			ts := newTestService()
 			// balance is the interface for `NewAccounting`; it is a Swap
 			balance := params.swaps[params.count]
+			dir := params.dirs[params.count]
 			// every node is a different instance of a Swap and gets a different entry in the map
 			params.count++
 			// to create the accounting, we also need a `Price` instance
@@ -152,9 +153,8 @@ func newSimServiceMap(params *swapSimulationParams) map[string]simulation.Servic
 			bucket.Store(bucketKeySwap, ts)
 
 			cleanup = func() {
-				for _, dir := range params.dirs {
-					os.RemoveAll(dir)
-				}
+				ts.swap.store.Close()
+				os.RemoveAll(dir)
 			}
 
 			return ts, cleanup, nil
@@ -187,7 +187,7 @@ func newSharedBackendSwaps(nodeCount int) (*swapSimulationParams, error) {
 		keys[i] = key
 		addrs[i] = crypto.PubkeyToAddress(key.PublicKey)
 		alloc[addrs[i]] = core.GenesisAccount{Balance: big.NewInt(10000000000)}
-		dir, err := ioutil.TempDir("", fmt.Sprintf("swap_test_store_%d", i))
+		dir, err := ioutil.TempDir("", fmt.Sprintf("swap_test_store_%x", addrs[i].Hex()))
 		if err != nil {
 			return nil, err
 		}

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -252,12 +252,6 @@ func TestPingPongChequeSimulation(t *testing.T) {
 
 	result := sim.Run(ctx, func(ctx context.Context, sim *simulation.Simulation) (err error) {
 		log.Info("simulation running")
-		disconnected := watchDisconnections(ctx, sim)
-		defer func() {
-			if err != nil && disconnected.bool() {
-				err = errors.New("disconnect events received")
-			}
-		}()
 
 		p1 := sim.UpNodeIDs()[0]
 		p2 := sim.UpNodeIDs()[1]
@@ -376,12 +370,6 @@ func TestMultiChequeSimulation(t *testing.T) {
 
 	result := sim.Run(ctx, func(ctx context.Context, sim *simulation.Simulation) (err error) {
 		log.Info("simulation running")
-		disconnected := watchDisconnections(ctx, sim)
-		defer func() {
-			if err != nil && disconnected.bool() {
-				err = errors.New("disconnect events received")
-			}
-		}()
 
 		// define the nodes
 		debitor := sim.UpNodeIDs()[0]
@@ -573,14 +561,6 @@ CONNS:
 
 	result := sim.Run(ctx, func(ctx context.Context, sim *simulation.Simulation) (err error) {
 		log.Info("simulation running")
-		/*
-			disconnected := watchDisconnections(ctx, sim)
-			defer func() {
-				if err != nil && disconnected.bool() {
-					err = errors.New("disconnect events received")
-				}
-			}()
-		*/
 
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
@@ -732,34 +712,6 @@ func waitForChequeProcessed(ts *testService) error {
 	}
 }
 
-// watchDisconnections receives simulation peer events in a new goroutine and sets atomic value
-// disconnected to true in case of a disconnect event.
-func watchDisconnections(ctx context.Context, sim *simulation.Simulation) (disconnected *boolean) {
-	log.Debug("Watching for disconnections")
-	disconnections := sim.PeerEvents(
-		ctx,
-		sim.NodeIDs(),
-		simulation.NewPeerEventsFilter().Drop(),
-	)
-	disconnected = &boolean{}
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case d := <-disconnections:
-				if d.Error != nil {
-					log.Error("peer drop event error", "node", d.NodeID, "peer", d.PeerID, "err", d.Error)
-				} else {
-					log.Error("peer drop", "node", d.NodeID, "peer", d.PeerID)
-				}
-				disconnected.set(true)
-			}
-		}
-	}()
-	return disconnected
-}
-
 func (ts *testService) Protocols() []p2p.Protocol {
 	spec := newTestSpec()
 	return []p2p.Protocol{
@@ -808,27 +760,4 @@ func (ts *testService) Start(server *p2p.Server) error {
 // are all terminated.
 func (ts *testService) Stop() error {
 	return nil
-}
-
-// boolean is used to concurrently set
-// and read a boolean value.
-type boolean struct {
-	v  bool
-	mu sync.RWMutex
-}
-
-// set sets the value.
-func (b *boolean) set(v bool) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	b.v = v
-}
-
-// bool reads the value.
-func (b *boolean) bool() bool {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-
-	return b.v
 }

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -292,6 +292,7 @@ func (s *Swap) handleEmitChequeMsg(ctx context.Context, p *Peer, msg *EmitCheque
 	auditLog.Info("received cheque from peer", "peer", p.ID().String(), "honey", cheque.Honey)
 	_, err := s.processAndVerifyCheque(cheque, p)
 	if err != nil {
+		log.Error("error processing and verifying cheque", "err", err)
 		return err
 	}
 
@@ -301,11 +302,13 @@ func (s *Swap) handleEmitChequeMsg(ctx context.Context, p *Peer, msg *EmitCheque
 	// as this is done by the creditor, receiving the cheque, the amount should be negative,
 	// so that updateBalance will calculate balance + amount which result in reducing the peer's balance
 	if err := p.updateBalance(-int64(cheque.Honey)); err != nil {
+		log.Error("error updating balance", "err", err)
 		return err
 	}
 
 	otherSwap, err := contract.InstanceAt(cheque.Contract, s.backend)
 	if err != nil {
+		log.Error("error getting contract", "err", err)
 		return err
 	}
 

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -85,6 +85,7 @@ type swapTestBackend struct {
 func init() {
 	testutil.Init()
 	mrand.Seed(time.Now().UnixNano())
+	auditLog = log.Root()
 }
 
 // newTestBackend creates a new test backend instance

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -1462,11 +1462,13 @@ func TestContractIntegration(t *testing.T) {
 // when testing, we don't need to wait for a transaction to be mined
 func testWaitForTx(auth *bind.TransactOpts, backend cswap.Backend, tx *types.Transaction) (*types.Receipt, error) {
 
-	if stb, ok := backend.(*swapTestBackend); !ok {
+	var stb *swapTestBackend
+	var ok bool
+	if stb, ok = backend.(*swapTestBackend); !ok {
 		return nil, errors.New("not the expected test backend")
-	} else {
-		stb.Commit()
 	}
+	stb.Commit()
+
 	receipt, err := backend.TransactionReceipt(context.TODO(), tx.Hash())
 	if err != nil {
 		return nil, err

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -1733,6 +1733,7 @@ func TestPeerProcessAndVerifyChequeInvalid(t *testing.T) {
 }
 
 func TestSwapLogToFile(t *testing.T) {
+<<<<<<< HEAD
 	// create a log dir
 	logDirDebitor, err := ioutil.TempDir("", "swap_test_log")
 	log.Debug("creating swap log dir")
@@ -1751,6 +1752,14 @@ func TestSwapLogToFile(t *testing.T) {
 	creditorSwap, storeDirCreditor := newBaseTestSwap(t, beneficiaryKey, testBackend)
 	// we are only checking one of the two nodes for logs
 	debitorSwap, storeDirDebitor := newBaseTestSwapWithParams(t, ownerKey, params, testBackend)
+=======
+	testBackend := newTestBackend()
+	defer testBackend.Close()
+
+	// create both test swap accounts
+	creditorSwap, storeDirCreditor, logDirCreditor := newBaseTestSwap(t, beneficiaryKey, testBackend)
+	debitorSwap, storeDirDebitor, logDirDebitor := newBaseTestSwap(t, ownerKey, testBackend)
+>>>>>>> swap: rebased to latest master
 
 	clean := func() {
 		creditorSwap.Close()

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -1095,7 +1095,7 @@ func TestRestoreBalanceFromStateStore(t *testing.T) {
 // causing subsequent TX to possibly fail due to nonce mismatch
 func testCashCheque(s *Swap, otherSwap cswap.Contract, opts *bind.TransactOpts, cheque *Cheque) {
 	cashCheque(s, otherSwap, opts, cheque)
-	// close the channel, signals to clients that this function actually finished
+	// send to the channel, signals to clients that this function actually finished
 	if stb, ok := s.backend.(*swapTestBackend); ok {
 		if stb.cashDone != nil {
 			stb.cashDone <- struct{}{}

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -64,7 +64,6 @@ var (
 	beneficiaryAddress = crypto.PubkeyToAddress(beneficiaryKey.PublicKey)
 	testChequeSig      = common.Hex2Bytes("a53e7308bb5590b45cabf44538508ccf1760b53eea721dd50bfdd044547e38b412142da9f3c690a940d6ee390d3f365a38df02b2688cea17f303f6de01268c2e1c")
 	testChequeContract = common.HexToAddress("0x4405415b2B8c9F9aA83E151637B8378dD3bcfEDD") // second contract created by ownerKey
-	gasLimit           = uint64(8000000)
 )
 
 // booking represents an accounting movement in relation to a particular node: `peer`
@@ -90,6 +89,7 @@ func init() {
 
 // newTestBackend creates a new test backend instance
 func newTestBackend() *swapTestBackend {
+	gasLimit := uint64(8000000)
 	defaultBackend := backends.NewSimulatedBackend(core.GenesisAlloc{
 		ownerAddress:       {Balance: big.NewInt(1000000000000000000)},
 		beneficiaryAddress: {Balance: big.NewInt(1000000000000000000)},

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -187,7 +187,7 @@ func testBalances(t *testing.T, swap *Swap, expectedBalances map[enode.ID]int64)
 // TestSentCheque verifies that sent cheques data is correctly obtained
 func TestSentCheque(t *testing.T) {
 	// create a test swap account
-	swap, clean := newTestSwap(t, ownerKey)
+	swap, clean := newTestSwap(t, ownerKey, nil)
 	defer clean()
 
 	// test cheque addition for peer
@@ -274,7 +274,7 @@ func TestSentCheque(t *testing.T) {
 // TestReceivedCheque verifies that received cheques data is correctly obtained
 func TestReceivedCheque(t *testing.T) {
 	// create a test swap account
-	swap, clean := newTestSwap(t, ownerKey)
+	swap, clean := newTestSwap(t, ownerKey, nil)
 	defer clean()
 
 	// test cheque addition for peer
@@ -361,7 +361,7 @@ func TestReceivedCheque(t *testing.T) {
 // Test getting cheques for all known peers
 func TestAllCheques(t *testing.T) {
 	// create a test swap account
-	swap, clean := newTestSwap(t, ownerKey)
+	swap, clean := newTestSwap(t, ownerKey, nil)
 	defer clean()
 
 	sentCheques, err := swap.SentCheques()

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -1,18 +1,18 @@
-// Copyright 2018 The go-ethereum Authors
-// This file is part of the go-ethereum library.
+// Copyright 2019 The Swarm Authors
+// This file is part of the Swarm library.
 //
-// The go-ethereum library is free software: you can redistribute it and/or modify
+// The Swarm library is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// The go-ethereum library is distributed in the hope that it will be useful,
+// The Swarm library is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
 
 package swap
 
@@ -101,8 +101,6 @@ func newTestBackend() *swapTestBackend {
 
 // Test getting a peer's balance
 func TestPeerBalance(t *testing.T) {
-	testBackend := newTestBackend()
-	defer testBackend.Close()
 	// create a test swap account
 	swap, testPeer, clean := newTestSwapAndPeer(t, ownerKey)
 	defer clean()
@@ -141,10 +139,8 @@ func TestPeerBalance(t *testing.T) {
 
 // Test getting balances for all known peers
 func TestAllBalances(t *testing.T) {
-	testBackend := newTestBackend()
-	defer testBackend.Close()
 	// create a test swap account
-	swap, clean := newTestSwap(t, ownerKey, testBackend)
+	swap, clean := newTestSwap(t, ownerKey, nil)
 	defer clean()
 
 	balances, err := swap.Balances()
@@ -510,10 +506,8 @@ func testStoreKeys(t *testing.T, testCases []storeKeysTestCases) {
 
 // Test the correct storing of peer balances through the store after node balance updates
 func TestStoreBalances(t *testing.T) {
-	testBackend := newTestBackend()
-	defer testBackend.Close()
 	// create a test swap account
-	s, clean := newTestSwap(t, ownerKey, testBackend)
+	s, clean := newTestSwap(t, ownerKey, nil)
 	defer clean()
 
 	// modify balances both in memory and in store
@@ -559,10 +553,8 @@ func comparePeerBalance(t *testing.T, s *Swap, peer enode.ID, expectedPeerBalanc
 
 // Test that repeated bookings do correct accounting
 func TestRepeatedBookings(t *testing.T) {
-	testBackend := newTestBackend()
-	defer testBackend.Close()
 	// create a test swap account
-	swap, clean := newTestSwap(t, ownerKey, testBackend)
+	swap, clean := newTestSwap(t, ownerKey, nil)
 	defer clean()
 
 	var bookings []booking
@@ -1072,11 +1064,8 @@ func calculateExpectedBalances(swap *Swap, bookings []booking) map[enode.ID]int6
 // Then we re-open the state store and check that
 // the balance is still the same
 func TestRestoreBalanceFromStateStore(t *testing.T) {
-	testBackend := newTestBackend()
-	defer testBackend.Close()
-
 	// create a test swap account
-	swap, testDir := newBaseTestSwap(t, ownerKey, testBackend)
+	swap, testDir := newBaseTestSwap(t, ownerKey, nil)
 	defer os.RemoveAll(testDir)
 
 	testPeer, err := swap.addPeer(newDummyPeer().Peer, common.Address{}, common.Address{})
@@ -1323,8 +1312,6 @@ func TestValidateCode(t *testing.T) {
 		t.Fatalf("Error in deploy: %v", err)
 	}
 
-	testBackend.Commit()
-
 	if err = cswap.ValidateCode(context.TODO(), testBackend, swap.GetParams().ContractAddress); err != nil {
 		t.Fatalf("Contract verification failed: %v", err)
 	}
@@ -1415,7 +1402,6 @@ func TestContractIntegration(t *testing.T) {
 	log.Debug("cash-in the cheque")
 
 	cashResult, receipt, err := issuerSwap.contract.CashChequeBeneficiary(opts, testBackend, beneficiaryAddress, big.NewInt(int64(cheque.CumulativePayout)), cheque.Signature)
-	testBackend.Commit()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1447,7 +1433,6 @@ func TestContractIntegration(t *testing.T) {
 
 	log.Debug("try to cash-in the bouncing cheque")
 	cashResult, receipt, err = issuerSwap.contract.CashChequeBeneficiary(opts, testBackend, beneficiaryAddress, big.NewInt(int64(bouncingCheque.CumulativePayout)), bouncingCheque.Signature)
-	testBackend.Commit()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -1149,11 +1149,23 @@ func newBaseTestSwapWithParams(t *testing.T, key *ecdsa.PrivateKey, params *Para
 	return swap, dir
 }
 
+<<<<<<< HEAD
 // create a test swap account with a backend
 // creates a stateStore for persistence and a Swap account
 func newBaseTestSwap(t *testing.T, key *ecdsa.PrivateKey, backend *swapTestBackend) (*Swap, string) {
 	params := newDefaultParams()
 	return newBaseTestSwapWithParams(t, key, params, backend)
+=======
+	// Dir for storing swap related logs
+	logdir, err := ioutil.TempDir("", "swap_test_log")
+	log.Debug("creating swap log dir")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	swap := new(logdir, stateStore, key, backend, DefaultDisconnectThreshold, DefaultPaymentThreshold)
+	return swap, dir, logdir
+>>>>>>> swap: rebased to latest master
 }
 
 // create a test swap account with a backend

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -1149,23 +1149,11 @@ func newBaseTestSwapWithParams(t *testing.T, key *ecdsa.PrivateKey, params *Para
 	return swap, dir
 }
 
-<<<<<<< HEAD
 // create a test swap account with a backend
 // creates a stateStore for persistence and a Swap account
 func newBaseTestSwap(t *testing.T, key *ecdsa.PrivateKey, backend *swapTestBackend) (*Swap, string) {
 	params := newDefaultParams()
 	return newBaseTestSwapWithParams(t, key, params, backend)
-=======
-	// Dir for storing swap related logs
-	logdir, err := ioutil.TempDir("", "swap_test_log")
-	log.Debug("creating swap log dir")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	swap := new(logdir, stateStore, key, backend, DefaultDisconnectThreshold, DefaultPaymentThreshold)
-	return swap, dir, logdir
->>>>>>> swap: rebased to latest master
 }
 
 // create a test swap account with a backend
@@ -1733,7 +1721,6 @@ func TestPeerProcessAndVerifyChequeInvalid(t *testing.T) {
 }
 
 func TestSwapLogToFile(t *testing.T) {
-<<<<<<< HEAD
 	// create a log dir
 	logDirDebitor, err := ioutil.TempDir("", "swap_test_log")
 	log.Debug("creating swap log dir")
@@ -1752,14 +1739,6 @@ func TestSwapLogToFile(t *testing.T) {
 	creditorSwap, storeDirCreditor := newBaseTestSwap(t, beneficiaryKey, testBackend)
 	// we are only checking one of the two nodes for logs
 	debitorSwap, storeDirDebitor := newBaseTestSwapWithParams(t, ownerKey, params, testBackend)
-=======
-	testBackend := newTestBackend()
-	defer testBackend.Close()
-
-	// create both test swap accounts
-	creditorSwap, storeDirCreditor, logDirCreditor := newBaseTestSwap(t, beneficiaryKey, testBackend)
-	debitorSwap, storeDirDebitor, logDirDebitor := newBaseTestSwap(t, ownerKey, testBackend)
->>>>>>> swap: rebased to latest master
 
 	clean := func() {
 		creditorSwap.Close()


### PR DESCRIPTION
This PR introduces 3 simple simulations for swap; 2 of them are by only two nodes.

They are the most basic inter-node simulations conceivable to confirm swap is working correctly when interacting with other nodes.

They mostly verify that accounting and cheque emission works correctly across multiple node message interactions.

It seems not appropriate and easily possible to test more realistic and integration scenarios with in-process simulations. Swap now depends of multiple components (blockchain/backends, oracles, etc.), which make an in-process simulation complex. Running a swap simulation with a real Swap-enabled protocol (e.g. `stream`) most realistically is only possible via `NewSwarm` - which requires the presence of command-line parameters like the `SwapBackendURL` which needs initialization via RPC/IPC, something not available through the `SimulatedBackend`. 

Thus, this PR introduces a completely contained `testService` which implements an independent swap-enabled protocol. This allows to test `Swap` independently of any other protocol and suitable for simple simulations - at the cost of additional code. I think this additional code is justified because it adds an additional testing layer, but I also agree it's value in the end to be questionable.

Thus I invite for critical review. Specifically I request feedback to the actual semantics and value of the 3 simulations (do they make sense? should we have more/better ones?).

EDIT: A considerable amount of work went into synchronizing the best way possible; with so many moving (async) parts (cheques, accounting, simulated blockchain) it has proven difficult - specifically for travis.