### PR TITLE
swarm: make pullsync disabled not expose stream protocol

### DIFF
--- a/network/discovery.go
+++ b/network/discovery.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/ethersphere/swarm/log"
 	"github.com/ethersphere/swarm/pot"
 )
 
@@ -97,7 +96,6 @@ func (d *Peer) NotifyPeer(a *BzzAddr, po uint8) {
 	resp := &peersMsg{
 		Peers: []*BzzAddr{a},
 	}
-	log.Warn("notifypeer", "notify", resp)
 	go d.Send(context.TODO(), resp)
 }
 

--- a/swarm.go
+++ b/swarm.go
@@ -559,7 +559,9 @@ func (s *Swarm) APIs() []rpc.API {
 	}
 
 	apis = append(apis, s.bzz.APIs()...)
-	apis = append(apis, s.streamer.APIs()...)
+	if s.config.SyncEnabled {
+		apis = append(apis, s.streamer.APIs()...)
+	}
 	apis = append(apis, s.bzzEth.APIs()...)
 
 	if s.ps != nil {

--- a/swarm.go
+++ b/swarm.go
@@ -559,6 +559,9 @@ func (s *Swarm) APIs() []rpc.API {
 	}
 
 	apis = append(apis, s.bzz.APIs()...)
+
+	// this is a workaround disabling syncing altogether from a node but
+	// must be changed when multiple stream implementations are at hand
 	if s.config.SyncEnabled {
 		apis = append(apis, s.streamer.APIs()...)
 	}


### PR DESCRIPTION
This PR makes the `--syncmode=pull` not expose stream protocol on the node. The exposure of the protocol caused syncing from other nodes that were actively syncing to make this node sync too.
