### PR TITLE
network: Reconnect to the same peers on startup

### DIFF
--- a/network/hive.go
+++ b/network/hive.go
@@ -260,7 +260,7 @@ func (h *Hive) loadPeers() error {
 	err = h.Store.Get(connectionsKey, &conns)
 	if err != nil {
 		if err == state.ErrNotFound {
-			log.Info(fmt.Sprintf("hive %08x: no persisted peerc onnections found", h.BaseAddr()[:4]))
+			log.Info(fmt.Sprintf("hive %08x: no persisted peer connections found", h.BaseAddr()[:4]))
 		} else {
 			log.Warn(fmt.Sprintf("hive %08x: error loading connections: %v", h.BaseAddr()[:4], err))
 		}
@@ -300,10 +300,6 @@ func (h *Hive) savePeers() error {
 	})
 
 	h.Kademlia.EachConn(nil, 256, func(p *Peer, i int) bool {
-		if p == nil {
-			log.Warn(fmt.Sprintf("empty peer: %v", i))
-			return true
-		}
 		log.Trace("saving connected peer", "OAddr", hexutil.Encode(p.OAddr), "UAddr", p.UAddr)
 		conns = append(conns, p.BzzAddr)
 		return true

--- a/network/hive_test.go
+++ b/network/hive_test.go
@@ -22,9 +22,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethersphere/swarm/log"
 	p2ptest "github.com/ethersphere/swarm/p2p/testing"
+	"github.com/ethersphere/swarm/pot"
 	"github.com/ethersphere/swarm/state"
 )
 
@@ -174,4 +179,140 @@ func TestHiveStatePersistence(t *testing.T) {
 	if len(peers) != 0 {
 		t.Fatalf("%d peers left over: %v", len(peers), peers)
 	}
+}
+
+// TestHiveStateConnections connect the node to some peers and then after cleanup/save in store those peers
+// are retrieved and used as suggested peer initially.
+func TestHiveStateConnections(t *testing.T) {
+	dir, err := ioutil.TempDir("", "hive_test_store")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	const peersCount = 5
+
+	nodeIdToBzzAddr := make(map[string]*BzzAddr)
+	addedChan := make(chan struct{}, 5)
+	startHive := func(t *testing.T, dir string) (h *Hive, cleanupFunc func()) {
+		store, err := state.NewDBStore(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		params := NewHiveParams()
+		params.Discovery = false
+
+		prvkey, err := crypto.GenerateKey()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		h = NewHive(params, NewKademlia(PrivateKeyToBzzKey(prvkey), NewKadParams()), store)
+		s := p2ptest.NewProtocolTester(prvkey, 0, func(p *p2p.Peer, rw p2p.MsgReadWriter) error { return nil })
+
+		if err := h.Start(s.Server); err != nil {
+			t.Fatal(err)
+		}
+		//Close ticker to avoid interference with initial peer suggestion
+		h.ticker.Stop()
+		//Overwrite addPeer so the Node is added as a peer automatically.
+		// The related Overlay address is retrieved from nodeIdToBzzAddr where it has been saved before
+		h.addPeer = func(node *enode.Node) {
+			bzzAddr := nodeIdToBzzAddr[encodeId(node.ID())]
+			if bzzAddr == nil {
+				t.Fatalf("Enode [%v] not found in saved peers!", encodeId(node.ID()))
+			}
+			bzzPeer := newConnPeerLocal(bzzAddr.Address(), h.Kademlia)
+			h.On(bzzPeer)
+			addedChan <- struct{}{}
+		}
+
+		cleanupFunc = func() {
+			err := h.Stop()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			s.Stop()
+		}
+		return h, cleanupFunc
+	}
+
+	h1, cleanup1 := startHive(t, dir)
+	peers := make(map[string]bool)
+	for i := 0; i < peersCount; i++ {
+		raddr := RandomBzzAddr()
+		h1.Register(raddr)
+		peers[raddr.String()] = true
+	}
+	const initialPeers = 5
+	for i := 0; i < initialPeers; i++ {
+		suggestedPeer, _, _ := h1.SuggestPeer()
+		if suggestedPeer != nil {
+			testAddPeer(suggestedPeer, h1, nodeIdToBzzAddr)
+		}
+
+	}
+	numConns := h1.conns.Size()
+	connAddresses := make(map[string]string)
+	h1.EachConn(h1.base, 255, func(peer *Peer, i int) bool {
+		key := hexutil.Encode(peer.Address())
+		connAddresses[key] = key
+		return true
+	})
+	log.Warn("After 5 suggestions", "numConns", numConns)
+	cleanup1()
+
+	// start the hive and check that we suggest previous connected peers
+	h2, _ := startHive(t, dir)
+	// there should be at some point 5 conns
+	connsAfterLoading := 0
+	iterations := 0
+	connsAfterLoading = h2.conns.Size()
+	for connsAfterLoading != numConns && iterations < 5 {
+		select {
+		case <-addedChan:
+			connsAfterLoading = h2.conns.Size()
+		case <-time.After(1 * time.Second):
+			iterations++
+		}
+		log.Trace("Iteration waiting for initial connections", "numConns", connsAfterLoading, "iterations", iterations)
+	}
+	if connsAfterLoading != numConns {
+		t.Errorf("Expected 5 peer connecteds from previous execution but got %v", connsAfterLoading)
+	}
+	h2.EachConn(h2.base, 255, func(peer *Peer, i int) bool {
+		key := hexutil.Encode(peer.Address())
+		if connAddresses[key] != key {
+			t.Errorf("Expected address %v to be in connections as it was a previous peer connected", key)
+		} else {
+			log.Warn("Previous peer connected again", "addr", key)
+		}
+		return true
+	})
+}
+
+// Create a Peer with the suggested address and store the relationshsip enode -> BzzAddr for later retrieval
+func testAddPeer(suggestedPeer *BzzAddr, h1 *Hive, nodeIdToBzzAddr map[string]*BzzAddr) {
+	byteAddresses := suggestedPeer.Address()
+	bzzPeer := newConnPeerLocal(byteAddresses, h1.Kademlia)
+	nodeIdToBzzAddr[encodeId(bzzPeer.ID())] = bzzPeer.BzzAddr
+	bzzPeer.kad = h1.Kademlia
+	h1.On(bzzPeer)
+}
+
+func encodeId(id enode.ID) string {
+	addr := id[:]
+	return hexutil.Encode(addr)
+}
+
+// We create a test Peer with underlay address to localhost and using overlay address provided
+func newConnPeerLocal(addr []byte, kademlia *Kademlia) *Peer {
+	hash := [common.HashLength]byte{}
+	copy(hash[:], addr)
+	potAddress := pot.Address(hash)
+	peer := newDiscPeer(potAddress)
+	peer.kad = kademlia
+	return peer
 }


### PR DESCRIPTION
Issue #1396 
When a swarm node was restarted, kademlia connection table changed because the suggested peers were different. This incurred in a big traffic loas as the node had to push part of its chunks to the new peers.
We wanted to prioritize known peers (latest connected peers) when reconnecting. To do that, we are saving the current peers bzz addresses on shutdown, and load them in startup and try to connect them. Of course if we need more peers or some of them can't be contacted, the usual peer suggestion will take place.