### PR TITLE
build: increase golangci-lint deadline

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -300,7 +300,7 @@ func doLint(cmdline []string) {
 	configs := []string{
 		"run",
 		"--tests",
-		"--deadline=2m",
+		"--deadline=5m",
 		"--disable-all",
 		"--enable=goimports",
 		"--enable=varcheck",


### PR DESCRIPTION
Some of the build on travis failed because of lint deadline was reached. This PR increases this deadline.