### PR TITLE
swap: return the balance in swap.Balance for an unconnected but prior peer

### DIFF
--- a/swap/swap.go
+++ b/swap/swap.go
@@ -352,12 +352,12 @@ func (s *Swap) processAndVerifyCheque(cheque *Cheque, p *Peer) (uint64, error) {
 }
 
 // Balance returns the balance for a given peer
-func (s *Swap) Balance(peer enode.ID) (int64, error) {
-	swapPeer := s.getPeer(peer)
-	if swapPeer == nil {
-		return 0, state.ErrNotFound
+func (s *Swap) Balance(peer enode.ID) (balance int64, err error) {
+	if swapPeer := s.getPeer(peer); swapPeer != nil {
+		return swapPeer.getBalance(), nil
 	}
-	return swapPeer.getBalance(), nil
+	err = s.store.Get(balanceKey(peer), &balance)
+	return balance, err
 }
 
 // Balances returns the balances for all known SWAP peers

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -128,6 +128,17 @@ func TestPeerBalance(t *testing.T) {
 	if err != state.ErrNotFound {
 		t.Fatalf("Expected test to fail with %s, but is %s", "ErrorNotFound", err.Error())
 	}
+
+	// test for unconnected node
+	testPeer2 := newDummyPeer().Peer
+	swap.saveBalance(testPeer2.ID(), 333)
+	b, err = swap.Balance(testPeer2.ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b != 333 {
+		t.Fatalf("Expected peer's balance to be %d, but is %d", 333, b)
+	}
 }
 
 // Test getting balances for all known peers


### PR DESCRIPTION
This PR fixes the `swap_Balance` call to return the last balance of a currently disconnected (but previously connected to) peer instead of a not found error. This behaviour was accidentally changed during the peer refactoring PR. A test for this was also added.