### PR TITLE
netkwork/hive: addPeer function assigned after launching goroutine co…

### DIFF
--- a/network/hive.go
+++ b/network/hive.go
@@ -90,6 +90,8 @@ func NewHive(params *HiveParams, kad *Kademlia, store state.Store) *Hive {
 // these are called on the p2p.Server which runs on the node
 func (h *Hive) Start(server *p2p.Server) error {
 	log.Info("Starting hive", "baseaddr", fmt.Sprintf("%x", h.BaseAddr()[:4]))
+	// assigns the p2p.Server#AddPeer function to connect to peers
+	h.addPeer = server.AddPeer
 	// if state store is specified, load peers to prepopulate the overlay address book
 	if h.Store != nil {
 		log.Info("Detected an existing store. trying to load peers")
@@ -98,8 +100,6 @@ func (h *Hive) Start(server *p2p.Server) error {
 			return err
 		}
 	}
-	// assigns the p2p.Server#AddPeer function to connect to peers
-	h.addPeer = server.AddPeer
 	// ticker to keep the hive alive
 	h.ticker = time.NewTicker(h.KeepAliveInterval)
 	// done channel to signal the connect goroutine to return after Stop


### PR DESCRIPTION
At hive Start() we launch the loadPeers and inside it we launch the goroutine `go h.connectInitialPeers(conns)`. After that addPeer is assigned, this resulted that in some test executions, the connection to the peers is done before the function is set.
We have moved the assign before the loadPeers call.


Previous error
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xb07f2d]

goroutine 31931 [running]:
github.com/ethersphere/swarm/network.(*Hive).connectInitialPeers(0xc00fa226e0, 0xc0148ed880, 0xd, 0xd)
    /home/rinke/go/src/github.com/ethersphere/swarm/network/hive.go:284 +0x5cd
created by github.com/ethersphere/swarm/network.(*Hive).loadPeers
    /home/rinke/go/src/github.com/ethersphere/swarm/network/hive.go:269 +0x59b
FAIL    github.com/ethersphere/swarm/network/simulations/discovery    14.576s
```