### PR TITLE
cmd/swarm: swap --sync-mode flag with --no-sync flag

### DIFF
--- a/cmd/swarm/config.go
+++ b/cmd/swarm/config.go
@@ -71,7 +71,7 @@ const (
 	SwarmEnvSwapBackendURL          = "SWARM_SWAP_BACKEND_URL"
 	SwarmEnvSwapPaymentThreshold    = "SWARM_SWAP_PAYMENT_THRESHOLD"
 	SwarmEnvSwapDisconnectThreshold = "SWARM_SWAP_DISCONNECT_THRESHOLD"
-	SwarmSyncMode                   = "SWARM_SYNC_MODE"
+	SwarmNoSync                     = "SWARM_NO_SYNC"
 	SwarmEnvSwapLogPath             = "SWARM_SWAP_LOG_PATH"
 	SwarmEnvSyncUpdateDelay         = "SWARM_ENV_SYNC_UPDATE_DELAY"
 	SwarmEnvMaxStreamPeerServers    = "SWARM_ENV_MAX_STREAM_PEER_SERVERS"
@@ -221,8 +221,9 @@ func flagsOverride(currentConfig *bzzapi.Config, ctx *cli.Context) *bzzapi.Confi
 	if disconnectThreshold := ctx.GlobalUint64(SwarmSwapDisconnectThresholdFlag.Name); disconnectThreshold != 0 {
 		currentConfig.SwapDisconnectThreshold = disconnectThreshold
 	}
-	if ctx.GlobalIsSet(SwarmSyncModeFlag.Name) {
-		currentConfig.SyncEnabled, currentConfig.PushSyncEnabled = syncModeParse(ctx.GlobalString(SwarmSyncModeFlag.Name))
+	if ctx.GlobalIsSet(SwarmNoSyncFlag.Name) {
+		val := !ctx.GlobalBool(SwarmNoSyncFlag.Name)
+		currentConfig.SyncEnabled, currentConfig.PushSyncEnabled = val, val // if the flag is set (true) - push and pull sync should be disabled
 	}
 	if d := ctx.GlobalDuration(SwarmSyncUpdateDelay.Name); d > 0 {
 		currentConfig.SyncUpdateDelay = d
@@ -271,22 +272,6 @@ func flagsOverride(currentConfig *bzzapi.Config, ctx *cli.Context) *bzzapi.Confi
 		currentConfig.EnablePinning = true
 	}
 	return currentConfig
-}
-
-func syncModeParse(s string) (pullSync, pushSync bool) {
-	switch s {
-	case "pull":
-		return true, false
-	case "push":
-		return false, true
-	case "all":
-		return true, true
-	case "none":
-		return false, false
-	default:
-		utils.Fatalf("unknown cli flag %s value: %v", SwarmSyncModeFlag.Name, s)
-		return
-	}
 }
 
 // dumpConfig is the dumpconfig command.

--- a/cmd/swarm/config_test.go
+++ b/cmd/swarm/config_test.go
@@ -231,7 +231,7 @@ func TestConfigCmdLineOverrides(t *testing.T) {
 		fmt.Sprintf("--%s", SwarmNetworkIdFlag.Name), "42",
 		fmt.Sprintf("--%s", SwarmPortFlag.Name), httpPort,
 		fmt.Sprintf("--%s", utils.ListenPortFlag.Name), "0",
-		fmt.Sprintf("--%s", SwarmSyncModeFlag.Name), "none",
+		fmt.Sprintf("--%s", SwarmNoSyncFlag.Name),
 		fmt.Sprintf("--%s", CorsStringFlag.Name), "*",
 		fmt.Sprintf("--%s", SwarmAccountFlag.Name), account.Address.String(),
 		fmt.Sprintf("--%s", SwarmDeliverySkipCheckFlag.Name),
@@ -421,7 +421,7 @@ func TestConfigEnvVars(t *testing.T) {
 	envVars = append(envVars, fmt.Sprintf("%s=%s", SwarmPortFlag.EnvVar, httpPort))
 	envVars = append(envVars, fmt.Sprintf("%s=%s", SwarmNetworkIdFlag.EnvVar, "999"))
 	envVars = append(envVars, fmt.Sprintf("%s=%s", CorsStringFlag.EnvVar, "*"))
-	envVars = append(envVars, fmt.Sprintf("%s=%s", SwarmSyncModeFlag.EnvVar, "none"))
+	envVars = append(envVars, fmt.Sprintf("%s=%s", SwarmNoSyncFlag.EnvVar, "true"))
 	envVars = append(envVars, fmt.Sprintf("%s=%s", SwarmDeliverySkipCheckFlag.EnvVar, "true"))
 
 	dir, err := ioutil.TempDir("", "bzztest")
@@ -567,7 +567,7 @@ func TestConfigCmdLineOverridesFile(t *testing.T) {
 	flags := []string{
 		fmt.Sprintf("--%s", SwarmNetworkIdFlag.Name), "77",
 		fmt.Sprintf("--%s", SwarmPortFlag.Name), httpPort,
-		fmt.Sprintf("--%s", SwarmSyncModeFlag.Name), "none",
+		fmt.Sprintf("--%s", SwarmNoSyncFlag.Name),
 		fmt.Sprintf("--%s", SwarmTomlConfigPathFlag.Name), f.Name(),
 		fmt.Sprintf("--%s", SwarmAccountFlag.Name), account.Address.String(),
 		fmt.Sprintf("--%s", EnsAPIFlag.Name), "",

--- a/cmd/swarm/flags.go
+++ b/cmd/swarm/flags.go
@@ -89,11 +89,10 @@ var (
 		Usage:  "honey amount at which a peer disconnects",
 		EnvVar: SwarmEnvSwapDisconnectThreshold,
 	}
-	SwarmSyncModeFlag = cli.StringFlag{
-		Name:   "sync-mode",
-		Usage:  "Syncing mode (available modes: pull, push, all, none)",
-		EnvVar: SwarmSyncMode,
-		Value:  "pull",
+	SwarmNoSyncFlag = cli.BoolFlag{
+		Name:   "no-sync",
+		Usage:  "disable syncing",
+		EnvVar: SwarmNoSync,
 	}
 	SwarmSwapLogPathFlag = cli.StringFlag{
 		Name:   "swap-audit-logpath",

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -187,7 +187,7 @@ func init() {
 		SwarmSwapChequebookFactoryFlag,
 		SwarmSwapInitialDepositFlag,
 		// end of swap flags
-		SwarmSyncModeFlag,
+		SwarmNoSyncFlag,
 		SwarmSyncUpdateDelay,
 		SwarmMaxStreamPeerServersFlag,
 		SwarmLightNodeEnabled,


### PR DESCRIPTION
This PR changes the `--sync-mode` flag to be `--no-sync` flag in order to still preserve the functionality of disabling syncing altogether, while adhering to the open task list on https://github.com/ethersphere/swarm/pull/1926
