### PR TITLE
network/stream: fix flaky tests and first delivered batch of chunks for an unwanted stream

### DIFF
--- a/network/stream/common_test.go
+++ b/network/stream/common_test.go
@@ -94,14 +94,13 @@ func nodeBinIndexes(t *testing.T, store interface {
 type SyncSimServiceOptions struct {
 	InitialChunkCount     uint64
 	SyncOnlyWithinDepth   bool
-	Autostart             bool
+	NoAutostart           bool
 	StreamConstructorFunc func(state.Store, []byte, ...StreamProvider) node.Service
 }
 
 func newSyncSimServiceFunc(o *SyncSimServiceOptions) func(ctx *adapters.ServiceContext, bucket *sync.Map) (s node.Service, cleanup func(), err error) {
 	if o == nil {
 		o = new(SyncSimServiceOptions)
-		o.Autostart = true // start stream on by default
 	}
 	if o.StreamConstructorFunc == nil {
 		o.StreamConstructorFunc = func(s state.Store, b []byte, p ...StreamProvider) node.Service {
@@ -156,7 +155,7 @@ func newSyncSimServiceFunc(o *SyncSimServiceOptions) func(ctx *adapters.ServiceC
 		if err != nil {
 			return nil, nil, err
 		}
-		sp := NewSyncProvider(netStore, kad, o.Autostart, o.SyncOnlyWithinDepth)
+		sp := NewSyncProvider(netStore, kad, !o.NoAutostart, o.SyncOnlyWithinDepth)
 		ss := o.StreamConstructorFunc(store, addr.Over(), sp)
 
 		cleanup = func() {

--- a/network/stream/common_test.go
+++ b/network/stream/common_test.go
@@ -94,7 +94,7 @@ func nodeBinIndexes(t *testing.T, store interface {
 type SyncSimServiceOptions struct {
 	InitialChunkCount     uint64
 	SyncOnlyWithinDepth   bool
-	NoAutostart           bool
+	Autostart             bool
 	StreamConstructorFunc func(state.Store, []byte, ...StreamProvider) node.Service
 }
 
@@ -155,7 +155,7 @@ func newSyncSimServiceFunc(o *SyncSimServiceOptions) func(ctx *adapters.ServiceC
 		if err != nil {
 			return nil, nil, err
 		}
-		sp := NewSyncProvider(netStore, kad, !o.NoAutostart, o.SyncOnlyWithinDepth)
+		sp := NewSyncProvider(netStore, kad, o.Autostart, o.SyncOnlyWithinDepth)
 		ss := o.StreamConstructorFunc(store, addr.Over(), sp)
 
 		cleanup = func() {

--- a/network/stream/common_test.go
+++ b/network/stream/common_test.go
@@ -94,12 +94,14 @@ func nodeBinIndexes(t *testing.T, store interface {
 type SyncSimServiceOptions struct {
 	InitialChunkCount     uint64
 	SyncOnlyWithinDepth   bool
+	Autostart             bool
 	StreamConstructorFunc func(state.Store, []byte, ...StreamProvider) node.Service
 }
 
 func newSyncSimServiceFunc(o *SyncSimServiceOptions) func(ctx *adapters.ServiceContext, bucket *sync.Map) (s node.Service, cleanup func(), err error) {
 	if o == nil {
 		o = new(SyncSimServiceOptions)
+		o.Autostart = true // start stream on by default
 	}
 	if o.StreamConstructorFunc == nil {
 		o.StreamConstructorFunc = func(s state.Store, b []byte, p ...StreamProvider) node.Service {
@@ -154,8 +156,7 @@ func newSyncSimServiceFunc(o *SyncSimServiceOptions) func(ctx *adapters.ServiceC
 		if err != nil {
 			return nil, nil, err
 		}
-
-		sp := NewSyncProvider(netStore, kad, true, o.SyncOnlyWithinDepth)
+		sp := NewSyncProvider(netStore, kad, o.Autostart, o.SyncOnlyWithinDepth)
 		ss := o.StreamConstructorFunc(store, addr.Over(), sp)
 
 		cleanup = func() {

--- a/network/stream/cursors_test.go
+++ b/network/stream/cursors_test.go
@@ -56,7 +56,7 @@ func TestNodesExchangeCorrectBinIndexes(t *testing.T) {
 	)
 	opts := &SyncSimServiceOptions{
 		InitialChunkCount: chunkCount,
-		NoAutostart:       true,
+		Autostart:         true,
 	}
 
 	sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
@@ -106,7 +106,7 @@ func TestNodesCorrectBinsDynamic(t *testing.T) {
 	)
 	opts := &SyncSimServiceOptions{
 		InitialChunkCount: chunkCount,
-		NoAutostart:       true,
+		Autostart:         true,
 	}
 
 	sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
@@ -184,10 +184,9 @@ func TestNodeRemovesAndReestablishCursors(t *testing.T) {
 	}
 
 	const chunkCount = 1000
-	opts := &SyncSimServiceOptions{NoAutostart: true}
 
 	sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
-		serviceNameStream: newSyncSimServiceFunc(opts),
+		serviceNameStream: newSyncSimServiceFunc(nil),
 	}, false)
 	defer sim.Close()
 
@@ -313,10 +312,9 @@ func generateReestablishCursorsSnapshot(t *testing.T, tagetPO int) {
 func setupReestablishCursorsSimulation(t *testing.T, tagetPO int) (sim *simulation.Simulation, pivotEnode, lookupEnode enode.ID) {
 	// initial node count
 	nodeCount := 5
-	opts := &SyncSimServiceOptions{NoAutostart: true}
 
 	sim = simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
-		serviceNameStream: newSyncSimServiceFunc(opts),
+		serviceNameStream: newSyncSimServiceFunc(nil),
 	}, false)
 
 	nodeIDs, err := sim.AddNodesAndConnectStar(nodeCount)
@@ -510,7 +508,6 @@ func TestCorrectCursorsExchangeRace(t *testing.T) {
 		StreamConstructorFunc: func(s state.Store, b []byte, p ...StreamProvider) node.Service {
 			return New(s, b, p...)
 		},
-		NoAutostart: true,
 	}
 	sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
 		serviceNameStream: newSyncSimServiceFunc(opts),

--- a/network/stream/cursors_test.go
+++ b/network/stream/cursors_test.go
@@ -56,7 +56,7 @@ func TestNodesExchangeCorrectBinIndexes(t *testing.T) {
 	)
 	opts := &SyncSimServiceOptions{
 		InitialChunkCount: chunkCount,
-		Autostart:         false,
+		NoAutostart:       true,
 	}
 
 	sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
@@ -106,7 +106,7 @@ func TestNodesCorrectBinsDynamic(t *testing.T) {
 	)
 	opts := &SyncSimServiceOptions{
 		InitialChunkCount: chunkCount,
-		Autostart:         false,
+		NoAutostart:       true,
 	}
 
 	sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
@@ -184,7 +184,7 @@ func TestNodeRemovesAndReestablishCursors(t *testing.T) {
 	}
 
 	const chunkCount = 1000
-	opts := &SyncSimServiceOptions{Autostart: false}
+	opts := &SyncSimServiceOptions{NoAutostart: true}
 
 	sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
 		serviceNameStream: newSyncSimServiceFunc(opts),
@@ -313,7 +313,7 @@ func generateReestablishCursorsSnapshot(t *testing.T, tagetPO int) {
 func setupReestablishCursorsSimulation(t *testing.T, tagetPO int) (sim *simulation.Simulation, pivotEnode, lookupEnode enode.ID) {
 	// initial node count
 	nodeCount := 5
-	opts := &SyncSimServiceOptions{Autostart: false}
+	opts := &SyncSimServiceOptions{NoAutostart: true}
 
 	sim = simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
 		serviceNameStream: newSyncSimServiceFunc(opts),
@@ -510,7 +510,7 @@ func TestCorrectCursorsExchangeRace(t *testing.T) {
 		StreamConstructorFunc: func(s state.Store, b []byte, p ...StreamProvider) node.Service {
 			return New(s, b, p...)
 		},
-		Autostart: false,
+		NoAutostart: true,
 	}
 	sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
 		serviceNameStream: newSyncSimServiceFunc(opts),

--- a/network/stream/cursors_test.go
+++ b/network/stream/cursors_test.go
@@ -54,11 +54,13 @@ func TestNodesExchangeCorrectBinIndexes(t *testing.T) {
 		nodeCount  = 2
 		chunkCount = 1000
 	)
+	opts := &SyncSimServiceOptions{
+		InitialChunkCount: chunkCount,
+		Autostart:         false,
+	}
 
 	sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
-		serviceNameStream: newSyncSimServiceFunc(&SyncSimServiceOptions{
-			InitialChunkCount: chunkCount,
-		}),
+		serviceNameStream: newSyncSimServiceFunc(opts),
 	}, false)
 	defer sim.Close()
 
@@ -102,11 +104,13 @@ func TestNodesCorrectBinsDynamic(t *testing.T) {
 		nodeCount  = 6
 		chunkCount = 500
 	)
+	opts := &SyncSimServiceOptions{
+		InitialChunkCount: chunkCount,
+		Autostart:         false,
+	}
 
 	sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
-		serviceNameStream: newSyncSimServiceFunc(&SyncSimServiceOptions{
-			InitialChunkCount: chunkCount,
-		}),
+		serviceNameStream: newSyncSimServiceFunc(opts),
 	}, false)
 	defer sim.Close()
 
@@ -180,9 +184,10 @@ func TestNodeRemovesAndReestablishCursors(t *testing.T) {
 	}
 
 	const chunkCount = 1000
+	opts := &SyncSimServiceOptions{Autostart: false}
 
 	sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
-		serviceNameStream: newSyncSimServiceFunc(nil),
+		serviceNameStream: newSyncSimServiceFunc(opts),
 	}, false)
 	defer sim.Close()
 
@@ -308,9 +313,10 @@ func generateReestablishCursorsSnapshot(t *testing.T, tagetPO int) {
 func setupReestablishCursorsSimulation(t *testing.T, tagetPO int) (sim *simulation.Simulation, pivotEnode, lookupEnode enode.ID) {
 	// initial node count
 	nodeCount := 5
+	opts := &SyncSimServiceOptions{Autostart: false}
 
 	sim = simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
-		serviceNameStream: newSyncSimServiceFunc(nil),
+		serviceNameStream: newSyncSimServiceFunc(opts),
 	}, false)
 
 	nodeIDs, err := sim.AddNodesAndConnectStar(nodeCount)
@@ -504,6 +510,7 @@ func TestCorrectCursorsExchangeRace(t *testing.T) {
 		StreamConstructorFunc: func(s state.Store, b []byte, p ...StreamProvider) node.Service {
 			return New(s, b, p...)
 		},
+		Autostart: false,
 	}
 	sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
 		serviceNameStream: newSyncSimServiceFunc(opts),

--- a/network/stream/snapshot_sync_test.go
+++ b/network/stream/snapshot_sync_test.go
@@ -91,7 +91,7 @@ func TestSyncingViaGlobalSync(t *testing.T) {
 
 func testSyncingViaGlobalSync(t *testing.T, chunkCount int, nodeCount int) {
 	sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
-		"bzz-sync": newSyncSimServiceFunc(nil),
+		"bzz-sync": newSyncSimServiceFunc(&SyncSimServiceOptions{Autostart: true}),
 	}, true)
 	defer sim.Close()
 

--- a/network/stream/stream.go
+++ b/network/stream/stream.go
@@ -541,6 +541,22 @@ func (r *Registry) clientHandleOfferedHashes(ctx context.Context, p *Peer, msg *
 		return
 	}
 
+	// we no longer want this stream. send an empty wanted
+	// hashes to upstream peer to not deliver the batch
+	// it is important that this case is handled after the `lenHashes==0`
+	// block above, since the case above is a special case where the
+	// upstream peer already deleted the `offer` object associated with
+	// the Ruid, while in this case we must send an empty message back to
+	// the upstream peer in order to mitigate a leak on `offer`s
+	if !provider.WantStream(p, w.stream) {
+		wantedHashesMsg.BitVector = []byte{}
+		if err := p.Send(ctx, wantedHashesMsg); err != nil {
+			p.logger.Error("error sending empty wanted hashes", "err", err)
+			p.Drop("error sending empty wanted hashes")
+		}
+		return
+	}
+
 	want, err := bv.New(lenHashes / HashSize)
 	if err != nil {
 		p.logger.Error("error initialising bitvector", "len", lenHashes/HashSize, "ruid", msg.Ruid, "err", err)
@@ -551,6 +567,7 @@ func (r *Registry) clientHandleOfferedHashes(ctx context.Context, p *Peer, msg *
 	for i := 0; i < lenHashes; i += HashSize {
 		hash := msg.Hashes[i : i+HashSize]
 		addresses[i/HashSize] = hash
+		p.logger.Trace("clientHandleOfferedHashes peer offered hash", "ruid", msg.Ruid, "stream", w.stream, "chunk", addresses[i/HashSize])
 	}
 
 	startNeed := time.Now()
@@ -624,7 +641,16 @@ func (r *Registry) clientHandleOfferedHashes(ctx context.Context, p *Peer, msg *
 		p.mtx.Lock()
 		delete(p.openWants, msg.Ruid)
 		p.mtx.Unlock()
-		p.Drop("batch has timed out")
+
+		// if the stream is wanted and has timed out
+		// then drop the peer. this safeguards the edge
+		// case that a batch times out when a kademlia
+		// depth change occurs between the call to
+		// clientSealBatch and a subsequent chunk delivery
+		// message
+		if provider.WantStream(p, w.stream) {
+			p.Drop("batch has timed out")
+		}
 		return
 	case <-r.quit:
 		return
@@ -755,6 +781,12 @@ func (r *Registry) serverHandleWantedHashes(ctx context.Context, p *Peer, msg *W
 // clientHandleChunkDelivery handles chunk delivery messages
 func (r *Registry) clientHandleChunkDelivery(ctx context.Context, p *Peer, msg *ChunkDelivery, w *want, provider StreamProvider) {
 	p.logger.Debug("clientHandleChunkDelivery", "ruid", msg.Ruid)
+
+	// don't process this message if we're no longer
+	// interested in this stream
+	if !provider.WantStream(p, w.stream) {
+		return
+	}
 	processReceivedChunksMsgCount.Inc(1)
 	r.setLastReceivedChunkTime() // needed for IsPullSyncing
 

--- a/network/stream/syncing_test.go
+++ b/network/stream/syncing_test.go
@@ -652,7 +652,7 @@ func TestStarNetworkSyncWithBogusNodes(t *testing.T) {
 		simTimeout    = 60 * time.Second
 		syncTime      = 4 * time.Second
 		filesize      = chunkCount * chunkSize
-		opts          = &SyncSimServiceOptions{SyncOnlyWithinDepth: false, Autostart: true}
+		opts          = &SyncSimServiceOptions{SyncOnlyWithinDepth: false}
 	)
 	sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
 		"bzz-sync": newSyncSimServiceFunc(opts),

--- a/network/stream/syncing_test.go
+++ b/network/stream/syncing_test.go
@@ -652,9 +652,10 @@ func TestStarNetworkSyncWithBogusNodes(t *testing.T) {
 		simTimeout    = 60 * time.Second
 		syncTime      = 4 * time.Second
 		filesize      = chunkCount * chunkSize
+		opts          = &SyncSimServiceOptions{SyncOnlyWithinDepth: false, Autostart: true}
 	)
 	sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
-		"bzz-sync": newSyncSimServiceFunc(&SyncSimServiceOptions{SyncOnlyWithinDepth: false}),
+		"bzz-sync": newSyncSimServiceFunc(opts),
 	}, false)
 	defer sim.Close()
 

--- a/network/stream/syncing_test.go
+++ b/network/stream/syncing_test.go
@@ -152,7 +152,7 @@ func TestTwoNodesSyncWithGaps(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
-				"bzz-sync": newSyncSimServiceFunc(nil),
+				"bzz-sync": newSyncSimServiceFunc(&SyncSimServiceOptions{Autostart: true}),
 			}, false)
 			defer sim.Close()
 			defer catchDuplicateChunkSync(t)()
@@ -223,7 +223,7 @@ func TestThreeNodesUnionHistoricalSync(t *testing.T) {
 	nodes := 3
 	chunkCount := 1000
 	sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
-		"bzz-sync": newSyncSimServiceFunc(nil),
+		"bzz-sync": newSyncSimServiceFunc(&SyncSimServiceOptions{Autostart: true}),
 	}, false)
 	defer sim.Close()
 	union := make(map[string]struct{})
@@ -317,7 +317,7 @@ func TestFullSync(t *testing.T) {
 			}
 
 			sim := simulation.NewInProc(map[string]simulation.ServiceFunc{
-				"bzz-sync": newSyncSimServiceFunc(nil),
+				"bzz-sync": newSyncSimServiceFunc(&SyncSimServiceOptions{Autostart: true}),
 			})
 			defer sim.Close()
 
@@ -567,7 +567,7 @@ func benchmarkHistoricalStream(b *testing.B, chunks uint64) {
 
 	for i := 0; i < b.N; i++ {
 		sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
-			"bzz-sync": newSyncSimServiceFunc(nil),
+			"bzz-sync": newSyncSimServiceFunc(&SyncSimServiceOptions{Autostart: true}),
 		}, false)
 
 		uploaderNode, err := sim.AddNode()
@@ -652,7 +652,7 @@ func TestStarNetworkSyncWithBogusNodes(t *testing.T) {
 		simTimeout    = 60 * time.Second
 		syncTime      = 4 * time.Second
 		filesize      = chunkCount * chunkSize
-		opts          = &SyncSimServiceOptions{SyncOnlyWithinDepth: false}
+		opts          = &SyncSimServiceOptions{SyncOnlyWithinDepth: false, Autostart: true}
 	)
 	sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
 		"bzz-sync": newSyncSimServiceFunc(opts),


### PR DESCRIPTION
This PR addresses three problems:
1. `TestStarNetworkSyncWithBogusNodes` was flaking on travis due to a too short sync delay timer. This, at least to my interpretation, means Swarm is getting slower over time. We should keep this in mind
2. `TestNodesCorrectBinsDynamic` was flaking because syncing was hardcoded to `Autostart` all the time. This resulted in incorrect bin indexes exchanged because some syncing has already occurred and has introduced non-determinism on the state of binIDs so as the cursors of the nodes. This is solved by a configurable parameter on `SyncSimServiceOptions` that toggles whether streams should be autostarted
3. A bug in `stream` package resulted in a first delivered batch of chunks before an unwanted stream is actually dropped. 

The scenario is the following: a node initially establishes streams on certain bins that become obsolete once kademlia depth changes (for example, depth is initially `0` and a stream on `SYNC|0` is requested from a node with PO `2`. Subsequently, kademlia depth changes to be depth `3` and the subscription on `SYNC|0` is no longer relevant).  Before this fix, the `ChunkDelivery` messages that would be received would actually put the chunks into the localstore without checking that `provider.WantStream()==true`. 

This resulted in a first requested range of a live stream always to be persisted, regardless whether that stream is wanted or not at the time of reception. The data race happened when the depth changed _between_ `HandleOfferedHashes` and the call to `requestSubsequentRange` at the end of `clientHandleOfferedHashes` method. 

This has now been amended to have the appropriate checks in `clientHandleOfferedHashes` and `clientHandleChunkDelivery` handlers. 

A change in kademlia depth is still possible between the send of `WantedHashes` message and the reception of the first `ChunkDelivery` message. Another change in depth can occur in between `ChunkDelivery` messages, in the case that the batch is split up to several messages. The two latter cases, however, are mitigated with the check that was added within `clientHandleChunkDelivery` handler, which will not process the chunks by returning, eventually causing the batch to time-out within `clientSealBatch` and the subsequent range to never be called