### PR TITLE
chunk, cmd/swarm: return last tag

### DIFF
--- a/chunk/tags.go
+++ b/chunk/tags.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"math/rand"
 	"sync"
+	"time"
 
 	"github.com/ethersphere/swarm/sctx"
 )
@@ -71,14 +72,15 @@ func (ts *Tags) Get(uid uint32) (*Tag, error) {
 	return t.(*Tag), nil
 }
 
-// GetByAddress returns the underlying tag for the address or an error if not found
+// GetByAddress returns the latest underlying tag for the address or an error if not found
 func (ts *Tags) GetByAddress(address Address) (*Tag, error) {
 	var t *Tag
+	var lastTime time.Time
 	ts.tags.Range(func(key interface{}, value interface{}) bool {
 		rcvdTag := value.(*Tag)
-		if bytes.Equal(rcvdTag.Address, address) {
+		if bytes.Equal(rcvdTag.Address, address) && rcvdTag.StartedAt.After(lastTime) {
 			t = rcvdTag
-			return false
+			lastTime = rcvdTag.StartedAt
 		}
 		return true
 	})

--- a/cmd/swarm/upload.go
+++ b/cmd/swarm/upload.go
@@ -174,6 +174,8 @@ func upload(ctx *cli.Context) {
 			return client.Upload(f, "", toEncrypt, toPin)
 		}
 	}
+	start := time.Now()
+
 	hash, err := doUpload()
 	if err != nil {
 		utils.Fatalf("Upload failed: %s", err)
@@ -202,7 +204,7 @@ func upload(ctx *cli.Context) {
 		pollTag(client, tag, bars)
 	}
 
-	fmt.Println("Done! took", time.Since(tag.StartedAt))
+	fmt.Println("Done! took", time.Since(start))
 	fmt.Println("Your Swarm hash should now be retrievable from other nodes!")
 }
 


### PR DESCRIPTION
Returns the last tag for correctness of CLI functionality. Also changes the CLI to show how long to execute the command in total