### PR TITLE
network/stream: skip longrunning simulation due to travis flakes

### DIFF
--- a/network/stream/v2/snapshot_sync_test.go
+++ b/network/stream/v2/snapshot_sync_test.go
@@ -69,7 +69,7 @@ func TestSyncingViaGlobalSync(t *testing.T) {
 		testSyncingViaGlobalSync(t, *chunks, *nodes)
 	} else {
 		chunkCounts := []int{4}
-		nodeCounts := []int{16, 32}
+		nodeCounts := []int{16} // 32 nodes flakes on travis
 
 		//if the `longrunning` flag has been provided
 		//run more test combinations


### PR DESCRIPTION
This PR disables the 32 node simulation since it flakes on travis.