### PR TITLE
retrieve: block unsolicited chunk deliveries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/containerd/containerd v1.2.7 // indirect
 	github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc // indirect
+	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set v0.0.0-20180603214616-504e848d77ea // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v0.7.3-0.20190806133308-ecdb0b22393b

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/containerd/containerd v1.2.7 // indirect
 	github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc // indirect
-	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set v0.0.0-20180603214616-504e848d77ea // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v0.7.3-0.20190806133308-ecdb0b22393b

--- a/network/protocol.go
+++ b/network/protocol.go
@@ -57,7 +57,7 @@ var DefaultTestNetworkID = rand.Uint64()
 // BzzSpec is the spec of the generic swarm handshake
 var BzzSpec = &protocols.Spec{
 	Name:       "bzz",
-	Version:    13,
+	Version:    14,
 	MaxMsgSize: 10 * 1024 * 1024,
 	Messages: []interface{}{
 		HandshakeMsg{},

--- a/network/protocol_test.go
+++ b/network/protocol_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	TestProtocolVersion = 13
+	TestProtocolVersion = 14
 )
 
 var TestProtocolNetworkID = DefaultTestNetworkID

--- a/network/retrieval/peer.go
+++ b/network/retrieval/peer.go
@@ -66,9 +66,10 @@ func (p *Peer) chunkReceived(ruid uint, addr storage.Address) error {
 	defer p.mtx.Unlock()
 	v, ok := p.openRetrievals[ruid]
 	if !ok {
-		return errors.New("chunk not retrieve request cannot be found")
+		return errors.New("unsolicited chunk delivery - cannot find ruid ruid")
 	}
 	if !bytes.Equal(v.addr, addr) {
+		panic(2)
 		return errors.New("retrieve request found but address does not match")
 	}
 

--- a/network/retrieval/peer.go
+++ b/network/retrieval/peer.go
@@ -66,10 +66,9 @@ func (p *Peer) chunkReceived(ruid uint, addr storage.Address) error {
 	defer p.mtx.Unlock()
 	v, ok := p.openRetrievals[ruid]
 	if !ok {
-		return errors.New("unsolicited chunk delivery - cannot find ruid ruid")
+		return errors.New("unsolicited chunk delivery - cannot find ruid")
 	}
 	if !bytes.Equal(v.addr, addr) {
-		panic(2)
 		return errors.New("retrieve request found but address does not match")
 	}
 

--- a/network/retrieval/peer.go
+++ b/network/retrieval/peer.go
@@ -44,14 +44,14 @@ type Peer struct {
 func NewPeer(peer *network.BzzPeer, baseKey []byte) *Peer {
 	return &Peer{
 		BzzPeer:        peer,
-		logger:         log.New("base", hex.EncodeToString(baseKey)[:16], "peer", peer.ID()[:16]),
+		logger:         log.New("base", hex.EncodeToString(baseKey)[:16], "peer", peer.ID().String()[:16]),
 		openRetrievals: make(map[uint]retrieval),
 	}
 }
 
 // RetrievalRequested adds a new retrieval to the openRetrievals map
 // this is in order to block unsolicited chunk delivery attack
-func (p *Peer) RetrievalRequested(ruid uint, addr storage.Address) error {
+func (p *Peer) chunkRequested(ruid uint, addr storage.Address) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 	ret := retrieval{
@@ -61,7 +61,7 @@ func (p *Peer) RetrievalRequested(ruid uint, addr storage.Address) error {
 	p.openRetrievals[ruid] = ret
 }
 
-func (p *Peer) RetrievalReceived(ruid uint, addr storage.Address) error {
+func (p *Peer) chunkReceived(ruid uint, addr storage.Address) error {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 	v, ok := p.openRetrievals[ruid]

--- a/network/retrieval/peer.go
+++ b/network/retrieval/peer.go
@@ -31,10 +31,10 @@ import (
 // Peer wraps BzzPeer with a contextual logger and tracks open
 // retrievals for that peer
 type Peer struct {
-	mtx              sync.Mutex             // synchronize retrievals
-	*network.BzzPeer                        // bzzpeer
-	logger           log.Logger             // logger with base and peer address
-	retrievals       map[uint]chunk.Address // current ongoing retrievals
+	*network.BzzPeer
+	logger     log.Logger             // logger with base and peer address
+	mtx        sync.Mutex             // synchronize retrievals
+	retrievals map[uint]chunk.Address // current ongoing retrievals
 }
 
 // NewPeer is the constructor for Peer
@@ -61,10 +61,9 @@ func (p *Peer) checkRequest(ruid uint, addr storage.Address) error {
 	defer p.mtx.Unlock()
 	v, ok := p.retrievals[ruid]
 	if !ok {
-		return errors.New("unsolicited chunk delivery - cannot find ruid")
+		return errors.New("cannot find ruid")
 	}
-
-	defer delete(p.retrievals, ruid) // since we got the delivery we wanted - it is safe to delete the retrieve request
+	delete(p.retrievals, ruid) // since we got the delivery we wanted - it is safe to delete the retrieve request
 	if !bytes.Equal(v, addr) {
 		return errors.New("retrieve request found but address does not match")
 	}

--- a/network/retrieval/peer.go
+++ b/network/retrieval/peer.go
@@ -17,20 +17,62 @@
 package retrieval
 
 import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"sync"
+
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethersphere/swarm/network"
+	"github.com/ethersphere/swarm/storage"
 )
+
+type retrieval struct {
+	ruid uint
+	addr storage.Address
+}
 
 // Peer wraps BzzPeer with a contextual logger for this peer
 type Peer struct {
+	mtx sync.Mutex
 	*network.BzzPeer
-	logger log.Logger
+	logger         log.Logger
+	openRetrievals map[uint]retrieval
 }
 
 // NewPeer is the constructor for Peer
-func NewPeer(peer *network.BzzPeer) *Peer {
+func NewPeer(peer *network.BzzPeer, baseKey []byte) *Peer {
 	return &Peer{
-		BzzPeer: peer,
-		logger:  log.New("peer", peer.ID()),
+		BzzPeer:        peer,
+		logger:         log.New("base", hex.EncodeToString(baseKey)[:16], "peer", peer.ID()[:16]),
+		openRetrievals: make(map[uint]retrieval),
 	}
+}
+
+// RetrievalRequested adds a new retrieval to the openRetrievals map
+// this is in order to block unsolicited chunk delivery attack
+func (p *Peer) RetrievalRequested(ruid uint, addr storage.Address) error {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	ret := retrieval{
+		ruid: ruid,
+		addr: addr,
+	}
+	p.openRetrievals[ruid] = ret
+}
+
+func (p *Peer) RetrievalReceived(ruid uint, addr storage.Address) error {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	v, ok := p.openRetrievals[ruid]
+	if !ok {
+		return errors.New("chunk not retrieve request cannot be found")
+	}
+	if !bytes.Equal(v.addr, addr) {
+		return errors.New("retrieve request found but address does not match")
+	}
+
+	delete(p.openRetrievals, ruid) // since we got the delivery we wanted - it is safe to delete the retrieve request
+
+	return nil
 }

--- a/network/retrieval/retrieve.go
+++ b/network/retrieval/retrieve.go
@@ -354,7 +354,7 @@ func (r *Retrieval) handleChunkDelivery(ctx context.Context, p *Peer, msg *Chunk
 	if err != nil {
 		// log, measure then drop
 		unsolicitedChunkDelivery.Inc(1)
-		p.logger.Error("unsolicited chunk delivery from peer. dropping", "ruid", msg.Ruid, "addr", msg.Addr)
+		p.logger.Error("unsolicited chunk delivery from peer. dropping", "ruid", msg.Ruid, "addr", msg.Addr, "err", err)
 		p.Drop("unsolicited chunk delivery")
 		return
 	}

--- a/network/retrieval/retrieve.go
+++ b/network/retrieval/retrieve.go
@@ -58,7 +58,7 @@ var (
 
 	spec = &protocols.Spec{
 		Name:       "bzz-retrieve",
-		Version:    1,
+		Version:    2,
 		MaxMsgSize: 10 * 1024 * 1024,
 		Messages: []interface{}{
 			ChunkDelivery{},

--- a/network/retrieval/retrieve.go
+++ b/network/retrieval/retrieve.go
@@ -350,7 +350,7 @@ func (r *Retrieval) handleRetrieveRequest(ctx context.Context, p *Peer, msg *Ret
 // we treat the chunk as a chunk received in syncing
 func (r *Retrieval) handleChunkDelivery(ctx context.Context, p *Peer, msg *ChunkDelivery) {
 	p.logger.Debug("retrieval.handleChunkDelivery", "ref", msg.Addr)
-	err := p.chunkReceived(msg.Ruid, msg.Addr)
+	err := p.checkRequest(msg.Ruid, msg.Addr)
 	if err != nil {
 		unsolicitedChunkDelivery.Inc(1)
 		p.logger.Error("unsolicited chunk delivery from peer. dropping", "ruid", msg.Ruid, "addr", msg.Addr, "err", err)
@@ -430,7 +430,7 @@ FINDPEER:
 		return nil, err
 	}
 
-	protoPeer.chunkRequested(ret.Ruid, ret.Addr)
+	protoPeer.addRetrieval(ret.Ruid, ret.Addr)
 
 	spID := protoPeer.ID()
 	return &spID, nil

--- a/network/retrieval/retrieve.go
+++ b/network/retrieval/retrieve.go
@@ -352,7 +352,6 @@ func (r *Retrieval) handleChunkDelivery(ctx context.Context, p *Peer, msg *Chunk
 	p.logger.Debug("retrieval.handleChunkDelivery", "ref", msg.Addr)
 	err := p.chunkReceived(msg.Ruid, msg.Addr)
 	if err != nil {
-		// log, measure then drop
 		unsolicitedChunkDelivery.Inc(1)
 		p.logger.Error("unsolicited chunk delivery from peer. dropping", "ruid", msg.Ruid, "addr", msg.Addr, "err", err)
 		p.Drop("unsolicited chunk delivery")

--- a/network/retrieval/retrieve.go
+++ b/network/retrieval/retrieve.go
@@ -99,7 +99,6 @@ type Retrieval struct {
 	peers    map[enode.ID]*Peer // compatible peers
 	spec     *protocols.Spec    // protocol spec
 	logger   log.Logger         // custom logger to append a basekey
-	baseKey  []byte             // this node's base address
 	quit     chan struct{}      // shutdown channel
 }
 
@@ -353,7 +352,7 @@ func (r *Retrieval) handleChunkDelivery(ctx context.Context, p *Peer, msg *Chunk
 	err := p.checkRequest(msg.Ruid, msg.Addr)
 	if err != nil {
 		unsolicitedChunkDelivery.Inc(1)
-		p.logger.Error("unsolicited chunk delivery from peer. dropping", "ruid", msg.Ruid, "addr", msg.Addr, "err", err)
+		p.logger.Error("unsolicited chunk delivery from peer", "ruid", msg.Ruid, "addr", msg.Addr, "err", err)
 		p.Drop("unsolicited chunk delivery")
 		return
 	}
@@ -423,10 +422,10 @@ FINDPEER:
 		Ruid: uint(rand.Uint32()),
 		Addr: req.Addr,
 	}
-	protoPeer.logger.Trace("sending retrieve request", "ref", ret.Addr, "origin", localID)
+	protoPeer.logger.Trace("sending retrieve request", "ref", ret.Addr, "origin", localID, "ruid", ret.Ruid)
 	err = protoPeer.Send(ctx, ret)
 	if err != nil {
-		protoPeer.logger.Error("error sending retrieve request to peer", "err", err)
+		protoPeer.logger.Error("error sending retrieve request to peer", "ruid", ret.Ruid, "err", err)
 		return nil, err
 	}
 

--- a/network/retrieval/retrieve.go
+++ b/network/retrieval/retrieve.go
@@ -93,9 +93,9 @@ func (cd *ChunkDelivery) Price() *protocols.Price {
 
 // Retrieval holds state and handles protocol messages for the `bzz-retrieve` protocol
 type Retrieval struct {
+	netStore *storage.NetStore
+	kad      *network.Kademlia
 	mtx      sync.RWMutex       // protect peer map
-	netStore *storage.NetStore  // netstore
-	kad      *network.Kademlia  // kademlia
 	peers    map[enode.ID]*Peer // compatible peers
 	spec     *protocols.Spec    // protocol spec
 	logger   log.Logger         // custom logger to append a basekey
@@ -106,10 +106,10 @@ type Retrieval struct {
 // New returns a new instance of the retrieval protocol handler
 func New(kad *network.Kademlia, ns *storage.NetStore, baseKey []byte, balance protocols.Balance) *Retrieval {
 	r := &Retrieval{
+		netStore: ns,
 		kad:      kad,
 		peers:    make(map[enode.ID]*Peer),
 		spec:     spec,
-		netStore: ns,
 		logger:   log.New("base", hex.EncodeToString(baseKey)[:16]),
 		quit:     make(chan struct{}),
 	}

--- a/network/retrieval/retrieve_test.go
+++ b/network/retrieval/retrieve_test.go
@@ -157,7 +157,7 @@ func TestUnsolicitedChunkDelivery(t *testing.T) {
 	// deliver with a RUID which cannot be found
 	tester.TestExchanges(
 		p2ptest.Exchange{
-			Label: "Non-existant RUID chunk delivery",
+			Label: "Non-existent RUID chunk delivery",
 			Triggers: []p2ptest.Trigger{
 				{
 					Code: 0,
@@ -171,6 +171,7 @@ func TestUnsolicitedChunkDelivery(t *testing.T) {
 			},
 		})
 
+	// expect peer disconnection
 	err = tester.TestDisconnected(&p2ptest.Disconnect{Peer: node.ID(), Error: errors.New("subprotocol error")})
 
 	if err != nil {
@@ -652,28 +653,3 @@ func newTestNetstore(t *testing.T) (prvkey *ecdsa.PrivateKey, netStore *storage.
 	}
 	return prvkey, netStore, cleanup
 }
-
-//func handshakeExchange(tester *p2ptest.ProtocolTester, peerID enode.ID, serveHeadersPeer, serveHeadersPivot bool) error {
-//return tester.TestExchanges(
-//p2ptest.Exchange{
-//Label: "Handshake",
-//Triggers: []p2ptest.Trigger{
-//{
-//Code: 0,
-//Msg: Handshake{
-//ServeHeaders: serveHeadersPeer,
-//},
-//Peer: peerID,
-//},
-//},
-//Expects: []p2ptest.Expect{
-//{
-//Code: 0,
-//Msg: Handshake{
-//ServeHeaders: serveHeadersPivot,
-//},
-//Peer: peerID,
-//},
-//},
-//})
-//}

--- a/network/retrieval/wire.go
+++ b/network/retrieval/wire.go
@@ -20,11 +20,13 @@ import "github.com/ethersphere/swarm/storage"
 
 // RetrieveRequest is the protocol msg for chunk retrieve requests
 type RetrieveRequest struct {
+	Ruid uint
 	Addr storage.Address
 }
 
 // ChunkDelivery is the protocol msg for delivering a solicited chunk to a peer
 type ChunkDelivery struct {
+	Ruid  uint
 	Addr  storage.Address
 	SData []byte
 }

--- a/simulation/examples/cluster/cluster_test.go
+++ b/simulation/examples/cluster/cluster_test.go
@@ -69,6 +69,10 @@ func TestCluster(t *testing.T) {
 
 	// Test kubernetes adapter
 	t.Run("kubernetes", func(t *testing.T) {
+		if env := build.Env(); env.Name == "local" {
+			t.Skip("skip locally")
+		}
+
 		config := simulation.DefaultKubernetesAdapterConfig()
 		if !simulation.IsKubernetesAvailable(config.KubeConfigPath) {
 			t.Skip("kubernetes is not available, skipping test")


### PR DESCRIPTION
This PR adds a `Ruid` to the `retrieve` protocol messages in order to block unsolicited chunk deliveries (which is an attack vector on several swarm properties)

fixes #1800 