### PR TITLE
pss: Limit by time the retries of messages in the outbox

### DIFF
--- a/pss/outbox/message.go
+++ b/pss/outbox/message.go
@@ -25,11 +25,3 @@ type outboxMsg struct {
 	msg       *message.Message
 	startedAt time.Time
 }
-
-// NewOutboxMessage creates a new outbox message wrapping a pss message.
-func NewOutboxMessage(msg *message.Message) *outboxMsg {
-	return &outboxMsg{
-		msg:       msg,
-		startedAt: time.Now(),
-	}
-}

--- a/pss/outbox/outbox.go
+++ b/pss/outbox/outbox.go
@@ -101,7 +101,7 @@ func (o *Outbox) Enqueue(outboxMsg *outboxMsg) error {
 	select {
 	case slot := <-o.slots:
 		o.queue[slot] = outboxMsg
-		metrics.GetOrRegisterGauge("pss.outbox.len", nil).Update(int64(o.len()))
+		metrics.GetOrRegisterGauge("pss.outbox.len", nil).Update(int64(o.Len()))
 		// we send this message slot to process.
 		select {
 		case <-o.stopC:
@@ -151,7 +151,7 @@ func (o *Outbox) processOutbox() {
 						metrics.GetOrRegisterCounter("pss.forward.expired", nil).Inc(1)
 						log.Warn("Message expired, won't be requeued", "limit", limit, "now", now)
 						o.free(slot)
-						metrics.GetOrRegisterGauge("pss.outbox.len", nil).Update(int64(o.len()))
+						metrics.GetOrRegisterGauge("pss.outbox.len", nil).Update(int64(o.Len()))
 						return
 					}
 					// requeue the message for processing
@@ -161,7 +161,7 @@ func (o *Outbox) processOutbox() {
 				}
 				//message processed, free the outbox slot
 				o.free(slot)
-				metrics.GetOrRegisterGauge("pss.outbox.len", nil).Update(int64(o.len()))
+				metrics.GetOrRegisterGauge("pss.outbox.len", nil).Update(int64(o.Len()))
 			}(slot)
 		}
 	}
@@ -181,10 +181,6 @@ func (o *Outbox) requeue(slot int) {
 	case o.process <- slot:
 	}
 }
-func (o *Outbox) len() int {
-	return cap(o.slots) - len(o.slots)
-}
-
-func (o *Outbox) CurrentSize() int {
+func (o *Outbox) Len() int {
 	return cap(o.slots) - len(o.slots)
 }

--- a/pss/outbox/outbox_test.go
+++ b/pss/outbox/outbox_test.go
@@ -200,19 +200,19 @@ func TestMessageRetriesExpired(t *testing.T) {
 		t.Errorf("Expected no error enqueueing, instead got %v", err)
 	}
 
-	numMessages := testOutbox.CurrentSize()
+	numMessages := testOutbox.Len()
 	if numMessages != 1 {
 		t.Errorf("Expected one message in outbox, instead got %v", numMessages)
 	}
 
 	mockClock.Set(now.Add(duration / 2))
-	numMessages = testOutbox.CurrentSize()
+	numMessages = testOutbox.Len()
 	if numMessages != 1 {
 		t.Errorf("Expected one message in outbox after half maxRetryTime, instead got %v", numMessages)
 	}
 
 	mockClock.Set(now.Add(duration + 1*time.Millisecond))
-	numMessages = testOutbox.CurrentSize()
+	numMessages = testOutbox.Len()
 	// Now we wait for the process routine to retry and expire message at least 10 iterations
 	iterations := 0
 	for numMessages != 0 && iterations < 10 {
@@ -220,7 +220,7 @@ func TestMessageRetriesExpired(t *testing.T) {
 		log.Debug("Still not there, waiting another iteration", numMessages, iterations)
 		time.Sleep(10 * time.Millisecond)
 		iterations++
-		numMessages = testOutbox.CurrentSize()
+		numMessages = testOutbox.Len()
 	}
 	if numMessages != 0 {
 		t.Errorf("Expected 0 message in outbox after expired message, instead got %v", numMessages)

--- a/pss/outbox/outbox_test.go
+++ b/pss/outbox/outbox_test.go
@@ -207,6 +207,14 @@ func TestMessageRetriesExpired(t *testing.T) {
 
 	mockClock.Set(now.Add(duration / 2))
 	numMessages = testOutbox.Len()
+	// Now we wait a bit expecting that the number of messages doesn't change
+	iterations := 0
+	for numMessages == 1 && iterations < 2 {
+		// Wait a bit more to check that the message has not been expired.
+		time.Sleep(10 * time.Millisecond)
+		iterations++
+		numMessages = testOutbox.Len()
+	}
 	if numMessages != 1 {
 		t.Errorf("Expected one message in outbox after half maxRetryTime, instead got %v", numMessages)
 	}
@@ -214,7 +222,7 @@ func TestMessageRetriesExpired(t *testing.T) {
 	mockClock.Set(now.Add(duration + 1*time.Millisecond))
 	numMessages = testOutbox.Len()
 	// Now we wait for the process routine to retry and expire message at least 10 iterations
-	iterations := 0
+	iterations = 0
 	for numMessages != 0 && iterations < 10 {
 		// Still not expired, wait a bit more
 		log.Debug("Still not there, waiting another iteration", numMessages, iterations)

--- a/pss/outbox/outbox_whitebox_test.go
+++ b/pss/outbox/outbox_whitebox_test.go
@@ -41,6 +41,14 @@ func TestFullOutbox(t *testing.T) {
 	testOutbox.Start()
 	defer testOutbox.Stop()
 
+	testOutboxMessage := testOutbox.NewOutboxMessage(&message.Message{
+		To:      nil,
+		Flags:   message.Flags{},
+		Expire:  0,
+		Topic:   message.Topic{},
+		Payload: nil,
+	})
+
 	err := testOutbox.Enqueue(testOutboxMessage)
 	if err != nil {
 		t.Fatalf("unexpected error enqueueing, %v", err)
@@ -64,11 +72,3 @@ func TestFullOutbox(t *testing.T) {
 		t.Fatalf("timeout waiting for a free slot")
 	}
 }
-
-var testOutboxMessage = NewOutboxMessage(&message.Message{
-	To:      nil,
-	Flags:   message.Flags{},
-	Expire:  0,
-	Topic:   message.Topic{},
-	Payload: nil,
-})

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -566,7 +566,8 @@ func (p *Pss) isSelfPossibleRecipient(msg *message.Message, prox bool) bool {
 func (p *Pss) enqueue(msg *message.Message) error {
 	defer metrics.GetOrRegisterResettingTimer("pss.enqueue", nil).UpdateSince(time.Now())
 
-	outboxMsg := outbox.NewOutboxMessage(msg)
+	// TODO: create and enqueue in one outbox method
+	outboxMsg := p.outbox.NewOutboxMessage(msg)
 	return p.outbox.Enqueue(outboxMsg)
 }
 


### PR DESCRIPTION
Whenever a message forwarding fails, the time since first added to the outbox is checked and if certain time has passed  (10 minutes) the message is not requeued.
Additionally a new counter `pss.forward.expired` is increased each time a message is expired.
Tillina clock is used for testability.
This PR solves issue #1804.