### PR TITLE
swap: prompt user for initial deposit amount

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -57,6 +57,7 @@ type Config struct {
 	SwapEnabled             bool           // whether SWAP incentives are enabled
 	SwapPaymentThreshold    uint64         // honey amount at which a payment is triggered
 	SwapDisconnectThreshold uint64         // honey amount at which a peer disconnects
+	SwapInitialDeposit      uint64         // initial deposit amount to the chequebook
 	SwapLogPath             string         // dir to swap related audit logs
 	Contract                common.Address // address of the chequebook contract
 	// end of Swap configs
@@ -93,6 +94,7 @@ func NewConfig() (c *Config) {
 		FileStoreParams:         storage.NewFileStoreParams(),
 		SwapBackendURL:          "",
 		SwapEnabled:             false,
+		SwapInitialDeposit:      swap.DefaultInitialDepositAmount,
 		SwapPaymentThreshold:    swap.DefaultPaymentThreshold,
 		SwapDisconnectThreshold: swap.DefaultDisconnectThreshold,
 		SwapLogPath:             "",

--- a/cmd/swarm/config.go
+++ b/cmd/swarm/config.go
@@ -59,12 +59,13 @@ var (
 
 //constants for environment variables
 const (
-	SwarmEnvChequebookAddr          = "SWARM_CHEQUEBOOK_ADDR"
 	SwarmEnvAccount                 = "SWARM_ACCOUNT"
 	SwarmEnvBzzKeyHex               = "SWARM_BZZ_KEY_HEX"
 	SwarmEnvListenAddr              = "SWARM_LISTEN_ADDR"
 	SwarmEnvPort                    = "SWARM_PORT"
 	SwarmEnvNetworkID               = "SWARM_NETWORK_ID"
+	SwarmEnvChequebookAddr          = "SWARM_CHEQUEBOOK_ADDR"
+	SwarmEnvInitialDeposit          = "SWARM_INITIAL_DEPOSIT"
 	SwarmEnvSwapEnable              = "SWARM_SWAP_ENABLE"
 	SwarmEnvSwapBackendURL          = "SWARM_SWAP_BACKEND_URL"
 	SwarmEnvSwapPaymentThreshold    = "SWARM_SWAP_PAYMENT_THRESHOLD"
@@ -207,6 +208,9 @@ func flagsOverride(currentConfig *bzzapi.Config, ctx *cli.Context) *bzzapi.Confi
 	}
 	if swapLogPath := ctx.GlobalString(SwarmSwapLogPathFlag.Name); currentConfig.SwapEnabled && swapLogPath != "" {
 		currentConfig.SwapLogPath = swapLogPath
+	}
+	if initialDepo := ctx.GlobalUint64(SwarmSwapInitialDepositFlag.Name); initialDepo != 0 {
+		currentConfig.SwapInitialDeposit = initialDepo
 	}
 	if paymentThreshold := ctx.GlobalUint64(SwarmSwapPaymentThresholdFlag.Name); paymentThreshold != 0 {
 		currentConfig.SwapPaymentThreshold = paymentThreshold

--- a/cmd/swarm/flags.go
+++ b/cmd/swarm/flags.go
@@ -54,9 +54,9 @@ var (
 		Value:  network.DefaultNetworkID,
 		EnvVar: SwarmEnvNetworkID,
 	}
-	SwarmSwapInitialDepositFlag= cli.StringFlag{
-		Name:   "initial-deposit",
-		Usage:  "Initial deposit amount",
+	SwarmSwapInitialDepositFlag = cli.StringFlag{
+		Name:   "swap-initial-deposit",
+		Usage:  "Initial deposit amount for swap chequebook",
 		EnvVar: SwarmEnvInitialDeposit,
 	}
 	SwarmSwapChequebookAddrFlag = cli.StringFlag{

--- a/cmd/swarm/flags.go
+++ b/cmd/swarm/flags.go
@@ -23,11 +23,6 @@ import (
 )
 
 var (
-	SwarmSwapChequebookAddrFlag = cli.StringFlag{
-		Name:   "chequebook",
-		Usage:  "chequebook contract address",
-		EnvVar: SwarmEnvChequebookAddr,
-	}
 	SwarmAccountFlag = cli.StringFlag{
 		Name:   "bzzaccount",
 		Usage:  "Swarm account key file",
@@ -58,6 +53,16 @@ var (
 		Usage:  "Numerical network identifier. The default is the public swarm testnet",
 		Value:  network.DefaultNetworkID,
 		EnvVar: SwarmEnvNetworkID,
+	}
+	SwarmSwapInitialDepositFlag= cli.StringFlag{
+		Name:   "initial-deposit",
+		Usage:  "Initial deposit amount",
+		EnvVar: SwarmEnvInitialDeposit,
+	}
+	SwarmSwapChequebookAddrFlag = cli.StringFlag{
+		Name:   "chequebook",
+		Usage:  "chequebook contract address",
+		EnvVar: SwarmEnvChequebookAddr,
 	}
 	SwarmSwapEnabledFlag = cli.BoolFlag{
 		Name:   "swap",

--- a/cmd/swarm/flags.go
+++ b/cmd/swarm/flags.go
@@ -60,8 +60,8 @@ var (
 		EnvVar: SwarmEnvInitialDeposit,
 	}
 	SwarmSwapChequebookAddrFlag = cli.StringFlag{
-		Name:   "chequebook",
-		Usage:  "chequebook contract address",
+		Name:   "swap-chequebook",
+		Usage:  "SWAP chequebook contract address",
 		EnvVar: SwarmEnvChequebookAddr,
 	}
 	SwarmSwapEnabledFlag = cli.BoolFlag{

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -183,6 +183,7 @@ func init() {
 		SwarmSwapPaymentThresholdFlag,
 		SwarmSwapLogPathFlag,
 		SwarmSwapChequebookAddrFlag,
+		SwarmSwapInitialDepositFlag,
 		// end of swap flags
 		SwarmSyncDisabledFlag,
 		SwarmSyncUpdateDelay,

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -152,12 +152,12 @@ func New(dbPath string, prvkey *ecdsa.PrivateKey, backendURL string, params *Par
 		return nil, fmt.Errorf("swap init error: error connecting to Ethereum API %s: %s", backendURL, err)
 	}
 
+	// we may not need this check, and we could maybe even get rid of this constant completely
 	if params != nil && params.InitialDepositAmount == 0 {
 		// need to prompt user for initial deposit amount
 		// if 0, can not cash in cheques
 		prompter := console.Stdin
 
-		// we may not need this check, and we could maybe even get rid of this constant completely
 		// ask user for input
 		input, err := prompter.PromptInput("Please provide the amount in Wei which will deposited to your chequebook upon deployment: ")
 		if err != nil {

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -159,7 +159,7 @@ func New(dbPath string, prvkey *ecdsa.PrivateKey, backendURL string, params *Par
 
 		// we may not need this check, and we could maybe even get rid of this constant completely
 		// ask user for input
-		input, err := prompter.PromptInput("Please provide the amount in Wei which will deposited to your chequebook upon deployment")
+		input, err := prompter.PromptInput("Please provide the amount in Wei which will deposited to your chequebook upon deployment: ")
 		if err != nil {
 			return nil, err
 		}

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -708,7 +708,7 @@ func newBaseTestSwap(t *testing.T, key *ecdsa.PrivateKey) (*Swap, string, string
 		t.Fatal(err)
 	}
 
-	swap := new(logdir, stateStore, key, testBackend, DefaultDisconnectThreshold, DefaultPaymentThreshold)
+	swap := new(logdir, stateStore, key, testBackend, DefaultDisconnectThreshold, DefaultPaymentThreshold, NewParams())
 	return swap, dir, logdir
 }
 

--- a/swarm.go
+++ b/swarm.go
@@ -118,14 +118,19 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 		if self.config.NetworkID != swap.AllowedNetworkID {
 			return nil, fmt.Errorf("swap can only be enabled under BZZ Network ID %d, found Network ID %d instead", swap.AllowedNetworkID, self.config.NetworkID)
 		}
+		swapParams := &swap.Params{
+			LogPath:              self.config.SwapLogPath,
+			InitialDepositAmount: self.config.SwapInitialDeposit,
+			DisconnectThreshold:  int64(self.config.SwapDisconnectThreshold),
+			PaymentThreshold:     int64(self.config.SwapPaymentThreshold),
+		}
+
 		// create the accounting objects
 		self.swap, err = swap.New(
-			config.SwapLogPath,
 			self.config.Path,
 			self.privateKey,
 			self.config.SwapBackendURL,
-			self.config.SwapDisconnectThreshold,
-			self.config.SwapPaymentThreshold,
+			swapParams,
 		)
 		if err != nil {
 			return nil, err

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -115,6 +115,7 @@ func TestNewSwarm(t *testing.T) {
 			configure: func(config *api.Config) {
 				config.SwapBackendURL = ipcEndpoint
 				config.SwapEnabled = true
+				config.SwapInitialDeposit = 999999999
 				config.NetworkID = swap.AllowedNetworkID
 			},
 			check: func(t *testing.T, s *Swarm, _ *api.Config) {


### PR DESCRIPTION
This PR adds a prompt for user input, but only if swap is enabled.

This is needed because currently we have a default initial deposit of 0. This means the user will not be able to cash-in cheques.

There is also a flag added with which the amount can be provided. This will allow bypassing the prompt, which apart from config ease also is mandatory to allow tests to pass.

Of course this is only a first step; we can't query the user all the time, nor do we need to pass a flag every time. As soon as the chequebook has been deployed, it should be queried for the value it has.