### PR TITLE
network/stream: fix slice append bug

### DIFF
--- a/network/stream/stream.go
+++ b/network/stream/stream.go
@@ -659,7 +659,7 @@ func (r *Registry) serverHandleWantedHashes(ctx context.Context, p *Peer, msg *W
 	if len(msg.BitVector) == 0 {
 		p.logger.Debug("peer does not want any hashes in this range", "ruid", o.ruid)
 		for i := 0; i < l; i++ {
-			allHashes = append(allHashes, o.hashes[i*HashSize:(i+1)*HashSize])
+			allHashes[i] = o.hashes[i*HashSize : (i+1)*HashSize]
 		}
 		// set all chunks as synced
 		if err := provider.Set(ctx, allHashes...); err != nil {


### PR DESCRIPTION
This PR fixes a bug in `stream` package where a slice representing the wanted hashes on a 0 wanted hashes message was appended to, instead of setting the slice elements which were preallocated. This resulted in the first `len(msg.Hashes)` to be zero address hashes, and the second `len(msg.Hashes)` to be the actual hashes.
In turn, in `localstore.Set` this caused an error (since the zero address chunk returned an error because it does not exist) and the rest of the hashes were not set, since the error handling in `Set` bails directly on the first error, instead of continuing to set the rest of the chunk addresses in the variadic function parameters. 

We should probably consider our error handling on if we bail immediately on error on these kind of operations. Maybe a potential partial set in this case would have prevented the problem (while masking the bug).