### PR TITLE
stream: avoid repeated SetSyncPull for chunk, change batch size

### DIFF
--- a/network/stream/stream.go
+++ b/network/stream/stream.go
@@ -45,7 +45,7 @@ import (
 
 const (
 	HashSize     = 32
-	BatchSize    = 128
+	BatchSize    = 64
 	MinFrameSize = 16
 )
 

--- a/network/stream/sync_provider.go
+++ b/network/stream/sync_provider.go
@@ -38,6 +38,7 @@ import (
 const (
 	syncStreamName      = "SYNC"
 	cacheCapacity       = 10000
+	setCacheCapacity    = 50000 // 50000 * 32 = ~1.6mb
 	maxBinZeroSyncPeers = 3
 )
 
@@ -50,6 +51,8 @@ type syncProvider struct {
 	quit                    chan struct{}     // shutdown
 	cacheMtx                sync.RWMutex      // synchronization primitive to protect cache
 	cache                   *lru.Cache        // cache to minimize load on netstore
+	setCacheMtx             sync.RWMutex      // set cache mutex
+	setCache                *lru.Cache        // cache to reduce load on localstore to not set the same chunk as synced
 	logger                  log.Logger        // logger that appends the base address to loglines
 	binZeroSem              chan struct{}     // semaphore to limit number of syncing peers on bin 0
 }
@@ -63,6 +66,10 @@ func NewSyncProvider(ns *storage.NetStore, kad *network.Kademlia, autostart bool
 	if err != nil {
 		panic(err)
 	}
+	sc, err := lru.New(cacheCapacity)
+	if err != nil {
+		panic(err)
+	}
 
 	return &syncProvider{
 		netStore:                ns,
@@ -72,6 +79,7 @@ func NewSyncProvider(ns *storage.NetStore, kad *network.Kademlia, autostart bool
 		name:                    syncStreamName,
 		quit:                    make(chan struct{}),
 		cache:                   c,
+		setCache:                sc,
 		logger:                  log.New("base", hex.EncodeToString(kad.BaseAddr()[:16])),
 		binZeroSem:              make(chan struct{}, maxBinZeroSyncPeers),
 	}
@@ -190,10 +198,27 @@ func (s *syncProvider) Get(ctx context.Context, addr ...chunk.Address) ([]chunk.
 
 // Set the supplied addrs as synced in order to allow for garbage collection
 func (s *syncProvider) Set(ctx context.Context, addrs ...chunk.Address) error {
-	err := s.netStore.Set(ctx, chunk.ModeSetSyncPull, addrs...)
+	var chunksToSet []chunk.Address
+
+	s.setCacheMtx.RLock()
+	for _, addr := range addrs {
+		if _, ok := s.setCache.Get(addr); !ok {
+			chunksToSet = append(chunksToSet, addr)
+		}
+	}
+	s.setCacheMtx.RUnlock()
+
+	err := s.netStore.Set(ctx, chunk.ModeSetSyncPull, chunksToSet...)
 	if err != nil {
 		metrics.GetOrRegisterCounter("syncProvider.set-sync-err", nil).Inc(1)
 		return err
+	}
+
+	s.setCacheMtx.Lock()
+	defer s.setCacheMtx.Unlock()
+
+	for _, addr := range chunksToSet {
+		s.setCache.Add(addr, struct{}{})
 	}
 	return nil
 }

--- a/network/stream/sync_provider.go
+++ b/network/stream/sync_provider.go
@@ -38,7 +38,7 @@ import (
 const (
 	syncStreamName      = "SYNC"
 	cacheCapacity       = 10000
-	setCacheCapacity    = 200000 // 200000 * 32 = ~6.4mb mem footprint, 200K chunks ~=800 megs of data
+	setCacheCapacity    = 80000 // 80000 * 32 = ~2.5mb mem footprint, 80K chunks ~=330 megs of data
 	maxBinZeroSyncPeers = 3
 )
 
@@ -207,7 +207,7 @@ func (s *syncProvider) Set(ctx context.Context, addrs ...chunk.Address) error {
 
 	s.setCacheMtx.RLock()
 	for _, addr := range addrs {
-		if _, ok := s.setCache.Get(addr); !ok {
+		if _, ok := s.setCache.Get(addr.String()); !ok {
 			chunksToSet = append(chunksToSet, addr)
 			setCacheMissCount.Inc(1)
 		} else {
@@ -226,7 +226,7 @@ func (s *syncProvider) Set(ctx context.Context, addrs ...chunk.Address) error {
 	defer s.setCacheMtx.Unlock()
 
 	for _, addr := range chunksToSet {
-		s.setCache.Add(addr, struct{}{})
+		s.setCache.Add(addr.String(), struct{}{})
 	}
 	return nil
 }


### PR DESCRIPTION
This PR tries to avoid multiple `Set`s of a chunk as Synced using an LRU cache.

Every time a node receives a chunk by syncing it will try to sync that chunk out again (for replication sake and in order to maintain integrity of bin IDs).
This is turn means that the node that sent the chunk to the node will be presented with an `OfferedHashes` message that contains chunks that this node already has and has already synced to other nodes. The number of such duplicate sets can potentially be very high and using an LRU cache for these sets can ease some of the load we're seeing on the localstore as a result.