### PR TITLE
network/retrieval: fix request race

### DIFF
--- a/network/retrieval/retrieve.go
+++ b/network/retrieval/retrieve.go
@@ -423,13 +423,12 @@ FINDPEER:
 		Addr: req.Addr,
 	}
 	protoPeer.logger.Trace("sending retrieve request", "ref", ret.Addr, "origin", localID, "ruid", ret.Ruid)
+	protoPeer.addRetrieval(ret.Ruid, ret.Addr)
 	err = protoPeer.Send(ctx, ret)
 	if err != nil {
 		protoPeer.logger.Error("error sending retrieve request to peer", "ruid", ret.Ruid, "err", err)
 		return nil, err
 	}
-
-	protoPeer.addRetrieval(ret.Ruid, ret.Addr)
 
 	spID := protoPeer.ID()
 	return &spID, nil


### PR DESCRIPTION
This PR fixes a race condition where a retrieve request has been answered by a node before the `peer.addRetrieval` function has been called.

discovered as an edge case when running two Swarm nodes within a VM (but could not be reproduced on a host system)