### PR TITLE
api, cmd: add pinning feature flag

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -79,6 +79,7 @@ type Config struct {
 	LightNodeEnabled     bool
 	BootnodeMode         bool
 	DisableAutoConnect   bool
+	EnablePinning        bool
 	SyncUpdateDelay      time.Duration
 	Cors                 string
 	BzzAccount           string
@@ -87,9 +88,8 @@ type Config struct {
 }
 
 //NewConfig creates a default config with all parameters to set to defaults
-func NewConfig() (c *Config) {
-
-	c = &Config{
+func NewConfig() *Config {
+	return &Config{
 		FileStoreParams:         storage.NewFileStoreParams(),
 		SwapBackendURL:          "",
 		SwapEnabled:             false,
@@ -109,9 +109,8 @@ func NewConfig() (c *Config) {
 		DeliverySkipCheck:       true,
 		MaxStreamPeerServers:    10000,
 		SyncUpdateDelay:         15 * time.Second,
+		EnablePinning:           false,
 	}
-
-	return
 }
 
 //some config params need to be initialized after the complete

--- a/api/http/middleware.go
+++ b/api/http/middleware.go
@@ -28,6 +28,8 @@ func Adapt(h http.Handler, adapters ...Adapter) http.Handler {
 
 type Adapter func(http.Handler) http.Handler
 
+// SetRequestID is a middleware that sets a random UUID
+// as a unique identifier and injects it into the request context
 func SetRequestID(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		r = r.WithContext(SetRUID(r.Context(), uuid.New()[:8]))
@@ -38,6 +40,8 @@ func SetRequestID(h http.Handler) http.Handler {
 	})
 }
 
+// SetRequestHost is a middleware that injects the
+// request Host into the request context
 func SetRequestHost(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		r = r.WithContext(sctx.SetHost(r.Context(), r.Host))
@@ -47,6 +51,8 @@ func SetRequestHost(h http.Handler) http.Handler {
 	})
 }
 
+// ParseURI is a middleware that parses the request URI
+// to a Swarm URI object that dissects the content presented after the HTTP URI's first slash
 func ParseURI(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		uri, err := api.Parse(strings.TrimLeft(r.URL.Path, "/"))
@@ -73,6 +79,8 @@ func ParseURI(h http.Handler) http.Handler {
 	})
 }
 
+// InitLoggingResponseWriter is a wrapper around the WriteHeader call
+// that allows saving the response code for local context
 func InitLoggingResponseWriter(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		tn := time.Now()
@@ -135,6 +143,7 @@ func InitUploadTag(h http.Handler, tags *chunk.Tags) http.Handler {
 	})
 }
 
+// InstrumentOpenTracing instruments an HTTP request with an OpenTracing span
 func InstrumentOpenTracing(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		uri := GetURI(r.Context())
@@ -150,6 +159,9 @@ func InstrumentOpenTracing(h http.Handler) http.Handler {
 	})
 }
 
+// PinningEnabledPassthrough allows a request through the middleware in the following cases:
+// 1. checkHeader = true;		api != nil;	header PinHeaderName = true (x-swarm-pin: true) // header is set (hence api use is needed) and api not nil
+// 2. checkHeader = false;	api != nil																									// api not nil (don't care about header)
 func PinningEnabledPassthrough(h http.Handler, api *pin.API, checkHeader bool) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// if checkHeader is true, it means that the passthrough should happen if the header is set and the pinAPI is not nil

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -106,6 +106,7 @@ func NewServer(api *api.API, pinAPI *pin.API, corsString string) *Server {
 	server := &Server{api: api, pinAPI: pinAPI}
 
 	defaultMiddlewares := []Adapter{
+		RecoverPanic,
 		SetRequestID,
 		SetRequestHost,
 		InitLoggingResponseWriter,

--- a/cmd/swarm/config.go
+++ b/cmd/swarm/config.go
@@ -260,6 +260,9 @@ func flagsOverride(currentConfig *bzzapi.Config, ctx *cli.Context) *bzzapi.Confi
 	if ctx.GlobalIsSet(SwarmGlobalStoreAPIFlag.Name) {
 		currentConfig.GlobalStoreAPI = ctx.GlobalString(SwarmGlobalStoreAPIFlag.Name)
 	}
+	if ctx.GlobalBool(SwarmEnablePinningFlag.Name) {
+		currentConfig.EnablePinning = true
+	}
 	return currentConfig
 }
 

--- a/cmd/swarm/config_test.go
+++ b/cmd/swarm/config_test.go
@@ -241,6 +241,7 @@ func TestConfigCmdLineOverrides(t *testing.T) {
 		"--verbosity", fmt.Sprintf("%d", *testutil.Loglevel),
 		fmt.Sprintf("--%s", SwarmSwapPaymentThresholdFlag.Name), strconv.Itoa(swap.DefaultPaymentThreshold + 1),
 		fmt.Sprintf("--%s", SwarmSwapDisconnectThresholdFlag.Name), strconv.Itoa(swap.DefaultDisconnectThreshold + 1),
+		fmt.Sprintf("--%s", SwarmEnablePinningFlag.Name),
 	}
 
 	node.Cmd = runSwarm(t, flags...)
@@ -293,6 +294,10 @@ func TestConfigCmdLineOverrides(t *testing.T) {
 
 	if info.SwapDisconnectThreshold != (swap.DefaultDisconnectThreshold + 1) {
 		t.Fatalf("Expected SwapDisconnectThreshold to be %d, but got %d", swap.DefaultDisconnectThreshold+1, info.SwapDisconnectThreshold)
+	}
+
+	if info.EnablePinning != true {
+		t.Fatalf("expected EnablePinning to be %t but got %t", true, info.EnablePinning)
 	}
 
 	node.Shutdown()

--- a/cmd/swarm/flags.go
+++ b/cmd/swarm/flags.go
@@ -223,4 +223,8 @@ var (
 		Name:  "pin",
 		Usage: "Use this flag to pin the file after upload is complete. This flag is used when uploading a file.",
 	}
+	SwarmEnablePinningFlag = cli.BoolFlag{
+		Name:  "enable-pinning",
+		Usage: "Use this flag to enable the pinning feature",
+	}
 )

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -194,6 +194,7 @@ func init() {
 		SwarmAccountFlag,
 		SwarmBzzKeyHexFlag,
 		SwarmNetworkIdFlag,
+		SwarmEnablePinningFlag,
 		// upload flags
 		SwarmApiFlag,
 		SwarmRecursiveFlag,

--- a/swarm.go
+++ b/swarm.go
@@ -237,9 +237,10 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 
 	self.api = api.NewAPI(self.fileStore, self.dns, feedsHandler, self.privateKey, self.tags)
 
-	// Instantiate the pinAPI object with the already opened localstore
-	self.pinAPI = pin.NewAPI(localStore, self.stateStore, self.config.FileStoreParams, self.tags, self.api)
-
+	if config.EnablePinning {
+		// Instantiate the pinAPI object with the already opened localstore
+		self.pinAPI = pin.NewAPI(localStore, self.stateStore, self.config.FileStoreParams, self.tags, self.api)
+	}
 	self.sfs = fuse.NewSwarmFS(self.api)
 	log.Debug("Initialized FUSE filesystem")
 


### PR DESCRIPTION
This PR adds a feature flag to enable/disable pinning on a node.
Nodes would now be started with pinning disabled on default in order to simplify deployment configuration for those running gateways (in order to prevent external users pinning content through gateways, therefore possibly overloading gateway storage and bandwidth).
Users that would like to use this feature should bring their nodes up with `--enable-pinning` flag.

fixes #1732 