### PR TITLE
docker: ignore build/bin when copying files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .github
 build/bin
+build/_workspace

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 .github
+build/bin


### PR DESCRIPTION
This will avoid that the `build/bin` directory gets copied to the container when doing `ADD . /swarm`