### PR TITLE
smoke: remove redundant check for bail flag

### DIFF
--- a/cmd/swarm-smoke/upload_and_sync.go
+++ b/cmd/swarm-smoke/upload_and_sync.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -186,6 +187,7 @@ func checkChunksVsMostProxHosts(addrs []storage.Address, allHostChunks map[strin
 	for k, v := range bzzAddrs {
 		log.Trace("bzzAddr", "bzz", v, "host", k)
 	}
+	errored := false
 
 	for i := range addrs {
 		var foundAt int
@@ -212,16 +214,12 @@ func checkChunksVsMostProxHosts(addrs []storage.Address, allHostChunks map[strin
 		}
 
 		log.Trace("sync mode", "sync mode", syncMode)
-
 		if syncMode == "pullsync" || syncMode == "both" {
 			for _, maxProxHost := range maxProxHosts {
 				if allHostChunks[maxProxHost][i] == '0' {
 					metrics.GetOrRegisterCounter("upload-and-sync.pull-sync.chunk-not-max-prox", nil).Inc(1)
-					e := fmt.Errorf("chunk not found at max prox host\tref: %s\thost: %s\tbzzAddr: %s", addrs[i], maxProxHost, bzzAddrs[maxProxHost])
-					if bail {
-						return e
-					}
-					log.Error(e.Error())
+					log.Error("chunk not found at max prox host", "ref", addrs[i], "host", maxProxHost, "bzzAddr", bzzAddrs[maxProxHost])
+					errored = true
 				} else {
 					log.Trace("chunk present at max prox host", "ref", addrs[i], "host", maxProxHost, "bzzAddr", bzzAddrs[maxProxHost])
 				}
@@ -230,11 +228,8 @@ func checkChunksVsMostProxHosts(addrs []storage.Address, allHostChunks map[strin
 			// if chunk found at less than 2 hosts, which is actually less that the min size of a NN
 			if foundAt < 2 {
 				metrics.GetOrRegisterCounter("upload-and-sync.pull-sync.chunk-less-nn", nil).Inc(1)
-				e := fmt.Errorf("chunk found at less than two hosts\tfoundAt: %d\tref: %s", foundAt, addrs[i])
-				if bail {
-					return e
-				}
-				log.Error(e.Error())
+				log.Error("chunk found at less than two hosts", "foundAt", foundAt, "ref", addrs[i])
+				errored = true
 			}
 		}
 
@@ -250,14 +245,14 @@ func checkChunksVsMostProxHosts(addrs []storage.Address, allHostChunks map[strin
 			if !found {
 				for _, maxProxHost := range maxProxHosts {
 					metrics.GetOrRegisterCounter("upload-and-sync.push-sync.chunk-not-max-prox", nil).Inc(1)
-					e := fmt.Errorf("chunk not found at any max prox host\tref: %s\thosts: %s\tbzzAddr: %s", addrs[i], maxProxHost, bzzAddrs[maxProxHost])
-					if bail {
-						return e
-					}
-					log.Error(e.Error())
+					log.Error("chunk not found at any max prox host", "ref", addrs[i], "host", maxProxHost, "bzzAddr", bzzAddrs[maxProxHost])
+					errored = true
 				}
 			}
 		}
+	}
+	if errored {
+		return errors.New("error in checkChunksVsMostProxHost. see smoke test output for more details")
 	}
 	return nil
 }


### PR DESCRIPTION
`bail` flag is already checked on the `trackChunks` call. I'm removing the check within the function that compares if chunks are in NN and found on more than minBinSize; this way, when the test fails we get proper counts reported for those metrics