### PR TITLE
chunk: align Tag fields for atomic operations on 32bit architectures

### DIFF
--- a/chunk/tag.go
+++ b/chunk/tag.go
@@ -51,17 +51,18 @@ type Tag struct {
 	Anonymous bool      // indicates if the tag is anonymous (i.e. if only pull sync should be used)
 	Name      string    // a name tag for this tag
 	Address   Address   // the associated swarm hash for this tag
-	Total     int64     // total chunks belonging to a tag
-	Split     int64     // number of chunks already processed by splitter for hashing
-	Seen      int64     // number of chunks already seen
-	Stored    int64     // number of chunks already stored locally
-	Sent      int64     // number of chunks sent for push syncing
-	Synced    int64     // number of chunks synced with proof
 	StartedAt time.Time // tag started to calculate ETA
 
 	// end-to-end tag tracing
 	ctx  context.Context  // tracing context
 	span opentracing.Span // tracing root span
+
+	Total  int64 // total chunks belonging to a tag
+	Split  int64 // number of chunks already processed by splitter for hashing
+	Seen   int64 // number of chunks already seen
+	Stored int64 // number of chunks already stored locally
+	Sent   int64 // number of chunks sent for push syncing
+	Synced int64 // number of chunks synced with proof
 }
 
 // NewTag creates a new tag, and returns it


### PR DESCRIPTION
It appears that Tag fields alignment was changed after adding Anonymous field. This change should fix atomic operations on 32bit architectures.

https://ci.appveyor.com/project/ethersphere/swarm/builds/28023742/job/rh0ymodqm0ri8vd2#L796