### PR TITLE
swap: clear metrics after test runs

### DIFF
--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -274,6 +274,7 @@ func TestPingPongChequeSimulation(t *testing.T) {
 	cter := metricsReg.Get("account.msg.credit")
 	counter := cter.(metrics.Counter)
 	counter.Clear()
+	defer counter.Clear()
 	var lastCount int64
 	expectedPayout1, expectedPayout2 := DefaultPaymentThreshold+1, DefaultPaymentThreshold+1
 
@@ -403,6 +404,7 @@ func TestMultiChequeSimulation(t *testing.T) {
 	cter := metricsReg.Get("account.msg.credit")
 	counter := cter.(metrics.Counter)
 	counter.Clear()
+	defer counter.Clear()
 	var lastCount int64
 	expectedPayout := DefaultPaymentThreshold + 1
 


### PR DESCRIPTION
This simple PR clears the metrics counter `account.msg.credit` after test runs. It has been suggested that with high run count, this could affect the stability of the tests.