### PR TITLE
chunk: fix tag Sent value on load, dont persist done tags

### DIFF
--- a/chunk/tags.go
+++ b/chunk/tags.go
@@ -119,7 +119,12 @@ func (ts *Tags) MarshalJSON() (out []byte, err error) {
 	m := make(map[string]*Tag)
 	ts.Range(func(k, v interface{}) bool {
 		key := fmt.Sprintf("%d", k)
-		m[key] = v.(*Tag)
+		val := v.(*Tag)
+
+		// don't persist tags which were already done
+		if !val.Done(StateSynced) {
+			m[key] = val
+		}
 		return true
 	})
 	return json.Marshal(m)
@@ -136,6 +141,11 @@ func (ts *Tags) UnmarshalJSON(value []byte) error {
 		if err != nil {
 			return err
 		}
+
+		// prevent a condition where a chunk was sent before shutdown
+		// and the node was turned off before the receipt was received
+		v.Sent = v.Synced
+
 		ts.tags.Store(key, v)
 	}
 


### PR DESCRIPTION
This PR fixes a state where a chunk was sent with push sync but for which a receipt was not received due to node shutdown. Thus, it is mandatory to set the `tag.Sent` counter to the `tag.Synced` counter, so that the next send of the same chunk (which still exists in push sync index) is accounted for correctly.

Another change introduced here is that `Done` tags should not be persisted. I am open to discuss this but it seemed like the right thing to do at the lack of some sort of pruning mechanism. I am considering either this approach or an approach where only tags which are done and older than `X` days should not be persisted across sessions. Inputs would be appreciated.