### PR TITLE
Fix Hive data races

### DIFF
--- a/network/hive.go
+++ b/network/hive.go
@@ -89,9 +89,16 @@ func NewHive(params *HiveParams, kad *Kademlia, store state.Store) *Hive {
 // server is used to connect to a peer based on its NodeID or enode URL
 // these are called on the p2p.Server which runs on the node
 func (h *Hive) Start(server *p2p.Server) error {
+	return h.start(server, server.AddPeer)
+}
+
+// start stars the hive, receives p2p.Server only at startup
+// server is used to connect to a peer based on its NodeID or enode URL
+// these are called on the p2p.Server which runs on the node
+func (h *Hive) start(server *p2p.Server, addPeerFunc func(*enode.Node)) error {
 	log.Info("Starting hive", "baseaddr", fmt.Sprintf("%x", h.BaseAddr()[:4]))
 	// assigns the p2p.Server#AddPeer function to connect to peers
-	h.addPeer = server.AddPeer
+	h.addPeer = addPeerFunc
 	// if state store is specified, load peers to prepopulate the overlay address book
 	if h.Store != nil {
 		log.Info("Detected an existing store. trying to load peers")

--- a/network/hive_test.go
+++ b/network/hive_test.go
@@ -268,7 +268,9 @@ func TestHiveStateConnections(t *testing.T) {
 	// there should be at some point 5 conns
 	connsAfterLoading := 0
 	iterations := 0
+	h2.Kademlia.lock.Lock()
 	connsAfterLoading = h2.conns.Size()
+	h2.Kademlia.lock.Unlock()
 	for connsAfterLoading != numConns && iterations < 5 {
 		select {
 		case <-addedChan:

--- a/network/hive_test.go
+++ b/network/hive_test.go
@@ -253,7 +253,9 @@ func TestHiveStateConnections(t *testing.T) {
 		}
 
 	}
+	h1.Kademlia.lock.Lock()
 	numConns := h1.conns.Size()
+	h1.Kademlia.lock.Unlock()
 	connAddresses := make(map[string]string)
 	h1.EachConn(h1.base, 255, func(peer *Peer, i int) bool {
 		key := hexutil.Encode(peer.Address())


### PR DESCRIPTION
This PR fixes two data races introduced by the recent change https://github.com/ethersphere/swarm/pull/1844 that affect only tests, not production code.

One is overriding Hive.addPeer function pointer after the Hive has been started:

```
==================
WARNING: DATA RACE
Read at 0x00c000cd4200 by goroutine 346:
  github.com/ethersphere/swarm/network.(*Hive).connectInitialPeers()
      /Users/janos/go/src/github.com/ethersphere/swarm/network/hive.go:291 +0x779

Previous write at 0x00c000cd4200 by goroutine 289:
  github.com/ethersphere/swarm/network.TestHiveStateConnections.func1()
      /Users/janos/go/src/github.com/ethersphere/swarm/network/hive_test.go:221 +0x8d2
  fmt.(*ss).doScanf()
      /usr/local/go/src/fmt/scan.go:1217 +0x382
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  github.com/syndtr/goleveldb/leveldb.(*DB).checkAndCleanFiles()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db_util.go:52 +0x2f8
  github.com/syndtr/goleveldb/leveldb.openDB()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:130 +0x9f0
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x284
  fmt.(*ss).doScanf()
      /usr/local/go/src/fmt/scan.go:1217 +0x382
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  github.com/syndtr/goleveldb/leveldb.(*DB).recoverJournal()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:476 +0xc5
  github.com/syndtr/goleveldb/leveldb.openDB()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:125 +0x9cc
  github.com/syndtr/goleveldb/leveldb.Open()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:197 +0x1d3
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).GetMeta.func1()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:666 +0x791
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).GetMeta.func2()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:356 +0xca
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).GetMeta()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:407 +0x6db
  github.com/syndtr/goleveldb/leveldb.(*session).recover()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/session.go:140 +0xf7
  github.com/syndtr/goleveldb/leveldb.Open()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:183 +0xf8
  github.com/syndtr/goleveldb/leveldb.OpenFile()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:219 +0xa5
  github.com/ethersphere/swarm/network.TestHiveStateConnections.func1()
      /Users/janos/go/src/github.com/ethersphere/swarm/state/dbstore.go:49 +0xae
  github.com/ethersphere/swarm/network.TestHiveStateConnections()
      /Users/janos/go/src/github.com/ethersphere/swarm/network/hive_test.go:268 +0x744
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x284
  fmt.(*ss).doScanf()
      /usr/local/go/src/fmt/scan.go:1217 +0x382
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  github.com/syndtr/goleveldb/leveldb.(*DB).checkAndCleanFiles()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db_util.go:52 +0x2f8
  github.com/syndtr/goleveldb/leveldb.openDB()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:130 +0x9f0
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x284
  fmt.(*ss).doScanf()
      /usr/local/go/src/fmt/scan.go:1217 +0x382
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  github.com/syndtr/goleveldb/leveldb.(*DB).recoverJournal()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:476 +0xc5
  github.com/syndtr/goleveldb/leveldb.openDB()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:125 +0x9cc
  github.com/syndtr/goleveldb/leveldb.Open()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:197 +0x1d3
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  github.com/syndtr/goleveldb/leveldb.(*session).recover.func1()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/session.go:134 +0xf4
  github.com/syndtr/goleveldb/leveldb.(*session).recover()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/session.go:142 +0x1938
  github.com/syndtr/goleveldb/leveldb.Open()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:183 +0xf8
  github.com/syndtr/goleveldb/leveldb.OpenFile()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:219 +0xa5
  github.com/ethersphere/swarm/network.TestHiveStateConnections.func1()
      /Users/janos/go/src/github.com/ethersphere/swarm/state/dbstore.go:49 +0xae
  github.com/ethersphere/swarm/network.TestHiveStateConnections()
      /Users/janos/go/src/github.com/ethersphere/swarm/network/hive_test.go:242 +0x1d6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Goroutine 346 (running) created at:
  github.com/ethersphere/swarm/network.(*Hive).loadPeers()
      /Users/janos/go/src/github.com/ethersphere/swarm/network/hive.go:276 +0x949
  github.com/ethersphere/swarm/network.(*Hive).start()
      /Users/janos/go/src/github.com/ethersphere/swarm/network/hive.go:105 +0x3bb
  github.com/ethersphere/swarm/network.(*Hive).Start()
      /Users/janos/go/src/github.com/ethersphere/swarm/network/hive.go:92 +0xa1
  github.com/ethersphere/swarm/network.TestHiveStateConnections.func1()
      /Users/janos/go/src/github.com/ethersphere/swarm/network/hive_test.go:214 +0x6d7
  fmt.(*ss).doScanf()
      /usr/local/go/src/fmt/scan.go:1217 +0x382
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  github.com/syndtr/goleveldb/leveldb.(*DB).checkAndCleanFiles()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db_util.go:52 +0x2f8
  github.com/syndtr/goleveldb/leveldb.openDB()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:130 +0x9f0
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x284
  fmt.(*ss).doScanf()
      /usr/local/go/src/fmt/scan.go:1217 +0x382
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  github.com/syndtr/goleveldb/leveldb.(*DB).recoverJournal()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:476 +0xc5
  github.com/syndtr/goleveldb/leveldb.openDB()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:125 +0x9cc
  github.com/syndtr/goleveldb/leveldb.Open()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:197 +0x1d3
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).GetMeta.func1()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:666 +0x791
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).GetMeta.func2()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:356 +0xca
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).GetMeta()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:407 +0x6db
  github.com/syndtr/goleveldb/leveldb.(*session).recover()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/session.go:140 +0xf7
  github.com/syndtr/goleveldb/leveldb.Open()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:183 +0xf8
  github.com/syndtr/goleveldb/leveldb.OpenFile()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:219 +0xa5
  github.com/ethersphere/swarm/network.TestHiveStateConnections.func1()
      /Users/janos/go/src/github.com/ethersphere/swarm/state/dbstore.go:49 +0xae
  github.com/ethersphere/swarm/network.TestHiveStateConnections()
      /Users/janos/go/src/github.com/ethersphere/swarm/network/hive_test.go:268 +0x744
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x284
  fmt.(*ss).doScanf()
      /usr/local/go/src/fmt/scan.go:1217 +0x382
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  github.com/syndtr/goleveldb/leveldb.(*DB).checkAndCleanFiles()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db_util.go:52 +0x2f8
  github.com/syndtr/goleveldb/leveldb.openDB()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:130 +0x9f0
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x284
  fmt.(*ss).doScanf()
      /usr/local/go/src/fmt/scan.go:1217 +0x382
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  github.com/syndtr/goleveldb/leveldb.(*DB).recoverJournal()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:476 +0xc5
  github.com/syndtr/goleveldb/leveldb.openDB()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:125 +0x9cc
  github.com/syndtr/goleveldb/leveldb.Open()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:197 +0x1d3
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  github.com/syndtr/goleveldb/leveldb.(*session).recover.func1()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/session.go:134 +0xf4
  github.com/syndtr/goleveldb/leveldb.(*session).recover()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/session.go:142 +0x1938
  github.com/syndtr/goleveldb/leveldb.Open()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:183 +0xf8
  github.com/syndtr/goleveldb/leveldb.OpenFile()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:219 +0xa5
  github.com/ethersphere/swarm/network.TestHiveStateConnections.func1()
      /Users/janos/go/src/github.com/ethersphere/swarm/state/dbstore.go:49 +0xae
  github.com/ethersphere/swarm/network.TestHiveStateConnections()
      /Users/janos/go/src/github.com/ethersphere/swarm/network/hive_test.go:242 +0x1d6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Goroutine 289 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:960 +0x651
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1202 +0xa6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1200 +0x521
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1117 +0x2ff
  main.main()
      _testmain.go:88 +0x223
==================
```

The second is the unprotected access to Kademlia connections pot in TestHiveStateConnections test.

```
==================
WARNING: DATA RACE
Write at 0x00c0003f6048 by goroutine 472:
  github.com/ethersphere/swarm/network.(*Kademlia).On()
      /Users/janos/go/src/github.com/ethersphere/swarm/network/kademlia.go:423 +0x21f
  github.com/ethersphere/swarm/network.TestHiveStateConnections.func1.2()
      /Users/janos/go/src/github.com/ethersphere/swarm/network/hive_test.go:222 +0x244
  github.com/ethersphere/swarm/network.(*Hive).connectInitialPeers()
      /Users/janos/go/src/github.com/ethersphere/swarm/network/hive.go:291 +0x796

Previous read at 0x00c0003f6048 by goroutine 393:
  github.com/ethersphere/swarm/network.TestHiveStateConnections()
      /Users/janos/go/src/github.com/ethersphere/swarm/network/hive_test.go:271 +0x78b
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  github.com/syndtr/goleveldb/leveldb.(*DB).checkAndCleanFiles()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db_util.go:52 +0x2f8
  github.com/syndtr/goleveldb/leveldb.openDB()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:130 +0x9f0
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x284
  fmt.(*ss).doScanf()
      /usr/local/go/src/fmt/scan.go:1217 +0x382
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  github.com/syndtr/goleveldb/leveldb.(*DB).recoverJournal()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:476 +0xc5
  github.com/syndtr/goleveldb/leveldb.openDB()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:125 +0x9cc
  github.com/syndtr/goleveldb/leveldb.Open()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:197 +0x1d3
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).GetMeta.func1()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:666 +0x791
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).GetMeta.func2()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:356 +0xca
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).GetMeta()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:407 +0x6db
  github.com/syndtr/goleveldb/leveldb.(*session).recover()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/session.go:140 +0xf7
  github.com/syndtr/goleveldb/leveldb.Open()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:183 +0xf8
  github.com/syndtr/goleveldb/leveldb.OpenFile()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:219 +0xa5
  github.com/ethersphere/swarm/network.TestHiveStateConnections.func1()
      /Users/janos/go/src/github.com/ethersphere/swarm/state/dbstore.go:49 +0xae
  github.com/ethersphere/swarm/network.TestHiveStateConnections()
      /Users/janos/go/src/github.com/ethersphere/swarm/network/hive_test.go:267 +0x744
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x284
  fmt.(*ss).doScanf()
      /usr/local/go/src/fmt/scan.go:1217 +0x382
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  github.com/syndtr/goleveldb/leveldb.(*DB).checkAndCleanFiles()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db_util.go:52 +0x2f8
  github.com/syndtr/goleveldb/leveldb.openDB()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:130 +0x9f0
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x284
  fmt.(*ss).doScanf()
      /usr/local/go/src/fmt/scan.go:1217 +0x382
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  github.com/syndtr/goleveldb/leveldb.(*DB).recoverJournal()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:476 +0xc5
  github.com/syndtr/goleveldb/leveldb.openDB()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:125 +0x9cc
  github.com/syndtr/goleveldb/leveldb.Open()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:197 +0x1d3
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  github.com/syndtr/goleveldb/leveldb.(*session).recover.func1()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/session.go:134 +0xf4
  github.com/syndtr/goleveldb/leveldb.(*session).recover()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/session.go:142 +0x1938
  github.com/syndtr/goleveldb/leveldb.Open()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:183 +0xf8
  github.com/syndtr/goleveldb/leveldb.OpenFile()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:219 +0xa5
  github.com/ethersphere/swarm/network.TestHiveStateConnections.func1()
      /Users/janos/go/src/github.com/ethersphere/swarm/state/dbstore.go:49 +0xae
  github.com/ethersphere/swarm/network.TestHiveStateConnections()
      /Users/janos/go/src/github.com/ethersphere/swarm/network/hive_test.go:241 +0x1d6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Goroutine 472 (running) created at:
  github.com/ethersphere/swarm/network.(*Hive).loadPeers()
      /Users/janos/go/src/github.com/ethersphere/swarm/network/hive.go:276 +0x949
  github.com/ethersphere/swarm/network.(*Hive).start()
      /Users/janos/go/src/github.com/ethersphere/swarm/network/hive.go:105 +0x3bb
  github.com/ethersphere/swarm/network.TestHiveStateConnections.func1()
      /Users/janos/go/src/github.com/ethersphere/swarm/network/hive_test.go:216 +0x7f4
  fmt.(*ss).doScanf()
      /usr/local/go/src/fmt/scan.go:1217 +0x382
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  github.com/syndtr/goleveldb/leveldb.(*DB).checkAndCleanFiles()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db_util.go:52 +0x2f8
  github.com/syndtr/goleveldb/leveldb.openDB()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:130 +0x9f0
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x284
  fmt.(*ss).doScanf()
      /usr/local/go/src/fmt/scan.go:1217 +0x382
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  github.com/syndtr/goleveldb/leveldb.(*DB).recoverJournal()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:476 +0xc5
  github.com/syndtr/goleveldb/leveldb.openDB()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:125 +0x9cc
  github.com/syndtr/goleveldb/leveldb.Open()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:197 +0x1d3
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).GetMeta.func1()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:666 +0x791
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).GetMeta.func2()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:356 +0xca
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).GetMeta()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:407 +0x6db
  github.com/syndtr/goleveldb/leveldb.(*session).recover()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/session.go:140 +0xf7
  github.com/syndtr/goleveldb/leveldb.Open()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:183 +0xf8
  github.com/syndtr/goleveldb/leveldb.OpenFile()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:219 +0xa5
  github.com/ethersphere/swarm/network.TestHiveStateConnections.func1()
      /Users/janos/go/src/github.com/ethersphere/swarm/state/dbstore.go:49 +0xae
  github.com/ethersphere/swarm/network.TestHiveStateConnections()
      /Users/janos/go/src/github.com/ethersphere/swarm/network/hive_test.go:267 +0x744
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x284
  fmt.(*ss).doScanf()
      /usr/local/go/src/fmt/scan.go:1217 +0x382
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  github.com/syndtr/goleveldb/leveldb.(*DB).checkAndCleanFiles()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db_util.go:52 +0x2f8
  github.com/syndtr/goleveldb/leveldb.openDB()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:130 +0x9f0
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x284
  fmt.(*ss).doScanf()
      /usr/local/go/src/fmt/scan.go:1217 +0x382
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  github.com/syndtr/goleveldb/leveldb.(*DB).recoverJournal()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:476 +0xc5
  github.com/syndtr/goleveldb/leveldb.openDB()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:125 +0x9cc
  github.com/syndtr/goleveldb/leveldb.Open()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:197 +0x1d3
  fmt.Fscanf()
      /usr/local/go/src/fmt/scan.go:143 +0xcf
  github.com/syndtr/goleveldb/leveldb/storage.fsParseName()
      /usr/local/go/src/fmt/scan.go:114 +0x192
  github.com/syndtr/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/storage/file_storage.go:458 +0x2c4
  github.com/syndtr/goleveldb/leveldb.(*session).recover.func1()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/session.go:134 +0xf4
  github.com/syndtr/goleveldb/leveldb.(*session).recover()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/session.go:142 +0x1938
  github.com/syndtr/goleveldb/leveldb.Open()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:183 +0xf8
  github.com/syndtr/goleveldb/leveldb.OpenFile()
      /Users/janos/go/pkg/mod/github.com/syndtr/goleveldb@v0.0.0-20190318030020-c3a204f8e965/leveldb/db.go:219 +0xa5
  github.com/ethersphere/swarm/network.TestHiveStateConnections.func1()
      /Users/janos/go/src/github.com/ethersphere/swarm/state/dbstore.go:49 +0xae
  github.com/ethersphere/swarm/network.TestHiveStateConnections()
      /Users/janos/go/src/github.com/ethersphere/swarm/network/hive_test.go:241 +0x1d6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Goroutine 393 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:960 +0x651
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1202 +0xa6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1200 +0x521
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1117 +0x2ff
  main.main()
      _testmain.go:88 +0x223
==================
```