### PR TITLE
network/retrieval: integrate kademlia load balancing

### DIFF
--- a/network/retrieval/retrieve_test.go
+++ b/network/retrieval/retrieve_test.go
@@ -452,7 +452,7 @@ func TestRequestFromPeers(t *testing.T) {
 	s := New(to, nil, addr, nil)
 
 	req := storage.NewRequest(storage.Address(hash0[:]))
-	id, err := s.findPeer(context.Background(), req)
+	id, err := s.findPeerLB(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR integrates the Kademlia Load Balancer component into the `retrieval` protocol. Apart from getting rid of the `Trace` log-lines which are not very meaningful at this point it does not seek to simplify the `findPeer` logic. The old method is left as is (without the loglines) for reference and comparison. Simplification of the `findPeerLB` should come as a subsequent iteration.

Also, a unit test for the load balancer that checks that `Off` peers don't get iterated over was added (this case was not originally implemented).

When reviewing please compare `findPeer` and `findPeerLB` side by side. Since the mechanics of the iterators are a bit different some changes had to be made on how peers are iterated over.