### PR TITLE
bzzeth: fix TestBzzBzzHandshakeWithMessage

### DIFF
--- a/bzzeth/bzzeth_test.go
+++ b/bzzeth/bzzeth_test.go
@@ -221,7 +221,7 @@ func TestBzzBzzHandshakeWithMessage(t *testing.T) {
 	}
 
 	// after successful handshake, expect peer added to peer pool
-	p := getPeerAfterConnection
+	p := getPeerAfterConnection(node.ID(), b)
 	if p == nil {
 		t.Fatal("bzzeth peer not added")
 	}


### PR DESCRIPTION
Currently TestBzzBzzHandshakeWithMessage is not calling getPeerAfterConnection but just assigning the function to the variable. I suppose that the validation should be on the result of that function call.