### PR TITLE
protocols, retrieval: swap-enabled messages implement Price

### DIFF
--- a/network/retrieval/retrieve.go
+++ b/network/retrieval/retrieve.go
@@ -67,43 +67,26 @@ var (
 	ErrNoPeerFound = errors.New("no peer found")
 )
 
-// RetrievalPrices define the price matrix that correlates a message
-// type to a certain price (or price function)
-type RetrievalPrices struct {
-	priceMatrix map[reflect.Type]*protocols.Price
-}
-
-// Price implements the protocols.Price interface and returns the price for a specific message
-func (p *RetrievalPrices) Price(msg interface{}) *protocols.Price {
-	t := reflect.TypeOf(msg).Elem()
-	return p.priceMatrix[t]
-}
-
-func (p *RetrievalPrices) retrieveRequestPrice() uint64 {
-	return swap.RetrieveRequestPrice
-}
-
-func (p *RetrievalPrices) chunkDeliveryPrice() uint64 {
-	return swap.ChunkDeliveryPrice
-}
-
-// createPriceOracle sets up a matrix which can be queried to get
-// the price for a message via the Price method
-func (r *Retrieval) createPriceOracle() {
-	p := &RetrievalPrices{}
-	p.priceMatrix = map[reflect.Type]*protocols.Price{
-		reflect.TypeOf(ChunkDelivery{}): {
-			Value:   p.chunkDeliveryPrice(),
-			PerByte: true,
-			Payer:   protocols.Receiver,
-		},
-		reflect.TypeOf(RetrieveRequest{}): {
-			Value:   p.retrieveRequestPrice(),
-			PerByte: false,
-			Payer:   protocols.Sender,
-		},
+// Price is the method through which a message type marks itself
+// as implementing the protocols.Price protocol and thus
+// as swap-enabled message
+func (rr *RetrieveRequest) Price() *protocols.Price {
+	return &protocols.Price{
+		Value:   swap.RetrieveRequestPrice,
+		PerByte: false,
+		Payer:   protocols.Sender,
 	}
-	r.prices = p
+}
+
+// Price is the method through which a message type marks itself
+// as implementing the protocols.Price protocol and thus
+// as swap-enabled message
+func (cd *ChunkDelivery) Price() *protocols.Price {
+	return &protocols.Price{
+		Value:   swap.ChunkDeliveryPrice,
+		PerByte: true,
+		Payer:   protocols.Receiver,
+	}
 }
 
 // Retrieval holds state and handles protocol messages for the `bzz-retrieve` protocol
@@ -128,10 +111,9 @@ func New(kad *network.Kademlia, ns *storage.NetStore, baseKey []byte, balance pr
 		logger:   log.New("base", hex.EncodeToString(baseKey)[:16]),
 		quit:     make(chan struct{}),
 	}
-	r.createPriceOracle()
 	if balance != nil && !reflect.ValueOf(balance).IsNil() {
 		// swap is enabled, so setup the hook
-		r.spec.Hook = protocols.NewAccounting(balance, r.prices)
+		r.spec.Hook = protocols.NewAccounting(balance)
 	}
 	return r
 }

--- a/network/retrieval/retrieve.go
+++ b/network/retrieval/retrieve.go
@@ -96,7 +96,6 @@ type Retrieval struct {
 	kad      *network.Kademlia
 	peers    map[enode.ID]*Peer
 	spec     *protocols.Spec
-	prices   protocols.Prices
 	logger   log.Logger
 	quit     chan struct{}
 }

--- a/network/retrieval/retrieve_test.go
+++ b/network/retrieval/retrieve_test.go
@@ -254,27 +254,15 @@ func TestRequestFromPeers(t *testing.T) {
 	}
 }
 
-//TestHasPriceImplementation is to check that Retrieval implements protocols.Prices
+//TestHasPriceImplementation is to check that Retrieval provides priced messages
 func TestHasPriceImplementation(t *testing.T) {
-	addr := network.RandomBzzAddr()
-	to := network.NewKademlia(addr.OAddr, network.NewKadParams())
-	r := New(to, nil, to.BaseAddr(), nil)
-
-	if r.prices == nil {
-		t.Fatal("No prices implementation available for retrieve protocol")
-	}
-
-	pricesInstance, ok := r.prices.(*RetrievalPrices)
-	if !ok {
-		t.Fatal("Retrieval does not have the expected Prices instance")
-	}
-	price := pricesInstance.Price(&ChunkDelivery{})
-	if price == nil || price.Value == 0 || price.Value != pricesInstance.chunkDeliveryPrice() {
+	price := (&ChunkDelivery{}).Price()
+	if price == nil || price.Value == 0 {
 		t.Fatal("No prices set for chunk delivery msg")
 	}
 
-	price = pricesInstance.Price(&RetrieveRequest{})
-	if price == nil || price.Value == 0 || price.Value != pricesInstance.retrieveRequestPrice() {
+	price = (&RetrieveRequest{}).Price()
+	if price == nil || price.Value == 0 {
 		t.Fatal("No prices set for retrieve requests")
 	}
 }

--- a/p2p/protocols/accounting.go
+++ b/p2p/protocols/accounting.go
@@ -96,8 +96,7 @@ type Balance interface {
 }
 
 // Accounting implements the Hook interface
-// It interfaces to the balances through the Balance interface,
-// while interfacing with protocols and its prices through the Prices interface
+// It interfaces to the balances through the Balance interface
 type Accounting struct {
 	Balance // interface to accounting logic
 }
@@ -120,7 +119,7 @@ func SetupAccountingMetrics(reportInterval time.Duration, path string) *Accounti
 }
 
 // Send takes a peer, a size and a msg and
-//   - calculates the cost for the local node sending a msg of size to peer using the Prices interface
+//   - calculates the cost for the local node sending a msg of size to peer querying the message for its price
 //   - credits/debits local node using balance interface
 func (ah *Accounting) Send(peer *Peer, size uint32, msg interface{}) error {
 	// get the price for a message
@@ -140,10 +139,10 @@ func (ah *Accounting) Send(peer *Peer, size uint32, msg interface{}) error {
 }
 
 // Receive takes a peer, a size and a msg and
-//   - calculates the cost for the local node receiving a msg of size from peer using the Prices interface
+//   - calculates the cost for the local node receiving a msg of size from peer querying the message for its price
 //   - credits/debits local node using balance interface
 func (ah *Accounting) Receive(peer *Peer, size uint32, msg interface{}) error {
-	// get the price for a message (through the protocol spec)
+	// get the price for a message (by querying the message type via the PricedMessage interface)
 	var pricedMessage PricedMessage
 	var ok bool
 	// if the msg implements `Price`, it is an accounted message

--- a/p2p/protocols/accounting.go
+++ b/p2p/protocols/accounting.go
@@ -125,10 +125,11 @@ func SetupAccountingMetrics(reportInterval time.Duration, path string) *Accounti
 //   - calculates the cost for the local node sending a msg of size to peer using the Prices interface
 //   - credits/debits local node using balance interface
 func (ah *Accounting) Send(peer *Peer, size uint32, msg interface{}) error {
-	// get the price for a message (through the protocol spec)
-	price := ah.Price(msg)
-	// this message doesn't need accounting
-	if price == nil {
+	// get the price for a message
+	var price *Price
+	var ok bool
+	// if the msg implements `Price`, it is an accounted message
+	if price, ok = msg.(*Price); !ok {
 		return nil
 	}
 	// evaluate the price for sending messages

--- a/p2p/protocols/accounting_simulation_test.go
+++ b/p2p/protocols/accounting_simulation_test.go
@@ -243,7 +243,7 @@ func (t *testNode) Add(a int64, p *Peer) error {
 func (t *testNode) run(p *p2p.Peer, rw p2p.MsgReadWriter) error {
 	spec := createTestSpec()
 	//create accounting hook
-	spec.Hook = NewAccounting(t, &dummyPrices{})
+	spec.Hook = NewAccounting(t)
 
 	//create a peer for this node
 	tp := &testPeer{NewPeer(p, rw, spec), t.i, t.bal.id2n[p.ID()], t.bal.wg}


### PR DESCRIPTION
This PR changes the way a message type is marked as accounted (enabled for swap accounting).

So far, the protocol would be queried with the message type, and then the protocol was responsible to return if a message was enabled for swap accounting or not.

This change simplifies this by just requiring accounted message types to implement the `protocols.Price` interface. The accounting module in `p2p/protocols` then just tries a type case to `Price`; if it succeeds, it will continue by accounting the price, if it fails it returns assuming the message needs no accounting.

This removes the need for reflection on the protocol's current `Price` implementation and catches bugs where an accounted message type would fail if it is a value type and not a pointer, as happened in the first `retrieval` iteration.

We should force to use pointers as message types on every protocol