### PR TITLE
network: fix hive autoconnect param for non-snapshot tests

### DIFF
--- a/network/stream/cursors_test.go
+++ b/network/stream/cursors_test.go
@@ -58,7 +58,7 @@ func TestNodesExchangeCorrectBinIndexes(t *testing.T) {
 		serviceNameStream: newSyncSimServiceFunc(&SyncSimServiceOptions{
 			InitialChunkCount: chunkCount,
 		}),
-	}, true)
+	}, false)
 	defer sim.Close()
 
 	_, err := sim.AddNodesAndConnectStar(nodeCount)
@@ -106,7 +106,7 @@ func TestNodesCorrectBinsDynamic(t *testing.T) {
 		serviceNameStream: newSyncSimServiceFunc(&SyncSimServiceOptions{
 			InitialChunkCount: chunkCount,
 		}),
-	}, true)
+	}, false)
 	defer sim.Close()
 
 	_, err := sim.AddNodesAndConnectStar(2)
@@ -182,7 +182,7 @@ func TestNodeRemovesAndReestablishCursors(t *testing.T) {
 
 	sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
 		serviceNameStream: newSyncSimServiceFunc(nil),
-	}, true)
+	}, false)
 	defer sim.Close()
 
 	// load the snapshot
@@ -310,7 +310,7 @@ func setupReestablishCursorsSimulation(t *testing.T, tagetPO int) (sim *simulati
 
 	sim = simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
 		serviceNameStream: newSyncSimServiceFunc(nil),
-	}, true)
+	}, false)
 
 	nodeIDs, err := sim.AddNodesAndConnectStar(nodeCount)
 	if err != nil {
@@ -501,7 +501,7 @@ func TestCorrectCursorsExchangeRace(t *testing.T) {
 	}
 	sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
 		serviceNameStream: newSyncSimServiceFunc(opts),
-	}, true)
+	}, false)
 	defer sim.Close()
 
 	// create the first node with the non mock initialiser

--- a/network/stream/syncing_test.go
+++ b/network/stream/syncing_test.go
@@ -153,7 +153,7 @@ func TestTwoNodesSyncWithGaps(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
 				"bzz-sync": newSyncSimServiceFunc(nil),
-			}, true)
+			}, false)
 			defer sim.Close()
 			defer catchDuplicateChunkSync(t)()
 
@@ -224,7 +224,7 @@ func TestThreeNodesUnionHistoricalSync(t *testing.T) {
 	chunkCount := 1000
 	sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
 		"bzz-sync": newSyncSimServiceFunc(nil),
-	}, true)
+	}, false)
 	defer sim.Close()
 	union := make(map[string]struct{})
 	nodeIDs := []enode.ID{}
@@ -568,7 +568,7 @@ func benchmarkHistoricalStream(b *testing.B, chunks uint64) {
 	for i := 0; i < b.N; i++ {
 		sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
 			"bzz-sync": newSyncSimServiceFunc(nil),
-		}, true)
+		}, false)
 
 		uploaderNode, err := sim.AddNode()
 		if err != nil {
@@ -655,7 +655,7 @@ func TestStarNetworkSyncWithBogusNodes(t *testing.T) {
 	)
 	sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
 		"bzz-sync": newSyncSimServiceFunc(&SyncSimServiceOptions{SyncOnlyWithinDepth: false}),
-	}, true)
+	}, false)
 	defer sim.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), simTimeout)


### PR DESCRIPTION
This PR fixes a test regression that was introduced with push sync PR and was disabling hive autoconnect for tests that rely on discovery for their completion