### PR TITLE
swap: also wait for the debit counter to reach maxMsgsInt64

### DIFF
--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -542,9 +542,12 @@ func TestBasicSwapSimulation(t *testing.T) {
 	allMessagesArrived := make(chan struct{})
 
 	metricsReg := metrics.AccountingRegistry
-	cter := metricsReg.Get("account.msg.credit")
-	counter := cter.(metrics.Counter)
-	counter.Clear()
+	creditCter := metricsReg.Get("account.msg.credit")
+	creditCounter := creditCter.(metrics.Counter)
+	creditCounter.Clear()
+	debitCter := metricsReg.Get("account.msg.debit")
+	debitCounter := debitCter.(metrics.Counter)
+	debitCounter.Clear()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -558,7 +561,7 @@ func TestBasicSwapSimulation(t *testing.T) {
 			default:
 			}
 			// all messages have been received
-			if counter.Count() == maxMsgsInt64 {
+			if creditCounter.Count() == maxMsgsInt64 && debitCounter.Count() == maxMsgsInt64 {
 				close(allMessagesArrived)
 				return
 			}
@@ -681,7 +684,8 @@ func TestBasicSwapSimulation(t *testing.T) {
 	if result.Error != nil {
 		t.Fatal(result.Error)
 	}
-	counter.Clear()
+	creditCounter.Clear()
+	debitCounter.Clear()
 	log.Info("Simulation ended")
 }
 


### PR DESCRIPTION
This PR fixes `TestBasicSwapSimulation` to also wait for the `account.msg.debit` counter to reach `maxMsgsInt64`. This is needed because one of the `testMsgByReceiver` might arrive after the last `testMsgBySender` message in which case one final `Add` happens after the credit counter reaches `maxMsgsInt64`.

This seems to finally fix the `TestBasicSwapSimulation` test. It successfully passed 10000 consecutive `-count=1` runs without an error on a vm which regularly failed before. 