### PR TITLE
simulation/examples: disable docker test from running locally

### DIFF
--- a/api/http/templates.go
+++ b/api/http/templates.go
@@ -295,7 +295,7 @@ const baseTemplate = `
 <!DOCTYPE html>
 <html>
 <head>
-	<title>Swarm Gateway</title>
+	<title>Swarm</title>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0"/>
 	<meta http-equiv="X-UA-Compatible" ww="chrome=1"/>

--- a/simulation/examples/cluster/cluster_test.go
+++ b/simulation/examples/cluster/cluster_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/ethersphere/swarm/internal/build"
 	"github.com/ethersphere/swarm/simulation"
 	"github.com/ethersphere/swarm/testutil"
 )
@@ -50,6 +51,10 @@ func TestCluster(t *testing.T) {
 
 	// Test docker adapter
 	t.Run("docker", func(t *testing.T) {
+		if env := build.Env(); env.Name == "local" {
+			t.Skip("skip locally")
+		}
+
 		config := simulation.DefaultDockerAdapterConfig()
 		if !simulation.IsDockerAvailable(config.DaemonAddr) {
 			t.Skip("docker is not available, skipping test")


### PR DESCRIPTION
Stops Docker integration tests from running on the local build environment (with love for those of us which are less fortunate with their internet connections)