### PR TITLE
cmd/swarm: only use the default bootnodes on the default network id

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -45,6 +45,7 @@ import (
 	bzzapi "github.com/ethersphere/swarm/api"
 	"github.com/ethersphere/swarm/internal/debug"
 	swarmmetrics "github.com/ethersphere/swarm/metrics"
+	"github.com/ethersphere/swarm/network"
 	"github.com/ethersphere/swarm/storage/mock"
 	mockrpc "github.com/ethersphere/swarm/storage/mock/rpc"
 	"github.com/ethersphere/swarm/tracing"
@@ -524,6 +525,11 @@ func addDefaultHelpSubcommands(commands []cli.Command) {
 
 func setSwarmBootstrapNodes(ctx *cli.Context, cfg *node.Config) {
 	if ctx.GlobalIsSet(utils.BootnodesFlag.Name) || ctx.GlobalIsSet(utils.BootnodesV4Flag.Name) {
+		return
+	}
+
+	networkid := ctx.GlobalUint64(SwarmNetworkIdFlag.Name)
+	if networkid != network.DefaultNetworkID {
 		return
 	}
 


### PR DESCRIPTION
It looks like that we try to connect to these bootnodes even when using a different network id than the default (4).

We shouldn't do this because the bootnode will reject these peers:

```
DEBUG[10-04|13:17:44.377|p2p/server.go:766]                                              Removing p2p peer                        id=1f204e1e9878e7ef conn=inbound    addr=212.51.xx.zz:53568   peers=52 duration=1.847ms   req=false err="Handshake error: Message handler error: (msg code 0): network id mismatch 61 (!= 4)"
```

It also looks like that the bootnode will blacklist the incoming IP for a while (30seconds):

```
DEBUG[10-04|13:17:55.970|p2p/server.go:874]                                              Rejected inbound connnection             addr=212.51.xx.zz:53606   err="too many attempts"
```

The client connecting to the bootnode will simply get an EOF without knowing why he's not being able to connect:

```
TRACE[10-04|15:05:19.591|p2p/dial.go:290]                                                Dial error                               task="staticdial 1401ec8b40b23cb2 3.122.203.99:30301" err=EOF
```