### PR TITLE
swap: fix and rename Peer.getLastSentCumulativePayout

### DIFF
--- a/swap/peer.go
+++ b/swap/peer.go
@@ -84,8 +84,8 @@ func (p *Peer) setLastSentCheque(cheque *Cheque) error {
 	return p.swap.saveLastSentCheque(p.ID(), cheque)
 }
 
-func (p *Peer) getLastCumulativePayout() uint64 {
-	lastCheque := p.getLastReceivedCheque()
+func (p *Peer) getLastSentCumulativePayout() uint64 {
+	lastCheque := p.getLastSentCheque()
 	if lastCheque != nil {
 		return lastCheque.CumulativePayout
 	}
@@ -133,7 +133,7 @@ func (p *Peer) createCheque() (*Cheque, error) {
 		return nil, fmt.Errorf("error getting price from oracle: %v", err)
 	}
 
-	total := p.getLastCumulativePayout()
+	total := p.getLastSentCumulativePayout()
 
 	cheque = &Cheque{
 		ChequeParams: ChequeParams{

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -1233,6 +1233,24 @@ func TestPeerProcessAndVerifyChequeInvalid(t *testing.T) {
 	}
 }
 
+func TestPeerGetLastSentCumulativePayout(t *testing.T) {
+	_, peer, clean := newTestSwapAndPeer(t, ownerKey)
+	defer clean()
+
+	if peer.getLastSentCumulativePayout() != 0 {
+		t.Fatalf("last cumulative payout should be 0 in the beginning, was %d", peer.getLastSentCumulativePayout())
+	}
+
+	cheque := newTestCheque()
+	if err := peer.setLastSentCheque(cheque); err != nil {
+		t.Fatal(err)
+	}
+
+	if peer.getLastSentCumulativePayout() != cheque.CumulativePayout {
+		t.Fatalf("last cumulative payout should be the payout of the last sent cheque, was: %d, expected %d", peer.getLastSentCumulativePayout(), cheque.CumulativePayout)
+	}
+}
+
 // dummyMsgRW implements MessageReader and MessageWriter
 // but doesn't do anything. Useful for dummy message sends
 type dummyMsgRW struct{}


### PR DESCRIPTION
* cumulative amount of the last **sent** cheque (previously it was the last received one) is used as a basis for the next one.
* `getLastCumulativePayout ` was renamed to `getLastSentCumulativePayout`