### PR TITLE
api/config: enable pushsync by default

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -109,7 +109,7 @@ func NewConfig() *Config {
 		Port:                    DefaultHTTPPort,
 		NetworkID:               network.DefaultNetworkID,
 		SyncEnabled:             true,
-		PushSyncEnabled:         false,
+		PushSyncEnabled:         true,
 		SyncingSkipCheck:        false,
 		DeliverySkipCheck:       true,
 		MaxStreamPeerServers:    10000,


### PR DESCRIPTION
This PR enabled Pushsync by default, since the flag configuration to disable/enable syncing has changed - pushsync should be on by default