### PR TITLE
api/http/langos: ensure only one second peek

### DIFF
--- a/api/http/langos/langos.go
+++ b/api/http/langos/langos.go
@@ -92,7 +92,9 @@ func (l *Langos) Read(p []byte) (n int, err error) {
 	case <-pe.done:
 	default:
 		// start the next peek while waiting for the current to finish
-		l.peek(l.cursor + int64(l.peekSize))
+		if len(l.peeks) == 0 { // ensure only one second peek
+			l.peek(l.cursor + int64(l.peekSize))
+		}
 	}
 
 	select {

--- a/api/http/langos/langos_test.go
+++ b/api/http/langos/langos_test.go
@@ -57,7 +57,7 @@ func TestLangosNumberOfReadCalls(t *testing.T) {
 			name:     "3 seq reads, EOF",
 			peekSize: 6,
 			numReads: 3,
-			expReads: 5,
+			expReads: 4,
 			expErr:   io.EOF,
 		},
 		{


### PR DESCRIPTION
This PR fixes a flaky langos test TestLangosNumberOfReadCalls which fails due to possible multiple second peek calls in Read method. This change ensures more correct behaviour, in less peek calls, but no data problems were discovered.