### PR TITLE
cmd/swarm: remove --no-track, add --progress flag

### DIFF
--- a/cmd/swarm/access_test.go
+++ b/cmd/swarm/access_test.go
@@ -88,7 +88,6 @@ func testPassword(t *testing.T, cluster *testCluster) {
 		"--bzzapi",
 		cluster.Nodes[0].URL,
 		"up",
-		"--no-track",
 		"--encrypt",
 		dataFilename)
 	_, matches := up.ExpectRegexp(hashRegexp)
@@ -241,7 +240,6 @@ func testPK(t *testing.T, cluster *testCluster) {
 		"--bzzapi",
 		cluster.Nodes[0].URL,
 		"up",
-		"--no-track",
 		"--encrypt",
 		dataFilename)
 	_, matches := up.ExpectRegexp(hashRegexp)
@@ -394,7 +392,6 @@ func testACT(t *testing.T, cluster *testCluster, bogusEntries int) {
 		"--bzzapi",
 		cluster.Nodes[0].URL,
 		"up",
-		"--no-track",
 		"--encrypt",
 		dataFilename)
 	_, matches := up.ExpectRegexp(hashRegexp)

--- a/cmd/swarm/export_test.go
+++ b/cmd/swarm/export_test.go
@@ -64,7 +64,7 @@ func TestCLISwarmExportImport(t *testing.T) {
 	defer os.Remove(fileName)
 
 	// upload the file with 'swarm up' and expect a hash
-	up := runSwarm(t, "--bzzapi", cluster.Nodes[0].URL, "up", "--no-track", fileName)
+	up := runSwarm(t, "--bzzapi", cluster.Nodes[0].URL, "up", fileName)
 	_, matches := up.ExpectRegexp(`[a-f\d]{64}`)
 	up.ExpectExit()
 	hash := matches[0]

--- a/cmd/swarm/flags.go
+++ b/cmd/swarm/flags.go
@@ -233,9 +233,9 @@ var (
 		Name:  "enable-pinning",
 		Usage: "Use this flag to enable the pinning feature",
 	}
-	SwarmNoTrackUploadFlag = cli.BoolFlag{
-		Name:  "no-track",
-		Usage: "Use this flag to disable tracking of the upload progress through the CLI (gives back a machine-readable content addressed hash)",
+	SwarmProgressFlag = cli.BoolFlag{
+		Name:  "progress",
+		Usage: "Use this flag to enable tracking of the upload progress through the CLI",
 	}
 	SwarmVerboseFlag = cli.BoolFlag{
 		Name:  "verbose",

--- a/cmd/swarm/fs_test.go
+++ b/cmd/swarm/fs_test.go
@@ -222,7 +222,6 @@ func doUploadEmptyDir(t *testing.T, node *testNode) string {
 		"--bzzapi", node.URL,
 		"--recursive",
 		"up",
-		"--no-track",
 		tmpDir}
 
 	log.Info("swarmfs cli test: uploading dir with 'swarm up'")

--- a/cmd/swarm/manifest_test.go
+++ b/cmd/swarm/manifest_test.go
@@ -100,7 +100,6 @@ func testManifestChange(t *testing.T, encrypt bool) {
 		"--defaultpath",
 		indexDataFilename,
 		"up",
-		"--no-track",
 	}
 	if encrypt {
 		args = append(args, "--encrypt")
@@ -126,7 +125,6 @@ func testManifestChange(t *testing.T, encrypt bool) {
 			"--bzzapi",
 			srv.URL,
 			"up",
-			"--no-track",
 			humansDataFilename,
 		)
 
@@ -182,7 +180,6 @@ func testManifestChange(t *testing.T, encrypt bool) {
 			"--bzzapi",
 			srv.URL,
 			"up",
-			"--no-track",
 			robotsDataFilename,
 		)
 
@@ -243,7 +240,6 @@ func testManifestChange(t *testing.T, encrypt bool) {
 			"--bzzapi",
 			srv.URL,
 			"up",
-			"--no-track",
 			indexDataFilename,
 		)
 
@@ -302,7 +298,6 @@ func testManifestChange(t *testing.T, encrypt bool) {
 			"--bzzapi",
 			srv.URL,
 			"up",
-			"--no-track",
 			robotsDataFilename,
 		)
 
@@ -469,7 +464,6 @@ func testNestedDefaultEntryUpdate(t *testing.T, encrypt bool) {
 		"--defaultpath",
 		indexDataFilename,
 		"up",
-		"--no-track",
 	}
 	if encrypt {
 		args = append(args, "--encrypt")
@@ -492,7 +486,6 @@ func testNestedDefaultEntryUpdate(t *testing.T, encrypt bool) {
 		"--bzzapi",
 		srv.URL,
 		"up",
-		"--no-track",
 		newIndexDataFilename,
 	)
 

--- a/cmd/swarm/upload.go
+++ b/cmd/swarm/upload.go
@@ -48,7 +48,7 @@ var (
 		Name:               "up",
 		Usage:              "uploads a file or directory to swarm using the HTTP API",
 		ArgsUsage:          "<file>",
-		Flags:              []cli.Flag{SwarmEncryptedFlag, SwarmPinFlag, SwarmNoTrackUploadFlag, SwarmVerboseFlag},
+		Flags:              []cli.Flag{SwarmEncryptedFlag, SwarmPinFlag, SwarmProgressFlag, SwarmVerboseFlag},
 		Description:        "uploads a file or directory to swarm using the HTTP API and prints the root hash",
 	}
 
@@ -77,7 +77,7 @@ func upload(ctx *cli.Context) {
 		client          = swarm.NewClient(bzzapi)
 		toEncrypt       = ctx.Bool(SwarmEncryptedFlag.Name)
 		toPin           = ctx.Bool(SwarmPinFlag.Name)
-		notrack         = ctx.Bool(SwarmNoTrackUploadFlag.Name)
+		progress        = ctx.Bool(SwarmProgressFlag.Name)
 		autoDefaultPath = false
 		file            string
 	)
@@ -179,8 +179,8 @@ func upload(ctx *cli.Context) {
 		utils.Fatalf("Upload failed: %s", err)
 	}
 
-	// dont show the progress bar (machine readable output)
-	if notrack {
+	// dont show the progress bar if `progress` flag is not set
+	if !progress {
 		fmt.Println(hash)
 		return
 	}

--- a/cmd/swarm/upload_test.go
+++ b/cmd/swarm/upload_test.go
@@ -90,14 +90,12 @@ func testDefault(t *testing.T, cluster *testCluster, toEncrypt bool) {
 	flags := []string{
 		"--bzzapi", cluster.Nodes[0].URL,
 		"up",
-		"--no-track",
 		tmpFileName}
 	if toEncrypt {
 		hashRegexp = `[a-f\d]{128}`
 		flags = []string{
 			"--bzzapi", cluster.Nodes[0].URL,
 			"up",
-			"--no-track",
 			"--encrypt",
 			tmpFileName}
 	}
@@ -206,7 +204,6 @@ func testRecursive(t *testing.T, cluster *testCluster, toEncrypt bool) {
 		"--bzzapi", cluster.Nodes[0].URL,
 		"--recursive",
 		"up",
-		"--no-track",
 		tmpUploadDir}
 	if toEncrypt {
 		hashRegexp = `[a-f\d]{128}`
@@ -214,7 +211,6 @@ func testRecursive(t *testing.T, cluster *testCluster, toEncrypt bool) {
 			"--bzzapi", cluster.Nodes[0].URL,
 			"--recursive",
 			"up",
-			"--no-track",
 			"--encrypt",
 			tmpUploadDir}
 	}
@@ -315,7 +311,6 @@ func testDefaultPath(t *testing.T, cluster *testCluster, toEncrypt bool, absDefa
 		"--defaultpath",
 		defaultPath,
 		"up",
-		"--no-track",
 	}
 	if toEncrypt {
 		args = append(args, "--encrypt")


### PR DESCRIPTION
If the API pointed to by `swarm up` doesn't support `pushsync` and the user hasn't added `--no-track`, we currently get an error:

```
[lash@furioso tmp]$ swarm --bzzapi https://swarm-gateways.net up photo_2019-10-02_10-10-59.jpg 
Fatal: failed to get tag data for hash: unexpected HTTP status: 404 Not Found
```

Even with session affinity, the progress bar doesn't work with `pullsync` (default Swarm configuration) today.

This PR is fixing this problem by falling back to `swarm up` functionality, which just displays the `hash` of the upload. If the user knows that the API supports `pushsync`, they can use `--progress` to see the progress bar.