### PR TITLE
log, network, storage, testutil: Log base address only in tests

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -18,6 +18,7 @@ var (
 // Export go-ethereum/log interface so that swarm/log can be used with it interchangeably
 type Logger = l.Logger
 
+// NewBaseAddressLogger creates a new logger with a `base` prefix
 func NewBaseAddressLogger(baseAddr string, ctx ...interface{}) l.Logger {
 	if logBaseAddr {
 		return l.New(append([]interface{}{"base", baseAddr}, ctx...)...)
@@ -26,6 +27,7 @@ func NewBaseAddressLogger(baseAddr string, ctx ...interface{}) l.Logger {
 	return l.New(ctx...)
 }
 
+// New creates new swarm logger
 func New(ctx ...interface{}) Logger {
 	return l.New(ctx)
 }

--- a/log/log.go
+++ b/log/log.go
@@ -11,6 +11,18 @@ const (
 	CallDepth = 1
 )
 
+var (
+	LogBaseAddr = false
+)
+
+func New(baseAddr string, ctx ...interface{}) l.Logger {
+	if LogBaseAddr {
+		return l.New(append([]interface{}{"base", baseAddr}, ctx...)...)
+	}
+
+	return l.New(ctx...)
+}
+
 // Warn is a convenient alias for log.Warn with stats
 func Warn(msg string, ctx ...interface{}) {
 	metrics.GetOrRegisterCounter("warn", nil).Inc(1)

--- a/log/log.go
+++ b/log/log.go
@@ -12,15 +12,28 @@ const (
 )
 
 var (
-	LogBaseAddr = false
+	logBaseAddr = false
 )
 
-func New(baseAddr string, ctx ...interface{}) l.Logger {
-	if LogBaseAddr {
+// Export go-ethereum/log interface so that swarm/log can be used with it interchangeably
+type Logger = l.Logger
+
+func NewBaseAddressLogger(baseAddr string, ctx ...interface{}) l.Logger {
+	if logBaseAddr {
 		return l.New(append([]interface{}{"base", baseAddr}, ctx...)...)
 	}
 
 	return l.New(ctx...)
+}
+
+func New(ctx ...interface{}) Logger {
+	return l.New(ctx)
+}
+
+// EnableBaseAddress enables the logging of the base address
+// it is used for tests
+func EnableBaseAddress() {
+	logBaseAddr = true
 }
 
 // Warn is a convenient alias for log.Warn with stats

--- a/network/retrieval/peer.go
+++ b/network/retrieval/peer.go
@@ -21,8 +21,8 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethersphere/swarm/chunk"
+	"github.com/ethersphere/swarm/log"
 	"github.com/ethersphere/swarm/network"
 	"github.com/ethersphere/swarm/storage"
 )
@@ -40,7 +40,7 @@ type Peer struct {
 func NewPeer(peer *network.BzzPeer, baseKey *network.BzzAddr) *Peer {
 	return &Peer{
 		BzzPeer:    peer,
-		logger:     log.New("base", baseKey.ShortString(), "peer", peer.BzzAddr.ShortString()),
+		logger:     log.NewBaseAddressLogger("base", baseKey.ShortString(), "peer", peer.BzzAddr.ShortString()),
 		retrievals: make(map[uint]chunk.Address),
 	}
 }

--- a/network/retrieval/retrieve.go
+++ b/network/retrieval/retrieve.go
@@ -26,21 +26,22 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ethereum/go-ethereum/log"
+	opentracing "github.com/opentracing/opentracing-go"
+	olog "github.com/opentracing/opentracing-go/log"
+
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethersphere/swarm/chunk"
+	"github.com/ethersphere/swarm/log"
 	"github.com/ethersphere/swarm/network"
 	"github.com/ethersphere/swarm/network/timeouts"
 	"github.com/ethersphere/swarm/p2p/protocols"
 	"github.com/ethersphere/swarm/spancontext"
 	"github.com/ethersphere/swarm/storage"
 	"github.com/ethersphere/swarm/swap"
-	opentracing "github.com/opentracing/opentracing-go"
-	olog "github.com/opentracing/opentracing-go/log"
 )
 
 var (
@@ -109,7 +110,7 @@ func New(kad *network.Kademlia, ns *storage.NetStore, baseKey *network.BzzAddr, 
 		kad:         kad,
 		peers:       make(map[enode.ID]*Peer),
 		spec:        spec,
-		logger:      log.New("base", baseKey.ShortString()),
+		logger:      log.NewBaseAddressLogger("base", baseKey.ShortString()),
 		baseAddress: baseKey,
 		quit:        make(chan struct{}),
 	}

--- a/network/stream/cursors_test.go
+++ b/network/stream/cursors_test.go
@@ -30,10 +30,10 @@ import (
 
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/simulations"
 	"github.com/ethereum/go-ethereum/rpc"
 
-	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethersphere/swarm/chunk"
 	"github.com/ethersphere/swarm/log"
 	"github.com/ethersphere/swarm/network"

--- a/network/stream/peer.go
+++ b/network/stream/peer.go
@@ -22,6 +22,8 @@ import (
 	"sync"
 	"time"
 
+	swarmlog "github.com/ethersphere/swarm/log"
+
 	"github.com/ethersphere/swarm/chunk"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -57,7 +59,7 @@ func newPeer(peer *network.BzzPeer, baseAddress *network.BzzAddr, i state.Store,
 		openWants:      make(map[uint]*want),
 		openOffers:     make(map[uint]offer),
 		quit:           make(chan struct{}),
-		logger:         log.New("base", baseAddress.ShortString(), "peer", peer.BzzAddr.ShortString()),
+		logger:         swarmlog.New(baseAddress.ShortString(), "peer", peer.BzzAddr.ShortString()),
 	}
 	return p
 }

--- a/network/stream/peer.go
+++ b/network/stream/peer.go
@@ -22,11 +22,8 @@ import (
 	"sync"
 	"time"
 
-	swarmlog "github.com/ethersphere/swarm/log"
-
 	"github.com/ethersphere/swarm/chunk"
-
-	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethersphere/swarm/log"
 	"github.com/ethersphere/swarm/network"
 	"github.com/ethersphere/swarm/network/stream/intervals"
 	"github.com/ethersphere/swarm/state"
@@ -59,7 +56,7 @@ func newPeer(peer *network.BzzPeer, baseAddress *network.BzzAddr, i state.Store,
 		openWants:      make(map[uint]*want),
 		openOffers:     make(map[uint]offer),
 		quit:           make(chan struct{}),
-		logger:         swarmlog.New(baseAddress.ShortString(), "peer", peer.BzzAddr.ShortString()),
+		logger:         log.NewBaseAddressLogger(baseAddress.ShortString(), "peer", peer.BzzAddr.ShortString()),
 	}
 	return p
 }

--- a/network/stream/stream.go
+++ b/network/stream/stream.go
@@ -118,7 +118,7 @@ func New(intervalsStore state.Store, address *network.BzzAddr, providers ...Stre
 		providers:      make(map[string]StreamProvider),
 		quit:           make(chan struct{}),
 		address:        address,
-		logger:         swarmlog.New(address.ShortString()),
+		logger:         swarmlog.NewBaseAddressLogger(address.ShortString()),
 		spec:           Spec,
 	}
 	for _, p := range providers {

--- a/network/stream/stream.go
+++ b/network/stream/stream.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethersphere/swarm/chunk"
+	swarmlog "github.com/ethersphere/swarm/log"
 	"github.com/ethersphere/swarm/network"
 	bv "github.com/ethersphere/swarm/network/bitvector"
 	"github.com/ethersphere/swarm/network/stream/intervals"
@@ -117,7 +118,7 @@ func New(intervalsStore state.Store, address *network.BzzAddr, providers ...Stre
 		providers:      make(map[string]StreamProvider),
 		quit:           make(chan struct{}),
 		address:        address,
-		logger:         log.New("base", address.ShortString()),
+		logger:         swarmlog.New(address.ShortString()),
 		spec:           Spec,
 	}
 	for _, p := range providers {

--- a/network/stream/sync_provider.go
+++ b/network/stream/sync_provider.go
@@ -24,14 +24,15 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p/enode"
+	lru "github.com/hashicorp/golang-lru"
+
 	"github.com/ethersphere/swarm/chunk"
+	"github.com/ethersphere/swarm/log"
 	"github.com/ethersphere/swarm/network"
 	"github.com/ethersphere/swarm/network/timeouts"
 	"github.com/ethersphere/swarm/storage"
-	lru "github.com/hashicorp/golang-lru"
 )
 
 const (
@@ -84,7 +85,7 @@ func NewSyncProvider(ns *storage.NetStore, kad *network.Kademlia, baseAddr *netw
 		quit:                    make(chan struct{}),
 		cache:                   c,
 		setCache:                sc,
-		logger:                  log.New("base", baseAddr.ShortString()),
+		logger:                  log.NewBaseAddressLogger("base", baseAddr.ShortString()),
 		binZeroSem:              make(chan struct{}, maxBinZeroSyncPeers),
 	}
 }

--- a/storage/netstore.go
+++ b/storage/netstore.go
@@ -24,7 +24,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethersphere/swarm/chunk"
@@ -35,6 +34,7 @@ import (
 	"github.com/syndtr/goleveldb/leveldb"
 	"golang.org/x/sync/singleflight"
 
+	"github.com/ethersphere/swarm/log"
 	"github.com/ethersphere/swarm/network"
 )
 
@@ -109,7 +109,7 @@ func NewNetStore(store chunk.Store, baseAddr *network.BzzAddr) *NetStore {
 		fetchers: fetchers,
 		Store:    store,
 		LocalID:  baseAddr.ID(),
-		logger:   log.New("base", baseAddr.ShortString()),
+		logger:   log.NewBaseAddressLogger("base", baseAddr.ShortString()),
 	}
 }
 

--- a/testutil/init.go
+++ b/testutil/init.go
@@ -38,10 +38,8 @@ func Init() {
 	testing.Init()
 
 	// enable base address logging
-	swarmlog.LogBaseAddr = true
-
+	swarmlog.EnableBaseAddress()
 	flag.Parse()
-
 	log.PrintOrigins(true)
 	log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(*Loglevel), log.StreamHandler(colorable.NewColorableStderr(), log.TerminalFormat(!*rawlog))))
 }

--- a/testutil/init.go
+++ b/testutil/init.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/log"
+	swarmlog "github.com/ethersphere/swarm/log"
 	"github.com/mattn/go-colorable"
 )
 
@@ -28,14 +29,16 @@ import (
 var (
 	Loglevel    = flag.Int("loglevel", 2, "verbosity of logs")
 	Longrunning = flag.Bool("longrunning", false, "do run long-running tests")
-
-	rawlog = flag.Bool("rawlog", false, "remove terminal formatting from logs")
+	rawlog      = flag.Bool("rawlog", false, "remove terminal formatting from logs")
 )
 
 // Init ensures that testing.Init is called before flag.Parse and sets common
 // logging options.
 func Init() {
 	testing.Init()
+
+	// enable base address logging
+	swarmlog.LogBaseAddr = true
 
 	flag.Parse()
 


### PR DESCRIPTION
Logging of base address is useful in tests and not so much in the production. This is one way of implementing this functionality without big changes to the code base.

The base address logging is enabled in `testutil/init`, however we could also do it with the init fuction of a separate test file, flag `testutil`, or custom build tags if it is more preferable. 