### PR TITLE
network: fix data race in simulation.NewBzzInProc

### DIFF
--- a/network/retrieval/retrieve_test.go
+++ b/network/retrieval/retrieve_test.go
@@ -318,13 +318,8 @@ func newBzzRetrieveWithLocalstore(ctx *adapters.ServiceContext, bucket *sync.Map
 		return nil, nil, err
 	}
 
-	var kad *network.Kademlia
-	if kv, ok := bucket.Load(simulation.BucketKeyKademlia); ok {
-		kad = kv.(*network.Kademlia)
-	} else {
-		kad = network.NewKademlia(addr.Over(), network.NewKadParams())
-		bucket.Store(simulation.BucketKeyKademlia, kad)
-	}
+	k, _ := bucket.LoadOrStore(simulation.BucketKeyKademlia, network.NewKademlia(addr.Over(), network.NewKadParams()))
+	kad := k.(*network.Kademlia)
 
 	netStore := storage.NewNetStore(localStore, kad.BaseAddr(), n.ID())
 	lnetStore := storage.NewLNetStore(netStore)

--- a/network/simulation/simulation.go
+++ b/network/simulation/simulation.go
@@ -107,15 +107,9 @@ func NewBzzInProc(services map[string]ServiceFunc) (s *Simulation) {
 		hp := network.NewHiveParams()
 		hp.KeepAliveInterval = time.Duration(200) * time.Millisecond
 		hp.Discovery = false
-		var kad *network.Kademlia
 
-		// check if another kademlia already exists and load it if necessary - we dont want two independent copies of it
-		if kv, ok := bucket.Load(BucketKeyKademlia); ok {
-			kad = kv.(*network.Kademlia)
-		} else {
-			kad = network.NewKademlia(addr.Over(), network.NewKadParams())
-			bucket.Store(BucketKeyKademlia, kad)
-		}
+		k, _ := bucket.LoadOrStore(BucketKeyKademlia, network.NewKademlia(addr.Over(), network.NewKadParams()))
+		kad := k.(*network.Kademlia)
 
 		config := &network.BzzConfig{
 			OverlayAddr:  addr.Over(),

--- a/network/stream/v2/common_test.go
+++ b/network/stream/v2/common_test.go
@@ -117,15 +117,9 @@ func newSyncSimServiceFunc(o *SyncSimServiceOptions) func(ctx *adapters.ServiceC
 			return nil, nil, err
 		}
 
-		var kad *network.Kademlia
-
 		// check if another kademlia already exists and load it if necessary - we dont want two independent copies of it
-		if kv, ok := bucket.Load(simulation.BucketKeyKademlia); ok {
-			kad = kv.(*network.Kademlia)
-		} else {
-			kad = network.NewKademlia(addr.Over(), network.NewKadParams())
-			bucket.Store(simulation.BucketKeyKademlia, kad)
-		}
+		k, _ := bucket.LoadOrStore(simulation.BucketKeyKademlia, network.NewKademlia(addr.Over(), network.NewKadParams()))
+		kad := k.(*network.Kademlia)
 
 		netStore := storage.NewNetStore(localStore, kad.BaseAddr(), n.ID())
 		lnetStore := storage.NewLNetStore(netStore)


### PR DESCRIPTION
Function simulation.NewBzzInProc and service constructors in stream and retrieval packages use a specific technique to ensure that only one kademlia instance exists for the single simulation node. However, using sync.Map Load and Store separately does not provide atomicity, allowing the possibility that the scheduler can schedule another Load in between Load and Store in different goroutines. Fortunately, sync.Map have LoadOrStore method which is used in this PR to ensure atomicity.