### PR TITLE
localstore: fix subscribe push iterator tag value

### DIFF
--- a/network/stream/cursors_test.go
+++ b/network/stream/cursors_test.go
@@ -56,7 +56,6 @@ func TestNodesExchangeCorrectBinIndexes(t *testing.T) {
 	)
 	opts := &SyncSimServiceOptions{
 		InitialChunkCount: chunkCount,
-		Autostart:         true,
 	}
 
 	sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{
@@ -106,7 +105,6 @@ func TestNodesCorrectBinsDynamic(t *testing.T) {
 	)
 	opts := &SyncSimServiceOptions{
 		InitialChunkCount: chunkCount,
-		Autostart:         true,
 	}
 
 	sim := simulation.NewBzzInProc(map[string]simulation.ServiceFunc{

--- a/storage/localstore/mode_set.go
+++ b/storage/localstore/mode_set.go
@@ -263,14 +263,14 @@ func (db *DB) setSync(batch *leveldb.Batch, addr chunk.Address, mode chunk.ModeS
 				// we cannot break or return here since the function needs to
 				// run to end from db.pushIndex.DeleteInBatch
 				log.Error("error getting tags on push sync set", "uid", i.Tag)
-			}
+			} else {
+				// setting a chunk for push sync assumes the tag is not anonymous
+				if t.Anonymous {
+					return 0, errors.New("got an anonymous chunk in push sync index")
+				}
 
-			// setting a chunk for push sync assumes the tag is not anonymous
-			if t.Anonymous {
-				return 0, errors.New("got an anonymous chunk in push sync index")
+				t.Inc(chunk.StateSynced)
 			}
-
-			t.Inc(chunk.StateSynced)
 		}
 
 		db.pushIndex.DeleteInBatch(batch, item)

--- a/storage/localstore/subscription_push.go
+++ b/storage/localstore/subscription_push.go
@@ -76,7 +76,7 @@ func (db *DB) SubscribePush(ctx context.Context) (c <-chan chunk.Chunk, stop fun
 					}
 
 					select {
-					case chunks <- chunk.NewChunk(dataItem.Address, dataItem.Data).WithTagID(dataItem.Tag):
+					case chunks <- chunk.NewChunk(dataItem.Address, dataItem.Data).WithTagID(item.Tag):
 						count++
 						// set next iteration start item
 						// when its chunk is successfully sent to channel


### PR DESCRIPTION
This PR fixes the value of the tag we set on the push index value. This was previously taken from the `retrievalDataIndex` item which does not contain the tag at all so a tag with value `0` would always be set in the push sync index.
The PR also adds an `else` block in `setSync` to prevent a panic on a nil pointer when the tag is `nil` (when an error is received from `localstore.tags`).
discovered by @janos <3