### PR TITLE
simulation: skip docker tests locally

### DIFF
--- a/simulation/docker_test.go
+++ b/simulation/docker_test.go
@@ -6,9 +6,14 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
+	"github.com/ethersphere/swarm/internal/build"
 )
 
 func TestDockerAdapterBuild(t *testing.T) {
+	if env := build.Env(); env.Name == "local" {
+		t.Skip("skip locally")
+	}
+
 	if !IsDockerAvailable(client.DefaultDockerHost) {
 		t.Skip("could not connect to the docker daemon")
 	}

--- a/simulation/examples/snapshot/docker_test.go
+++ b/simulation/examples/snapshot/docker_test.go
@@ -4,10 +4,15 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/ethersphere/swarm/internal/build"
 	"github.com/ethersphere/swarm/simulation"
 )
 
 func TestDockerSnapshotFromFile(t *testing.T) {
+	if env := build.Env(); env.Name == "local" {
+		t.Skip("skip locally")
+	}
+
 	snap, err := simulation.LoadSnapshotFromFile("docker.json")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This PR makes the test suite skip the docker tests that pull images on local build environment