### PR TITLE
storage/localstore: add subscriptions wait group before closing leveldb

### DIFF
--- a/network/stream/stream.go
+++ b/network/stream/stream.go
@@ -1145,7 +1145,7 @@ func (r *Registry) Stop() error {
 	select {
 	case <-done:
 	case <-time.After(5 * time.Second):
-		log.Error("stream closed with still active handlers")
+		r.logger.Error("stream closed with still active handlers")
 		// Print a full goroutine dump to debug blocking.
 		// TODO: use a logger to write a goroutine profile
 		pprof.Lookup("goroutine").WriteTo(os.Stdout, 2)

--- a/network/stream/stream.go
+++ b/network/stream/stream.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"encoding/hex"
 	"math/rand"
+	"os"
+	"runtime/pprof"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1144,6 +1146,9 @@ func (r *Registry) Stop() error {
 	case <-done:
 	case <-time.After(5 * time.Second):
 		log.Error("stream closed with still active handlers")
+		// Print a full goroutine dump to debug blocking.
+		// TODO: use a logger to write a goroutine profile
+		pprof.Lookup("goroutine").WriteTo(os.Stdout, 2)
 	}
 
 	for _, v := range r.providers {

--- a/storage/localstore/localstore.go
+++ b/storage/localstore/localstore.go
@@ -19,6 +19,8 @@ package localstore
 import (
 	"encoding/binary"
 	"errors"
+	"os"
+	"runtime/pprof"
 	"sync"
 	"time"
 
@@ -436,15 +438,24 @@ func New(path string, baseKey []byte, o *Options) (db *DB, err error) {
 // Close closes the underlying database.
 func (db *DB) Close() (err error) {
 	close(db.close)
-	db.updateGCWG.Wait()
-	db.subscritionsWG.Wait()
 
-	// wait for gc worker to
-	// return before closing the shed
+	// wait for all handlers to finish
+	done := make(chan struct{})
+	go func() {
+		db.updateGCWG.Wait()
+		db.subscritionsWG.Wait()
+		// wait for gc worker to
+		// return before closing the shed
+		<-db.collectGarbageWorkerDone
+		close(done)
+	}()
 	select {
-	case <-db.collectGarbageWorkerDone:
+	case <-done:
 	case <-time.After(5 * time.Second):
-		log.Error("localstore: collect garbage worker did not return after db close")
+		log.Error("localstore closed with still active goroutines")
+		// Print a full goroutine dump to debug blocking.
+		// TODO: use a logger to write a goroutine profile
+		pprof.Lookup("goroutine").WriteTo(os.Stdout, 2)
 	}
 	return db.shed.Close()
 }

--- a/storage/localstore/subscription_pull.go
+++ b/storage/localstore/subscription_pull.go
@@ -61,7 +61,9 @@ func (db *DB) SubscribePull(ctx context.Context, bin uint8, since, until uint64)
 	// stop subscription when until chunk descriptor is reached
 	var errStopSubscription = errors.New("stop subscription")
 
+	db.subscritionsWG.Add(1)
 	go func() {
+		defer db.subscritionsWG.Done()
 		defer metrics.GetOrRegisterCounter(metricName+".stop", nil).Inc(1)
 		// close the returned chunk.Descriptor channel at the end to
 		// signal that the subscription is done

--- a/storage/localstore/subscription_push.go
+++ b/storage/localstore/subscription_push.go
@@ -49,7 +49,9 @@ func (db *DB) SubscribePush(ctx context.Context) (c <-chan chunk.Chunk, stop fun
 	stopChan := make(chan struct{})
 	var stopChanOnce sync.Once
 
+	db.subscritionsWG.Add(1)
 	go func() {
+		defer db.subscritionsWG.Done()
 		defer metrics.GetOrRegisterCounter(metricName+".done", nil).Inc(1)
 		// close the returned chunkInfo channel at the end to
 		// signal that the subscription is done


### PR DESCRIPTION
This PR add a protection against creating a LevelDB iterator after it has been closed. It is possible that a subscription goroutine can be scheduled after localstore DB Close method is called, resulting a panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x787fa8]
goroutine 3267 [running]:
github.com/syndtr/goleveldb/leveldb.(*DB).newRawIterator(0xc00025a340, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc0001149f0, 0x54)
    /home/travis/gopath/src/github.com/ethersphere/swarm/vendor/github.com/syndtr/goleveldb/leveldb/db_iter.go:54 +0x2a8
github.com/syndtr/goleveldb/leveldb.(*DB).newIterator(0xc00025a340, 0x0, 0x0, 0x0, 0x0, 0x54, 0x0, 0x0, 0x8b2a40)
    /home/travis/gopath/src/github.com/ethersphere/swarm/vendor/github.com/syndtr/goleveldb/leveldb/db_iter.go:79 +0x99
github.com/syndtr/goleveldb/leveldb.(*DB).NewIterator(0xc00025a340, 0x0, 0x0, 0x0, 0x0)
    /home/travis/gopath/src/github.com/ethersphere/swarm/vendor/github.com/syndtr/goleveldb/leveldb/db.go:891 +0x189
github.com/ethersphere/swarm/shed.(*DB).NewIterator(0xc000041680, 0xc000548001, 0x1)
    /home/travis/gopath/src/github.com/ethersphere/swarm/shed/db.go:140 +0xc0
github.com/ethersphere/swarm/shed.Index.Iterate(0xc000041680, 0xc00002c8e9, 0x1, 0x1, 0xc00304c640, 0xc0020c5800, 0x9210e8, 0x9210f0, 0xc0000c5d70, 0xc0000c5d08, ...)
    /home/travis/gopath/src/github.com/ethersphere/swarm/shed/index.go:304 +0x107
github.com/ethersphere/swarm/storage/localstore.(*DB).SubscribePull.func1(0x90aca5, 0x18, 0xc001095080, 0x0, 0xc000f32000, 0x5, 0xc0010950e0, 0x0, 0x99dca0, 0xc0007a0640, ...)
    /home/travis/gopath/src/github.com/ethersphere/swarm/storage/localstore/subscription_pull.go:90 +0x676
created by github.com/ethersphere/swarm/storage/localstore.(*DB).SubscribePull
    /home/travis/gopath/src/github.com/ethersphere/swarm/storage/localstore/subscription_pull.go:64 +0x3c4
FAIL    github.com/ethersphere/swarm/storage/localstore    31.341s
```

The issue was found by @acud.