### PR TITLE
network: Patch crash on pre-capability state store load

### DIFF
--- a/network/hive.go
+++ b/network/hive.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethersphere/swarm/log"
+	"github.com/ethersphere/swarm/network/capability"
 	"github.com/ethersphere/swarm/state"
 )
 
@@ -239,6 +240,14 @@ func (h *Hive) loadPeers() error {
 			return nil
 		}
 		return err
+	}
+	// workaround for old node stores not containing capabilities
+	for i := range as {
+		if as[i].Capabilities == nil {
+			caps := capability.NewCapabilities()
+			caps.Add(fullCapability)
+			as[i] = as[i].WithCapabilities(caps)
+		}
 	}
 	log.Info(fmt.Sprintf("hive %08x: peers loaded", h.BaseAddr()[:4]))
 


### PR DESCRIPTION
Peer stores saved before Capabilities feature was added do not contain Capabilities member in the serialized BzzAddr. The automatic deserialization in the state store used when loading peers leaves the Capabilities field to nil, which crashes the node on startup.

This patch merely sets the a missing Capabiliity field to the (temporary) `fullCapability` value.

Since a hardening of the peer loading routine is planned as part of the kademlia roadmap, a proper evaluation of serialization formats used by the state store will be deferred to the same task.

Since this bug was not caught with any unit or integration tests, a test _should_ be added to audit data integrity in data structures created from the store.