### PR TITLE
Add unfiltered chunk retrieval API

### DIFF
--- a/direct.go
+++ b/direct.go
@@ -1,0 +1,29 @@
+package swarm
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethersphere/swarm/chunk"
+	"github.com/ethersphere/swarm/storage"
+)
+
+type directAccessAPI struct {
+	chunkStore storage.ChunkStore
+}
+
+func NewDirectAccessAPI(chunkStore storage.ChunkStore) *directAccessAPI {
+	return &directAccessAPI{
+		chunkStore: chunkStore,
+	}
+}
+
+func (d *directAccessAPI) GetByReference(addr storage.Address) (hexutil.Bytes, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	chunk, err := d.chunkStore.Get(ctx, chunk.ModeGetRequest, addr)
+	if err != nil {
+		return nil, err
+	}
+	return hexutil.Bytes(chunk.Data()), nil
+}

--- a/swarm.go
+++ b/swarm.go
@@ -559,14 +559,14 @@ func (s *Swarm) APIs() []rpc.API {
 		// public APIs
 		{
 			Namespace: "bzz",
-			Version:   "4.0",
+			Version:   "4.1",
 			Service:   &Info{s.config},
 			Public:    true,
 		},
 		// admin APIs
 		{
 			Namespace: "bzz",
-			Version:   "4.0",
+			Version:   "4.1",
 			Service:   s.inspector,
 			Public:    false,
 		},
@@ -581,6 +581,13 @@ func (s *Swarm) APIs() []rpc.API {
 			Version:   protocols.AccountingVersion,
 			Service:   protocols.NewAccountingApi(s.accountingMetrics),
 			Public:    false,
+		},
+		{
+
+			Namespace: "bzz",
+			Version:   "4.1",
+			Service:   NewDirectAccessAPI(storage.NewLNetStore(s.netStore)),
+			Public:    true,
 		},
 	}
 


### PR DESCRIPTION
This PR adds an RPC call the enables direct retrieval of the raw chunk contents from a reference. The use case that prompted the change was the desire tocircumvent the lookup algorithm of feeds to access only a particular update if it exists, without having to wait for the additional lookups the algorithms execute to finish (and fail if there are no newer ones).

