### PR TITLE
network/retrieval: fix Price method reflect call

### DIFF
--- a/network/retrieval/retrieve.go
+++ b/network/retrieval/retrieve.go
@@ -432,7 +432,7 @@ FINDPEER:
 		goto FINDPEER
 	}
 
-	ret := RetrieveRequest{
+	ret := &RetrieveRequest{
 		Addr: req.Addr,
 	}
 	protoPeer.logger.Trace("sending retrieve request", "ref", ret.Addr, "origin", localID)


### PR DESCRIPTION
This PR changes the RequestFromPeers Send to use RetrieveRequest pointer instead of value in order that the Price method correctly gets the type with reflection.