### PR TITLE
localstore: change gc batch size 

### DIFF
--- a/storage/localstore/gc.go
+++ b/storage/localstore/gc.go
@@ -37,7 +37,7 @@ var (
 	gcTargetRatio = 0.9
 	// gcBatchSize limits the number of chunks in a single
 	// leveldb batch on garbage collection.
-	gcBatchSize uint64 = 1000
+	gcBatchSize uint64 = 200
 )
 
 // collectGarbageWorker is a long running function that waits for


### PR DESCRIPTION
This PR changes the GC batch size to ease pressure on the batch mutex in localstore