### PR TITLE
bzzeth: correct the order of cleanup steps in newTestNetworkStore

### DIFF
--- a/bzzeth/bzzeth_test.go
+++ b/bzzeth/bzzeth_test.go
@@ -84,15 +84,14 @@ func newTestNetworkStore(t *testing.T) (prvkey *ecdsa.PrivateKey, netStore *stor
 	netStore = storage.NewNetStore(localStore, bzzAddr, enode.ID{})
 
 	cleanup = func() {
-		err := os.RemoveAll(dir)
-		if err != nil {
-			t.Fatalf("Could not remove localstore dir")
-		}
 		err = netStore.Close()
 		if err != nil {
 			t.Fatalf("Could not close netStore")
 		}
-
+		err := os.RemoveAll(dir)
+		if err != nil {
+			t.Fatalf("Could not remove localstore dir")
+		}
 	}
 	return prvkey, netStore, cleanup
 }


### PR DESCRIPTION
This PR addresses the issue with running bzzeth tests on windows:

--- FAIL: TestNewBlockHeaders (0.02s)
    bzzeth_test.go:89: Could not remove localstore dir
FAIL
coverage: 41.3% of statements
FAIL	github.com/ethersphere/swarm/bzzeth	2.366s

https://ci.appveyor.com/project/ethersphere/swarm/builds/27657610/job/h5gimfoikowh6v86#L597

The order of cleanup steps in newTestNetworkStore is incorrect. First the files need to be closed, then removed from the system.