### PR TITLE
metrics: remove metrics.influxdb.accounting flag

### DIFF
--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -298,6 +298,9 @@ func bzzd(ctx *cli.Context) error {
 		cfg.DataDir = bzzconfig.Path
 	}
 
+	// disable USB devices
+	cfg.NoUSB = true
+
 	// start any custom pprof profiles
 	pprofProfiles(ctx)
 

--- a/metrics/flags.go
+++ b/metrics/flags.go
@@ -34,10 +34,6 @@ var (
 		Name:  "metrics.influxdb.export",
 		Usage: "Enable metrics export/push to an external InfluxDB database",
 	}
-	MetricsEnableInfluxDBAccountingExportFlag = cli.BoolFlag{
-		Name:  "metrics.influxdb.accounting",
-		Usage: "Enable accounting metrics export/push to an external InfluxDB database",
-	}
 	MetricsInfluxDBEndpointFlag = cli.StringFlag{
 		Name:  "metrics.influxdb.endpoint",
 		Usage: "Metrics InfluxDB endpoint",
@@ -73,7 +69,6 @@ var (
 var Flags = []cli.Flag{
 	utils.MetricsEnabledFlag,
 	MetricsEnableInfluxDBExportFlag,
-	MetricsEnableInfluxDBAccountingExportFlag,
 	MetricsInfluxDBEndpointFlag,
 	MetricsInfluxDBDatabaseFlag,
 	MetricsInfluxDBUsernameFlag,
@@ -85,13 +80,12 @@ func Setup(ctx *cli.Context) {
 	if gethmetrics.Enabled {
 		log.Info("Enabling swarm metrics collection")
 		var (
-			endpoint               = ctx.GlobalString(MetricsInfluxDBEndpointFlag.Name)
-			database               = ctx.GlobalString(MetricsInfluxDBDatabaseFlag.Name)
-			username               = ctx.GlobalString(MetricsInfluxDBUsernameFlag.Name)
-			password               = ctx.GlobalString(MetricsInfluxDBPasswordFlag.Name)
-			enableExport           = ctx.GlobalBool(MetricsEnableInfluxDBExportFlag.Name)
-			enableAccountingExport = ctx.GlobalBool(MetricsEnableInfluxDBAccountingExportFlag.Name)
-			datadir                = ctx.GlobalString("datadir")
+			endpoint     = ctx.GlobalString(MetricsInfluxDBEndpointFlag.Name)
+			database     = ctx.GlobalString(MetricsInfluxDBDatabaseFlag.Name)
+			username     = ctx.GlobalString(MetricsInfluxDBUsernameFlag.Name)
+			password     = ctx.GlobalString(MetricsInfluxDBPasswordFlag.Name)
+			enableExport = ctx.GlobalBool(MetricsEnableInfluxDBExportFlag.Name)
+			datadir      = ctx.GlobalString("datadir")
 		)
 
 		// Start system runtime metrics collection
@@ -108,10 +102,6 @@ func Setup(ctx *cli.Context) {
 		if enableExport {
 			log.Info("Enabling swarm metrics export to InfluxDB")
 			go influxdb.InfluxDBWithTags(gethmetrics.DefaultRegistry, 10*time.Second, endpoint, database, username, password, "swarm.", tagsMap)
-		}
-
-		if enableAccountingExport {
-			log.Info("Exporting swarm accounting metrics to InfluxDB")
 			go influxdb.InfluxDBWithTags(gethmetrics.AccountingRegistry, 10*time.Second, endpoint, database, username, password, "accounting.", tagsMap)
 		}
 	}


### PR DESCRIPTION
After @holisticode reported that the accounting metrics were not being forwarded on one of his deployments, I discovered this flag.... 

I'm no sure why these were dealt differently but I suggest to remove this flag.