### PR TITLE
storage/netstore: optimize fetchers for faster forwarding

### DIFF
--- a/network/timeouts/timeouts.go
+++ b/network/timeouts/timeouts.go
@@ -10,6 +10,9 @@ var FailedPeerSkipDelay = 20 * time.Second
 // Basically this is the amount of time a singleflight request for a given chunk lives
 var FetcherGlobalTimeout = 10 * time.Second
 
+// FetcherSlowChunkDeliveryThreshold is the threshold above which we log a slow chunk delivery in netstore
+var FetcherSlowChunkDeliveryThreshold = 5 * time.Second
+
 // SearchTimeout is the max time requests wait for a peer to deliver a chunk, after which another peer is tried
 var SearchTimeout = 1500 * time.Millisecond
 


### PR DESCRIPTION
This PR aims to optimize fetchers for faster forwarding of chunks.

The main problem with the current implementation on `master` is that a delivery of a fetcher is notified to the goroutines blocking on the delivery only after the chunk has been put to the localstore (by the means of closing the `Delivered` channel on the fetcher). This is an obvious forfeit on performance. 

The proposed solution is to add a `Chunk` field on the `Fetcher` struct. This field will be safely set when `once.Do()` is called upon chunk delivery. The goroutines blocking on the delivery will then unblock and read the data from the `Chunk` field. This skips the localstore `Put` and `Get` when delivering the chunks.