### PR TITLE
stream: fix missing pointer in Send call

### DIFF
--- a/network/stream/v2/sync_provider.go
+++ b/network/stream/v2/sync_provider.go
@@ -334,7 +334,7 @@ func (s *syncProvider) updateSyncSubscriptions(p *Peer, subBins, quitBins []int)
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		if err := p.Send(ctx, StreamInfoReq{Streams: streams}); err != nil {
+		if err := p.Send(ctx, &StreamInfoReq{Streams: streams}); err != nil {
 			p.logger.Error("error establishing subsequent subscription", "err", err)
 			p.Drop()
 			return


### PR DESCRIPTION
This PR is analogous to #1765; only it is applied to the `stream` protocol rather than the `retrieve` protocol.

- **the bug**: there's a struct passed to a `peer.Send` call, which should be passed as a pointer instead of a plain struct
  - the call is made inside of the `updateSyncSubscriptions` function
  - the struct in question is the `StreamInfoReq` message
- the bug was discovered while trying to implement accounting in the `stream` protocol
  - a `reflect` call with the purpose of adding price to the message will `panic` if the struct is passed as a value
  - accounting on top of the `stream` protocol might end up not being merged, but we should merge this fix anyways