### PR TITLE
cmd/swarm: correct bzznetworkid flag description

### DIFF
--- a/cmd/swarm/config.go
+++ b/cmd/swarm/config.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"os"
 	"reflect"
-	"strconv"
 	"strings"
 	"unicode"
 
@@ -36,6 +35,7 @@ import (
 	"github.com/naoina/toml"
 
 	bzzapi "github.com/ethersphere/swarm/api"
+	"github.com/ethersphere/swarm/network"
 )
 
 var (
@@ -181,14 +181,9 @@ func flagsOverride(currentConfig *bzzapi.Config, ctx *cli.Context) *bzzapi.Confi
 		currentConfig.Contract = common.HexToAddress(chbookaddr)
 	}
 
-	if networkid := ctx.GlobalString(SwarmNetworkIdFlag.Name); networkid != "" {
-		id, err := strconv.ParseUint(networkid, 10, 64)
-		if err != nil {
-			utils.Fatalf("invalid cli flag %s: %v", SwarmNetworkIdFlag.Name, err)
-		}
-		if id != 0 {
-			currentConfig.NetworkID = id
-		}
+	networkid := ctx.GlobalUint64(SwarmNetworkIdFlag.Name)
+	if networkid != 0 && networkid != network.DefaultNetworkID {
+		currentConfig.NetworkID = networkid
 	}
 
 	if ctx.GlobalIsSet(utils.DataDirFlag.Name) {

--- a/cmd/swarm/config_test.go
+++ b/cmd/swarm/config_test.go
@@ -392,7 +392,7 @@ func TestConfigFileOverrides(t *testing.T) {
 	}
 
 	if info.DbCapacity != 9000000 {
-		t.Fatalf("Expected network ID to be %d, got %d", 54, info.NetworkID)
+		t.Fatalf("Expected DbCapacity to be %d, got %d", 9000000, info.DbCapacity)
 	}
 
 	if info.HiveParams.KeepAliveInterval != 6000000000 {

--- a/cmd/swarm/flags.go
+++ b/cmd/swarm/flags.go
@@ -17,7 +17,10 @@
 // Command feed allows the user to create and update signed Swarm feeds
 package main
 
-import cli "gopkg.in/urfave/cli.v1"
+import (
+	"github.com/ethersphere/swarm/network"
+	cli "gopkg.in/urfave/cli.v1"
+)
 
 var (
 	ChequebookAddrFlag = cli.StringFlag{
@@ -52,7 +55,8 @@ var (
 	}
 	SwarmNetworkIdFlag = cli.IntFlag{
 		Name:   "bzznetworkid",
-		Usage:  "Network identifier (integer, default 3=swarm testnet)",
+		Usage:  "Numerical network identifier. The default is the public swarm testnet",
+		Value:  network.DefaultNetworkID,
 		EnvVar: SwarmEnvNetworkID,
 	}
 	SwarmSwapEnabledFlag = cli.BoolFlag{


### PR DESCRIPTION
As reported by @holisticode , the flag description is currently wrong.

Before:
`
--bzznetworkid value               Network identifier (integer, default 3=swarm testnet) (default: 0) [$SWARM_NETWORK_ID]
`

After:
`
--bzznetworkid value                Numerical network identifier. The default is the public swarm testnet (default: 4) [$SWARM_NETWORK_ID]
`