### PR TITLE
pss: Pushsync and PSS fixes

### DIFF
--- a/pss/api.go
+++ b/pss/api.go
@@ -174,7 +174,7 @@ func (pssapi *API) SendRaw(addr hexutil.Bytes, topic message.Topic, msg hexutil.
 	if err := validateMsg(msg); err != nil {
 		return err
 	}
-	return pssapi.Pss.SendRaw(PssAddress(addr), topic, msg[:])
+	return pssapi.Pss.SendRaw(PssAddress(addr), topic, msg[:], pssapi.Pss.msgTTL)
 }
 
 func (pssapi *API) GetPeerTopics(pubkeyhex string) ([]message.Topic, error) {

--- a/pss/outbox/mock.go
+++ b/pss/outbox/mock.go
@@ -22,7 +22,6 @@ import (
 
 const (
 	defaultOutboxCapacity = 1000
-	defaultNumWorkers     = 100
 )
 
 var mockForwardFunction = func(msg *message.Message) error {
@@ -36,7 +35,6 @@ func NewMock(config *Config) (outboxMock *Outbox) {
 	if config == nil {
 		config = &Config{
 			NumberSlots: defaultOutboxCapacity,
-			NumWorkers:  defaultNumWorkers,
 			Forward:     mockForwardFunction,
 		}
 	} else {
@@ -45,9 +43,6 @@ func NewMock(config *Config) (outboxMock *Outbox) {
 		}
 		if config.NumberSlots == 0 {
 			config.NumberSlots = defaultOutboxCapacity
-		}
-		if config.NumWorkers == 0 {
-			config.NumWorkers = defaultNumWorkers
 		}
 	}
 	return NewOutbox(config)

--- a/pss/outbox/outbox_test.go
+++ b/pss/outbox/outbox_test.go
@@ -72,7 +72,7 @@ func TestOutbox(t *testing.T) {
 		testOutbox.Enqueue(testOutboxMessage)
 		completionC <- struct{}{}
 	}()
-	expectNotTimeout(completionC, t)
+	expectNotTimeout(t, completionC)
 
 	// We wait for the forward function to success.
 	<-successC
@@ -83,7 +83,7 @@ func TestOutbox(t *testing.T) {
 		testOutbox.Enqueue(testOutboxMessage)
 		completionC <- struct{}{}
 	}()
-	expectNotTimeout(completionC, t)
+	expectNotTimeout(t, completionC)
 
 	// We wait for the forward function to fail
 	select {
@@ -172,7 +172,7 @@ func newTestMessage(num byte) *message.Message {
 
 const blockTimeout = 100 * time.Millisecond
 
-func expectNotTimeout(completionC chan struct{}, t *testing.T) {
+func expectNotTimeout(t *testing.T, completionC chan struct{}) {
 	select {
 	case <-completionC:
 	case <-time.After(blockTimeout):
@@ -180,7 +180,7 @@ func expectNotTimeout(completionC chan struct{}, t *testing.T) {
 	}
 }
 
-func expectTimeout(completionC chan struct{}, t *testing.T) {
+func expectTimeout(t *testing.T, completionC chan struct{}) {
 	select {
 	case <-completionC:
 		t.Fatalf("epxected blocking enqueue")
@@ -221,7 +221,7 @@ func TestMessageRetriesExpired(t *testing.T) {
 		completionC <- struct{}{}
 	}()
 
-	expectNotTimeout(completionC, t)
+	expectNotTimeout(t, completionC)
 
 	numMessages := testOutbox.Len()
 	if numMessages != 1 {

--- a/pss/outbox/outbox_test.go
+++ b/pss/outbox/outbox_test.go
@@ -67,20 +67,24 @@ func TestOutbox(t *testing.T) {
 		Payload: nil,
 	})
 
-	err := testOutbox.Enqueue(testOutboxMessage)
-	if err != nil {
-		t.Fatalf("unexpected error enqueueing, %v", err)
-	}
+	completionC := make(chan struct{})
+	go func() {
+		testOutbox.Enqueue(testOutboxMessage)
+		completionC <- struct{}{}
+	}()
+	expectNotTimeout(completionC, t)
 
 	// We wait for the forward function to success.
 	<-successC
 
 	forwardFail = true
 
-	err = testOutbox.Enqueue(testOutboxMessage)
-	if err != nil {
-		t.Fatalf("unexpected error enqueueing, %v", err)
-	}
+	go func() {
+		testOutbox.Enqueue(testOutboxMessage)
+		completionC <- struct{}{}
+	}()
+	expectNotTimeout(completionC, t)
+
 	// We wait for the forward function to fail
 	select {
 	case <-failedC:
@@ -104,8 +108,7 @@ func TestOutbox(t *testing.T) {
 // TestOutboxWorkers checks that the number of goroutines for processing have a maximum and that there is no
 // deadlock operating.
 func TestOutboxWorkers(t *testing.T) {
-	outboxCapacity := 100
-	workers := 3
+	outboxCapacity := 3
 	endProcess := make(chan struct{}, outboxCapacity)
 
 	var parallel int32
@@ -127,7 +130,6 @@ func TestOutboxWorkers(t *testing.T) {
 	testOutbox := outbox.NewMock(&outbox.Config{
 		NumberSlots: outboxCapacity,
 		Forward:     mockForwardFunction,
-		NumWorkers:  workers,
 	})
 
 	testOutbox.Start()
@@ -153,8 +155,8 @@ func TestOutboxWorkers(t *testing.T) {
 
 	wg.Wait()
 
-	if int(maxParallel) > workers {
-		t.Errorf("Expected maximum %v worker(s) in parallel but got %v", workers, maxParallel)
+	if int(maxParallel) > outboxCapacity {
+		t.Errorf("Expected maximum %v worker(s) in parallel but got %v", outboxCapacity, maxParallel)
 	}
 }
 
@@ -165,6 +167,24 @@ func newTestMessage(num byte) *message.Message {
 		Expire:  0,
 		Topic:   message.Topic{},
 		Payload: []byte{num},
+	}
+}
+
+const blockTimeout = 100 * time.Millisecond
+
+func expectNotTimeout(completionC chan struct{}, t *testing.T) {
+	select {
+	case <-completionC:
+	case <-time.After(blockTimeout):
+		t.Fatalf("timeout waiting for enqueue")
+	}
+}
+
+func expectTimeout(completionC chan struct{}, t *testing.T) {
+	select {
+	case <-completionC:
+		t.Fatalf("epxected blocking enqueue")
+	case <-time.After(blockTimeout):
 	}
 }
 
@@ -195,10 +215,13 @@ func TestMessageRetriesExpired(t *testing.T) {
 		Payload: nil,
 	})
 
-	err := testOutbox.Enqueue(msg)
-	if err != nil {
-		t.Errorf("Expected no error enqueueing, instead got %v", err)
-	}
+	completionC := make(chan struct{})
+	go func() {
+		testOutbox.Enqueue(msg)
+		completionC <- struct{}{}
+	}()
+
+	expectNotTimeout(completionC, t)
 
 	numMessages := testOutbox.Len()
 	if numMessages != 1 {

--- a/pss/outbox/outbox_whitebox_test.go
+++ b/pss/outbox/outbox_whitebox_test.go
@@ -49,20 +49,27 @@ func TestFullOutbox(t *testing.T) {
 		Payload: nil,
 	})
 
-	err := testOutbox.Enqueue(testOutboxMessage)
-	if err != nil {
-		t.Fatalf("unexpected error enqueueing, %v", err)
-	}
+	completionC := make(chan struct{})
+	go func() {
+		testOutbox.Enqueue(testOutboxMessage)
+		completionC <- struct{}{}
+	}()
+	expectNotTimeout(completionC, t)
 
-	err = testOutbox.Enqueue(testOutboxMessage)
-	if err != nil {
-		t.Fatalf("unexpected error enqueueing, %v", err)
-	}
-	// As we haven't signaled processC, the messages are still in the outbox.
-	err = testOutbox.Enqueue(testOutboxMessage)
-	if err != ErrOutboxFull {
-		t.Fatalf("unexpected error type, got %v, wanted %v", err, ErrOutboxFull)
-	}
+	go func() {
+		testOutbox.Enqueue(testOutboxMessage)
+		completionC <- struct{}{}
+	}()
+	expectNotTimeout(completionC, t)
+
+	go func() {
+		testOutbox.Enqueue(testOutboxMessage)
+		completionC <- struct{}{}
+	}()
+	expectTimeout(completionC, t)
+
+	// Now we advance the messages stuck in the forward function. At least 2 of them to leave one space available.
+	processC <- struct{}{}
 	processC <- struct{}{}
 
 	// There should be a slot in the outbox to enqueue.
@@ -70,5 +77,23 @@ func TestFullOutbox(t *testing.T) {
 	case <-testOutbox.slots:
 	case <-time.After(timeout):
 		t.Fatalf("timeout waiting for a free slot")
+	}
+}
+
+const blockTimeout = 100 * time.Millisecond
+
+func expectNotTimeout(completionC chan struct{}, t *testing.T) {
+	select {
+	case <-completionC:
+	case <-time.After(blockTimeout):
+		t.Fatalf("timeout waiting for enqueue")
+	}
+}
+
+func expectTimeout(completionC chan struct{}, t *testing.T) {
+	select {
+	case <-completionC:
+		t.Fatalf("epxected blocking enqueue")
+	case <-time.After(blockTimeout):
 	}
 }

--- a/pss/outbox/outbox_whitebox_test.go
+++ b/pss/outbox/outbox_whitebox_test.go
@@ -54,19 +54,19 @@ func TestFullOutbox(t *testing.T) {
 		testOutbox.Enqueue(testOutboxMessage)
 		completionC <- struct{}{}
 	}()
-	expectNotTimeout(completionC, t)
+	expectNotTimeout(t, completionC)
 
 	go func() {
 		testOutbox.Enqueue(testOutboxMessage)
 		completionC <- struct{}{}
 	}()
-	expectNotTimeout(completionC, t)
+	expectNotTimeout(t, completionC)
 
 	go func() {
 		testOutbox.Enqueue(testOutboxMessage)
 		completionC <- struct{}{}
 	}()
-	expectTimeout(completionC, t)
+	expectTimeout(t, completionC)
 
 	// Now we advance the messages stuck in the forward function. At least 2 of them to leave one space available.
 	processC <- struct{}{}
@@ -82,7 +82,7 @@ func TestFullOutbox(t *testing.T) {
 
 const blockTimeout = 100 * time.Millisecond
 
-func expectNotTimeout(completionC chan struct{}, t *testing.T) {
+func expectNotTimeout(t *testing.T, completionC chan struct{}) {
 	select {
 	case <-completionC:
 	case <-time.After(blockTimeout):
@@ -90,10 +90,10 @@ func expectNotTimeout(completionC chan struct{}, t *testing.T) {
 	}
 }
 
-func expectTimeout(completionC chan struct{}, t *testing.T) {
+func expectTimeout(t *testing.T, completionC chan struct{}) {
 	select {
 	case <-completionC:
-		t.Fatalf("epxected blocking enqueue")
+		t.Fatalf("expected blocking enqueue")
 	case <-time.After(blockTimeout):
 	}
 }

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -493,7 +493,6 @@ func (p *Pss) handlePssMsg(ctx context.Context, pssmsg *message.Message) error {
 func (p *Pss) process(pssmsg *message.Message, raw bool, prox bool) error {
 	defer metrics.GetOrRegisterResettingTimer("pss.process", nil).UpdateSince(time.Now())
 
-	var err error
 	var payload []byte
 	var from PssAddress
 	var asymmetric bool
@@ -512,6 +511,7 @@ func (p *Pss) process(pssmsg *message.Message, raw bool, prox bool) error {
 			keyFunc = p.processAsym
 		}
 
+		var err error
 		payload, keyid, from, err = keyFunc(pssmsg)
 		if err != nil {
 			return errors.New("decryption failed")
@@ -522,7 +522,7 @@ func (p *Pss) process(pssmsg *message.Message, raw bool, prox bool) error {
 		p.enqueue(pssmsg)
 	}
 	p.executeHandlers(psstopic, payload, from, raw, prox, asymmetric, keyid)
-	return err
+	return nil
 }
 
 // copy all registered handlers for respective topic in order to avoid data race or deadlock

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -596,7 +596,7 @@ func (p *Pss) enqueue(msg *message.Message) {
 // Send a raw message (any encryption is responsibility of calling client)
 //
 // Will fail if raw messages are disallowed
-func (p *Pss) SendRaw(address PssAddress, topic message.Topic, msg []byte, messageTtl time.Duration) error {
+func (p *Pss) SendRaw(address PssAddress, topic message.Topic, msg []byte, messageTTL time.Duration) error {
 	defer metrics.GetOrRegisterResettingTimer("pss.send.raw", nil).UpdateSince(time.Now())
 
 	if err := validateAddress(address); err != nil {
@@ -609,7 +609,7 @@ func (p *Pss) SendRaw(address PssAddress, topic message.Topic, msg []byte, messa
 
 	pssMsg := message.New(pssMsgParams)
 	pssMsg.To = address
-	pssMsg.Expire = uint32(time.Now().Add(p.msgTTL).Unix())
+	pssMsg.Expire = uint32(time.Now().Add(messageTTL).Unix())
 	pssMsg.Payload = msg
 	pssMsg.Topic = topic
 
@@ -737,7 +737,7 @@ func sendMsg(p *Pss, sp *network.Peer, msg *message.Message) bool {
 //// forwarding fails, the node should try to forward it to the next best peer, until the message is
 //// successfully forwarded to at least one peer.
 func (p *Pss) forward(msg *message.Message) error {
-	defer metrics.GetOrRegisterResettingTimer("pss.forward.time", nil).UpdateSince(time.Now())
+	defer metrics.GetOrRegisterResettingTimer("pss.forward", nil).UpdateSince(time.Now())
 	sent := 0 // number of successful sends
 	to := make([]byte, addressLength)
 	copy(to[:len(msg.To)], msg.To)

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -439,7 +439,6 @@ func (p *Pss) handle(ctx context.Context, peer *protocols.Peer, msg interface{})
 // If yes, it CAN be for us, and we process it
 // Only passes error to pss protocol handler if payload is not valid pssmsg
 func (p *Pss) handlePssMsg(ctx context.Context, pssmsg *message.Message) error {
-	metrics.GetOrRegisterCounter("pss.handle.num", nil).Inc(1)
 	defer metrics.GetOrRegisterResettingTimer("pss.handle", nil).UpdateSince(time.Now())
 
 	log.Trace("handler", "self", label(p.Kademlia.BaseAddr()), "topic", label(pssmsg.Topic[:]))
@@ -492,7 +491,6 @@ func (p *Pss) handlePssMsg(ctx context.Context, pssmsg *message.Message) error {
 // Attempts symmetric and asymmetric decryption with stored keys.
 // Dispatches message to all handlers matching the message topic
 func (p *Pss) process(pssmsg *message.Message, raw bool, prox bool) error {
-	metrics.GetOrRegisterCounter("pss.process.num", nil).Inc(1)
 	defer metrics.GetOrRegisterResettingTimer("pss.process", nil).UpdateSince(time.Now())
 
 	var err error
@@ -588,7 +586,6 @@ func (p *Pss) isSelfPossibleRecipient(msg *message.Message, prox bool) bool {
 /////////////////////////////////////////////////////////////////////
 
 func (p *Pss) enqueue(msg *message.Message) {
-	metrics.GetOrRegisterCounter("pss.enqueue.num", nil).Inc(1)
 	defer metrics.GetOrRegisterResettingTimer("pss.enqueue", nil).UpdateSince(time.Now())
 
 	// TODO: create and enqueue in one outbox method
@@ -700,6 +697,7 @@ var sendFunc = sendMsg
 
 // tries to send a message, returns true if successful
 func sendMsg(p *Pss, sp *network.Peer, msg *message.Message) bool {
+	defer metrics.GetOrRegisterResettingTimer("pss.pp.send", nil).UpdateSince(time.Now())
 	var isPssEnabled bool
 	info := sp.Info()
 	for _, capability := range info.Caps {
@@ -725,7 +723,6 @@ func sendMsg(p *Pss, sp *network.Peer, msg *message.Message) bool {
 		metrics.GetOrRegisterCounter("pss.pp.send.error", nil).Inc(1)
 		log.Error(err.Error())
 	}
-	metrics.GetOrRegisterCounter("pss.pp.send", nil).Inc(1)
 	return err == nil
 }
 
@@ -740,7 +737,6 @@ func sendMsg(p *Pss, sp *network.Peer, msg *message.Message) bool {
 //// forwarding fails, the node should try to forward it to the next best peer, until the message is
 //// successfully forwarded to at least one peer.
 func (p *Pss) forward(msg *message.Message) error {
-	metrics.GetOrRegisterCounter("pss.forward", nil).Inc(1)
 	defer metrics.GetOrRegisterResettingTimer("pss.forward.time", nil).UpdateSince(time.Now())
 	sent := 0 // number of successful sends
 	to := make([]byte, addressLength)

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -707,7 +707,7 @@ func sendMsg(p *Pss, sp *network.Peer, msg *message.Message) bool {
 		}
 	}
 	if !isPssEnabled {
-		log.Warn("peer doesn't have matching pss capabilities, skipping", "peer", info.Name, "caps", info.Caps, "peer", label(sp.BzzAddr.Address()))
+		log.Trace("peer doesn't have matching pss capabilities, skipping", "peer", info.Name, "caps", info.Caps, "peer", label(sp.BzzAddr.Address()))
 		return false
 	}
 

--- a/pss/pubsub.go
+++ b/pss/pubsub.go
@@ -17,11 +17,12 @@
 package pss
 
 import (
+	"time"
+
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethersphere/swarm/network"
 	"github.com/ethersphere/swarm/pss/message"
-	"time"
 )
 
 // PubSub implements the pushsync.PubSub interface using pss
@@ -70,5 +71,5 @@ func (p *PubSub) Send(to []byte, topic string, msg []byte) error {
 	metrics.GetOrRegisterCounter("pss.pubsub.send.num", nil).Inc(1)
 	defer metrics.GetOrRegisterResettingTimer("pss.pubsub.send", nil).UpdateSince(time.Now())
 	pt := message.NewTopic([]byte(topic))
-	return p.pss.SendRaw(PssAddress(to), pt, msg, 20 * time.Second)
+	return p.pss.SendRaw(PssAddress(to), pt, msg, 20*time.Second)
 }

--- a/pss/pubsub.go
+++ b/pss/pubsub.go
@@ -28,7 +28,7 @@ import (
 // PubSub implements the pushsync.PubSub interface using pss
 type PubSub struct {
 	pss        *Pss
-	messageTTL time.Duration  // expire duration of a pubsub message. Depends on the use case.
+	messageTTL time.Duration // expire duration of a pubsub message. Depends on the use case.
 }
 
 // NewPubSub creates a new PubSub

--- a/pss/pubsub.go
+++ b/pss/pubsub.go
@@ -17,9 +17,11 @@
 package pss
 
 import (
+	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethersphere/swarm/network"
 	"github.com/ethersphere/swarm/pss/message"
+	"time"
 )
 
 // PubSub implements the pushsync.PubSub interface using pss
@@ -65,6 +67,8 @@ func (p *PubSub) Register(topic string, prox bool, handler func(msg []byte, p *p
 
 // Send sends a message using pss SendRaw
 func (p *PubSub) Send(to []byte, topic string, msg []byte) error {
+	metrics.GetOrRegisterCounter("pss.pubsub.send.num", nil).Inc(1)
+	defer metrics.GetOrRegisterResettingTimer("pss.pubsub.send", nil).UpdateSince(time.Now())
 	pt := message.NewTopic([]byte(topic))
-	return p.pss.SendRaw(PssAddress(to), pt, msg)
+	return p.pss.SendRaw(PssAddress(to), pt, msg, 20 * time.Second)
 }

--- a/pushsync/simulation_test.go
+++ b/pushsync/simulation_test.go
@@ -204,7 +204,7 @@ func newServiceFunc(ctx *adapters.ServiceContext, bucket *sync.Map) (node.Servic
 	r := retrieval.New(kad, netStore, kad.BaseAddr(), nil)
 	netStore.RemoteGet = r.RequestFromPeers
 
-	pubSub := pss.NewPubSub(ps)
+	pubSub := pss.NewPubSub(ps, 1*time.Second)
 	// setup pusher
 	p := NewPusher(lstore, pubSub, tags)
 	bucket.Store(bucketKeyPushSyncer, p)

--- a/swarm.go
+++ b/swarm.go
@@ -258,7 +258,8 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 	}
 
 	if config.PushSyncEnabled {
-		pubsub := pss.NewPubSub(self.ps)
+		// expire time for push-sync messages should be lower than regular chat-like messages to avoid network flooding
+		pubsub := pss.NewPubSub(self.ps, 20*time.Second)
 		self.pushSync = pushsync.NewPusher(localStore, pubsub, self.tags)
 		self.storer = pushsync.NewStorer(self.netStore, pubsub)
 	}


### PR DESCRIPTION
This PR tries to improve the performance of PSS under the push-sync use case. It has been tested with the integration tests and several minor fixes has been applied:

- Removed non-blocking nature of outbox.Enqueue. From now on, when all slots are used, the caller code will block.
- Removed numberWorkers params. Now both the outbox length and the number of workers are the same and controlled by the same parameter.
- Changed default Outbox capacity (too much parallelism degraded sending performance)
- Changed cache TTL, message expiration for push sync messages and cache clean interval based on observations.
- Added several metrics to monitor PSS performance:
  - Number of handled messages
  - Number of processed messages (messages meant for this node)
  - Number of forwarded messages
  - Time spent in outbox
  - Time spent in forwarding function
  - Time spent in p2p send function
  - Cache hits and misses
  - ...

A new dashboard could be added to Grafana. I have an example combining PSS and pushsync metrics in [epiclabs repo](https://raw.githubusercontent.com/epiclabs-io/swarm-helm-charts/charts-fix/swarm-private/grafana-dashboards/pss-pushsync.json 
)

Because Enqueue doesn't return an error anymore, the tests have been complicated to check for blocking/non-blocking of the Enqueue method.
