### PR TITLE
localstore: fix data races on subscriptions

### DIFF
--- a/storage/localstore/subscription_pull.go
+++ b/storage/localstore/subscription_pull.go
@@ -201,12 +201,12 @@ func (db *DB) LastPullSubscriptionBinID(bin uint8) (id uint64, err error) {
 // this function should be called.
 func (db *DB) triggerPullSubscriptions(bin uint8) {
 	db.pullTriggersMu.RLock()
+	defer db.pullTriggersMu.RUnlock()
+
 	triggers, ok := db.pullTriggers[bin]
-	db.pullTriggersMu.RUnlock()
 	if !ok {
 		return
 	}
-
 	for _, t := range triggers {
 		select {
 		case t <- struct{}{}:

--- a/storage/localstore/subscription_push.go
+++ b/storage/localstore/subscription_push.go
@@ -150,10 +150,9 @@ func (db *DB) SubscribePush(ctx context.Context) (c <-chan chunk.Chunk, stop fun
 // this function should be called.
 func (db *DB) triggerPushSubscriptions() {
 	db.pushTriggersMu.RLock()
-	triggers := db.pushTriggers
-	db.pushTriggersMu.RUnlock()
+	defer db.pushTriggersMu.RUnlock()
 
-	for _, t := range triggers {
+	for _, t := range db.pushTriggers {
 		select {
 		case t <- struct{}{}:
 		default:


### PR DESCRIPTION
This PR fixes data races that were detected by the go race detector:
```
WARNING: DATA RACE
Write at 0x00c0082deb80 by goroutine 2475:
  runtime.slicecopy()
      /usr/local/go/src/runtime/slice.go:197 +0x0
  github.com/ethersphere/swarm/storage/localstore.(*DB).SubscribePull.func2()
      /home/growlie/go/src/github.com/ethersphere/swarm/storage/localstore/subscription_pull.go:173 +0x38b
  github.com/ethersphere/swarm/network/stream.(*Registry).serverCollectBatch()
      /home/growlie/go/src/github.com/ethersphere/swarm/network/stream/stream.go:962 +0xb22
  github.com/ethersphere/swarm/network/stream.(*Registry).serverHandleGetRange()
      /home/growlie/go/src/github.com/ethersphere/swarm/network/stream/stream.go:443 +0x682
  github.com/ethersphere/swarm/network/stream.(*Registry).HandleMsg.func1.1()
      /home/growlie/go/src/github.com/ethersphere/swarm/network/stream/stream.go:188 +0xa6b

Previous read at 0x00c0082deb80 by goroutine 2477:
  github.com/ethersphere/swarm/storage/localstore.(*DB).triggerPullSubscriptions()
      /home/growlie/go/src/github.com/ethersphere/swarm/storage/localstore/subscription_pull.go:210 +0x10d
  github.com/ethersphere/swarm/storage/localstore.(*DB).put()
      /home/growlie/go/src/github.com/ethersphere/swarm/storage/localstore/mode_put.go:150 +0x5aa
  github.com/ethersphere/swarm/storage/localstore.(*DB).Put()
      /home/growlie/go/src/github.com/ethersphere/swarm/storage/localstore/mode_put.go:41 +0x234
  github.com/ethersphere/swarm/storage.(*NetStore).Put()
      /home/growlie/go/src/github.com/ethersphere/swarm/storage/netstore.go:116 +0x479
  github.com/ethersphere/swarm/storage.(*LNetStore).Put()
      <autogenerated>:1 +0xc9
  github.com/ethersphere/swarm/storage.(*FileStore).Put()
```