### PR TITLE
storage/localstore: decode tags in push index only if it is complete

### DIFF
--- a/storage/localstore/localstore.go
+++ b/storage/localstore/localstore.go
@@ -350,7 +350,7 @@ func New(path string, baseKey []byte, o *Options) (db *DB, err error) {
 			return tag, nil
 		},
 		DecodeValue: func(keyItem shed.Item, value []byte) (e shed.Item, err error) {
-			if value != nil {
+			if len(value) == 4 { // only values with tag should be decoded
 				e.Tag = binary.BigEndian.Uint32(value)
 			}
 			return e, nil


### PR DESCRIPTION
This adds more strict check for tags value in localstore push index. It is possible that the encoded value is not nil, but has a length of 0, resulting with a panic:

```
INFO [11-29|18:47:10.363] IPC endpoint opened                      url=/root/.ethereum/bzzd.ipc
panic: runtime error: index out of range [3] with length 0

goroutine 63 [running]:
encoding/binary.bigEndian.Uint32(...)
    /usr/local/go/src/encoding/binary/binary.go:111
github.com/ethersphere/swarm/storage/localstore.New.func19(0xc000202279, 0x20, 0x27, 0x0, 0x0, 0x0, 0x0, 0x15dba89f83c7111d, 0x1, 0x0, ...)
    /root/go/src/github.com/ethersphere/swarm/storage/localstore/localstore.go:354 +0x7b
github.com/ethersphere/swarm/shed.Index.Get(0xc0001e2600, 0xc000271a39, 0x1, 0x1, 0xc000235a80, 0xc0003a45a0, 0x11ea570, 0x11ea578, 0xc000202279, 0x20, ...)
    /root/go/src/github.com/ethersphere/swarm/shed/index.go:147 +0x148
github.com/ethersphere/swarm/storage/localstore.(*DB).setSync(0xc000214000, 0xc000d28440, 0xc000202279, 0x20, 0x27, 0x1, 0x1ce6b80, 0x1a54c98, 0xc000059500)
    /root/go/src/github.com/ethersphere/swarm/storage/localstore/mode_set.go:249 +0xcc1
github.com/ethersphere/swarm/storage/localstore.(*DB).set(0xc000214000, 0x1, 0xc00039f000, 0xcc, 0x100, 0x0, 0x0)
    /root/go/src/github.com/ethersphere/swarm/storage/localstore/mode_set.go:84 +0x1c3
github.com/ethersphere/swarm/storage/localstore.(*DB).Set(0xc000214000, 0x13595e0, 0xc00003e0b8, 0x1, 0xc00039f000, 0xcc, 0x100, 0x0, 0x0)
    /root/go/src/github.com/ethersphere/swarm/storage/localstore/mode_set.go:40 +0x1ed
github.com/ethersphere/swarm/pushsync.(*Pusher).chunksWorker.func1(0xc0022d3ed8, 0xc0003343f0, 0x13595e0, 0xc00003e0b8, 0xc0022d3e40, 0xc0022d3f38, 0xc0022d3ef0, 0xc0000c8e10)
    /root/go/src/github.com/ethersphere/swarm/pushsync/pusher.go:181 +0x19c
github.com/ethersphere/swarm/pushsync.(*Pusher).chunksWorker(0xc0003343f0)
    /root/go/src/github.com/ethersphere/swarm/pushsync/pusher.go:214 +0x6af
created by github.com/ethersphere/swarm/pushsync.NewPusher
    /root/go/src/github.com/ethersphere/swarm/pushsync/pusher.go:90 +0x271
```

This issue was found and reported by @mortelli https://beehive.ethswarm.org/swarm/pl/zm9hw95qabbe5pmdx3re4hx3qr.