### PR TITLE
network/simulation: Basic bootnode support + expanded enode.ID exclusion

### DIFF
--- a/network/simulation/node.go
+++ b/network/simulation/node.go
@@ -35,11 +35,13 @@ import (
 	"github.com/ethersphere/swarm/network"
 )
 
-var (
-	BucketKeyBzzPrivateKey BucketKey = "bzzprivkey"
-
+const (
 	// PropertyBootnode is a property string for NodeConfig, representing that a node is a bootnode
 	PropertyBootnode = "bootnode"
+)
+
+var (
+	BucketKeyBzzPrivateKey BucketKey = "bzzprivkey"
 )
 
 // NodeIDs returns NodeIDs for all nodes in the network.

--- a/network/simulation/simulation.go
+++ b/network/simulation/simulation.go
@@ -117,6 +117,7 @@ func NewBzzInProc(services map[string]ServiceFunc, disableAutoConnect bool) (s *
 			OverlayAddr:  addr.Over(),
 			UnderlayAddr: addr.Under(),
 			HiveParams:   hp,
+			BootnodeMode: ctx.Config.BootNode,
 		}
 		return network.NewBzz(config, kad, nil, nil, nil, nil, nil), nil, nil
 	}

--- a/network/simulation/simulation.go
+++ b/network/simulation/simulation.go
@@ -117,8 +117,16 @@ func NewBzzInProc(services map[string]ServiceFunc, disableAutoConnect bool) (s *
 			OverlayAddr:  addr.Over(),
 			UnderlayAddr: addr.Under(),
 			HiveParams:   hp,
-			BootnodeMode: ctx.Config.BootNode,
 		}
+
+		// Check for relevant properties
+		for _, property := range ctx.Config.Properties {
+			switch property {
+			case PropertyBootnode:
+				config.BootnodeMode = true
+			}
+		}
+
 		return network.NewBzz(config, kad, nil, nil, nil, nil, nil), nil, nil
 	}
 


### PR DESCRIPTION
**Note:** This PR is dependent on [this go-ethereum PR](https://github.com/ethereum/go-ethereum/pull/20060).

- Adds basic bootnode support to simulations, using the new `NodeConfig.BootNode` flag. (Lightnode support was omitted since it will soon be deprecated in Swarm)
- Expands stop/start random node functions to support the exclusion of certain nodes (So for instance, bootnodes can be excluded)
- Minor comment cleanup

