### PR TITLE
pushsync, storage/localstore: set tags synced state in localstore

### DIFF
--- a/storage/localstore/localstore.go
+++ b/storage/localstore/localstore.go
@@ -54,6 +54,7 @@ var (
 // database related objects.
 type DB struct {
 	shed *shed.DB
+	tags *chunk.Tags
 
 	// schema name of loaded data
 	schemaName shed.StringField
@@ -131,6 +132,7 @@ type Options struct {
 	Capacity uint64
 	// MetricsPrefix defines a prefix for metrics names.
 	MetricsPrefix string
+	Tags          *chunk.Tags
 }
 
 // New returns a new DB.  All fields and indexes are initialized
@@ -146,6 +148,7 @@ func New(path string, baseKey []byte, o *Options) (db *DB, err error) {
 	db = &DB{
 		capacity: o.Capacity,
 		baseKey:  baseKey,
+		tags:     o.Tags,
 		// channel collectGarbageTrigger
 		// needs to be buffered with the size of 1
 		// to signal another event if it

--- a/swarm.go
+++ b/swarm.go
@@ -190,9 +190,12 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 
 	feedsHandler = feed.NewHandler(fhParams)
 
+	self.tags = chunk.NewTags() //todo load from state store
+
 	localStore, err := localstore.New(config.ChunkDbPath, config.BaseKey, &localstore.Options{
 		MockStore: mockStore,
 		Capacity:  config.DbCapacity,
+		Tags:      self.tags,
 	})
 	if err != nil {
 		return nil, err
@@ -222,7 +225,6 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 
 	syncProvider := stream.NewSyncProvider(self.netStore, to, syncing, false)
 	self.streamer = stream.New(self.stateStore, bzzconfig.OverlayAddr, syncProvider)
-	self.tags = chunk.NewTags() //todo load from state store
 
 	// Swarm Hash Merklised Chunking for Arbitrary-length Document/File storage
 	lnetStore := storage.NewLNetStore(self.netStore)


### PR DESCRIPTION
Do not merge.

This is one example solution for tags to get along with both push and pull syncing. Tag synced state cannot reach total number of chunks as pull syncing is removing chunks from push index on ModeSetSync.

It is debatable if it is correct approach as push and pull syncing have different definition of chunk being synced. But it is the most simple thing to do now.