### PR TITLE
build, .travis.yml, Makefile, README.md: remove GO111MODULE=on

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ go_import_path: github.com/ethersphere/swarm
 sudo: false
 env:
   global:
-    - GO111MODULE=on
     - GOFLAGS=-mod=vendor
 branches:
   only:

--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,11 @@ alltools:
 # Wrap go modules vendor command to copy forked cgo libraries
 # from go module cache and correct their file permissons.
 .PHONY: vendor
-vendor: export GO111MODULE=on
 vendor:
 	@go mod vendor
-	@cp -rf "$(shell GO111MODULE=on go list -f {{.Dir}} github.com/karalabe/usb)/hidapi" vendor/github.com/karalabe/usb/hidapi
+	@cp -rf "$(shell go list -f {{.Dir}} github.com/karalabe/usb)/hidapi" vendor/github.com/karalabe/usb/hidapi
 	@chmod -R u+w vendor/github.com/karalabe/usb/hidapi
-	@cp -rf "$(shell GO111MODULE=on go list -f {{.Dir}} github.com/karalabe/usb)/libusb" vendor/github.com/karalabe/usb/libusb
+	@cp -rf "$(shell go list -f {{.Dir}} github.com/karalabe/usb)/libusb" vendor/github.com/karalabe/usb/libusb
 	@chmod -R u+w vendor/github.com/karalabe/usb/libusb
-	@cp -rf "$(shell GO111MODULE=on go list -f {{.Dir}} github.com/ethereum/go-ethereum/crypto/secp256k1)/libsecp256k1" vendor/github.com/ethereum/go-ethereum/crypto/secp256k1/libsecp256k1
+	@cp -rf "$(shell go list -f {{.Dir}} github.com/ethereum/go-ethereum/crypto/secp256k1)/libsecp256k1" vendor/github.com/ethereum/go-ethereum/crypto/secp256k1/libsecp256k1
 	@chmod -R u+w vendor/github.com/ethereum/go-ethereum/crypto/secp256k1/libsecp256k1

--- a/README.md
+++ b/README.md
@@ -191,9 +191,9 @@ $ git clone git@github.com:nirname/swarm.git $GOPATH/src/github.com/ethersphere/
 
 Vendoring is done by Makefile rule `make vendor` which uses `go mod vendor` and additionally copies cgo dependencies into `vendor` directory from go modules cache.
 
-If you want to add a new dependency, run `GO111MODULE=on go get <import-path>`, vendor it `make vendor`, then commit the result.
+If you want to add a new dependency, run `go get <import-path>`, vendor it `make vendor`, then commit the result.
 
-If you want to update all dependencies to their latest upstream version, run `GO111MODULE=on go get -u all` and vendor them with `make vendor`.
+If you want to update all dependencies to their latest upstream version, run `go get -u all` and vendor them with `make vendor`.
 
 By default, `go` tool will use dependencies defined in `go.mod` file from modules cache. In order to import code from `vendor` directory, an additional flag `-mod=vendor` must be provided when calling `go run`, `go test`, `go build` and `go install`. If `vendor` directory is in sync with `go.mod` file by updating it with `make vendor`, there should be no difference to use the flag or not. All Swarm build tools are using code only from the `vendor` directory and it is encouraged to do the same in the development process, as well.
 

--- a/build/ci.go
+++ b/build/ci.go
@@ -79,8 +79,6 @@ func executablePath(name string) string {
 func main() {
 	log.SetFlags(log.Lshortfile)
 
-	// Use modules in subcommands.
-	os.Setenv("GO111MODULE", "on")
 	goflgs := "-mod=vendor"
 	if v := os.Getenv("GOFLAGS"); v != "" && v != "-mod=vendor" {
 		goflgs = v + " " + goflgs

--- a/build/env.sh
+++ b/build/env.sh
@@ -21,7 +21,6 @@ fi
 # Set up the environment to use the workspace.
 GOPATH="$workspace"
 export GOPATH
-export GO111MODULE=on
 export GOFLAGS=-mod=vendor
 
 # Run the command inside the workspace.


### PR DESCRIPTION
This PR removes setting GO111MODULE=on environment variable, as it is no longer needed for Go 1.13.