### PR TITLE
pusher: db.Set before check for synced

### DIFF
--- a/cmd/swarm-smoke/upload_and_sync.go
+++ b/cmd/swarm-smoke/upload_and_sync.go
@@ -304,11 +304,15 @@ func uploadAndSync(c *cli.Context, randomBytes []byte) error {
 	// wait to push sync sync
 	if pushsyncDelay {
 		waitToPushSynced(tag)
+
+		log.Info("push synced successfully", "hash", hash)
 	}
 
 	// wait to sync and log chunks before fetch attempt, only if syncDelay is set to true
 	if syncDelay {
 		waitToSync()
+
+		log.Info("pull synced successfully", "hash", hash)
 	}
 
 	if debug {

--- a/pushsync/pusher.go
+++ b/pushsync/pusher.go
@@ -171,9 +171,9 @@ func (p *Pusher) chunksWorker() {
 					unsubscribe()
 				}
 
+				// reset synced list
 				p.syncedAddrsMu.Lock()
 				syncedAddrs := p.syncedAddrs
-				// reset synced list
 				p.syncedAddrs = nil
 				p.syncedAddrsMu.Unlock()
 
@@ -182,8 +182,8 @@ func (p *Pusher) chunksWorker() {
 					log.Error("pushsync: error setting chunks to synced", "err", err)
 				}
 
-				p.pushedMu.Lock()
 				// delete from pushed item
+				p.pushedMu.Lock()
 				for i := 0; i < len(syncedAddrs); i++ {
 					hexaddr := syncedAddrs[i].Hex()
 					item, found := p.pushed[hexaddr]
@@ -195,9 +195,6 @@ func (p *Pusher) chunksWorker() {
 					delete(p.pushed, hexaddr)
 				}
 				p.pushedMu.Unlock()
-
-				// reset synced list
-				syncedAddrs = nil
 
 				// we don't want to record the first iteration
 				if chunksInBatch != -1 {

--- a/pushsync/pusher.go
+++ b/pushsync/pusher.go
@@ -177,6 +177,11 @@ func (p *Pusher) chunksWorker() {
 				p.syncedAddrs = nil
 				p.syncedAddrsMu.Unlock()
 
+				// set chunk status to synced, insert to db GC index
+				if err := p.store.Set(ctx, chunk.ModeSetSyncPush, syncedAddrs...); err != nil {
+					log.Error("pushsync: error setting chunks to synced", "err", err)
+				}
+
 				p.pushedMu.Lock()
 				// delete from pushed item
 				for i := 0; i < len(syncedAddrs); i++ {
@@ -190,11 +195,6 @@ func (p *Pusher) chunksWorker() {
 					delete(p.pushed, hexaddr)
 				}
 				p.pushedMu.Unlock()
-
-				// set chunk status to synced, insert to db GC index
-				if err := p.store.Set(ctx, chunk.ModeSetSyncPush, syncedAddrs...); err != nil {
-					log.Error("pushsync: error setting chunks to synced", "err", err)
-				}
 
 				// reset synced list
 				syncedAddrs = nil


### PR DESCRIPTION
We want to mark chunks as synced, before actually checking that the tags for a given upload.