### PR TITLE
bzzeth: Phase2 of bzz eth protocol

### DIFF
--- a/bzzeth/bzzeth.go
+++ b/bzzeth/bzzeth.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
@@ -568,8 +567,6 @@ func (b *BzzEth) getBlockHeadersEth(ctx context.Context, headersC, giveBackC cha
 		go b.getDelivery(ctx, req, &wg)
 	}
 	wg.Wait()
-
-	fmt.Println("Finishing getBlockHeadersEth")
 }
 
 func (b *BzzEth) getDelivery(ctx context.Context, req *request, wg *sync.WaitGroup) {

--- a/bzzeth/bzzeth.go
+++ b/bzzeth/bzzeth.go
@@ -314,9 +314,7 @@ func (b *BzzEth) validateHeader(ctx context.Context, header []byte, req *request
 		} else {
 			setHeaderAsReceived(req, ch.Address().Hex())
 			// This channel is used to track deliveries
-			if req.c != nil {
-				req.c <- header
-			}
+			req.c <- header
 			return ch, nil
 		}
 	} else {

--- a/bzzeth/bzzeth.go
+++ b/bzzeth/bzzeth.go
@@ -21,26 +21,27 @@ import (
 	"encoding/hex"
 	"errors"
 	"sync"
+	"time"
 
-	"golang.org/x/sync/errgroup"
-
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethersphere/swarm/chunk"
 	"github.com/ethersphere/swarm/log"
 	"github.com/ethersphere/swarm/network"
+	"github.com/ethersphere/swarm/network/timeouts"
 	"github.com/ethersphere/swarm/p2p/protocols"
+	"github.com/ethersphere/swarm/spancontext"
 	"github.com/ethersphere/swarm/storage"
+	"golang.org/x/sync/errgroup"
 )
 
 var (
-	errUnsolicitedHeader = errors.New("unsolicited header received")
-	errDuplicateHeader   = errors.New("duplicate header received")
-)
-
-var (
+	errUnsolicitedHeader    = errors.New("unsolicited header received")
+	errDuplicateHeader      = errors.New("duplicate header received")
 	errRcvdMsgFromSwarmNode = errors.New("received message from Swarm node")
 )
 
@@ -105,6 +106,8 @@ func (b *BzzEth) handleMsg(p *Peer) func(context.Context, interface{}) error {
 			go b.handleNewBlockHeaders(ctx, p, msg)
 		case *BlockHeaders:
 			go b.handleBlockHeaders(ctx, p, msg)
+		case *GetBlockHeaders:
+			go b.handleGetBlockHeaders(ctx, p, msg)
 		}
 		return nil
 	}
@@ -155,12 +158,13 @@ func (b *BzzEth) handleNewBlockHeaders(ctx context.Context, p *Peer, msg *NewBlo
 
 	// request them from the offering peer and deliver in a channel
 	deliveries := make(chan []byte)
-	req, err := p.getBlockHeaders(ctx, hashes, deliveries)
+	req, err := p.getBlockHeaders(ctx, hashes, deliveries, nil)
 	if err != nil {
 		p.logger.Error("Error sending GetBlockHeader message", "Reason", err)
 		return
 	}
 	defer req.cancel()
+	defer close(req.c)
 
 	// this loop blocks until all delivered or context done
 	// only needed to log results
@@ -175,7 +179,7 @@ func (b *BzzEth) handleNewBlockHeaders(ctx context.Context, p *Peer, msg *NewBlo
 			deliveredCnt++
 			p.logger.Trace("bzzeth.handleNewBlockHeaders", "hash", hex.EncodeToString(hash), "delivered", deliveredCnt)
 			if deliveredCnt == len(req.hashes) {
-				p.logger.Debug("Delivered all headers", "count", deliveredCnt)
+				p.logger.Debug("all headers delivered", "count", deliveredCnt)
 				finishDeliveryFunc(req.hashes)
 				return
 			}
@@ -241,6 +245,29 @@ func (b *BzzEth) handleBlockHeaders(ctx context.Context, p *Peer, msg *BlockHead
 	}
 }
 
+// debug function to display header contents
+func displayHeader(h []byte) {
+	var hdr types.Header
+	err := rlp.DecodeBytes(h, &hdr)
+	if err != nil {
+		log.Error("Could not decode header")
+		return
+	}
+	log.Trace("Header ", "ParentHash", hdr.ParentHash.Hex())
+	log.Trace("Header ", "UncleHash", hdr.UncleHash.Hex())
+	log.Trace("Header ", "Coinbase", hdr.Coinbase.Hex())
+	log.Trace("Header ", "Root", hdr.Root.Hex())
+	log.Trace("Header ", "TxHash", hdr.TxHash.Hex())
+	log.Trace("Header ", "ReceiptHash", hdr.ReceiptHash.Hex())
+	log.Trace("Header ", "MixDigest", hdr.MixDigest.Hex())
+
+	log.Trace("Header ", "Difficulty", hdr.Difficulty)
+	log.Trace("Header ", "Number", hdr.Number)
+	log.Trace("Header ", "GasLimit", hdr.GasLimit)
+	log.Trace("Header ", "GasUsed", hdr.GasUsed)
+	log.Trace("Header ", "Time", time.Unix(int64(hdr.Time), 0))
+}
+
 // Validates and headers asynchronously and stores the valid chunks in one go
 func (b *BzzEth) deliverAndStoreAll(ctx context.Context, req *request, headers [][]byte) error {
 	chunks := make([]chunk.Chunk, 0)
@@ -266,10 +293,22 @@ func (b *BzzEth) deliverAndStoreAll(ctx context.Context, req *request, headers [
 
 	// wait for all validations to get over and close the channels
 	err := wg.Wait()
+
+	// Store all the valid header chunks in one shot
+	storeErr := b.storeChunks(ctx, chunks)
+	if storeErr != nil {
+		return err
+	}
+
+	// Pass on the validation error if any
 	if err != nil {
 		return err
 	}
 
+	return nil
+}
+
+func (b *BzzEth) storeChunks(ctx context.Context, chunks []chunk.Chunk) error {
 	// Store all the valid header chunks in one shot
 	results, err := b.netStore.Put(ctx, chunk.ModePutUpload, chunks...)
 	if err != nil {
@@ -296,7 +335,14 @@ func (b *BzzEth) validateHeader(ctx context.Context, header []byte, req *request
 			return nil, errDuplicateHeader
 		} else {
 			setHeaderAsReceived(req, ch.Address().Hex())
-			req.c <- ch.Address()
+			// This channel is used ot track deliveries
+			if req.c != nil {
+				req.c <- ch.Address()
+			}
+			// This channel is used to give back the header to the requesting eth node
+			if req.giveBackC != nil {
+				req.giveBackC <- header
+			}
 			return ch, nil
 		}
 	} else {
@@ -324,6 +370,256 @@ func setHeaderAsReceived(req *request, addr string) {
 func newChunk(data []byte) chunk.Chunk {
 	hash := crypto.Keccak256(data)
 	return chunk.NewChunk(hash, data)
+}
+
+var arrangeHeaderFunc = arrangeHeader
+
+// arrangeHeader is used in testing the response headers delivered to the light client
+// This function does nothing in normal operation, but in test case, it arranges the headers
+// as per the position of the hashes received, soas to become predictable
+func arrangeHeader(hashes [][]byte, headers [][]byte) [][]byte {
+	return headers
+}
+
+// handles GetBlockHeader requests, in the protocol handler this call is asynchronous
+// so it is safe to have it run until delivery is finished
+func (b *BzzEth) handleGetBlockHeaders(ctx context.Context, p *Peer, msg *GetBlockHeaders) {
+	p.logger.Debug("bzzeth.handleGetBlockHeaders", "id", msg.Rid, "hash", hex.EncodeToString(msg.Hashes[0]))
+	total := len(msg.Hashes)
+	ctx, osp := spancontext.StartSpan(ctx, "bzzeth.handleGetBlockHeaders")
+	defer osp.Finish()
+
+	deliveries := make(chan []byte)
+	defer close(deliveries)
+	trigger := make(chan chan [][]byte)
+	defer close(trigger)
+	batches := make(chan [][]byte)
+	defer close(batches)
+
+	// deliver in batches, this blocks until total number of requests are delivered or considered not found
+	go readToBatches(deliveries, trigger)
+
+	// asynchronously request all headers as swarm chunks
+	go b.requestAll(ctx, deliveries, msg.Hashes, p)
+
+	// Send a trigger to create a batch
+	trigger <- batches
+
+	deliveredCnt := 0
+	var err error
+	// this loop terminates if
+	// - batches channel is closed (because the underlying deliveries channel is closed) OR
+	// - context is done
+	// the implementation aspires to send as many as possible as early as possible
+DELIVERY:
+	for headers := range batches {
+		deliveredCnt += len(headers)
+		headers = arrangeHeaderFunc(msg.Hashes, headers)
+
+		// convert bytes to rlp.RawValue
+		rawHeaders := make([]rlp.RawValue, len(headers))
+		for i, h := range headers {
+			rawHeaders[i] = h
+			displayHeader(h)
+		}
+
+		p.logger.Debug("sending headers", "count", len(rawHeaders))
+		if err = p.Send(ctx, &BlockHeaders{
+			Rid:     uint32(msg.Rid),
+			Headers: rawHeaders,
+		}); err != nil { // in case of a send error, the peer will disconnect so can safely return
+			break DELIVERY
+		}
+		// Break if all the headers are delivered
+		if deliveredCnt >= total {
+			break DELIVERY
+		}
+		select {
+		case trigger <- batches: // signal that we are ready for another batch
+		case <-ctx.Done():
+			break DELIVERY
+		}
+	}
+	p.logger.Debug("bzzeth.handleGetBlockHeaders", "id", msg.Rid, "total", total, "delivered", deliveredCnt, "err", err)
+	if err == nil && deliveredCnt < total { // if there was no send error and we deliver less than requested
+		err := p.Send(ctx, &BlockHeaders{Rid: uint32(msg.Rid)}) // it is prudent to send an empty BlockHeaders message
+		if err != nil {
+			p.logger.Error("could not send empty BlockHeader")
+		}
+	}
+	p.logger.Debug("bzzeth.handleGetBlockHeaders: sent all headers", "id", msg.Rid)
+}
+
+var batchWait = 100 * time.Millisecond // time to wait for collecting headers in a batch
+var minBatchSize = 1                   // minimum headers in a batch
+
+// readToBatches reads items from an input channel into a buffer and
+// sends non-empty buffers on a channel read from the out
+func readToBatches(in chan []byte, out chan chan [][]byte) {
+	var buffer [][]byte
+	var trigger chan chan [][]byte
+BATCH:
+	for {
+		select {
+		case batches := <-trigger: // new batch channel available
+			if batches == nil { // terminate if batches channel is closed, no more batches accepted
+				return
+			}
+			batches <- buffer // otherwise write buffer into batch channel
+			if in == nil {    // terminate if in channel is already closed, sent last batch
+				return
+			}
+			buffer = nil  // otherwise start new buffer
+			trigger = nil // block this case: disallow new batches until enough in buffer
+
+		case item, more := <-in: // reading input
+
+			if !more {
+				in = nil       // block this case: disallow read from closed channel
+				continue BATCH // wait till last batch can send
+			}
+			// otherwise collect item in buffer
+			buffer = append(buffer, item)
+		default:
+			if len(buffer) >= minBatchSize { // if buffer is not empty
+				trigger = out  // allow sending batch
+				continue BATCH // wait till next batch can send
+			}
+			time.Sleep(batchWait) // otherwise wait and continue
+		}
+	}
+}
+
+// getBlockHeaderBzz retrieves a block header by its hash from swarm
+func (b *BzzEth) getBlockHeaderBzz(ctx context.Context, hash []byte) ([]byte, error) {
+	req := &storage.Request{
+		Addr:   hash,
+		Origin: b.netStore.LocalID,
+	}
+	chnk, err := b.netStore.Get(ctx, chunk.ModeGetRequest, req)
+	if err != nil {
+		return nil, err
+	}
+	return chnk.Data(), nil
+}
+
+// requestAll requests each hash and channel
+func (b *BzzEth) requestAll(ctx context.Context, deliveries chan []byte, hashes [][]byte, rcvdPeer *Peer) {
+	ctx, cancel := context.WithTimeout(ctx, timeouts.FetcherGlobalTimeout)
+	defer cancel()
+
+	// missingHeaders collects hashes of headers not found within swarm
+	// ie., the hashes to request from the eth full nodes
+	missingHeaders := make(chan []byte)
+	defer close(missingHeaders)
+	var wg sync.WaitGroup
+
+BZZ:
+	for _, h := range hashes {
+		hdr := make([]byte, len(h))
+		copy(hdr, h)
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+			header, err := b.getBlockHeaderBzz(ctx, hdr)
+			if err != nil {
+				log.Debug("bzzeth.requestAll: netstore.Get can not retrieve chunk", "ref", hex.EncodeToString(h), "err", err)
+				select {
+				case missingHeaders <- hdr: // fallback: request header from eth peers
+				case <-ctx.Done():
+				}
+				return
+			}
+			// deliver the headers received from Swarm
+			select {
+			case deliveries <- header:
+			case <-ctx.Done():
+			}
+		}()
+
+		select {
+		case <-ctx.Done():
+			break BZZ
+		default:
+		}
+	}
+
+	// fall back to retrieval from eth clients
+	// collect missing block header hashes
+	// terminates after missingHeaders is read and closed or context is done
+	wg.Add(1)
+	go b.getBlockHeadersEth(ctx, missingHeaders, deliveries, &wg, rcvdPeer)
+
+	// wait till all hashes are requested from swarm OR from another eth node,
+	wg.Wait()
+
+}
+
+// getBlockHeadersEth manages fetching headers from ethereum bzzeth nodes
+// This is part of the response to GetBlockHeaders requests by bzzeth light/syncing nodes
+// As a fallback after header retrieval from local storage and swarm network are unsuccessful
+// When called, it
+// - reads requested header hashes from a channel (headerC) and
+// - creates batch requests and sends them to an adequate bzzeth peer
+// - channels the responses into a delivery channel (deliveries)
+func (b *BzzEth) getBlockHeadersEth(ctx context.Context, headersC, giveBackC chan []byte, pwg *sync.WaitGroup, rcvdPeer *Peer) {
+	log.Debug("getting missing headers from another ETH node", "count", len(giveBackC))
+	defer pwg.Done() // unblock the parent so that i can continue
+
+	// read header requests into batches
+	readNext := make(chan chan [][]byte)
+	batches := make(chan [][]byte)
+	go readToBatches(headersC, readNext)
+	readNext <- batches
+
+	// send GetBlockHeader requests to adequate bzzeth peers
+	// this loop terminates when batches channel is closed as a result of input headersC being closed
+	requiredCount := 0
+	var wg sync.WaitGroup
+	deliveryC := make(chan []byte)
+	total := len(headersC)
+	defer close(deliveryC)
+	for header := range batches {
+		p := b.peers.getEth(rcvdPeer) // find candidate peer to serve the headers
+		if p == nil {                 // if no peer found just skip the batch TODO: smarter retry?
+			continue
+		}
+		// initiate request with the chosen peer
+		req, err := p.getBlockHeaders(ctx, header, deliveryC, giveBackC)
+		if err != nil { // in case of failure, no retries TODO: smarter retry?
+			continue
+		}
+
+		wg.Add(1)
+		go b.getDelivery(ctx, req, &wg)
+		requiredCount++
+
+		if requiredCount >= total {
+			break
+		}
+	}
+	wg.Wait()
+}
+
+func (b *BzzEth) getDelivery(ctx context.Context, req *request, wg *sync.WaitGroup) {
+	defer wg.Done()
+	defer req.cancel()
+	for {
+		select {
+		case hash, ok := <-req.c:
+			if !ok {
+				log.Debug("could not get delivery of a missing header")
+				return
+			}
+			if _, ok := req.hashes[hex.EncodeToString(hash)]; ok {
+				log.Debug("delivered missing header ", "header", hex.EncodeToString(hash))
+				return
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
 }
 
 // Protocols returns the p2p protocol

--- a/bzzeth/bzzeth.go
+++ b/bzzeth/bzzeth.go
@@ -310,13 +310,12 @@ func (b *BzzEth) validateHeader(ctx context.Context, header []byte, req *request
 		if headerAlreadyReceived {
 			// header already received
 			return nil, errDuplicateHeader
-		} else {
-			// header is still marked as "yet to be received" and we got that header
-			setHeaderAsReceived(req, ch.Address().Hex())
-			// This channel is used to track deliveries
-			req.c <- header
-			return ch, nil
 		}
+		// header is still marked as "yet to be received" and we got that header
+		setHeaderAsReceived(req, ch.Address().Hex())
+		// This channel is used to track deliveries
+		req.c <- header
+		return ch, nil
 	} else {
 		// header is not present in the request hash.
 		return nil, errUnsolicitedHeader

--- a/bzzeth/bzzeth_test.go
+++ b/bzzeth/bzzeth_test.go
@@ -23,16 +23,19 @@ import (
 	"encoding/hex"
 	"errors"
 	"io/ioutil"
+	"math/big"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethersphere/swarm/chunk"
 	"github.com/ethersphere/swarm/network"
+	"github.com/ethersphere/swarm/network/retrieval"
 	p2ptest "github.com/ethersphere/swarm/p2p/testing"
 	"github.com/ethersphere/swarm/storage"
 	"github.com/ethersphere/swarm/storage/localstore"
@@ -64,17 +67,19 @@ func newBzzEthTester(t *testing.T, prvkey *ecdsa.PrivateKey, netStore *storage.N
 }
 
 func newTestNetworkStore(t *testing.T) (prvkey *ecdsa.PrivateKey, netStore *storage.NetStore, cleanup func()) {
+	t.Helper()
 	prvkey, err := crypto.GenerateKey()
 	if err != nil {
 		t.Fatalf("Could not generate key")
 	}
+	bzzAddr := network.PrivateKeyToBzzKey(prvkey)
 
+	kad := network.NewKademlia(bzzAddr, network.NewKadParams())
 	dir, err := ioutil.TempDir("", "localstore-")
 	if err != nil {
 		t.Fatalf("Could not create localStore temp dir")
 	}
 
-	bzzAddr := network.PrivateKeyToBzzKey(prvkey)
 	localStore, err := localstore.New(dir, bzzAddr, nil)
 	if err != nil {
 		os.RemoveAll(dir)
@@ -82,6 +87,8 @@ func newTestNetworkStore(t *testing.T) (prvkey *ecdsa.PrivateKey, netStore *stor
 	}
 
 	netStore = storage.NewNetStore(localStore, bzzAddr, enode.ID{})
+	r := retrieval.New(kad, netStore, bzzAddr, nil)
+	netStore.RemoteGet = r.RequestFromPeers
 
 	cleanup = func() {
 		err = netStore.Close()
@@ -138,11 +145,10 @@ func dummyHandshakeMessage(tester *p2ptest.ProtocolTester, peerID enode.ID) erro
 		})
 }
 
-// tests handshake between eth node and swarm node
+// TestBzzEthHandshake between eth node and swarm node
 // on successful handshake the protocol does not go idle
 // peer added to the pool and serves headers is registered
 func TestBzzEthHandshake(t *testing.T) {
-	t.Helper()
 	tester, b, teardown, err := newBzzEthTester(t, nil, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -276,7 +282,7 @@ func newBlockHeaderExchange(tester *p2ptest.ProtocolTester, peerID enode.ID, req
 				{
 					Code: 2,
 					Msg: GetBlockHeaders{
-						Rid:    requestID,
+						Rid:    uint64(requestID),
 						Hashes: wanted,
 					},
 					Peer: peerID,
@@ -302,6 +308,33 @@ func blockHeaderExchange(tester *p2ptest.ProtocolTester, peerID enode.ID, reques
 		})
 }
 
+func getBlockHeaderExchange(tester *p2ptest.ProtocolTester, peerID enode.ID, requestID uint32, wantedHashes [][]byte, offeredHeaders []rlp.RawValue) error {
+	return tester.TestExchanges(
+		p2ptest.Exchange{
+			Label: "GetBlockHeaders",
+			Triggers: []p2ptest.Trigger{
+				{
+					Code: 2,
+					Msg: GetBlockHeaders{
+						Rid:    uint64(requestID),
+						Hashes: wantedHashes,
+					},
+					Peer: peerID,
+				},
+			},
+			Expects: []p2ptest.Expect{
+				{
+					Code: 3,
+					Msg: BlockHeaders{
+						Rid:     requestID,
+						Headers: offeredHeaders,
+					},
+					Peer: peerID,
+				},
+			},
+		})
+}
+
 // TestNewBlockHeaders full eth node sends new block header hashes
 // respond with a GetBlockHeaders requesting headers falling into the proximity of this node
 // Also test two other conditions
@@ -309,6 +342,12 @@ func blockHeaderExchange(tester *p2ptest.ProtocolTester, peerID enode.ID, reques
 // - If a unsolicited header is received, dont store it on localstore
 // Apart from that it also tests if all the headers are delivered and stored in localstore
 func TestNewBlockHeaders(t *testing.T) {
+	var wg sync.WaitGroup
+
+	// Add two.. one for storage and another for delivery
+	// these groups are moved to Done after storage and delivery checks are complete
+	wg.Add(2)
+
 	prvKey, netstore, cleanup := newTestNetworkStore(t)
 	defer cleanup()
 
@@ -323,7 +362,8 @@ func TestNewBlockHeaders(t *testing.T) {
 	//Construct the blocks hashes that are offered from the eth node
 	offeredBlocks := make(NewBlockHeaders, 256)
 	for i := 0; i < len(offeredBlocks); i++ {
-		offeredBlocks[i].Hash = common.BytesToHash(crypto.Keccak256([]byte{uint8(i)}))
+		hdr := types.Header{Number: new(big.Int).SetUint64(uint64(i))}
+		offeredBlocks[i].Hash = hdr.Hash()
 		offeredBlocks[i].BlockHeight = uint64(i)
 	}
 
@@ -348,11 +388,16 @@ func TestNewBlockHeaders(t *testing.T) {
 	}
 
 	// construct the wanted headers
-	wantedHeaderHashes := make([][]byte, len(wantedIndexes))
-	wantedHeaderData := make([]rlp.RawValue, len(wantedIndexes)+1)
+	wanted := make([][]byte, len(wantedIndexes))
+	wantedData := make([]rlp.RawValue, len(wantedIndexes)+1)
 	for i, w := range wantedIndexes {
-		wantedHeaderHashes[i] = crypto.Keccak256([]byte{uint8(w)})
-		wantedHeaderData[i] = rlp.RawValue{uint8(w)}
+		hdr := types.Header{Number: new(big.Int).SetUint64(uint64(w))}
+		res, err := rlp.EncodeToBytes(hdr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantedData[i] = res
+		wanted[i] = hdr.Hash().Bytes()
 	}
 
 	// overwrite newRequestIDFunc to be deterministic
@@ -366,13 +411,15 @@ func TestNewBlockHeaders(t *testing.T) {
 
 	// overwrite finishStorageFunc to test deterministic storage of headers
 	finishStorageTesting := func(chunks []chunk.Chunk) {
-		checkStorage(t, wantedIndexes, wantedHeaderHashes, wantedHeaderData, netstore)
+		checkStorage(t, wantedIndexes, wanted, wantedData, netstore)
+		wg.Done()
 	}
 	finishStorageFunc = finishStorageTesting
 
 	// overwrite finishDeliveryFunc to test deterministic delivery of headers
 	finishDeliveryTesting := func(hashes map[string]bool) {
-		checkDelivery(t, wantedIndexes, wantedHeaderHashes, hashes)
+		checkDelivery(t, wantedIndexes, wanted, hashes)
+		wg.Done()
 	}
 	finishDeliveryFunc = finishDeliveryTesting
 
@@ -384,33 +431,127 @@ func TestNewBlockHeaders(t *testing.T) {
 
 	// Add a header to localstore
 	// this header should not be requested in GetBlockHeaders
-	_, err = netstore.Store.Put(context.Background(), chunk.ModePutUpload, newChunk([]byte{uint8(ignoreIndexes[0])}))
+	hdr := types.Header{Number: new(big.Int).SetUint64(uint64(ignoreIndexes[0]))}
+	res, err := rlp.EncodeToBytes(hdr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = netstore.Store.Put(context.Background(), chunk.ModePutUpload, newChunk(res))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = newBlockHeaderExchange(tester, node.ID(), newRequestIDFunc(), &offeredBlocks, wantedHeaderHashes)
+	// Adding ignored hash also .. this hash will be ignored while storing
+	err = newBlockHeaderExchange(tester, node.ID(), newRequestIDFunc(), &offeredBlocks, wanted)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Add a unsolicited header
-	wantedHeaderData[len(wantedIndexes)] = rlp.RawValue{uint8(255)}
-	err = blockHeaderExchange(tester, node.ID(), newRequestIDFunc(), wantedHeaderData)
+	unsolHdr := types.Header{Number: new(big.Int).SetUint64(255)}
+	unsolRes, err := rlp.EncodeToBytes(unsolHdr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantedData[len(wantedIndexes)] = unsolRes
+	err = blockHeaderExchange(tester, node.ID(), newRequestIDFunc(), wantedData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the storage and delivery checks to complete
+	// only after that the cleanup functions should be allowed
+	wg.Wait()
+}
+
+//TestGetAvailableBlockHeaders tests the other side of the protocol where a light client
+// asks the Swarm node for blocks
+func TestGetAvailableBlockHeaders(t *testing.T) {
+	prvKey, netstore, cleanup := newTestNetworkStore(t)
+	defer cleanup()
+
+	// bzz pivot - full eth node peer
+	tester, _, teardown, err := newBzzEthTester(t, prvKey, netstore)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer teardown()
+
+	// Set this to same number of requested headers to avoid batch splitting during testcase
+	minBatchSize = 20
+
+	// construct the wanted headers hashes to request and the offered headers to check
+	// Also store the headers in the localstore to avoid remote lookup
+	// Dont use more than 2 as there is a risk of getting multiple batches which is not testcase friendly
+	wantedHeaderHashes := make([][]byte, 20)
+	offeredHeaders := make([]rlp.RawValue, 20)
+	for i := range wantedHeaderHashes {
+		hdr := types.Header{Number: new(big.Int).SetUint64(uint64(i))}
+		res, err := rlp.EncodeToBytes(hdr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantedHeaderHashes[i] = hdr.Hash().Bytes()
+		offeredHeaders[i] = res
+
+		// store the headers in localstore so that they are offered in response
+		chunkToStore := newChunk(res)
+		yes, err := netstore.Store.Put(context.Background(), chunk.ModePutUpload, chunkToStore)
+		if err != nil {
+			t.Fatalf("could not store chunk")
+		}
+		if yes[0] {
+			t.Fatalf("chunk already found")
+		}
+	}
+
+	// arrange the headers in the order requested for the test case to pass
+	arrangeHeaderTesting := func(hashes [][]byte, headers [][]byte) [][]byte {
+		hdrMap := make(map[string][]byte)
+		for _, h := range headers {
+			var hdr types.Header
+			err := rlp.DecodeBytes(h, &hdr)
+			if err != nil {
+				t.Fatal("Could not decode header")
+				return nil
+			}
+			hdrMap[hdr.Hash().Hex()] = h
+		}
+
+		myheaders := make([][]byte, len(hashes))
+		i := 0
+		for _, k := range hashes {
+			key := "0x" + hex.EncodeToString(k)
+			if hdr, ok := hdrMap[key]; ok {
+				myheaders[i] = hdr
+				i++
+			}
+		}
+		return myheaders
+	}
+	arrangeHeaderFunc = arrangeHeaderTesting
+
+	node := tester.Nodes[0]
+	err = handshakeExchange(tester, node.ID(), true, true)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	//Now trigger the get header request
+	err = getBlockHeaderExchange(tester, node.ID(), newRequestIDFunc(), wantedHeaderHashes, offeredHeaders)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func checkStorage(t *testing.T, wantedIndexes []int, wanted [][]byte, wantedData []rlp.RawValue, netstore *storage.NetStore) {
-	t.Helper()
-
 	// Check if requested headers arrived and are stored in localstore
 	for i := range wantedIndexes {
 		chunk, err := netstore.Store.Get(context.Background(), chunk.ModeGetLookup, wanted[i])
 		if err != nil {
-			t.Fatalf("chunk  %v not found %v", hex.EncodeToString(wanted[i]), wantedData[i])
+			t.Fatalf("chunk  %v not found", hex.EncodeToString(wanted[i]))
 		}
+
 		if !bytes.Equal(wantedData[i], chunk.Data()) {
 			t.Fatalf("expected %v, got %v", wanted[i], chunk.Data())
 		}
@@ -428,7 +569,6 @@ func checkStorage(t *testing.T, wantedIndexes []int, wanted [][]byte, wantedData
 }
 
 func checkDelivery(t *testing.T, wantedIndexes []int, wanted [][]byte, hashes map[string]bool) {
-	t.Helper()
 	for i := range wantedIndexes {
 		hash := hex.EncodeToString(wanted[i])
 		if _, ok := hashes[hash]; !ok {

--- a/bzzeth/bzzeth_test.go
+++ b/bzzeth/bzzeth_test.go
@@ -267,7 +267,7 @@ func isPeerDisconnected(id enode.ID, b *BzzEth) (p *Peer) {
 	return
 }
 
-func newBlockHeaderExchange(tester *p2ptest.ProtocolTester, peerID enode.ID, requestID uint32, offered *NewBlockHeaders, wanted [][]byte) error {
+func newBlockHeaderExchange(tester *p2ptest.ProtocolTester, peerID enode.ID, requestID uint32, offered *NewBlockHeaders, wanted []chunk.Address) error {
 	return tester.TestExchanges(
 		p2ptest.Exchange{
 			Label: "NewBlockHeaders",
@@ -308,7 +308,7 @@ func blockHeaderExchange(tester *p2ptest.ProtocolTester, peerID enode.ID, reques
 		})
 }
 
-func getBlockHeaderExchange(tester *p2ptest.ProtocolTester, peerID enode.ID, requestID uint32, wantedHashes [][]byte, offeredHeaders []rlp.RawValue) error {
+func getBlockHeaderExchange(tester *p2ptest.ProtocolTester, peerID enode.ID, requestID uint32, wantedHashes []chunk.Address, offeredHeaders []rlp.RawValue) error {
 	return tester.TestExchanges(
 		p2ptest.Exchange{
 			Label: "GetBlockHeaders",
@@ -388,7 +388,7 @@ func TestNewBlockHeaders(t *testing.T) {
 	}
 
 	// construct the wanted headers
-	wanted := make([][]byte, len(wantedIndexes))
+	wanted := make([]chunk.Address, len(wantedIndexes))
 	wantedData := make([]rlp.RawValue, len(wantedIndexes)+1)
 	for i, w := range wantedIndexes {
 		hdr := types.Header{Number: new(big.Int).SetUint64(uint64(w))}
@@ -483,7 +483,7 @@ func TestGetAvailableBlockHeaders(t *testing.T) {
 	// construct the wanted headers hashes to request and the offered headers to check
 	// Also store the headers in the localstore to avoid remote lookup
 	// Dont use more than 2 as there is a risk of getting multiple batches which is not testcase friendly
-	wantedHeaderHashes := make([][]byte, 20)
+	wantedHeaderHashes := make([]chunk.Address, 20)
 	offeredHeaders := make([]rlp.RawValue, 20)
 	for i := range wantedHeaderHashes {
 		hdr := types.Header{Number: new(big.Int).SetUint64(uint64(i))}
@@ -506,7 +506,7 @@ func TestGetAvailableBlockHeaders(t *testing.T) {
 	}
 
 	// arrange the headers in the order requested for the test case to pass
-	arrangeHeaderTesting := func(hashes [][]byte, headers [][]byte) [][]byte {
+	arrangeHeaderTesting := func(hashes []chunk.Address, headers []chunk.Address) []chunk.Address {
 		hdrMap := make(map[string][]byte)
 		for _, h := range headers {
 			var hdr types.Header
@@ -518,7 +518,7 @@ func TestGetAvailableBlockHeaders(t *testing.T) {
 			hdrMap[hdr.Hash().Hex()] = h
 		}
 
-		myheaders := make([][]byte, len(hashes))
+		myheaders := make([]chunk.Address, len(hashes))
 		i := 0
 		for _, k := range hashes {
 			key := "0x" + hex.EncodeToString(k)
@@ -544,7 +544,7 @@ func TestGetAvailableBlockHeaders(t *testing.T) {
 	}
 }
 
-func checkStorage(t *testing.T, wantedIndexes []int, wanted [][]byte, wantedData []rlp.RawValue, netstore *storage.NetStore) {
+func checkStorage(t *testing.T, wantedIndexes []int, wanted []chunk.Address, wantedData []rlp.RawValue, netstore *storage.NetStore) {
 	// Check if requested headers arrived and are stored in localstore
 	for i := range wantedIndexes {
 		chunk, err := netstore.Store.Get(context.Background(), chunk.ModeGetLookup, wanted[i])
@@ -568,7 +568,7 @@ func checkStorage(t *testing.T, wantedIndexes []int, wanted [][]byte, wantedData
 	}
 }
 
-func checkDelivery(t *testing.T, wantedIndexes []int, wanted [][]byte, hashes map[string]bool) {
+func checkDelivery(t *testing.T, wantedIndexes []int, wanted []chunk.Address, hashes map[string]bool) {
 	for i := range wantedIndexes {
 		hash := hex.EncodeToString(wanted[i])
 		if _, ok := hashes[hash]; !ok {

--- a/bzzeth/peer.go
+++ b/bzzeth/peer.go
@@ -22,6 +22,8 @@ import (
 	"math/rand"
 	"sync"
 
+	"github.com/ethersphere/swarm/chunk"
+
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethersphere/swarm/p2p/protocols"
@@ -101,7 +103,7 @@ type request struct {
 	hashes    map[string]bool // remembers the block hashes that are requested in this connection
 	lock      sync.RWMutex    // mutex to update the hashes received status
 	c         chan []byte     // channel in which the received block headers hash are passed on
-	giveBackC chan []byte     // channel in which channel in which the received block headers hash are passed onthe received block headers contents are passed back
+	giveBackC chan []byte     // channel in which the received block headers hash are passed
 	cancel    func()          // function to call in case of cancellation of the GetBlockHeaders event
 }
 
@@ -124,7 +126,7 @@ func newRequests() *requests {
 // create constructs a new request
 // registers it on the peer request pool
 // request.cancel() should be called to cleanup
-func (r *requests) create(hashes [][]byte, c chan []byte, g chan []byte) (*request, uint32) {
+func (r *requests) create(hashes []chunk.Address, c chan []byte, g chan []byte) (*request, uint32) {
 	req := &request{
 		hashes:    make(map[string]bool),
 		c:         c,
@@ -160,7 +162,7 @@ func (r *requests) get(id uint32) (*request, bool) {
 
 // getBlockHeaders sends a GetBlockHeaders message to the remote peer requesting headers by their _hashes_
 // and delivers the actual block header responses to the deliveries channel
-func (p *Peer) getBlockHeaders(ctx context.Context, hashes [][]byte, deliveries chan []byte,
+func (p *Peer) getBlockHeaders(ctx context.Context, hashes []chunk.Address, deliveries chan []byte,
 	givebackC chan []byte) (*request, error) {
 	req, id := p.requests.create(hashes, deliveries, givebackC)
 	err := p.Send(ctx, &GetBlockHeaders{

--- a/bzzeth/peer.go
+++ b/bzzeth/peer.go
@@ -78,9 +78,9 @@ func (p *peers) getEth(rcvdPeer *Peer) *Peer {
 	defer p.mtx.RUnlock()
 
 	for _, peer := range p.peers {
-
 		// Dont ask from the same peer which sent the request
 		if rcvdPeer != nil && rcvdPeer == peer {
+			log.Debug("Ignoring peer which requested headers")
 			continue
 		}
 

--- a/bzzeth/peer.go
+++ b/bzzeth/peer.go
@@ -75,17 +75,12 @@ func (p *peers) remove(peer *Peer) {
 }
 
 // getEthPeer finds a peer that serves headers and calls the function argument on this peer
-func (p *peers) getEth(rcvdPeer *Peer) *Peer {
+func (p *peers) getEth() *Peer {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
 	for _, peer := range p.peers {
-		// Dont ask from the same peer which sent the request
-		if rcvdPeer != nil && rcvdPeer == peer {
-			log.Debug("Ignoring peer which requested headers")
-			continue
-		}
-
+		// Only peers that can serve headers will be selected
 		if peer.serveHeaders {
 			return peer
 		}
@@ -100,11 +95,10 @@ type requests struct {
 }
 
 type request struct {
-	hashes    map[string]bool // remembers the block hashes that are requested in this connection
-	lock      sync.RWMutex    // mutex to update the hashes received status
-	c         chan []byte     // channel in which the received block headers hash are passed on
-	giveBackC chan []byte     // channel in which the received block headers hash are passed
-	cancel    func()          // function to call in case of cancellation of the GetBlockHeaders event
+	hashes map[string]bool // remembers the block hashes that are requested in this connection
+	lock   sync.RWMutex    // mutex to update the hashes received status
+	c      chan []byte     // channel in which the received block headers hash are passed on
+	cancel func()          // function to call in case of cancellation of the GetBlockHeaders event
 }
 
 // newRequestIDFunc is used to generate unique ID for requests
@@ -126,11 +120,10 @@ func newRequests() *requests {
 // create constructs a new request
 // registers it on the peer request pool
 // request.cancel() should be called to cleanup
-func (r *requests) create(hashes []chunk.Address, c chan []byte, g chan []byte) (*request, uint32) {
+func (r *requests) create(hashes []chunk.Address, c chan []byte) (*request, uint32) {
 	req := &request{
-		hashes:    make(map[string]bool),
-		c:         c,
-		giveBackC: g,
+		hashes: make(map[string]bool),
+		c:      c,
 	}
 	id := newRequestIDFunc()
 	for _, h := range hashes {
@@ -162,9 +155,8 @@ func (r *requests) get(id uint32) (*request, bool) {
 
 // getBlockHeaders sends a GetBlockHeaders message to the remote peer requesting headers by their _hashes_
 // and delivers the actual block header responses to the deliveries channel
-func (p *Peer) getBlockHeaders(ctx context.Context, hashes []chunk.Address, deliveries chan []byte,
-	givebackC chan []byte) (*request, error) {
-	req, id := p.requests.create(hashes, deliveries, givebackC)
+func (p *Peer) getBlockHeaders(ctx context.Context, hashes []chunk.Address, deliveries chan []byte) (*request, error) {
+	req, id := p.requests.create(hashes, deliveries)
 	err := p.Send(ctx, &GetBlockHeaders{
 		Rid:    uint64(id),
 		Hashes: hashes,

--- a/bzzeth/wire.go
+++ b/bzzeth/wire.go
@@ -51,7 +51,7 @@ type NewBlockHeaders []struct {
 // 1. When an Ethereum node asks the header corresponding to the hashes in the message (eth -> bzz)
 // 2. When a Swarm node cannot find a particular header in the network, it asks the ethereum node for the header in order to push it to the network (bzz -> eth)
 type GetBlockHeaders struct {
-	Rid    uint32   // request id
+	Rid    uint64   // request id
 	Hashes [][]byte // slice of hashes
 }
 

--- a/bzzeth/wire.go
+++ b/bzzeth/wire.go
@@ -19,6 +19,7 @@ package bzzeth
 import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethersphere/swarm/chunk"
 	"github.com/ethersphere/swarm/p2p/protocols"
 )
 
@@ -51,8 +52,8 @@ type NewBlockHeaders []struct {
 // 1. When an Ethereum node asks the header corresponding to the hashes in the message (eth -> bzz)
 // 2. When a Swarm node cannot find a particular header in the network, it asks the ethereum node for the header in order to push it to the network (bzz -> eth)
 type GetBlockHeaders struct {
-	Rid    uint64   // request id
-	Hashes [][]byte // slice of hashes
+	Rid    uint64          // request id
+	Hashes []chunk.Address // slice of hashes
 }
 
 // BlockHeaders encapsulates actual header blobs sent as a response to GetBlockHeaders


### PR DESCRIPTION
The following tasks are in the Phase 2

= Use the actual eth block header and decode it.
= Handle GetBlockHeaders from a light client and serve the stored headers
= Update test cases to use the actual block header and other other stuff
= Test with Trinity client on the other side getting the blocks

