### PR TITLE
api/client: fix data race in TarUpload

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -571,7 +571,7 @@ func (c *Client) TarUpload(hash string, uploader Uploader, defaultPath string, t
 		if err := tw.WriteHeader(hdr); err != nil {
 			return err
 		}
-		_, err = io.Copy(tw, file)
+		_, err := io.Copy(tw, file)
 		return err
 	}
 


### PR DESCRIPTION
This PR resolves a possible data race on a variable in api.Client.TarUpload method. The problem is in assigning an outerscope err variable inside uploadFn while it is assigned on other places in TarUpload.

The problem can be reproduced but does not happen always:

```
go build -race ./cmd/swarm
./swarm --recursive up /tmp/somedirectorywithfiles
==================
WARNING: DATA RACE
Write at 0x00c0000b83b0 by main goroutine:
  github.com/ethersphere/swarm/api/client.(*Client).TarUpload()
      /Users/janos/go/src/github.com/ethersphere/swarm/api/client/client.go:588 +0xe7d
  github.com/ethersphere/swarm/api/client.(*Client).UploadDirectory()
      /Users/janos/go/src/github.com/ethersphere/swarm/api/client/client.go:208 +0x163
  main.upload.func1()
      /Users/janos/go/src/github.com/ethersphere/swarm/cmd/swarm/upload.go:139 +0x13d
  main.upload()
      /Users/janos/go/src/github.com/ethersphere/swarm/cmd/swarm/upload.go:154 +0x974
  github.com/ethersphere/swarm/vendor/gopkg.in/urfave/cli%2ev1.HandleAction()
      /Users/janos/go/src/github.com/ethersphere/swarm/vendor/gopkg.in/urfave/cli.v1/app.go:492 +0x8d
  github.com/ethersphere/swarm/vendor/gopkg.in/urfave/cli%2ev1.Command.Run()
      /Users/janos/go/src/github.com/ethersphere/swarm/vendor/gopkg.in/urfave/cli.v1/command.go:210 +0xda2
  github.com/ethersphere/swarm/vendor/gopkg.in/urfave/cli%2ev1.(*App).Run()
      /Users/janos/go/src/github.com/ethersphere/swarm/vendor/gopkg.in/urfave/cli.v1/app.go:255 +0xa46
  main.main()
      /Users/janos/go/src/github.com/ethersphere/swarm/cmd/swarm/main.go:236 +0x8c

Previous write at 0x00c0000b83b0 by goroutine 38:
  github.com/ethersphere/swarm/api/client.(*Client).TarUpload.func1()
      /Users/janos/go/src/github.com/ethersphere/swarm/api/client/client.go:574 +0x2e2
  github.com/ethersphere/swarm/api/client.(*DirectoryUploader).Upload.func1()
      /Users/janos/go/src/github.com/ethersphere/swarm/api/client/client.go:480 +0x17f
  path/filepath.walk()
      /usr/local/go/src/path/filepath/path.go:358 +0x501
  path/filepath.walk()
      /usr/local/go/src/path/filepath/path.go:382 +0x39d
  path/filepath.walk()
      /usr/local/go/src/path/filepath/path.go:382 +0x39d
  path/filepath.Walk()
      /usr/local/go/src/path/filepath/path.go:404 +0x143
  github.com/ethersphere/swarm/api/client.(*DirectoryUploader).Upload()
      /Users/janos/go/src/github.com/ethersphere/swarm/api/client/client.go:464 +0xea
  github.com/ethersphere/swarm/api/client.(*Client).TarUpload.func2()
      /Users/janos/go/src/github.com/ethersphere/swarm/api/client/client.go:581 +0x4c

Goroutine 38 (finished) created at:
  github.com/ethersphere/swarm/api/client.(*Client).TarUpload()
      /Users/janos/go/src/github.com/ethersphere/swarm/api/client/client.go:580 +0xda4
  github.com/ethersphere/swarm/api/client.(*Client).UploadDirectory()
      /Users/janos/go/src/github.com/ethersphere/swarm/api/client/client.go:208 +0x163
  main.upload.func1()
      /Users/janos/go/src/github.com/ethersphere/swarm/cmd/swarm/upload.go:139 +0x13d
  main.upload()
      /Users/janos/go/src/github.com/ethersphere/swarm/cmd/swarm/upload.go:154 +0x974
  github.com/ethersphere/swarm/vendor/gopkg.in/urfave/cli%2ev1.HandleAction()
      /Users/janos/go/src/github.com/ethersphere/swarm/vendor/gopkg.in/urfave/cli.v1/app.go:492 +0x8d
  github.com/ethersphere/swarm/vendor/gopkg.in/urfave/cli%2ev1.Command.Run()
      /Users/janos/go/src/github.com/ethersphere/swarm/vendor/gopkg.in/urfave/cli.v1/command.go:210 +0xda2
  github.com/ethersphere/swarm/vendor/gopkg.in/urfave/cli%2ev1.(*App).Run()
      /Users/janos/go/src/github.com/ethersphere/swarm/vendor/gopkg.in/urfave/cli.v1/app.go:255 +0xa46
  main.main()
      /Users/janos/go/src/github.com/ethersphere/swarm/cmd/swarm/main.go:236 +0x8c
==================
```
