### PR TITLE
chunk, pushsync: do not increment synced tags in pushsync

### DIFF
--- a/cmd/swarm/upload.go
+++ b/cmd/swarm/upload.go
@@ -212,7 +212,7 @@ func upload(ctx *cli.Context) {
 }
 
 func pollTag(client *client.Client, hash string, tag *chunk.Tag, bars map[string]*mpb.Bar) {
-	oldTag := *tag
+	oldTag := tag
 	lastTime := time.Now()
 
 	for {
@@ -243,7 +243,7 @@ func pollTag(client *client.Client, hash string, tag *chunk.Tag, bars map[string
 			return
 		}
 
-		oldTag = *newTag
+		oldTag = newTag
 		lastTime = time.Now()
 	}
 }

--- a/pushsync/pusher.go
+++ b/pushsync/pusher.go
@@ -205,14 +205,9 @@ func (p *Pusher) sync() {
 				for i := 0; i < len(syncedAddrs); i++ {
 					hexaddr := syncedAddrs[i].Hex()
 					item, found := p.pushed[hexaddr]
-					if found {
-						tag := item.tag
-						if tag != nil {
-							if tag.Done(chunk.StateSynced) {
-								p.logger.Debug("closing root span for tag", "taguid", tag.Uid, "tagname", tag.Name)
-								tag.FinishRootSpan()
-							}
-						}
+					if found && item.tag != nil && item.tag.Done(chunk.StateSynced) {
+						p.logger.Debug("closing root span for tag", "taguid", item.tag.Uid, "tagname", item.tag.Name)
+						item.tag.FinishRootSpan()
 					}
 
 					delete(p.pushed, hexaddr)

--- a/pushsync/pusher_test.go
+++ b/pushsync/pusher_test.go
@@ -254,6 +254,12 @@ func (tp *testPushSyncIndex) Set(ctx context.Context, _ chunk.ModeSet, addrs ...
 	for _, addr := range addrs {
 		idx := int(binary.BigEndian.Uint64(addr[:8]))
 		tp.sent.Delete(idx)
+
+		tagID := tp.tagIDs[idx%len(tp.tagIDs)]
+		if tag, _ := tp.tags.Get(tagID); tag != nil {
+			tag.Inc(chunk.StateSynced)
+		}
+
 		tp.synced <- idx
 		log.Debug("set chunk synced", "idx", idx, "addr", addr)
 	}

--- a/pushsync/simulation_test.go
+++ b/pushsync/simulation_test.go
@@ -99,7 +99,7 @@ func testPushsyncSimulation(nodeCnt, chunkCnt, testcases int, sf simulation.Serv
 	}
 
 	start := time.Now()
-	log.Error("Snapshot loaded. Simulation starting", "at", start)
+	log.Info("Snapshot loaded. Simulation starting", "at", start)
 	result := sim.Run(ctx, func(ctx context.Context, sim *simulation.Simulation) error {
 		var errg errgroup.Group
 		for j := 0; j < testcases; j++ {
@@ -117,7 +117,7 @@ func testPushsyncSimulation(nodeCnt, chunkCnt, testcases int, sf simulation.Serv
 	if result.Error != nil {
 		return fmt.Errorf("simulation error: %v", result.Error)
 	}
-	log.Error("simulation", "duration", time.Since(start))
+	log.Info("simulation", "duration", time.Since(start))
 	return nil
 }
 
@@ -175,7 +175,12 @@ func newServiceFunc(ctx *adapters.ServiceContext, bucket *sync.Map) (node.Servic
 	if err != nil {
 		return nil, nil, err
 	}
-	lstore, err := localstore.New(dir, addr.Over(), nil)
+
+	tags := chunk.NewTags()
+
+	lstore, err := localstore.New(dir, addr.Over(), &localstore.Options{
+		Tags: tags,
+	})
 	if err != nil {
 		os.RemoveAll(dir)
 		return nil, nil, err
@@ -201,7 +206,7 @@ func newServiceFunc(ctx *adapters.ServiceContext, bucket *sync.Map) (node.Servic
 
 	pubSub := pss.NewPubSub(ps)
 	// setup pusher
-	p := NewPusher(lstore, pubSub, chunk.NewTags())
+	p := NewPusher(lstore, pubSub, tags)
 	bucket.Store(bucketKeyPushSyncer, p)
 
 	// setup storer


### PR DESCRIPTION
This PR is updating the pushsync event loop to not increment tags for synced chunks on receive of receipts (as we are already doing that as part of the localstore mode set).