### PR TITLE
swap: fix instabilities in simulation tests

### DIFF
--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -702,7 +702,7 @@ func waitForChequeProcessed(t *testing.T, ts *testService, counter metrics.Count
 		for {
 			select {
 			case <-ctx.Done():
-				t.Fatal("Timed out waiting for all swap peer connections to be established")
+				t.Fatal("Timed out waiting for peer to have processed accounted message")
 			default:
 				if counter.Count() == lastCount+1 {
 					wg.Done()


### PR DESCRIPTION
This PR fixes #1899 .

It does this by introducing an additional check when waiting for the cheque to be processed, which is not enough (as documented by @ralph-pichler at https://github.com/ethersphere/swarm/issues/1899#issuecomment-549981413), due to the high parallelization of the test.

We now also wait and check that the message has been received on the other end by checking the appropriate metrics counter.

Note that this should (but may not) fix the test, but does not address an underlying process vulnerability which has been exposed by #1899 , which is that if the message sequence is expressed in an unexpected way, there may be bugs in the workflow