### PR TITLE
swap: exchange chain id on handshake

### DIFF
--- a/swap/protocol.go
+++ b/swap/protocol.go
@@ -34,6 +34,9 @@ var (
 	// ErrEmptyAddressInSignature is used when the empty address is used for the chequebook in the handshake
 	ErrEmptyAddressInSignature = errors.New("empty address in handshake")
 
+	// ErrDifferentChainId is used when the chain id exchanged during the handshake does not match
+	ErrDifferentChainId = errors.New("different chain id")
+
 	// ErrInvalidHandshakeMsg is used when the message received during handshake does not conform to the
 	// structure of the HandshakeMsg
 	ErrInvalidHandshakeMsg = errors.New("invalid handshake message")
@@ -98,6 +101,10 @@ func (s *Swap) verifyHandshake(msg interface{}) error {
 		return ErrEmptyAddressInSignature
 	}
 
+	if handshake.ChainID.Cmp(s.chainID) != 0 {
+		return ErrDifferentChainId
+	}
+
 	return s.chequebookFactory.VerifyContract(handshake.ContractAddress)
 }
 
@@ -107,6 +114,7 @@ func (s *Swap) run(p *p2p.Peer, rw p2p.MsgReadWriter) error {
 
 	handshake, err := protoPeer.Handshake(context.Background(), &HandshakeMsg{
 		ContractAddress: s.GetParams().ContractAddress,
+		ChainID:         s.chainID,
 	}, s.verifyHandshake)
 	if err != nil {
 		return err

--- a/swap/protocol.go
+++ b/swap/protocol.go
@@ -34,8 +34,8 @@ var (
 	// ErrEmptyAddressInSignature is used when the empty address is used for the chequebook in the handshake
 	ErrEmptyAddressInSignature = errors.New("empty address in handshake")
 
-	// ErrDifferentChainId is used when the chain id exchanged during the handshake does not match
-	ErrDifferentChainId = errors.New("different chain id")
+	// ErrDifferentChainID is used when the chain id exchanged during the handshake does not match
+	ErrDifferentChainID = errors.New("different chain id")
 
 	// ErrInvalidHandshakeMsg is used when the message received during handshake does not conform to the
 	// structure of the HandshakeMsg
@@ -102,7 +102,7 @@ func (s *Swap) verifyHandshake(msg interface{}) error {
 	}
 
 	if handshake.ChainID != s.chainID {
-		return ErrDifferentChainId
+		return ErrDifferentChainID
 	}
 
 	return s.chequebookFactory.VerifyContract(handshake.ContractAddress)

--- a/swap/protocol.go
+++ b/swap/protocol.go
@@ -101,7 +101,7 @@ func (s *Swap) verifyHandshake(msg interface{}) error {
 		return ErrEmptyAddressInSignature
 	}
 
-	if handshake.ChainID.Cmp(s.chainID) != 0 {
+	if handshake.ChainID != s.chainID {
 		return ErrDifferentChainId
 	}
 

--- a/swap/protocol.go
+++ b/swap/protocol.go
@@ -90,7 +90,7 @@ func (s *Swap) Stop() error {
 	return s.Close()
 }
 
-// verifyHandshake verifies the chequebook address transmitted in the swap handshake
+// verifyHandshake verifies the chequebook address and chain id transmitted in the swap handshake
 func (s *Swap) verifyHandshake(msg interface{}) error {
 	handshake, ok := msg.(*HandshakeMsg)
 	if !ok {

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -90,6 +90,7 @@ func TestHandshake(t *testing.T) {
 				Code: 0,
 				Msg: &HandshakeMsg{
 					ContractAddress: swap.GetParams().ContractAddress,
+					ChainID:         swap.chainID,
 				},
 				Peer: creditor.ID(),
 			},
@@ -99,6 +100,7 @@ func TestHandshake(t *testing.T) {
 				Code: 0,
 				Msg: &HandshakeMsg{
 					ContractAddress: swap.GetParams().ContractAddress,
+					ChainID:         swap.chainID,
 				},
 				Peer: debitor.ID(),
 			},

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"math/big"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -123,7 +122,7 @@ func (s *swapTester) testHandshake(lhs, rhs *HandshakeMsg, disconnects ...*p2pte
 }
 
 // creates a new HandshakeMsg
-func newSwapHandshakeMsg(contractAddress common.Address, chainID *big.Int) *HandshakeMsg {
+func newSwapHandshakeMsg(contractAddress common.Address, chainID uint64) *HandshakeMsg {
 	return &HandshakeMsg{
 		ContractAddress: contractAddress,
 		ChainID:         chainID,
@@ -164,7 +163,7 @@ func TestHandshakeInvalidChainID(t *testing.T) {
 
 	err = protocolTester.testHandshake(
 		correctSwapHandshakeMsg(protocolTester.swap),
-		newSwapHandshakeMsg(protocolTester.swap.GetParams().ContractAddress, big.NewInt(1234)),
+		newSwapHandshakeMsg(protocolTester.swap.GetParams().ContractAddress, 1234),
 		&p2ptest.Disconnect{
 			Peer:  protocolTester.Nodes[0].ID(),
 			Error: errors.New("Handshake error: Message handler error: (msg code 0): different chain id"),
@@ -186,7 +185,7 @@ func TestHandshakeEmptyContract(t *testing.T) {
 
 	err = protocolTester.testHandshake(
 		correctSwapHandshakeMsg(protocolTester.swap),
-		newSwapHandshakeMsg(common.Address{}, big.NewInt(1234)),
+		newSwapHandshakeMsg(common.Address{}, 1234),
 		&p2ptest.Disconnect{
 			Peer:  protocolTester.Nodes[0].ID(),
 			Error: errors.New("Handshake error: Message handler error: (msg code 0): empty address in handshake"),

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -18,7 +18,6 @@ package swap
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -166,7 +165,7 @@ func TestHandshakeInvalidChainID(t *testing.T) {
 		newSwapHandshakeMsg(protocolTester.swap.GetParams().ContractAddress, 1234),
 		&p2ptest.Disconnect{
 			Peer:  protocolTester.Nodes[0].ID(),
-			Error: errors.New("Handshake error: Message handler error: (msg code 0): different chain id"),
+			Error: fmt.Errorf("Handshake error: Message handler error: (msg code 0): %v", ErrDifferentChainID),
 		},
 	)
 	if err != nil {
@@ -188,7 +187,7 @@ func TestHandshakeEmptyContract(t *testing.T) {
 		newSwapHandshakeMsg(common.Address{}, 1234),
 		&p2ptest.Disconnect{
 			Peer:  protocolTester.Nodes[0].ID(),
-			Error: errors.New("Handshake error: Message handler error: (msg code 0): empty address in handshake"),
+			Error: fmt.Errorf("Handshake error: Message handler error: (msg code 0): %v", ErrEmptyAddressInSignature),
 		},
 	)
 	if err != nil {
@@ -210,7 +209,7 @@ func TestHandshakeInvalidContract(t *testing.T) {
 		newSwapHandshakeMsg(ownerAddress, protocolTester.swap.chainID),
 		&p2ptest.Disconnect{
 			Peer:  protocolTester.Nodes[0].ID(),
-			Error: errors.New("Handshake error: Message handler error: (msg code 0): not deployed by factory"),
+			Error: fmt.Errorf("Handshake error: Message handler error: (msg code 0): %v", contract.ErrNotDeployedByFactory),
 		},
 	)
 	if err != nil {

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -230,7 +230,7 @@ func newSharedBackendSwaps(t *testing.T, nodeCount int) (*swapSimulationParams, 
 		if err != nil {
 			t.Fatal(err)
 		}
-		params.swaps[i] = newSwapInstance(stores[i], owner, testBackend, defParams, factory)
+		params.swaps[i] = newSwapInstance(stores[i], owner, testBackend, big.NewInt(10), defParams, factory)
 	}
 
 	params.backend = testBackend

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -230,7 +230,7 @@ func newSharedBackendSwaps(t *testing.T, nodeCount int) (*swapSimulationParams, 
 		if err != nil {
 			t.Fatal(err)
 		}
-		params.swaps[i] = newSwapInstance(stores[i], owner, testBackend, big.NewInt(10), defParams, factory)
+		params.swaps[i] = newSwapInstance(stores[i], owner, testBackend, 10, defParams, factory)
 	}
 
 	params.backend = testBackend

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -62,6 +62,7 @@ type Swap struct {
 	contract          contract.Contract          // reference to the smart contract
 	chequebookFactory contract.SimpleSwapFactory // the chequebook factory used
 	honeyPriceOracle  HoneyOracle                // oracle which resolves the price of honey (in Wei)
+	chainID           *big.Int
 }
 
 // Owner encapsulates information related to accessing the contract
@@ -130,7 +131,7 @@ func swapRotatingFileHandler(logdir string) (log.Handler, error) {
 }
 
 // newSwapInstance is a swap constructor function without integrity checks
-func newSwapInstance(stateStore state.Store, owner *Owner, backend contract.Backend, params *Params, chequebookFactory contract.SimpleSwapFactory) *Swap {
+func newSwapInstance(stateStore state.Store, owner *Owner, backend contract.Backend, chainID *big.Int, params *Params, chequebookFactory contract.SimpleSwapFactory) *Swap {
 	return &Swap{
 		store:             stateStore,
 		peers:             make(map[enode.ID]*Peer),
@@ -139,6 +140,7 @@ func newSwapInstance(stateStore state.Store, owner *Owner, backend contract.Back
 		params:            params,
 		chequebookFactory: chequebookFactory,
 		honeyPriceOracle:  NewHoneyPriceOracle(),
+		chainID:           chainID,
 	}
 }
 
@@ -193,6 +195,7 @@ func New(dbPath string, prvkey *ecdsa.PrivateKey, backendURL string, params *Par
 		stateStore,
 		owner,
 		backend,
+		chainID,
 		params,
 		factory,
 	)

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -62,7 +62,7 @@ type Swap struct {
 	contract          contract.Contract          // reference to the smart contract
 	chequebookFactory contract.SimpleSwapFactory // the chequebook factory used
 	honeyPriceOracle  HoneyOracle                // oracle which resolves the price of honey (in Wei)
-	chainID           *big.Int
+	chainID           uint64                     // id of the chain the backend is connected to
 }
 
 // Owner encapsulates information related to accessing the contract
@@ -131,7 +131,7 @@ func swapRotatingFileHandler(logdir string) (log.Handler, error) {
 }
 
 // newSwapInstance is a swap constructor function without integrity checks
-func newSwapInstance(stateStore state.Store, owner *Owner, backend contract.Backend, chainID *big.Int, params *Params, chequebookFactory contract.SimpleSwapFactory) *Swap {
+func newSwapInstance(stateStore state.Store, owner *Owner, backend contract.Backend, chainID uint64, params *Params, chequebookFactory contract.SimpleSwapFactory) *Swap {
 	return &Swap{
 		store:             stateStore,
 		peers:             make(map[enode.ID]*Peer),
@@ -195,7 +195,7 @@ func New(dbPath string, prvkey *ecdsa.PrivateKey, backendURL string, params *Par
 		stateStore,
 		owner,
 		backend,
-		chainID,
+		chainID.Uint64(),
 		params,
 		factory,
 	)

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -56,13 +56,13 @@ type Swap struct {
 	store             state.Store                // store is needed in order to keep balances and cheques across sessions
 	peers             map[enode.ID]*Peer         // map of all swap Peers
 	peersLock         sync.RWMutex               // lock for peers map
-	backend           contract.Backend           // the backend (blockchain) used
 	owner             *Owner                     // contract access
+	backend           contract.Backend           // the backend (blockchain) used
+	chainID           uint64                     // id of the chain the backend is connected to
 	params            *Params                    // economic and operational parameters
 	contract          contract.Contract          // reference to the smart contract
 	chequebookFactory contract.SimpleSwapFactory // the chequebook factory used
 	honeyPriceOracle  HoneyOracle                // oracle which resolves the price of honey (in Wei)
-	chainID           uint64                     // id of the chain the backend is connected to
 }
 
 // Owner encapsulates information related to accessing the contract

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -1371,7 +1371,7 @@ func newBaseTestSwapWithParams(t *testing.T, key *ecdsa.PrivateKey, params *Para
 	if err != nil {
 		t.Fatal(err)
 	}
-	swap := newSwapInstance(stateStore, owner, backend, big.NewInt(10), params, factory)
+	swap := newSwapInstance(stateStore, owner, backend, 10, params, factory)
 	return swap, dir
 }
 

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -1371,7 +1371,7 @@ func newBaseTestSwapWithParams(t *testing.T, key *ecdsa.PrivateKey, params *Para
 	if err != nil {
 		t.Fatal(err)
 	}
-	swap := newSwapInstance(stateStore, owner, backend, params, factory)
+	swap := newSwapInstance(stateStore, owner, backend, big.NewInt(10), params, factory)
 	return swap, dir
 }
 

--- a/swap/types.go
+++ b/swap/types.go
@@ -17,6 +17,8 @@
 package swap
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -36,6 +38,7 @@ type Cheque struct {
 
 // HandshakeMsg is exchanged on peer handshake
 type HandshakeMsg struct {
+	ChainID         *big.Int
 	ContractAddress common.Address
 }
 

--- a/swap/types.go
+++ b/swap/types.go
@@ -36,8 +36,8 @@ type Cheque struct {
 
 // HandshakeMsg is exchanged on peer handshake
 type HandshakeMsg struct {
-	ChainID         uint64
-	ContractAddress common.Address
+	ChainID         uint64         // chain id of the blockchain the peer is connected to
+	ContractAddress common.Address // chequebook contract address of the peer
 }
 
 // EmitChequeMsg is sent from the debitor to the creditor with the actual cheque

--- a/swap/types.go
+++ b/swap/types.go
@@ -17,8 +17,6 @@
 package swap
 
 import (
-	"math/big"
-
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -38,7 +36,7 @@ type Cheque struct {
 
 // HandshakeMsg is exchanged on peer handshake
 type HandshakeMsg struct {
-	ChainID         *big.Int
+	ChainID         uint64
 	ContractAddress common.Address
 }
 


### PR DESCRIPTION
This PR
* adds the chain id to the swap handshake and aborts on mismatch
* includes a complete rewrite of the handshake test which was broken before (inspired by the protocol tests from the network package)
* introduces tests for all scenarios where the handshake should fail