### PR TITLE
cmd/swarm: simplify testCluster.StartNewNodes

### DIFF
--- a/cmd/swarm/run_test.go
+++ b/cmd/swarm/run_test.go
@@ -167,31 +167,18 @@ func (c *testCluster) Stop() {
 }
 
 func (c *testCluster) StartNewNodes(t *testing.T, size int) {
-	c.Nodes = make([]*testNode, 0, size)
-
-	errors := make(chan error, size)
-	nodes := make(chan *testNode, size)
+	c.Nodes = make([]*testNode, size)
 	for i := 0; i < size; i++ {
-		go func(nodeIndex int) {
-			dir := filepath.Join(c.TmpDir, fmt.Sprintf("swarm%02d", nodeIndex))
-			if err := os.Mkdir(dir, 0700); err != nil {
-				errors <- err
-				return
-			}
+		name := fmt.Sprintf("swarm%02d", i)
 
-			node := newTestNode(t, dir)
-			node.Name = fmt.Sprintf("swarm%02d", nodeIndex)
-			nodes <- node
-		}(i)
-	}
-
-	for i := 0; i < size; i++ {
-		select {
-		case node := <-nodes:
-			c.Nodes = append(c.Nodes, node)
-		case err := <-errors:
-			t.Error(err)
+		dir := filepath.Join(c.TmpDir, name)
+		if err := os.Mkdir(dir, 0777); err != nil {
+			t.Fatal(err)
 		}
+
+		node := newTestNode(t, dir)
+		node.Name = name
+		c.Nodes[i] = node
 	}
 
 	if t.Failed() {


### PR DESCRIPTION
Method StartNewNodes starts test nodes in parallel and handles errors. However, in tests only 1, 2 or 3 nodes are started making this complexity hard to justify. This code would not be changed if it was not observed that it deadlocks on travis very rarely https://travis-ci.org/ethersphere/swarm/jobs/586074055#L2095 on waiting on the error channel. I was not able to reproduce the problem of find the root cause, so I simplified the code by making it synchronous as it does not prolong test execution time significantly.