### PR TITLE
cmd/swarm-smoke: add flag to bail on error

### DIFF
--- a/cmd/swarm-smoke/flags.go
+++ b/cmd/swarm-smoke/flags.go
@@ -1,0 +1,137 @@
+// Copyright 2019 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+package main
+
+import (
+	"github.com/ethereum/go-ethereum/cmd/utils"
+	swarmmetrics "github.com/ethersphere/swarm/metrics"
+	"github.com/ethersphere/swarm/tracing"
+	cli "gopkg.in/urfave/cli.v1"
+)
+
+var (
+	flags         []cli.Flag
+	allhosts      string
+	hosts         []string
+	filesize      int
+	syncDelay     bool
+	pushsyncDelay bool
+	syncMode      string
+	inputSeed     int
+	httpPort      int
+	wsPort        int
+	verbosity     int
+	timeout       int
+	single        bool
+	onlyUpload    bool
+	debug         bool
+	bail          bool
+)
+
+func init() {
+	flags = []cli.Flag{
+		cli.StringFlag{
+			Name:        "hosts",
+			Value:       "",
+			Usage:       "comma-separated list of swarm hosts",
+			Destination: &allhosts,
+		},
+		cli.IntFlag{
+			Name:        "http-port",
+			Value:       80,
+			Usage:       "http port",
+			Destination: &httpPort,
+		},
+		cli.IntFlag{
+			Name:        "ws-port",
+			Value:       8546,
+			Usage:       "ws port",
+			Destination: &wsPort,
+		},
+		cli.IntFlag{
+			Name:        "seed",
+			Value:       0,
+			Usage:       "input seed in case we need deterministic upload",
+			Destination: &inputSeed,
+		},
+		cli.IntFlag{
+			Name:        "filesize",
+			Value:       1024,
+			Usage:       "file size for generated random file in KB",
+			Destination: &filesize,
+		},
+		cli.StringFlag{
+			Name:        "sync-mode",
+			Value:       "pullsync",
+			Usage:       "sync mode - pushsync or pullsync or both",
+			Destination: &syncMode,
+		},
+		cli.BoolFlag{
+			Name:        "pushsync-delay",
+			Usage:       "wait for content to be push synced",
+			Destination: &pushsyncDelay,
+		},
+		cli.BoolFlag{
+			Name:        "sync-delay",
+			Usage:       "wait for content to be synced",
+			Destination: &syncDelay,
+		},
+		cli.IntFlag{
+			Name:        "verbosity",
+			Value:       1,
+			Usage:       "verbosity",
+			Destination: &verbosity,
+		},
+		cli.IntFlag{
+			Name:        "timeout",
+			Value:       180,
+			Usage:       "timeout in seconds after which kill the process",
+			Destination: &timeout,
+		},
+		cli.BoolFlag{
+			Name:        "single",
+			Usage:       "whether to fetch content from a single node or from all nodes",
+			Destination: &single,
+		},
+		cli.BoolFlag{
+			Name:        "only-upload",
+			Usage:       "whether to only upload content to a single node without fetching",
+			Destination: &onlyUpload,
+		},
+		cli.BoolFlag{
+			Name:        "debug",
+			Usage:       "whether to call debug APIs as part of the smoke test",
+			Destination: &debug,
+		},
+		cli.BoolFlag{
+			Name:        "bail",
+			Usage:       "whether to fail the smoke test on any intermediate errors (such as chunks not found on max prox)",
+			Destination: &bail,
+		},
+	}
+
+	flags = append(flags, []cli.Flag{
+		utils.MetricsEnabledFlag,
+		swarmmetrics.MetricsInfluxDBEndpointFlag,
+		swarmmetrics.MetricsInfluxDBDatabaseFlag,
+		swarmmetrics.MetricsInfluxDBUsernameFlag,
+		swarmmetrics.MetricsInfluxDBPasswordFlag,
+		swarmmetrics.MetricsInfluxDBTagsFlag,
+	}...)
+
+	flags = append(flags, tracing.Flags...)
+
+}

--- a/cmd/swarm-smoke/main.go
+++ b/cmd/swarm-smoke/main.go
@@ -36,115 +36,12 @@ var (
 	gitCommit string // Git SHA1 commit hash of the release (set via linker flags)
 )
 
-var (
-	allhosts      string
-	hosts         []string
-	filesize      int
-	syncDelay     bool
-	pushsyncDelay bool
-	syncMode      string
-	inputSeed     int
-	httpPort      int
-	wsPort        int
-	verbosity     int
-	timeout       int
-	single        bool
-	onlyUpload    bool
-	debug         bool
-)
-
 func main() {
 	app := cli.NewApp()
 	app.Name = "smoke-test"
 	app.Usage = ""
 
-	app.Flags = []cli.Flag{
-		cli.StringFlag{
-			Name:        "hosts",
-			Value:       "",
-			Usage:       "comma-separated list of swarm hosts",
-			Destination: &allhosts,
-		},
-		cli.IntFlag{
-			Name:        "http-port",
-			Value:       80,
-			Usage:       "http port",
-			Destination: &httpPort,
-		},
-		cli.IntFlag{
-			Name:        "ws-port",
-			Value:       8546,
-			Usage:       "ws port",
-			Destination: &wsPort,
-		},
-		cli.IntFlag{
-			Name:        "seed",
-			Value:       0,
-			Usage:       "input seed in case we need deterministic upload",
-			Destination: &inputSeed,
-		},
-		cli.IntFlag{
-			Name:        "filesize",
-			Value:       1024,
-			Usage:       "file size for generated random file in KB",
-			Destination: &filesize,
-		},
-		cli.StringFlag{
-			Name:        "sync-mode",
-			Value:       "pullsync",
-			Usage:       "sync mode - pushsync or pullsync or both",
-			Destination: &syncMode,
-		},
-		cli.BoolFlag{
-			Name:        "pushsync-delay",
-			Usage:       "wait for content to be push synced",
-			Destination: &pushsyncDelay,
-		},
-		cli.BoolFlag{
-			Name:        "sync-delay",
-			Usage:       "wait for content to be synced",
-			Destination: &syncDelay,
-		},
-		cli.IntFlag{
-			Name:        "verbosity",
-			Value:       1,
-			Usage:       "verbosity",
-			Destination: &verbosity,
-		},
-		cli.IntFlag{
-			Name:        "timeout",
-			Value:       180,
-			Usage:       "timeout in seconds after which kill the process",
-			Destination: &timeout,
-		},
-		cli.BoolFlag{
-			Name:        "single",
-			Usage:       "whether to fetch content from a single node or from all nodes",
-			Destination: &single,
-		},
-		cli.BoolFlag{
-			Name:        "only-upload",
-			Usage:       "whether to only upload content to a single node without fetching",
-			Destination: &onlyUpload,
-		},
-		cli.BoolFlag{
-			Name:        "debug",
-			Usage:       "whether to call debug APIs as part of the smoke test",
-			Destination: &debug,
-		},
-	}
-
-	app.Flags = append(app.Flags, []cli.Flag{
-		utils.MetricsEnabledFlag,
-		swarmmetrics.MetricsInfluxDBEndpointFlag,
-		swarmmetrics.MetricsInfluxDBDatabaseFlag,
-		swarmmetrics.MetricsInfluxDBUsernameFlag,
-		swarmmetrics.MetricsInfluxDBPasswordFlag,
-		swarmmetrics.MetricsInfluxDBTagsFlag,
-	}...)
-
-	app.Flags = append(app.Flags, tracing.Flags...)
-
+	app.Flags = flags
 	app.Commands = []cli.Command{
 		{
 			Name:    "upload_and_sync",

--- a/cmd/swarm-smoke/upload_and_sync.go
+++ b/cmd/swarm-smoke/upload_and_sync.go
@@ -155,7 +155,11 @@ func trackChunks(testData []byte) error {
 
 	wg.Wait()
 
-	checkChunksVsMostProxHosts(addrs, allHostChunks, bzzAddrs)
+	err = checkChunksVsMostProxHosts(addrs, allHostChunks, bzzAddrs)
+	if err != nil {
+		return err
+	}
+
 	metrics.GetOrRegisterGauge("deployment.nodes", nil).Update(int64(len(hosts)))
 
 	if !hasErr {
@@ -179,7 +183,7 @@ func trackChunks(testData []byte) error {
 // addrs - a slice with all uploaded chunk refs
 // allHostChunks - host->bit vector, showing what chunks are present on what hosts
 // bzzAddrs - host->bzz address, used when determining the most proximate host for a given chunk
-func checkChunksVsMostProxHosts(addrs []storage.Address, allHostChunks map[string]string, bzzAddrs map[string]string) {
+func checkChunksVsMostProxHosts(addrs []storage.Address, allHostChunks map[string]string, bzzAddrs map[string]string) error {
 	for k, v := range bzzAddrs {
 		log.Trace("bzzAddr", "bzz", v, "host", k)
 	}
@@ -212,7 +216,11 @@ func checkChunksVsMostProxHosts(addrs []storage.Address, allHostChunks map[strin
 			for _, maxProxHost := range maxProxHosts {
 				if allHostChunks[maxProxHost][i] == '0' {
 					metrics.GetOrRegisterCounter("upload-and-sync.pull-sync.chunk-not-max-prox", nil).Inc(1)
-					log.Error("chunk not found at max prox host", "ref", addrs[i], "host", maxProxHost, "bzzAddr", bzzAddrs[maxProxHost])
+					e := fmt.Errorf("chunk not found at max prox host\tref: %s\thost: %s\tbzzAddr: %s", addrs[i], maxProxHost, bzzAddrs[maxProxHost])
+					if bail {
+						return e
+					}
+					log.Error(e.Error())
 				} else {
 					log.Trace("chunk present at max prox host", "ref", addrs[i], "host", maxProxHost, "bzzAddr", bzzAddrs[maxProxHost])
 				}
@@ -221,7 +229,11 @@ func checkChunksVsMostProxHosts(addrs []storage.Address, allHostChunks map[strin
 			// if chunk found at less than 2 hosts, which is actually less that the min size of a NN
 			if foundAt < 2 {
 				metrics.GetOrRegisterCounter("upload-and-sync.pull-sync.chunk-less-nn", nil).Inc(1)
-				log.Error("chunk found at less than two hosts", "foundAt", foundAt, "ref", addrs[i])
+				e := fmt.Errorf("chunk found at less than two hosts\tfoundAt: %d\tref: %s", foundAt, addrs[i])
+				if bail {
+					return e
+				}
+				log.Error(e.Error())
 			}
 		}
 
@@ -237,11 +249,16 @@ func checkChunksVsMostProxHosts(addrs []storage.Address, allHostChunks map[strin
 			if !found {
 				for _, maxProxHost := range maxProxHosts {
 					metrics.GetOrRegisterCounter("upload-and-sync.push-sync.chunk-not-max-prox", nil).Inc(1)
-					log.Error("chunk not found at any max prox host", "ref", addrs[i], "hosts", maxProxHost, "bzzAddr", bzzAddrs[maxProxHost])
+					e := fmt.Errorf("chunk not found at any max prox host\tref: %s\thosts: %s\tbzzAddr: %s", addrs[i], maxProxHost, bzzAddrs[maxProxHost])
+					if bail {
+						return e
+					}
+					log.Error(e.Error())
 				}
 			}
 		}
 	}
+	return nil
 }
 
 func getAllRefs(testData []byte) (storage.AddressCollection, error) {
@@ -291,13 +308,14 @@ func uploadAndSync(c *cli.Context, randomBytes []byte) error {
 	// wait to sync and log chunks before fetch attempt, only if syncDelay is set to true
 	if syncDelay {
 		waitToSync()
+	}
 
-		log.Debug("chunks before fetch attempt", "hash", hash)
-
-		if debug {
-			err = trackChunks(randomBytes)
-			if err != nil {
-				log.Error(err.Error())
+	if debug {
+		err = trackChunks(randomBytes)
+		if err != nil {
+			log.Error(err.Error())
+			if bail {
+				return err
 			}
 		}
 	}


### PR DESCRIPTION
This PR adds a `--bail` flag to the smoke test binary which tells the upload and sync test to bail on any intermediate errors found (such as `chunk not found max prox` and `chunk at less than two hosts`)

fixes #1622 