### PR TITLE
api: Add bzz-feed-raw scheme to retrieve arbitary feed update

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -208,6 +208,14 @@ func (a *API) Retrieve(ctx context.Context, addr storage.Address) (reader storag
 	return a.fileStore.Retrieve(ctx, addr)
 }
 
+func (a *API) RetrieveFeedUpdate(ctx context.Context, addr storage.Address) ([]byte, error) {
+	chunk, err := a.fileStore.ChunkStore.Get(ctx, chunk.ModeGetRequest, addr)
+	if err != nil {
+		return nil, err
+	}
+	return chunk.Data(), err
+}
+
 // Store wraps the Store API call of the embedded FileStore
 func (a *API) Store(ctx context.Context, data io.Reader, size int64, toEncrypt bool) (addr storage.Address, wait func(ctx context.Context) error, err error) {
 	log.Debug("api.store", "size", size)

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -732,15 +732,15 @@ func (s *Server) HandleGetFeedRaw(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	b, err := s.api.RetrieveFeedUpdate(r.Context(), ref)
+	data, err := s.api.RetrieveFeedUpdate(r.Context(), ref)
 	if err != nil {
 		httpStatus := http.StatusNotFound
 		respondError(w, r, fmt.Sprintf("feed chunk not found: %s", err), httpStatus)
 		return
 	}
-	w.Header().Add("Content-type", "application/octet-stream")
+	w.Header().Set("Content-Type", api.MimeOctetStream)
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprint(w, b)
+	http.ServeContent(w, r, "", time.Now(), bytes.NewReader(data))
 }
 
 func (s *Server) translateFeedError(w http.ResponseWriter, r *http.Request, supErr string, err error) (int, error) {

--- a/api/http/server_test.go
+++ b/api/http/server_test.go
@@ -333,6 +333,18 @@ func TestFeedRaw(t *testing.T) {
 	}
 
 	responseData, _ := ioutil.ReadAll(resp.Body)
+	buf := bytes.NewBuffer(nil)
+	version := [8]byte{}
+	buf.Write(version[:])
+	buf.Write(topic[:])
+	buf.Write(user.Bytes())
+	buf.Write(version[:7])
+	buf.Write([]byte{31})
+	buf.Write(dataBytes[:])
+	buf.Write(updateRequest.Signature[:])
+	if !bytes.Equal(buf.Bytes(), responseData) {
+		t.Fatalf("data mismatch: expected %x, got %x", buf.Bytes(), responseData)
+	}
 }
 
 // Test the transparent resolving of feed updates with bzz:// scheme

--- a/api/http/test_server.go
+++ b/api/http/test_server.go
@@ -82,7 +82,6 @@ func NewTestSwarmServer(t *testing.T, serverFunc func(*api.API, *pin.API) TestSe
 		Hasher:    storage.MakeHashFunc(storage.DefaultHash)(),
 		cleanup: func() {
 			apiServer.Close()
-			fileStore.Close()
 			feeds.Close()
 			os.RemoveAll(swarmDir)
 			os.RemoveAll(feedsDir)

--- a/api/http/test_server.go
+++ b/api/http/test_server.go
@@ -65,7 +65,7 @@ func NewTestSwarmServer(t *testing.T, serverFunc func(*api.API, *pin.API) TestSe
 		t.Fatal(err)
 	}
 
-	feeds, err := feed.NewTestHandler(feedsDir, &feed.HandlerParams{})
+	feeds, err := feed.NewTestHandlerWithStore(feedsDir, localStore, &feed.HandlerParams{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/uri.go
+++ b/api/uri.go
@@ -86,7 +86,7 @@ func Parse(rawuri string) (*URI, error) {
 
 	// check the scheme is valid
 	switch uri.Scheme {
-	case "bzz", "bzz-raw", "bzz-immutable", "bzz-list", "bzz-hash", "bzz-feed", "bzz-tag", "bzz-pin":
+	case "bzz", "bzz-raw", "bzz-immutable", "bzz-list", "bzz-hash", "bzz-feed", "bzz-feed-raw", "bzz-tag", "bzz-pin":
 	default:
 		return nil, fmt.Errorf("unknown scheme %q", u.Scheme)
 	}

--- a/storage/feed/handler.go
+++ b/storage/feed/handler.go
@@ -265,8 +265,11 @@ func (h *Handler) Update(ctx context.Context, r *Request) (updateAddr storage.Ad
 	}
 
 	// send the chunk
-	h.chunkStore.Put(ctx, chunk.ModePutUpload, ch)
-	log.Trace("feed update", "updateAddr", r.idAddr, "epoch time", r.Epoch.Time, "epoch level", r.Epoch.Level, "data", ch.Data())
+	_, err = h.chunkStore.Put(ctx, chunk.ModePutUpload, ch)
+	if err != nil {
+		return nil, err
+	}
+
 	// update our feed updates map cache entry if the new update is older than the one we have, if we have it.
 	if feedUpdate != nil && r.Epoch.After(feedUpdate.Epoch) {
 		feedUpdate.Epoch = r.Epoch

--- a/storage/feed/testutil.go
+++ b/storage/feed/testutil.go
@@ -61,7 +61,10 @@ func NewTestHandler(datadir string, params *HandlerParams) (*TestHandler, error)
 
 func NewTestHandlerWithStore(datadir string, db chunk.Store, params *HandlerParams) (*TestHandler, error) {
 	fh := NewHandler(params)
+	return newTestHandlerWithStore(fh, datadir, db, params)
+}
 
+func newTestHandlerWithStore(fh *Handler, datadir string, db chunk.Store, params *HandlerParams) (*TestHandler, error) {
 	localStore := chunk.NewValidatorStore(db, storage.NewContentAddressValidator(storage.MakeHashFunc(feedsHashAlgorithm)), fh)
 
 	netStore := storage.NewNetStore(localStore, make([]byte, 32), enode.ID{})

--- a/storage/feed/testutil.go
+++ b/storage/feed/testutil.go
@@ -36,7 +36,7 @@ type TestHandler struct {
 }
 
 func (t *TestHandler) Close() {
-	//	t.chunkStore.Close()
+	t.chunkStore.Close()
 }
 
 // NewTestHandler creates Handler object to be used for testing purposes.

--- a/storage/feed/testutil.go
+++ b/storage/feed/testutil.go
@@ -36,7 +36,7 @@ type TestHandler struct {
 }
 
 func (t *TestHandler) Close() {
-	t.chunkStore.Close()
+	//	t.chunkStore.Close()
 }
 
 // NewTestHandler creates Handler object to be used for testing purposes.
@@ -48,6 +48,19 @@ func NewTestHandler(datadir string, params *HandlerParams) (*TestHandler, error)
 	if err != nil {
 		return nil, err
 	}
+
+	localStore := chunk.NewValidatorStore(db, storage.NewContentAddressValidator(storage.MakeHashFunc(feedsHashAlgorithm)), fh)
+
+	netStore := storage.NewNetStore(localStore, make([]byte, 32), enode.ID{})
+	netStore.RemoteGet = func(ctx context.Context, req *storage.Request, localID enode.ID) (*enode.ID, error) {
+		return nil, errors.New("not found")
+	}
+	fh.SetStore(netStore)
+	return &TestHandler{fh}, nil
+}
+
+func NewTestHandlerWithStore(datadir string, db chunk.Store, params *HandlerParams) (*TestHandler, error) {
+	fh := NewHandler(params)
 
 	localStore := chunk.NewValidatorStore(db, storage.NewContentAddressValidator(storage.MakeHashFunc(feedsHashAlgorithm)), fh)
 


### PR DESCRIPTION
This PR adds an HTTP scheme `bzz-feed-raw` the enables direct retrieval of the raw chunk contents from a reference. The use case that prompted the change was the desire tocircumvent the lookup algorithm of feeds to access only a particular update if it exists, without having to wait for the additional lookups the algorithms execute to finish (and fail if there are no newer ones)