### PR TITLE
network/stream: refactor cursors tests

### DIFF
--- a/network/stream/v2/common_test.go
+++ b/network/stream/v2/common_test.go
@@ -57,8 +57,6 @@ var (
 	bucketKeyFileStore         = "filestore"
 	bucketKeyLocalStore        = "localstore"
 	bucketKeyInitialBinIndexes = "bin-indexes"
-
-	simContextTimeout = 90 * time.Second
 )
 
 func nodeRegistry(sim *simulation.Simulation, id enode.ID) (s *Registry) {

--- a/network/stream/v2/cursors_test.go
+++ b/network/stream/v2/cursors_test.go
@@ -145,7 +145,6 @@ func TestNodesCorrectBinsDynamic(t *testing.T) {
 		pivotKademlia := nodeKademlia(sim, idPivot)
 		pivotDepth := uint(pivotKademlia.NeighbourhoodDepth())
 
-		idPivot = nodeIDs[0]
 		for i := 1; i < j; i++ {
 			idOther := nodeIDs[i]
 			otherKademlia := sim.MustNodeItem(idOther, simulation.BucketKeyKademlia).(*network.Kademlia)


### PR DESCRIPTION
This PR changes two tests that are still flaky on travis. It utilizes already existing cursors wait function with retry loop. They also use t.Error and t.Fatal to have better visibility on failure. All tests have been re-run for many times manually on travis without failures. There were no failures in a few hundred runs locally.