### PR TITLE
travis: remove go1.12 job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,19 +21,6 @@ jobs:
       script:
         - go run build/ci.go lint
 
-    # Go 1.12.x is needed because of the Ubuntu PPA builds
-    - stage: build
-      os: linux
-      dist: trusty
-      sudo: required
-      go: 1.12.x
-      script:
-        - sudo modprobe fuse
-        - sudo chmod 666 /dev/fuse
-        - sudo chown root:$USER /etc/fuse.conf
-        - go run build/ci.go install
-        - go run build/ci.go test -coverage $TEST_PACKAGES
-
     # Go 1.11.x is needed because of the Ubuntu PPA builds
     - stage: build
       os: linux

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethersphere/swarm
 
-go 1.12
+go 1.13
 
 require (
 	bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898


### PR DESCRIPTION
This is not needed. The Ubuntu PPA is using go1.11.