### PR TITLE
build: configure golangci-lint timeout in .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,8 @@
+# options for analysis running
+run:
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 10m
+
 linters-settings:
   goconst:
     # minimal length of string constant, 3 by default

--- a/build/ci.go
+++ b/build/ci.go
@@ -271,7 +271,6 @@ func doLint(cmdline []string) {
 	configs := []string{
 		"run",
 		"--tests",
-		"--deadline=5m",
 		"--disable-all",
 		"--enable=goimports",
 		"--enable=varcheck",
@@ -279,17 +278,10 @@ func doLint(cmdline []string) {
 		"--enable=gofmt",
 		"--enable=misspell",
 		"--enable=goconst",
+		"--enable=unconvert",
+		"--enable=gosimple",
 	}
 	build.MustRunCommand(filepath.Join(GOBIN, "golangci-lint"), append(configs, packages...)...)
-
-	// Run slow linters one by one
-	for _, linter := range []string{
-		"unconvert",
-		"gosimple",
-	} {
-		configs = []string{"run", "--tests", "--deadline=10m", "--disable-all", "--enable=" + linter}
-		build.MustRunCommand(filepath.Join(GOBIN, "golangci-lint"), append(configs, packages...)...)
-	}
 }
 
 // Release Packaging


### PR DESCRIPTION
This PR removes setting --deadline cli option in golangci-lint calls as it is deprecated and prints a warning about it. The timeout is configured in .golangci.yml. Additionally, there is only one golangci-lint call to simplify and that also reduces total execution time.