### PR TITLE
api, metrics, network: check caps when deciding on next peer for a chunk

### DIFF
--- a/api/inspector.go
+++ b/api/inspector.go
@@ -69,7 +69,7 @@ func (i *Inspector) DeliveriesPerPeer() map[string]int64 {
 	// iterate connection in kademlia
 	i.hive.Kademlia.EachConn(nil, 255, func(p *network.Peer, po int) bool {
 		// get how many chunks we receive for retrieve requests per peer
-		peermetric := fmt.Sprintf("chunk.delivery.%x", p.Over()[:16])
+		peermetric := fmt.Sprintf("network.retrieve.chunk.delivery.%x", p.Over()[:16])
 
 		res[fmt.Sprintf("%x", p.Over()[:16])] = metrics.GetOrRegisterCounter(peermetric, nil).Count()
 

--- a/metrics/flags.go
+++ b/metrics/flags.go
@@ -121,7 +121,7 @@ func datadirDiskUsage(path string, d time.Duration) {
 	for range time.Tick(d) {
 		bytes, err := dirSize(path)
 		if err != nil {
-			log.Warn("cannot get disk space", "err", err)
+			log.Trace("cannot get disk space", "err", err)
 		}
 
 		metrics.GetOrRegisterGauge("datadir.usage", nil).Update(bytes)

--- a/network/retrieval/retrieve.go
+++ b/network/retrieval/retrieve.go
@@ -415,11 +415,11 @@ FINDPEER:
 
 	protoPeer := r.getPeer(sp.ID())
 	if protoPeer == nil {
-		r.logger.Warn("findPeer returned a peer to skip", "peer", sp.String(), "retry", retries)
+		r.logger.Warn("findPeer returned a peer to skip", "peer", sp.String(), "retry", retries, "ref", req.Addr)
 		req.PeersToSkip.Store(sp.ID().String(), time.Now())
 		retries++
 		if retries == maxFindPeerRetries {
-			r.logger.Error("max find peer retries reached", "max retries", maxFindPeerRetries)
+			r.logger.Error("max find peer retries reached", "max retries", maxFindPeerRetries, "ref", req.Addr)
 			return nil, ErrNoPeerFound
 		}
 

--- a/network/retrieval/retrieve.go
+++ b/network/retrieval/retrieve.go
@@ -34,7 +34,6 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethersphere/swarm/chunk"
 	"github.com/ethersphere/swarm/network"
-	"github.com/ethersphere/swarm/network/stream/v2"
 	"github.com/ethersphere/swarm/network/timeouts"
 	"github.com/ethersphere/swarm/p2p/protocols"
 	"github.com/ethersphere/swarm/spancontext"
@@ -232,7 +231,7 @@ func (r *Retrieval) findPeer(ctx context.Context, req *storage.Request) (retPeer
 			return true
 		}
 
-		if !p.HasCap(stream.Spec.Name) {
+		if !p.HasCap("bzz-stream") {
 			return true
 		}
 

--- a/network/retrieval/retrieve.go
+++ b/network/retrieval/retrieve.go
@@ -226,7 +226,12 @@ func (r *Retrieval) findPeer(ctx context.Context, req *storage.Request) (retPeer
 	r.kad.EachConn(req.Addr[:], 255, func(p *network.Peer, po int) bool {
 		id := p.ID()
 
-		if !p.HasCap("bzz-retrieve") {
+		if !p.HasCap(Spec.Name) {
+			return true
+		}
+
+		// skip light nodes, even though they support `bzz-retrieve` protocol
+		if p.LightNode {
 			return true
 		}
 

--- a/network/retrieval/retrieve.go
+++ b/network/retrieval/retrieve.go
@@ -226,7 +226,7 @@ func (r *Retrieval) findPeer(ctx context.Context, req *storage.Request) (retPeer
 	r.kad.EachConn(req.Addr[:], 255, func(p *network.Peer, po int) bool {
 		id := p.ID()
 
-		if !p.HasCap("bzz-stream") {
+		if !p.HasCap("bzz-retrieve") {
 			return true
 		}
 

--- a/network/retrieval/retrieve.go
+++ b/network/retrieval/retrieve.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethersphere/swarm/chunk"
 	"github.com/ethersphere/swarm/network"
+	"github.com/ethersphere/swarm/network/stream/v2"
 	"github.com/ethersphere/swarm/network/timeouts"
 	"github.com/ethersphere/swarm/p2p/protocols"
 	"github.com/ethersphere/swarm/spancontext"
@@ -228,6 +229,10 @@ func (r *Retrieval) findPeer(ctx context.Context, req *storage.Request) (retPeer
 
 		// skip light nodes
 		if p.LightNode {
+			return true
+		}
+
+		if !p.HasCap(stream.Spec.Name) {
 			return true
 		}
 

--- a/network/retrieval/retrieve.go
+++ b/network/retrieval/retrieve.go
@@ -226,11 +226,6 @@ func (r *Retrieval) findPeer(ctx context.Context, req *storage.Request) (retPeer
 	r.kad.EachConn(req.Addr[:], 255, func(p *network.Peer, po int) bool {
 		id := p.ID()
 
-		// skip light nodes
-		if p.LightNode {
-			return true
-		}
-
 		if !p.HasCap("bzz-stream") {
 			return true
 		}

--- a/network/retrieval/retrieve_test.go
+++ b/network/retrieval/retrieve_test.go
@@ -233,7 +233,7 @@ func TestRequestFromPeers(t *testing.T) {
 
 	addr := network.RandomAddr()
 	to := network.NewKademlia(addr.OAddr, network.NewKadParams())
-	protocolsPeer := protocols.NewPeer(p2p.NewPeer(dummyPeerID, "dummy", []p2p.Cap{p2p.Cap{Name: "bzz-retrieve", Version: 1}}), nil, nil)
+	protocolsPeer := protocols.NewPeer(p2p.NewPeer(dummyPeerID, "dummy", []p2p.Cap{{Name: "bzz-retrieve", Version: 1}}), nil, nil)
 	peer := network.NewPeer(&network.BzzPeer{
 		BzzAddr:   network.RandomAddr(),
 		LightNode: false,
@@ -262,7 +262,7 @@ func TestRequestFromPeersWithLightNode(t *testing.T) {
 	addr := network.RandomAddr()
 	to := network.NewKademlia(addr.OAddr, network.NewKadParams())
 
-	protocolsPeer := protocols.NewPeer(p2p.NewPeer(dummyPeerID, "dummy", nil), nil, nil)
+	protocolsPeer := protocols.NewPeer(p2p.NewPeer(dummyPeerID, "dummy", []p2p.Cap{{Name: "bzz-retrieve", Version: 1}}), nil, nil)
 
 	// setting up a lightnode
 	peer := network.NewPeer(&network.BzzPeer{

--- a/network/retrieval/retrieve_test.go
+++ b/network/retrieval/retrieve_test.go
@@ -233,7 +233,7 @@ func TestRequestFromPeers(t *testing.T) {
 
 	addr := network.RandomAddr()
 	to := network.NewKademlia(addr.OAddr, network.NewKadParams())
-	protocolsPeer := protocols.NewPeer(p2p.NewPeer(dummyPeerID, "dummy", nil), nil, nil)
+	protocolsPeer := protocols.NewPeer(p2p.NewPeer(dummyPeerID, "dummy", []p2p.Cap{p2p.Cap{Name: "bzz-retrieve", Version: 1}}), nil, nil)
 	peer := network.NewPeer(&network.BzzPeer{
 		BzzAddr:   network.RandomAddr(),
 		LightNode: false,

--- a/storage/netstore.go
+++ b/storage/netstore.go
@@ -264,7 +264,7 @@ func (n *NetStore) RemoteFetch(ctx context.Context, req *Request, fi *Fetcher) e
 			osp.Finish()
 			break
 		case <-ctx.Done(): // global fetcher timeout
-			n.logger.Trace("remote.fetch, fail", "ref", ref)
+			n.logger.Warn("remote.fetch, global timeout fail", "ref", ref)
 			metrics.GetOrRegisterCounter("remote.fetch.timeout.global", nil).Inc(1)
 
 			osp.LogFields(olog.Bool("fail", true))


### PR DESCRIPTION
The `findPeer` function, which decides which peer the `retrieve` protocol should ask for a chunk, currently does not check if the returned peer supports the `stream` protocol - it only ignores light nodes. Because of that it is possible for it to return a `bootnode` in a given network.

So this PR is adding a filter in the `findPeer` function, so that we only suggest peers that run the `stream` protocol. With that change we might not need to even check for light nodes (the `if`-condition above).