### PR TITLE
cmd/swarm: disable USB devices

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -298,6 +298,9 @@ func bzzd(ctx *cli.Context) error {
 		cfg.DataDir = bzzconfig.Path
 	}
 
+	// disable USB devices
+	cfg.NoUSB = true
+
 	// start any custom pprof profiles
 	pprofProfiles(ctx)
 
@@ -443,6 +446,10 @@ func getPrivKey(ctx *cli.Context) *ecdsa.PrivateKey {
 	if _, err := os.Stat(bzzconfig.Path); err == nil {
 		cfg.DataDir = bzzconfig.Path
 	}
+
+	// disable USB devices
+	cfg.NoUSB = true
+
 	utils.SetNodeConfig(ctx, &cfg)
 	stack, err := node.New(&cfg)
 	if err != nil {


### PR DESCRIPTION
I think that support for USB devices (Ledger, Trezor... etc) should be introduced and reviewed at a later stage...

I'm currently disabling these by default.