### PR TITLE
network: increase fetcher timeout

### DIFF
--- a/network/timeouts/timeouts.go
+++ b/network/timeouts/timeouts.go
@@ -11,14 +11,14 @@ var FailedPeerSkipDelay = 20 * time.Second
 var FetcherGlobalTimeout = 10 * time.Second
 
 // SearchTimeout is the max time requests wait for a peer to deliver a chunk, after which another peer is tried
-var SearchTimeout = 500 * time.Millisecond
+var SearchTimeout = 1500 * time.Millisecond
 
 // SyncerClientWaitTimeout is the max time a syncer client waits for a chunk to be delivered during syncing
 var SyncerClientWaitTimeout = 20 * time.Second
 
-// Within handleOfferedHashesMsg - how long to wait for a given batch of chunks to be delivered by the peer offering them
+// how long should the downstream peer wait for an open batch from the upstream peer
 var SyncBatchTimeout = 10 * time.Second
 
-// Within SwarmSyncerServer - If at least one chunk is added to the batch and no new chunks
+// Within serverCollectBatch - If at least one chunk is added to the batch and no new chunks
 // are added in BatchTimeout period, the batch will be returned.
 var BatchTimeout = 2 * time.Second


### PR DESCRIPTION
Due to fetcher timeouts visible on grafana dashboards in smoke tests, and also due to reported timeouts on retrievals from end users, the fetcher search timeout is hereby increased.

Also piggybacking the change of `stream` timeouts to get their timeouts from `timeouts` package