### PR TITLE
storage/localstore: do not later batch in setSync if moveToGc is false

### DIFF
--- a/storage/localstore/mode_set_test.go
+++ b/storage/localstore/mode_set_test.go
@@ -220,7 +220,6 @@ func TestModeSetSyncPull(t *testing.T) {
 						po := db.po(ch.Address())
 						binIDs[po]++
 
-						newRetrieveIndexesTestWithAccess(db, ch, wantTimestamp, wantTimestamp)(t)
 						newPullIndexTest(db, ch, binIDs[po], nil)(t)
 						newPushIndexTest(db, ch, wantTimestamp, mtc.expErrPushIndex)(t)
 						newGCIndexTest(db, ch, wantTimestamp, wantTimestamp, binIDs[po], mtc.expErrGCIndex)(t)
@@ -230,6 +229,7 @@ func TestModeSetSyncPull(t *testing.T) {
 						if mtc.anonymous && mtc.mode != chunk.ModeSetSyncPush {
 							// run gc index count test
 							newItemsCountTest(db.gcIndex, tc.count)
+							newRetrieveIndexesTestWithAccess(db, ch, wantTimestamp, wantTimestamp)(t)
 						}
 					}
 


### PR DESCRIPTION
This PR fixes the issue with localstore setSync altering batch when moveToGc is set to false. The batch set in this case is not complete in order to changed access time and gc size change. The result of such mistake is incorrect gc size tracking.

@nonsense This can be validated by running smoke tests and checking bzz_storageIndices rpc response.