### PR TITLE
pushsync: optimize TestPushsyncSimulation

### DIFF
--- a/chunk/testing/chunk.go
+++ b/chunk/testing/chunk.go
@@ -1,0 +1,54 @@
+// Copyright 2019 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package testing
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/ethersphere/swarm/chunk"
+)
+
+func init() {
+	// needed for GenerateTestRandomChunk
+	rand.Seed(time.Now().UnixNano())
+}
+
+// GenerateTestRandomChunk generates a Chunk that is not
+// valid, but it contains a random key and a random value.
+// This function is faster then storage.GenerateRandomChunk
+// which generates a valid chunk.
+// Some tests in do not need valid chunks, just
+// random data, and their execution time can be decreased
+// using this function.
+func GenerateTestRandomChunk() chunk.Chunk {
+	data := make([]byte, chunk.DefaultSize)
+	rand.Read(data)
+	key := make([]byte, 32)
+	rand.Read(key)
+	return chunk.NewChunk(key, data)
+}
+
+// GenerateTestRandomChunks generates a slice of random
+// Chunks by using GenerateTestRandomChunk function.
+func GenerateTestRandomChunks(count int) []chunk.Chunk {
+	chunks := make([]chunk.Chunk, count)
+	for i := 0; i < count; i++ {
+		chunks[i] = GenerateTestRandomChunk()
+	}
+	return chunks
+}

--- a/pushsync/simulation_test.go
+++ b/pushsync/simulation_test.go
@@ -54,7 +54,7 @@ var (
 var (
 	nodeCntFlag   = flag.Int("nodes", 4, "number of nodes in simulation")
 	chunkCntFlag  = flag.Int("chunks", 1000, "number of chunks per upload in simulation")
-	testCasesFlag = flag.Int("cases", 4, "number of concurrent upload-download cases to test in simulation")
+	testCasesFlag = flag.Int("cases", 2, "number of concurrent upload-download cases to test in simulation")
 )
 
 // test syncer using pss

--- a/pushsync/simulation_test.go
+++ b/pushsync/simulation_test.go
@@ -52,10 +52,18 @@ var (
 )
 
 var (
+	defaultChunkCnt = 100
+
 	nodeCntFlag   = flag.Int("nodes", 4, "number of nodes in simulation")
-	chunkCntFlag  = flag.Int("chunks", 100, "number of chunks per upload in simulation")
+	chunkCntFlag  = flag.Int("chunks", defaultChunkCnt, "number of chunks per upload in simulation")
 	testCasesFlag = flag.Int("cases", 4, "number of concurrent upload-download cases to test in simulation")
 )
+
+func init() {
+	if os.Getenv("APPVEYOR") != "" {
+		defaultChunkCnt = 4
+	}
+}
 
 // test syncer using pss
 // the test

--- a/pushsync/simulation_test.go
+++ b/pushsync/simulation_test.go
@@ -53,8 +53,8 @@ var (
 
 var (
 	nodeCntFlag   = flag.Int("nodes", 4, "number of nodes in simulation")
-	chunkCntFlag  = flag.Int("chunks", 1000, "number of chunks per upload in simulation")
-	testCasesFlag = flag.Int("cases", 2, "number of concurrent upload-download cases to test in simulation")
+	chunkCntFlag  = flag.Int("chunks", 100, "number of chunks per upload in simulation")
+	testCasesFlag = flag.Int("cases", 4, "number of concurrent upload-download cases to test in simulation")
 )
 
 // test syncer using pss

--- a/storage/localstore/localstore_test.go
+++ b/storage/localstore/localstore_test.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/ethersphere/swarm/chunk"
+	chunktesting "github.com/ethersphere/swarm/chunk/testing"
 	"github.com/ethersphere/swarm/shed"
 	"github.com/syndtr/goleveldb/leveldb"
 )
@@ -165,35 +166,10 @@ func newTestDB(t testing.TB, o *Options) (db *DB, cleanupFunc func()) {
 	return db, cleanupFunc
 }
 
-func init() {
-	// needed for generateTestRandomChunk
-	rand.Seed(time.Now().UnixNano())
-}
-
-// generateTestRandomChunk generates a Chunk that is not
-// valid, but it contains a random key and a random value.
-// This function is faster then storage.generateTestRandomChunk
-// which generates a valid chunk.
-// Some tests in this package do not need valid chunks, just
-// random data, and their execution time can be decreased
-// using this function.
-func generateTestRandomChunk() chunk.Chunk {
-	data := make([]byte, chunk.DefaultSize)
-	rand.Read(data)
-	key := make([]byte, 32)
-	rand.Read(key)
-	return chunk.NewChunk(key, data)
-}
-
-// generateTestRandomChunks generates a slice of random
-// Chunks by using generateTestRandomChunk function.
-func generateTestRandomChunks(count int) []chunk.Chunk {
-	chunks := make([]chunk.Chunk, count)
-	for i := 0; i < count; i++ {
-		chunks[i] = generateTestRandomChunk()
-	}
-	return chunks
-}
+var (
+	generateTestRandomChunk  = chunktesting.GenerateTestRandomChunk
+	generateTestRandomChunks = chunktesting.GenerateTestRandomChunks
+)
 
 // chunkAddresses return chunk addresses of provided chunks.
 func chunkAddresses(chunks []chunk.Chunk) []chunk.Address {


### PR DESCRIPTION
This PR addresses issues when running TestPushsyncSimulation with larger number of chunks.

The main problem was in the download function trying to get all the chunks at once.

It was noticed in profiling that storage.GenerateRandomChunk took a noticeable time to acquire a mutex lock. It is replaced by a faster variant which does not generate a valid chunk, but a chunk that is good enough for the simulation.