### PR TITLE
network: Documented, simplified and cleaner eachBin function in pot.go

### DIFF
--- a/network/kademlia.go
+++ b/network/kademlia.go
@@ -303,8 +303,10 @@ func (k *Kademlia) SuggestPeer() (suggestedPeer *BzzAddr, saturationDepth int, c
 	var lastPO int       // the last non-empty PO bin in the iteration
 	saturationDepth = -1 // the deepest PO such that all shallower bins have >= k.MinBinSize peers
 	var pastDepth bool   // whether po of iteration >= depth
-	k.conns.EachBin(k.base, Pof, 0, func(po, size int, f func(func(val pot.Val) bool) bool) bool {
+	k.conns.EachBin(k.base, Pof, 0, func(bin *pot.Bin) bool {
 		// process skipped empty bins
+		po := bin.ProximityOrder
+		size := bin.Size
 		for ; lastPO < po; lastPO++ {
 			// find the lowest unsaturated bin
 			if saturationDepth == -1 {
@@ -361,9 +363,10 @@ func (k *Kademlia) SuggestPeer() (suggestedPeer *BzzAddr, saturationDepth int, c
 		}
 		cur := 0
 		curPO := bins[0]
-		k.addrs.EachBin(k.base, Pof, curPO, func(po, _ int, f func(func(pot.Val) bool) bool) bool {
+		k.addrs.EachBin(k.base, Pof, curPO, func(bin *pot.Bin) bool {
 			curPO = bins[cur]
 			// find the next bin that has size size
+			po := bin.ProximityOrder
 			if curPO == po {
 				cur++
 			} else {
@@ -383,7 +386,7 @@ func (k *Kademlia) SuggestPeer() (suggestedPeer *BzzAddr, saturationDepth int, c
 			// curPO found
 			// find a callable peer out of the addresses in the unsaturated bin
 			// stop if found
-			f(func(val pot.Val) bool {
+			bin.ValIterator(func(val pot.Val) bool {
 				e := val.(*entry)
 				if k.callable(e) {
 					suggestedPeer = e.BzzAddr
@@ -649,8 +652,8 @@ func depthForPot(p *pot.Pot, neighbourhoodSize int, pivotAddr []byte) (depth int
 	// the second step is to test for empty bins in order from shallowest to deepest
 	// if an empty bin is found, this will be the actual depth
 	// we stop iterating if we hit the maxDepth determined in the first step
-	p.EachBin(pivotAddr, Pof, 0, func(po int, _ int, f func(func(pot.Val) bool) bool) bool {
-		if po == depth {
+	p.EachBin(pivotAddr, Pof, 0, func(bin *pot.Bin) bool {
+		if bin.ProximityOrder == depth {
 			if maxDepth == depth {
 				return false
 			}
@@ -713,13 +716,14 @@ func (k *Kademlia) kademliaInfo() (ki KademliaInfo) {
 	ki.Connections = make([][]string, k.MaxProxDisplay)
 	ki.Known = make([][]string, k.MaxProxDisplay)
 
-	k.conns.EachBin(k.base, Pof, 0, func(po, size int, f func(func(val pot.Val) bool) bool) bool {
+	k.conns.EachBin(k.base, Pof, 0, func(bin *pot.Bin) bool {
+		po := bin.ProximityOrder
 		if po >= k.MaxProxDisplay {
 			po = k.MaxProxDisplay - 1
 		}
 
 		row := []string{}
-		f(func(val pot.Val) bool {
+		bin.ValIterator(func(val pot.Val) bool {
 			e := val.(*Peer)
 			row = append(row, hex.EncodeToString(e.Address()))
 			return true
@@ -730,13 +734,14 @@ func (k *Kademlia) kademliaInfo() (ki KademliaInfo) {
 		return true
 	})
 
-	k.addrs.EachBin(k.base, Pof, 0, func(po, size int, f func(func(val pot.Val) bool) bool) bool {
+	k.addrs.EachBin(k.base, Pof, 0, func(bin *pot.Bin) bool {
+		po := bin.ProximityOrder
 		if po >= k.MaxProxDisplay {
 			po = k.MaxProxDisplay - 1
 		}
 
 		row := []string{}
-		f(func(val pot.Val) bool {
+		bin.ValIterator(func(val pot.Val) bool {
 			e := val.(*entry)
 			row = append(row, hex.EncodeToString(e.Address()))
 			return true
@@ -775,14 +780,16 @@ func (k *Kademlia) string() string {
 
 	depth := depthForPot(k.conns, k.NeighbourhoodSize, k.base)
 	rest := k.conns.Size()
-	k.conns.EachBin(k.base, Pof, 0, func(po, size int, f func(func(val pot.Val) bool) bool) bool {
+	k.conns.EachBin(k.base, Pof, 0, func(bin *pot.Bin) bool {
 		var rowlen int
+		po := bin.ProximityOrder
 		if po >= k.MaxProxDisplay {
 			po = k.MaxProxDisplay - 1
 		}
+		size := bin.Size
 		row := []string{fmt.Sprintf("%2d", size)}
 		rest -= size
-		f(func(val pot.Val) bool {
+		bin.ValIterator(func(val pot.Val) bool {
 			e := val.(*Peer)
 			row = append(row, hex.EncodeToString(e.Address()[:2]))
 			rowlen++
@@ -794,17 +801,19 @@ func (k *Kademlia) string() string {
 		return true
 	})
 
-	k.addrs.EachBin(k.base, Pof, 0, func(po, size int, f func(func(val pot.Val) bool) bool) bool {
+	k.addrs.EachBin(k.base, Pof, 0, func(bin *pot.Bin) bool {
 		var rowlen int
+		po := bin.ProximityOrder
 		if po >= k.MaxProxDisplay {
 			po = k.MaxProxDisplay - 1
 		}
+		size := bin.Size
 		if size < 0 {
 			panic("wtf")
 		}
 		row := []string{fmt.Sprintf("%2d", size)}
 		// we are displaying live peers too
-		f(func(val pot.Val) bool {
+		bin.ValIterator(func(val pot.Val) bool {
 			e := val.(*entry)
 			row = append(row, Label(e))
 			rowlen++
@@ -906,12 +915,13 @@ func (k *Kademlia) Saturation() int {
 func (k *Kademlia) saturation() int {
 	prev := -1
 	radius := neighbourhoodRadiusForPot(k.conns, k.NeighbourhoodSize, k.base)
-	k.conns.EachBin(k.base, Pof, 0, func(po, size int, f func(func(val pot.Val) bool) bool) bool {
+	k.conns.EachBin(k.base, Pof, 0, func(bin *pot.Bin) bool {
 		prev++
+		po := bin.ProximityOrder
 		if po >= radius {
 			return false
 		}
-		return prev == po && size >= k.MinBinSize
+		return prev == po && bin.Size >= k.MinBinSize
 	})
 	if prev < 0 {
 		return 0
@@ -934,12 +944,13 @@ func (k *Kademlia) isSaturated(peersPerBin []int, depth int) bool {
 		return false
 	}
 	unsaturatedBins := make([]int, 0)
-	k.conns.EachBin(k.base, Pof, 0, func(po, size int, f func(func(val pot.Val) bool) bool) bool {
-
+	k.conns.EachBin(k.base, Pof, 0, func(bin *pot.Bin) bool {
+		po := bin.ProximityOrder
 		if po >= depth {
 			return false
 		}
 		log.Trace("peers per bin", "peersPerBin[po]", peersPerBin[po], "po", po)
+		size := bin.Size
 		// if there are actually peers in the PeerPot who can fulfill k.MinBinSize
 		if size < k.MinBinSize && size < peersPerBin[po] {
 			log.Trace("connections for po", "po", po, "size", size)

--- a/pot/pot.go
+++ b/pot/pot.go
@@ -453,8 +453,8 @@ func union(t0, t1 *Pot, pof Pof) (*Pot, int) {
 type ValConsumer func(Val) bool
 
 // ValIterator is a function that iterates values and executes for each of them a supplied ValConsumer.
-// it returns the result of the last ValConsumer executed. Usually is the pin of a pot but it could be the last element
-// executed in some other order. It could hint users of this interface to continue iterating other Val collections.
+// it returns the result of the last ValConsumer executed. It could hint users of this interface to continue iterating other ValIterators
+// (for example in EachBin will continue or not with the next Bin).
 // Iterator<Val>  Iterator<T> => func (Consumer<T>) bool
 type ValIterator func(ValConsumer) bool
 


### PR DESCRIPTION
I've tried to make EachBin function more clear to developers. It used to have this signature:
```go
func (t *Pot) EachBin(val Val, pof Pof, po int, f func(int, int, func(func(val Val) bool) bool) bool) {
```
...and almost no documentation. It was difficult to understand what was the purpose of each of the three annonymous function parameters of `EachBin`.

I've created several abstractions to try to express better the behaviour of these iterators.

There is a new type `ValConsumer` with signature: `type ValConsumer func(Val) bool` that consumes a value `Val` and returns whether the caller wants to consume more values.
This consumer can be generalized so I created also `BinConsumer` with similar signature:
`type BinConsumer func(bin *Bin) bool`. Unsurprisingly, this function consumes a Bin and returns whether to continue consuming Bins or stop.

There is also a `ValIterator` function type:
`type ValIterator func(ValConsumer) bool`
that completes the abstraction of iterators. An iterator of type `T` takes a consumer of type `T` (`ValConsumer` in this case) and starts iterating `T` elements. The iterator returns a boolean signaling the last value returned by the last consume function. The `ValIterator` in our case is responsible of iterating `Val` elements inside a `Bin`.
Finally, `Bin` is just a struct with the information provided to a `BinConsumer`, its `ProximityOrder`, its `Size` and the `ValIterator` to traverse all its `Val` elements:
```go
type Bin struct {
	ProximityOrder int
	Size           int
	ValIterator    ValIterator
}
```

With this new types, the signature of `EachBin` now is:
```go
func (t *Pot) EachBin(pivotVal Val, pof Pof, minProximityOrder int, binConsumer BinConsumer) {
```

I also renamed the parameters to express their use.