### PR TITLE
localstore: skip tag not found on migration

### DIFF
--- a/chunk/tags.go
+++ b/chunk/tags.go
@@ -30,7 +30,10 @@ import (
 	"github.com/ethersphere/swarm/sctx"
 )
 
-var TagUidFunc = rand.Uint32
+var (
+	TagUidFunc     = rand.Uint32
+	TagNotFoundErr = errors.New("tag not found")
+)
 
 // Tags hold tag information indexed by a unique random uint32
 type Tags struct {
@@ -72,7 +75,7 @@ func (ts *Tags) All() (t []*Tag) {
 func (ts *Tags) Get(uid uint32) (*Tag, error) {
 	t, ok := ts.tags.Load(uid)
 	if !ok {
-		return nil, errors.New("tag not found")
+		return nil, TagNotFoundErr
 	}
 	return t.(*Tag), nil
 }

--- a/storage/localstore/migration.go
+++ b/storage/localstore/migration.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/ethersphere/swarm/chunk"
 	"github.com/ethersphere/swarm/log"
 	"github.com/ethersphere/swarm/shed"
 	"github.com/syndtr/goleveldb/leveldb"
@@ -161,9 +162,15 @@ func migrateSanctuary(db *DB) error {
 
 	err = db.pushIndex.Iterate(func(item shed.Item) (stop bool, err error) {
 		tag, err := db.tags.Get(item.Tag)
+		if err != nil {
+			if err == chunk.TagNotFoundErr {
+				return false, nil
+			}
+			return true, err
+		}
 
 		// anonymous tags should no longer appear in pushIndex
-		if err == nil && tag != nil && tag.Anonymous {
+		if tag != nil && tag.Anonymous {
 			db.pushIndex.DeleteInBatch(batch, item)
 		}
 		return false, nil

--- a/storage/localstore/migration.go
+++ b/storage/localstore/migration.go
@@ -161,12 +161,9 @@ func migrateSanctuary(db *DB) error {
 
 	err = db.pushIndex.Iterate(func(item shed.Item) (stop bool, err error) {
 		tag, err := db.tags.Get(item.Tag)
-		if err != nil {
-			return true, err
-		}
 
 		// anonymous tags should no longer appear in pushIndex
-		if tag != nil && tag.Anonymous {
+		if err == nil && tag != nil && tag.Anonymous {
 			db.pushIndex.DeleteInBatch(batch, item)
 		}
 		return false, nil


### PR DESCRIPTION
If the tag is not found we should not interrupt the migration, but continue to the next item. Since the anonymity of the upload cannot be assumed, it will be picked up by the push syncer and be eventually synced and subsequently removed from the index when `setSync` is called in localstore.