### PR TITLE
forky: Fixed Chunk Data Size Store

### DIFF
--- a/cmd/swarm/db.go
+++ b/cmd/swarm/db.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common"
@@ -168,10 +167,6 @@ func dbImport(ctx *cli.Context) {
 }
 
 func openLDBStore(path string, basekey []byte) (*localstore.DB, error) {
-	if _, err := os.Stat(filepath.Join(path, "CURRENT")); err != nil {
-		return nil, fmt.Errorf("invalid chunkdb path: %s", err)
-	}
-
 	return localstore.New(path, basekey, nil)
 }
 

--- a/storage/fcds/doc.go
+++ b/storage/fcds/doc.go
@@ -1,0 +1,43 @@
+// Copyright 2019 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package fcds provides storage layers for storing chunk data only.
+//
+// FCDS stands for Fixed Chunk Data Storage.
+//
+// Swarm Chunk data limited size property allows a very specific chunk storage
+// solution that can be more performant than more generalized key/value
+// databases. FCDS stores chunk data in files (shards) at fixed length offsets.
+// Relations between chunk address, file number and offset in that file are
+// managed by a separate MetaStore implementation.
+//
+// Package fcds contains the main implementation based on simple file operations
+// for persisting chunk data and relaying on specific chunk meta information
+// storage.
+//
+// The reference chunk meta information storage is implemented in fcds/mem
+// package. It can be used in tests.
+//
+// LevelDB based chunk meta information storage is implemented in fcds/leveldb
+// package. This implementation should be used as default in production.
+//
+// Additional FCDS Store implementation is in fcds/mock. It uses mock store and
+// can be used for centralized chunk storage options that mock storage package
+// provides.
+//
+// Package fcds/test contains test functions which can be used to validate
+// behaviour of different FCDS or its MetaStore implementations.
+package fcds

--- a/storage/fcds/fcds.go
+++ b/storage/fcds/fcds.go
@@ -192,7 +192,7 @@ func (s *Store) Put(ch chunk.Chunk) (err error) {
 func (s *Store) getOffset(shard uint8) (offset int64, reclaimed bool, err error) {
 	if !s.shardHasFreeOffsets(shard) {
 		// shard does not have free offset
-		return -1, false, err
+		return -1, false, nil
 	}
 
 	offset = -1 // negative offset denotes no available free offset

--- a/storage/fcds/fcds.go
+++ b/storage/fcds/fcds.go
@@ -70,10 +70,10 @@ type Option func(*Store)
 
 // WithCache is an optional argument to New constructor that enables
 // in memory cache of free chunk data positions in files
-func WithCache(yes bool, ttl time.Duration) Option {
+func WithCache(yes bool) Option {
 	return func(s *Store) {
 		if yes {
-			s.freeCache = newOffsetCache(shardCount, ttl)
+			s.freeCache = newOffsetCache(shardCount)
 		} else {
 			s.freeCache = nil
 		}

--- a/storage/fcds/fcds.go
+++ b/storage/fcds/fcds.go
@@ -176,6 +176,15 @@ func (s *Store) Put(ch chunk.Chunk) (err error) {
 	sh.mu.Lock()
 	defer sh.mu.Unlock()
 
+	_, err = s.getMeta(addr)
+	switch err {
+	case chunk.ErrChunkNotFound:
+	case nil:
+		return nil
+	default:
+		return err
+	}
+
 	offset, reclaimed, err := s.getOffset(shard)
 	if err != nil {
 		return err

--- a/storage/fcds/fcds.go
+++ b/storage/fcds/fcds.go
@@ -162,6 +162,11 @@ func (s *Store) Put(ch chunk.Chunk) (err error) {
 	addr := ch.Address()
 	data := ch.Data()
 
+	size := len(data)
+	if size > s.maxChunkSize {
+		return fmt.Errorf("chunk data size %v exceeds %v bytes", size, s.maxChunkSize)
+	}
+
 	section := make([]byte, s.maxChunkSize)
 	copy(section, data)
 
@@ -197,7 +202,7 @@ func (s *Store) Put(ch chunk.Chunk) (err error) {
 		s.freeCache.remove(shard, offset)
 	}
 	return s.meta.Set(addr, shard, reclaimed, &Meta{
-		Size:   uint16(len(data)),
+		Size:   uint16(size),
 		Offset: offset,
 	})
 }

--- a/storage/fcds/fcds.go
+++ b/storage/fcds/fcds.go
@@ -1,0 +1,305 @@
+// Copyright 2019 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package fcds
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/ethersphere/swarm/chunk"
+)
+
+const shardCount = 32
+
+var ErrDBClosed = errors.New("closed database")
+
+type Interface interface {
+	Get(addr chunk.Address) (ch chunk.Chunk, err error)
+	Has(addr chunk.Address) (yes bool, err error)
+	Put(ch chunk.Chunk) (err error)
+	Delete(addr chunk.Address) (err error)
+	Count() (count int, err error)
+	Iterate(func(ch chunk.Chunk) (stop bool, err error)) (err error)
+	Close() (err error)
+}
+
+var _ Interface = new(Store)
+
+type Store struct {
+	shards       map[uint8]*os.File
+	shardsMu     map[uint8]*sync.Mutex
+	meta         MetaStore
+	free         map[uint8]struct{}
+	freeMu       sync.RWMutex
+	freeCache    *offsetCache
+	wg           sync.WaitGroup
+	maxChunkSize int
+	quit         chan struct{}
+	quitOnce     sync.Once
+}
+
+func NewStore(path string, maxChunkSize int, metaStore MetaStore, noCache bool) (s *Store, err error) {
+	shards := make(map[byte]*os.File, shardCount)
+	shardsMu := make(map[uint8]*sync.Mutex)
+	for i := byte(0); i < shardCount; i++ {
+		shards[i], err = os.OpenFile(filepath.Join(path, fmt.Sprintf("chunks-%v.db", i)), os.O_CREATE|os.O_RDWR, 0666)
+		if err != nil {
+			return nil, err
+		}
+		shardsMu[i] = new(sync.Mutex)
+	}
+	var (
+		freeCache *offsetCache
+	)
+	if !noCache {
+		freeCache = newOffsetCache(shardCount)
+	}
+	return &Store{
+		shards:       shards,
+		shardsMu:     shardsMu,
+		meta:         metaStore,
+		freeCache:    freeCache,
+		free:         make(map[uint8]struct{}),
+		maxChunkSize: maxChunkSize,
+		quit:         make(chan struct{}),
+	}, nil
+}
+
+func (s *Store) Get(addr chunk.Address) (ch chunk.Chunk, err error) {
+	done, err := s.protect()
+	if err != nil {
+		return nil, err
+	}
+	defer done()
+
+	mu := s.shardsMu[getShard(addr)]
+	mu.Lock()
+	defer mu.Unlock()
+
+	m, err := s.getMeta(addr)
+	if err != nil {
+		return nil, err
+	}
+	data := make([]byte, m.Size)
+	n, err := s.shards[getShard(addr)].ReadAt(data, m.Offset)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if n != int(m.Size) {
+		return nil, fmt.Errorf("incomplete chunk data, read %v of %v", n, m.Size)
+	}
+	return chunk.NewChunk(addr, data), nil
+}
+
+func (s *Store) Has(addr chunk.Address) (yes bool, err error) {
+	done, err := s.protect()
+	if err != nil {
+		return false, err
+	}
+	defer done()
+
+	mu := s.shardsMu[getShard(addr)]
+	mu.Lock()
+	defer mu.Unlock()
+
+	_, err = s.getMeta(addr)
+	if err != nil {
+		if err == chunk.ErrChunkNotFound {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func (s *Store) Put(ch chunk.Chunk) (err error) {
+	done, err := s.protect()
+	if err != nil {
+		return err
+	}
+	defer done()
+
+	addr := ch.Address()
+	shard := getShard(addr)
+	f := s.shards[shard]
+	data := ch.Data()
+	section := make([]byte, s.maxChunkSize)
+	copy(section, data)
+
+	s.freeMu.RLock()
+	_, hasFree := s.free[shard]
+	s.freeMu.RUnlock()
+
+	var offset int64
+	var reclaimed bool
+	mu := s.shardsMu[shard]
+	mu.Lock()
+	if hasFree {
+		var freeOffset int64 = -1
+		if s.freeCache != nil {
+			freeOffset = s.freeCache.get(shard)
+		}
+		if freeOffset < 0 {
+			freeOffset, err = s.meta.FreeOffset(shard)
+			if err != nil {
+				return err
+			}
+		}
+		if freeOffset < 0 {
+			offset, err = f.Seek(0, io.SeekEnd)
+			if err != nil {
+				mu.Unlock()
+				return err
+			}
+			s.freeMu.Lock()
+			delete(s.free, shard)
+			s.freeMu.Unlock()
+		} else {
+			offset, err = f.Seek(freeOffset, io.SeekStart)
+			if err != nil {
+				mu.Unlock()
+				return err
+			}
+			reclaimed = true
+		}
+	} else {
+		offset, err = f.Seek(0, io.SeekEnd)
+		if err != nil {
+			mu.Unlock()
+			return err
+		}
+	}
+	_, err = f.Write(section)
+	if err != nil {
+		mu.Unlock()
+		return err
+	}
+	if reclaimed {
+		if s.freeCache != nil {
+			s.freeCache.remove(shard, offset)
+		}
+		defer mu.Unlock()
+	} else {
+		mu.Unlock()
+	}
+	return s.meta.Set(addr, shard, reclaimed, &Meta{
+		Size:   uint16(len(data)),
+		Offset: offset,
+	})
+}
+
+func (s *Store) Delete(addr chunk.Address) (err error) {
+	done, err := s.protect()
+	if err != nil {
+		return err
+	}
+	defer done()
+
+	shard := getShard(addr)
+	s.freeMu.Lock()
+	s.free[shard] = struct{}{}
+	s.freeMu.Unlock()
+
+	mu := s.shardsMu[shard]
+	mu.Lock()
+	defer mu.Unlock()
+
+	if s.freeCache != nil {
+		m, err := s.getMeta(addr)
+		if err != nil {
+			return err
+		}
+		s.freeCache.set(shard, m.Offset)
+	}
+	return s.meta.Remove(addr, shard)
+}
+
+func (s *Store) Count() (count int, err error) {
+	return s.meta.Count()
+}
+
+func (s *Store) Iterate(fn func(chunk.Chunk) (stop bool, err error)) (err error) {
+	done, err := s.protect()
+	if err != nil {
+		return err
+	}
+	defer done()
+
+	for _, mu := range s.shardsMu {
+		mu.Lock()
+	}
+	defer func() {
+		for _, mu := range s.shardsMu {
+			mu.Unlock()
+		}
+	}()
+
+	return s.meta.Iterate(func(addr chunk.Address, m *Meta) (stop bool, err error) {
+		data := make([]byte, m.Size)
+		_, err = s.shards[getShard(addr)].ReadAt(data, m.Offset)
+		if err != nil {
+			return true, err
+		}
+		return fn(chunk.NewChunk(addr, data))
+	})
+}
+
+func (s *Store) Close() (err error) {
+	s.quitOnce.Do(func() {
+		close(s.quit)
+	})
+
+	done := make(chan struct{})
+	go func() {
+		s.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+	}
+
+	for _, f := range s.shards {
+		if err := f.Close(); err != nil {
+			return err
+		}
+	}
+	return s.meta.Close()
+}
+
+func (s *Store) protect() (done func(), err error) {
+	select {
+	case <-s.quit:
+		return nil, ErrDBClosed
+	default:
+	}
+	s.wg.Add(1)
+	return s.wg.Done, nil
+}
+
+func (s *Store) getMeta(addr chunk.Address) (m *Meta, err error) {
+	return s.meta.Get(addr)
+}
+
+func getShard(addr chunk.Address) (shard uint8) {
+	return addr[len(addr)-1] % shardCount
+}

--- a/storage/fcds/fcds.go
+++ b/storage/fcds/fcds.go
@@ -142,14 +142,7 @@ func (s *Store) Has(addr chunk.Address) (yes bool, err error) {
 	mu.Lock()
 	defer mu.Unlock()
 
-	_, err = s.getMeta(addr)
-	if err != nil {
-		if err == chunk.ErrChunkNotFound {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
+	return s.meta.Has(addr)
 }
 
 // Put stores chunk data.
@@ -176,13 +169,12 @@ func (s *Store) Put(ch chunk.Chunk) (err error) {
 	sh.mu.Lock()
 	defer sh.mu.Unlock()
 
-	_, err = s.getMeta(addr)
-	switch err {
-	case chunk.ErrChunkNotFound:
-	case nil:
-		return nil
-	default:
+	has, err := s.meta.Has(addr)
+	if err != nil {
 		return err
+	}
+	if has {
+		return nil
 	}
 
 	offset, reclaimed, err := s.getOffset(shard)

--- a/storage/fcds/fcds.go
+++ b/storage/fcds/fcds.go
@@ -30,10 +30,10 @@ import (
 	"github.com/ethersphere/swarm/chunk"
 )
 
-// Interface specifies methods required for FCDS implementation.
+// Storer specifies methods required for FCDS implementation.
 // It can be used where alternative implementations are needed to
 // switch at runtime.
-type Interface interface {
+type Storer interface {
 	Get(addr chunk.Address) (ch chunk.Chunk, err error)
 	Has(addr chunk.Address) (yes bool, err error)
 	Put(ch chunk.Chunk) (err error)
@@ -43,7 +43,7 @@ type Interface interface {
 	Close() (err error)
 }
 
-var _ Interface = new(Store)
+var _ Storer = new(Store)
 
 // Number of files that store chunk data.
 const shardCount = 32

--- a/storage/fcds/fcds.go
+++ b/storage/fcds/fcds.go
@@ -70,10 +70,10 @@ type Option func(*Store)
 
 // WithCache is an optional argument to New constructor that enables
 // in memory cache of free chunk data positions in files
-func WithCache(yes bool) Option {
+func WithCache(yes bool, ttl time.Duration) Option {
 	return func(s *Store) {
 		if yes {
-			s.freeCache = newOffsetCache(shardCount)
+			s.freeCache = newOffsetCache(shardCount, ttl)
 		} else {
 			s.freeCache = nil
 		}

--- a/storage/fcds/fcds.go
+++ b/storage/fcds/fcds.go
@@ -177,8 +177,13 @@ func (s *Store) Put(ch chunk.Chunk) (err error) {
 	}
 
 	if offset < 0 {
+		// no free offsets found,
+		// append the chunk data by
+		// seeking to the end of the file
 		offset, err = sh.f.Seek(0, io.SeekEnd)
 	} else {
+		// seek to the offset position
+		// to replace the chunk data at that position
 		_, err = sh.f.Seek(offset, io.SeekStart)
 	}
 	if err != nil {
@@ -224,7 +229,7 @@ func (s *Store) getOffset(shard uint8) (offset int64, reclaimed bool, err error)
 	return offset, true, nil
 }
 
-// Delete removes chunk data.
+// Delete makes the chunk unavailable.
 func (s *Store) Delete(addr chunk.Address) (err error) {
 	if err := s.protect(); err != nil {
 		return err

--- a/storage/fcds/leveldb/leveldb.go
+++ b/storage/fcds/leveldb/leveldb.go
@@ -1,0 +1,161 @@
+// Copyright 2019 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package leveldb
+
+import (
+	"encoding/binary"
+
+	"github.com/ethersphere/swarm/chunk"
+	"github.com/ethersphere/swarm/storage/fcds"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/opt"
+)
+
+var _ fcds.MetaStore = new(MetaStore)
+
+type MetaStore struct {
+	db *leveldb.DB
+}
+
+func NewMetaStore(filename string) (s *MetaStore, err error) {
+	db, err := leveldb.OpenFile(filename, &opt.Options{})
+	if err != nil {
+		return nil, err
+	}
+	return &MetaStore{
+		db: db,
+	}, err
+}
+
+func (s *MetaStore) Get(addr chunk.Address) (m *fcds.Meta, err error) {
+	data, err := s.db.Get(chunkKey(addr), nil)
+	if err != nil {
+		if err == leveldb.ErrNotFound {
+			return nil, chunk.ErrChunkNotFound
+		}
+		return nil, err
+	}
+	m = new(fcds.Meta)
+	if err := m.UnmarshalBinary(data); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func (s *MetaStore) Set(addr chunk.Address, shard uint8, reclaimed bool, m *fcds.Meta) (err error) {
+	batch := new(leveldb.Batch)
+	if reclaimed {
+		batch.Delete(freeKey(shard, m.Offset))
+	}
+	meta, err := m.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	batch.Put(chunkKey(addr), meta)
+	return s.db.Write(batch, nil)
+}
+
+func (s *MetaStore) FreeOffset(shard uint8) (offset int64, err error) {
+	i := s.db.NewIterator(nil, nil)
+	defer i.Release()
+
+	i.Seek([]byte{freePrefix, shard})
+	key := i.Key()
+	if key == nil || key[0] != freePrefix || key[1] != shard {
+		return -1, nil
+	}
+	offset = int64(binary.BigEndian.Uint64(key[2:10]))
+	return offset, nil
+}
+
+func (s *MetaStore) Remove(addr chunk.Address, shard uint8) (err error) {
+	m, err := s.Get(addr)
+	if err != nil {
+		return err
+	}
+	batch := new(leveldb.Batch)
+	batch.Put(freeKey(shard, m.Offset), nil)
+	batch.Delete(chunkKey(addr))
+	return s.db.Write(batch, nil)
+}
+
+func (s *MetaStore) Count() (count int, err error) {
+	it := s.db.NewIterator(nil, nil)
+	defer it.Release()
+
+	for ok := it.First(); ok; ok = it.Next() {
+		value := it.Value()
+		if len(value) == 0 {
+			continue
+		}
+		key := it.Key()
+		if len(key) < 1 {
+			continue
+		}
+		count++
+	}
+	return count, it.Error()
+}
+
+func (s *MetaStore) Iterate(fn func(chunk.Address, *fcds.Meta) (stop bool, err error)) (err error) {
+	it := s.db.NewIterator(nil, nil)
+	defer it.Release()
+
+	for ok := it.First(); ok; ok = it.Next() {
+		value := it.Value()
+		if len(value) == 0 {
+			continue
+		}
+		key := it.Key()
+		if len(key) < 1 {
+			continue
+		}
+		m := new(fcds.Meta)
+		if err := m.UnmarshalBinary(value); err != nil {
+			return err
+		}
+		stop, err := fn(chunk.Address(key[1:]), m)
+		if err != nil {
+			return err
+		}
+		if stop {
+			return nil
+		}
+	}
+	return it.Error()
+}
+
+func (s *MetaStore) Close() (err error) {
+	return s.db.Close()
+}
+
+const (
+	chunkPrefix = 0
+	freePrefix  = 1
+)
+
+func chunkKey(addr chunk.Address) (key []byte) {
+	return append([]byte{chunkPrefix}, addr...)
+}
+
+func freeKey(shard uint8, offset int64) (key []byte) {
+	key = make([]byte, 10)
+	key[0] = freePrefix
+	key[1] = shard
+	binary.BigEndian.PutUint64(key[2:10], uint64(offset))
+	return key
+}

--- a/storage/fcds/leveldb/leveldb.go
+++ b/storage/fcds/leveldb/leveldb.go
@@ -60,6 +60,17 @@ func (s *MetaStore) Get(addr chunk.Address) (m *fcds.Meta, err error) {
 	return m, nil
 }
 
+// Has returns true if chunk has meta information stored.
+func (s *MetaStore) Has(addr chunk.Address) (yes bool, err error) {
+	if _, err = s.db.Get(chunkKey(addr), nil); err != nil {
+		if err == leveldb.ErrNotFound {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 // Set adds a new chunk meta information for a shard.
 // Reclaimed flag denotes that the chunk is at the place of
 // already deleted chunk, not appended to the end of the file.

--- a/storage/fcds/leveldb/leveldb_test.go
+++ b/storage/fcds/leveldb/leveldb_test.go
@@ -29,7 +29,7 @@ import (
 // TestFCDS runs a standard series of tests on main Store implementation
 // with LevelDB meta store.
 func TestFCDS(t *testing.T) {
-	test.RunAll(t, func(t *testing.T) (fcds.Interface, func()) {
+	test.RunAll(t, func(t *testing.T) (fcds.Storer, func()) {
 		path, err := ioutil.TempDir("", "swarm-fcds-")
 		if err != nil {
 			t.Fatal(err)

--- a/storage/fcds/leveldb/leveldb_test.go
+++ b/storage/fcds/leveldb/leveldb_test.go
@@ -1,0 +1,43 @@
+// Copyright 2019 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package leveldb_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/ethersphere/swarm/storage/fcds"
+	"github.com/ethersphere/swarm/storage/fcds/leveldb"
+	"github.com/ethersphere/swarm/storage/fcds/test"
+)
+
+func TestFCDS(t *testing.T) {
+	test.Test(t, func(t *testing.T) (fcds.Interface, func()) {
+		path, err := ioutil.TempDir("", "swarm-fcds-")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		metaStore, err := leveldb.NewMetaStore(filepath.Join(path, "meta"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return test.NewFCDSStore(t, path, metaStore)
+	})
+}

--- a/storage/fcds/leveldb/leveldb_test.go
+++ b/storage/fcds/leveldb/leveldb_test.go
@@ -26,8 +26,10 @@ import (
 	"github.com/ethersphere/swarm/storage/fcds/test"
 )
 
+// TestFCDS runs a standard series of tests on main Store implementation
+// with LevelDB meta store.
 func TestFCDS(t *testing.T) {
-	test.Test(t, func(t *testing.T) (fcds.Interface, func()) {
+	test.RunAll(t, func(t *testing.T) (fcds.Interface, func()) {
 		path, err := ioutil.TempDir("", "swarm-fcds-")
 		if err != nil {
 			t.Fatal(err)

--- a/storage/fcds/mem/mem.go
+++ b/storage/fcds/mem/mem.go
@@ -1,0 +1,112 @@
+// Copyright 2019 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package mem
+
+import (
+	"sync"
+
+	"github.com/ethersphere/swarm/chunk"
+	"github.com/ethersphere/swarm/storage/fcds"
+)
+
+var _ fcds.MetaStore = new(MetaStore)
+
+type MetaStore struct {
+	meta map[string]*fcds.Meta
+	free map[uint8]map[int64]struct{}
+	mu   sync.RWMutex
+}
+
+func NewMetaStore() (s *MetaStore) {
+	free := make(map[uint8]map[int64]struct{})
+	for shard := uint8(0); shard < 255; shard++ {
+		free[shard] = make(map[int64]struct{})
+	}
+	return &MetaStore{
+		meta: make(map[string]*fcds.Meta),
+		free: free,
+	}
+}
+
+func (s *MetaStore) Get(addr chunk.Address) (m *fcds.Meta, err error) {
+	s.mu.RLock()
+	m = s.meta[string(addr)]
+	s.mu.RUnlock()
+	if m == nil {
+		return nil, chunk.ErrChunkNotFound
+	}
+	return m, nil
+}
+
+func (s *MetaStore) Set(addr chunk.Address, shard uint8, reclaimed bool, m *fcds.Meta) (err error) {
+	s.mu.Lock()
+	if reclaimed {
+		delete(s.free[shard], m.Offset)
+	}
+	s.meta[string(addr)] = m
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *MetaStore) Remove(addr chunk.Address, shard uint8) (err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := string(addr)
+	m := s.meta[key]
+	if m == nil {
+		return chunk.ErrChunkNotFound
+	}
+	s.free[shard][m.Offset] = struct{}{}
+	delete(s.meta, key)
+	return nil
+}
+
+func (s *MetaStore) FreeOffset(shard uint8) (offset int64, err error) {
+	s.mu.RLock()
+	for o := range s.free[shard] {
+		s.mu.RUnlock()
+		return o, nil
+	}
+	s.mu.RUnlock()
+	return -1, nil
+}
+
+func (s *MetaStore) Count() (count int, err error) {
+	s.mu.RLock()
+	count = len(s.meta)
+	s.mu.RUnlock()
+	return count, nil
+}
+
+func (s *MetaStore) Iterate(fn func(chunk.Address, *fcds.Meta) (stop bool, err error)) (err error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for a, m := range s.meta {
+		stop, err := fn(chunk.Address(a), m)
+		if err != nil {
+			return err
+		}
+		if stop {
+			return nil
+		}
+	}
+	return nil
+}
+
+func (s *MetaStore) Close() (err error) {
+	return nil
+}

--- a/storage/fcds/mem/mem.go
+++ b/storage/fcds/mem/mem.go
@@ -56,6 +56,14 @@ func (s *MetaStore) Get(addr chunk.Address) (m *fcds.Meta, err error) {
 	return m, nil
 }
 
+// Get returns true is meta information is stored.
+func (s *MetaStore) Has(addr chunk.Address) (yes bool, err error) {
+	s.mu.RLock()
+	_, yes = s.meta[string(addr)]
+	s.mu.RUnlock()
+	return yes, nil
+}
+
 // Set adds a new chunk meta information for a shard.
 // Reclaimed flag denotes that the chunk is at the place of
 // already deleted chunk, not appended to the end of the file.

--- a/storage/fcds/mem/mem_test.go
+++ b/storage/fcds/mem/mem_test.go
@@ -25,12 +25,10 @@ import (
 	"github.com/ethersphere/swarm/storage/fcds/test"
 )
 
-func init() {
-	test.Init()
-}
-
+// TestFCDS runs a standard series of tests on main Store implementation
+// with in-memory meta store.
 func TestFCDS(t *testing.T) {
-	test.Test(t, func(t *testing.T) (fcds.Interface, func()) {
+	test.RunAll(t, func(t *testing.T) (fcds.Interface, func()) {
 		path, err := ioutil.TempDir("", "swarm-fcds-")
 		if err != nil {
 			t.Fatal(err)

--- a/storage/fcds/mem/mem_test.go
+++ b/storage/fcds/mem/mem_test.go
@@ -1,0 +1,41 @@
+// Copyright 2019 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package mem_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/ethersphere/swarm/storage/fcds"
+	"github.com/ethersphere/swarm/storage/fcds/mem"
+	"github.com/ethersphere/swarm/storage/fcds/test"
+)
+
+func init() {
+	test.Init()
+}
+
+func TestFCDS(t *testing.T) {
+	test.Test(t, func(t *testing.T) (fcds.Interface, func()) {
+		path, err := ioutil.TempDir("", "swarm-fcds-")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return test.NewFCDSStore(t, path, mem.NewMetaStore())
+	})
+}

--- a/storage/fcds/mem/mem_test.go
+++ b/storage/fcds/mem/mem_test.go
@@ -28,7 +28,7 @@ import (
 // TestFCDS runs a standard series of tests on main Store implementation
 // with in-memory meta store.
 func TestFCDS(t *testing.T) {
-	test.RunAll(t, func(t *testing.T) (fcds.Interface, func()) {
+	test.RunAll(t, func(t *testing.T) (fcds.Storer, func()) {
 		path, err := ioutil.TempDir("", "swarm-fcds-")
 		if err != nil {
 			t.Fatal(err)

--- a/storage/fcds/meta.go
+++ b/storage/fcds/meta.go
@@ -27,6 +27,7 @@ import (
 // chunk meta information in Store FCDS implementation.
 type MetaStore interface {
 	Get(addr chunk.Address) (*Meta, error)
+	Has(addr chunk.Address) (bool, error)
 	Set(addr chunk.Address, shard uint8, reclaimed bool, m *Meta) error
 	Remove(addr chunk.Address, shard uint8) error
 	Count() (int, error)

--- a/storage/fcds/meta.go
+++ b/storage/fcds/meta.go
@@ -23,6 +23,8 @@ import (
 	"github.com/ethersphere/swarm/chunk"
 )
 
+// MetaStore defines methods to store and manage
+// chunk meta information in Store FCDS implementation.
 type MetaStore interface {
 	Get(addr chunk.Address) (*Meta, error)
 	Set(addr chunk.Address, shard uint8, reclaimed bool, m *Meta) error
@@ -33,11 +35,13 @@ type MetaStore interface {
 	Close() error
 }
 
+// Meta stores chunk data size and its offset in a file.
 type Meta struct {
 	Size   uint16
 	Offset int64
 }
 
+// MarshalBinary returns binary encoded value of meta chunk information.
 func (m *Meta) MarshalBinary() (data []byte, err error) {
 	data = make([]byte, 10)
 	binary.BigEndian.PutUint64(data[:8], uint64(m.Offset))
@@ -45,6 +49,7 @@ func (m *Meta) MarshalBinary() (data []byte, err error) {
 	return data, nil
 }
 
+// UnmarshalBinary sets meta chunk information from encoded data.
 func (m *Meta) UnmarshalBinary(data []byte) error {
 	m.Offset = int64(binary.BigEndian.Uint64(data[:8]))
 	m.Size = binary.BigEndian.Uint16(data[8:10])

--- a/storage/fcds/meta.go
+++ b/storage/fcds/meta.go
@@ -1,0 +1,59 @@
+// Copyright 2019 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package fcds
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/ethersphere/swarm/chunk"
+)
+
+type MetaStore interface {
+	Get(addr chunk.Address) (*Meta, error)
+	Set(addr chunk.Address, shard uint8, reclaimed bool, m *Meta) error
+	Remove(addr chunk.Address, shard uint8) error
+	Count() (int, error)
+	Iterate(func(chunk.Address, *Meta) (stop bool, err error)) error
+	FreeOffset(shard uint8) (int64, error)
+	Close() error
+}
+
+type Meta struct {
+	Size   uint16
+	Offset int64
+}
+
+func (m *Meta) MarshalBinary() (data []byte, err error) {
+	data = make([]byte, 10)
+	binary.BigEndian.PutUint64(data[:8], uint64(m.Offset))
+	binary.BigEndian.PutUint16(data[8:10], m.Size)
+	return data, nil
+}
+
+func (m *Meta) UnmarshalBinary(data []byte) error {
+	m.Offset = int64(binary.BigEndian.Uint64(data[:8]))
+	m.Size = binary.BigEndian.Uint16(data[8:10])
+	return nil
+}
+
+func (m *Meta) String() (s string) {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("{Size: %v, Offset %v}", m.Size, m.Offset)
+}

--- a/storage/fcds/mock/mock.go
+++ b/storage/fcds/mock/mock.go
@@ -1,0 +1,113 @@
+// Copyright 2019 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package mock
+
+import (
+	"github.com/ethersphere/swarm/chunk"
+	"github.com/ethersphere/swarm/storage/fcds"
+	"github.com/ethersphere/swarm/storage/mock"
+)
+
+var _ fcds.Interface = new(Store)
+
+type Store struct {
+	m *mock.NodeStore
+}
+
+func NewStore(m *mock.NodeStore) (s *Store) {
+	return &Store{
+		m: m,
+	}
+}
+
+func (s *Store) Get(addr chunk.Address) (c chunk.Chunk, err error) {
+	data, err := s.m.Get(addr)
+	if err != nil {
+		if err == mock.ErrNotFound {
+			return nil, chunk.ErrChunkNotFound
+		}
+		return nil, err
+	}
+	return chunk.NewChunk(addr, data), nil
+}
+
+func (s *Store) Has(addr chunk.Address) (yes bool, err error) {
+	_, err = s.m.Get(addr)
+	if err != nil {
+		if err == mock.ErrNotFound {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func (s *Store) Put(ch chunk.Chunk) (err error) {
+	return s.m.Put(ch.Address(), ch.Data())
+}
+
+func (s *Store) Delete(addr chunk.Address) (err error) {
+	return s.m.Delete(addr)
+}
+
+func (s *Store) Count() (count int, err error) {
+	var startKey []byte
+	for {
+		keys, err := s.m.Keys(startKey, 0)
+		if err != nil {
+			return 0, err
+		}
+		count += len(keys.Keys)
+		if keys.Next == nil {
+			break
+		}
+		startKey = keys.Next
+	}
+	return count, nil
+}
+
+func (s *Store) Iterate(fn func(chunk.Chunk) (stop bool, err error)) (err error) {
+	var startKey []byte
+	for {
+		keys, err := s.m.Keys(startKey, 0)
+		if err != nil {
+			return err
+		}
+		for _, addr := range keys.Keys {
+			data, err := s.m.Get(addr)
+			if err != nil {
+				return err
+			}
+			stop, err := fn(chunk.NewChunk(addr, data))
+			if err != nil {
+				return err
+			}
+			if stop {
+				return nil
+			}
+		}
+		if keys.Next == nil {
+			break
+		}
+		startKey = keys.Next
+	}
+	return nil
+}
+
+func (s *Store) Close() error {
+	return nil
+}

--- a/storage/fcds/mock/mock.go
+++ b/storage/fcds/mock/mock.go
@@ -22,7 +22,7 @@ import (
 	"github.com/ethersphere/swarm/storage/mock"
 )
 
-var _ fcds.Interface = new(Store)
+var _ fcds.Storer = new(Store)
 
 // Store implements FCDS Interface by using mock
 // store for persistence.

--- a/storage/fcds/mock/mock.go
+++ b/storage/fcds/mock/mock.go
@@ -24,16 +24,21 @@ import (
 
 var _ fcds.Interface = new(Store)
 
+// Store implements FCDS Interface by using mock
+// store for persistence.
 type Store struct {
 	m *mock.NodeStore
 }
 
+// NewStore returns a new store with mock NodeStore
+// for storing Chunk data.
 func NewStore(m *mock.NodeStore) (s *Store) {
 	return &Store{
 		m: m,
 	}
 }
 
+// Get returns a chunk with data.
 func (s *Store) Get(addr chunk.Address) (c chunk.Chunk, err error) {
 	data, err := s.m.Get(addr)
 	if err != nil {
@@ -45,6 +50,7 @@ func (s *Store) Get(addr chunk.Address) (c chunk.Chunk, err error) {
 	return chunk.NewChunk(addr, data), nil
 }
 
+// Has returns true if chunk is stored.
 func (s *Store) Has(addr chunk.Address) (yes bool, err error) {
 	_, err = s.m.Get(addr)
 	if err != nil {
@@ -56,14 +62,17 @@ func (s *Store) Has(addr chunk.Address) (yes bool, err error) {
 	return true, nil
 }
 
+// Put stores chunk data.
 func (s *Store) Put(ch chunk.Chunk) (err error) {
 	return s.m.Put(ch.Address(), ch.Data())
 }
 
+// Delete removes chunk data.
 func (s *Store) Delete(addr chunk.Address) (err error) {
 	return s.m.Delete(addr)
 }
 
+// Count returns a number of stored chunks.
 func (s *Store) Count() (count int, err error) {
 	var startKey []byte
 	for {
@@ -80,6 +89,7 @@ func (s *Store) Count() (count int, err error) {
 	return count, nil
 }
 
+// Iterate iterates over stored chunks in no particular order.
 func (s *Store) Iterate(fn func(chunk.Chunk) (stop bool, err error)) (err error) {
 	var startKey []byte
 	for {
@@ -108,6 +118,8 @@ func (s *Store) Iterate(fn func(chunk.Chunk) (stop bool, err error)) (err error)
 	return nil
 }
 
+// Close doesn't do anything.
+// It exists to implement fcdb.MetaStore interface.
 func (s *Store) Close() error {
 	return nil
 }

--- a/storage/fcds/mock/mock.go
+++ b/storage/fcds/mock/mock.go
@@ -30,9 +30,9 @@ type Store struct {
 	m *mock.NodeStore
 }
 
-// NewStore returns a new store with mock NodeStore
+// New returns a new store with mock NodeStore
 // for storing Chunk data.
-func NewStore(m *mock.NodeStore) (s *Store) {
+func New(m *mock.NodeStore) (s *Store) {
 	return &Store{
 		m: m,
 	}

--- a/storage/fcds/mock/mock_test.go
+++ b/storage/fcds/mock/mock_test.go
@@ -26,12 +26,9 @@ import (
 	"github.com/ethersphere/swarm/storage/mock/mem"
 )
 
-func init() {
-	test.Init()
-}
-
+// TestFCDS runs a standard series of tests on mock Store implementation.
 func TestFCDS(t *testing.T) {
-	test.Test(t, func(t *testing.T) (fcds.Interface, func()) {
+	test.RunAll(t, func(t *testing.T) (fcds.Interface, func()) {
 		return mock.NewStore(
 			mem.NewGlobalStore().NewNodeStore(
 				common.BytesToAddress(make([]byte, 20)),

--- a/storage/fcds/mock/mock_test.go
+++ b/storage/fcds/mock/mock_test.go
@@ -28,7 +28,7 @@ import (
 
 // TestFCDS runs a standard series of tests on mock Store implementation.
 func TestFCDS(t *testing.T) {
-	test.RunAll(t, func(t *testing.T) (fcds.Interface, func()) {
+	test.RunAll(t, func(t *testing.T) (fcds.Storer, func()) {
 		return mock.New(
 			mem.NewGlobalStore().NewNodeStore(
 				common.BytesToAddress(make([]byte, 20)),

--- a/storage/fcds/mock/mock_test.go
+++ b/storage/fcds/mock/mock_test.go
@@ -29,7 +29,7 @@ import (
 // TestFCDS runs a standard series of tests on mock Store implementation.
 func TestFCDS(t *testing.T) {
 	test.RunAll(t, func(t *testing.T) (fcds.Interface, func()) {
-		return mock.NewStore(
+		return mock.New(
 			mem.NewGlobalStore().NewNodeStore(
 				common.BytesToAddress(make([]byte, 20)),
 			),

--- a/storage/fcds/mock/mock_test.go
+++ b/storage/fcds/mock/mock_test.go
@@ -1,0 +1,41 @@
+// Copyright 2019 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package mock_test
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethersphere/swarm/storage/fcds"
+	"github.com/ethersphere/swarm/storage/fcds/mock"
+	"github.com/ethersphere/swarm/storage/fcds/test"
+	"github.com/ethersphere/swarm/storage/mock/mem"
+)
+
+func init() {
+	test.Init()
+}
+
+func TestFCDS(t *testing.T) {
+	test.Test(t, func(t *testing.T) (fcds.Interface, func()) {
+		return mock.NewStore(
+			mem.NewGlobalStore().NewNodeStore(
+				common.BytesToAddress(make([]byte, 20)),
+			),
+		), func() {}
+	})
+}

--- a/storage/fcds/offsetcache.go
+++ b/storage/fcds/offsetcache.go
@@ -18,11 +18,14 @@ package fcds
 
 import "sync"
 
+// offsetCache is a simple cache of offset integers
+// by shard files.
 type offsetCache struct {
 	m  map[uint8]map[int64]struct{}
 	mu sync.RWMutex
 }
 
+// newOffsetCache constructs offsetCache for a fixed number of shards.
 func newOffsetCache(shardCount uint8) (c *offsetCache) {
 	m := make(map[uint8]map[int64]struct{})
 	for i := uint8(0); i < shardCount; i++ {
@@ -33,6 +36,9 @@ func newOffsetCache(shardCount uint8) (c *offsetCache) {
 	}
 }
 
+// get returns a free offset in a shard. If the returned
+// value is less then 0, there are no free offset in that
+// shard.
 func (c *offsetCache) get(shard uint8) (offset int64) {
 	c.mu.RLock()
 	for o := range c.m[shard] {
@@ -43,12 +49,14 @@ func (c *offsetCache) get(shard uint8) (offset int64) {
 	return -1
 }
 
+// set sets a free offset for a shard file.
 func (c *offsetCache) set(shard uint8, offset int64) {
 	c.mu.Lock()
 	c.m[shard][offset] = struct{}{}
 	c.mu.Unlock()
 }
 
+// remove removes a free offset for a shard file.
 func (c *offsetCache) remove(shard uint8, offset int64) {
 	c.mu.Lock()
 	delete(c.m[shard], offset)

--- a/storage/fcds/offsetcache.go
+++ b/storage/fcds/offsetcache.go
@@ -1,0 +1,56 @@
+// Copyright 2019 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package fcds
+
+import "sync"
+
+type offsetCache struct {
+	m  map[uint8]map[int64]struct{}
+	mu sync.RWMutex
+}
+
+func newOffsetCache(shardCount uint8) (c *offsetCache) {
+	m := make(map[uint8]map[int64]struct{})
+	for i := uint8(0); i < shardCount; i++ {
+		m[i] = make(map[int64]struct{})
+	}
+	return &offsetCache{
+		m: m,
+	}
+}
+
+func (c *offsetCache) get(shard uint8) (offset int64) {
+	c.mu.RLock()
+	for o := range c.m[shard] {
+		c.mu.RUnlock()
+		return o
+	}
+	c.mu.RUnlock()
+	return -1
+}
+
+func (c *offsetCache) set(shard uint8, offset int64) {
+	c.mu.Lock()
+	c.m[shard][offset] = struct{}{}
+	c.mu.Unlock()
+}
+
+func (c *offsetCache) remove(shard uint8, offset int64) {
+	c.mu.Lock()
+	delete(c.m[shard], offset)
+	c.mu.Unlock()
+}

--- a/storage/fcds/test/store.go
+++ b/storage/fcds/test/store.go
@@ -1,0 +1,332 @@
+// Copyright 2019 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package test
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethersphere/swarm/chunk"
+	"github.com/ethersphere/swarm/storage/fcds"
+)
+
+var (
+	chunksFlag      = flag.Int("chunks", 100, "Number of chunks to use in tests.")
+	concurrencyFlag = flag.Int("concurrency", 8, "Maximal number of parallel operations.")
+	noCacheFlag     = flag.Bool("no-cache", false, "Disable memory cache.")
+)
+
+func Init() {
+	testing.Init()
+	flag.Parse()
+}
+
+func Test(t *testing.T, newStoreFunc func(t *testing.T) (fcds.Interface, func())) {
+
+	t.Run("empty", func(t *testing.T) {
+		TestStore(t, &TestStoreOptions{
+			ChunkCount:   *chunksFlag,
+			NewStoreFunc: newStoreFunc,
+		})
+	})
+
+	t.Run("cleaned", func(t *testing.T) {
+		TestStore(t, &TestStoreOptions{
+			ChunkCount:   *chunksFlag,
+			NewStoreFunc: newStoreFunc,
+			Cleaned:      true,
+		})
+	})
+
+	for _, tc := range []struct {
+		name        string
+		deleteSplit int
+	}{
+		{
+			name:        "delete-all",
+			deleteSplit: 1,
+		},
+		{
+			name:        "delete-half",
+			deleteSplit: 2,
+		},
+		{
+			name:        "delete-fifth",
+			deleteSplit: 5,
+		},
+		{
+			name:        "delete-tenth",
+			deleteSplit: 10,
+		},
+		{
+			name:        "delete-percent",
+			deleteSplit: 100,
+		},
+		{
+			name:        "delete-permill",
+			deleteSplit: 1000,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			TestStore(t, &TestStoreOptions{
+				ChunkCount:   *chunksFlag,
+				DeleteSplit:  tc.deleteSplit,
+				NewStoreFunc: newStoreFunc,
+			})
+		})
+	}
+
+	t.Run("iterator", func(t *testing.T) {
+		TestIterator(t, newStoreFunc)
+	})
+}
+
+type TestStoreOptions struct {
+	ChunkCount   int
+	DeleteSplit  int
+	Cleaned      bool
+	NewStoreFunc func(t *testing.T) (fcds.Interface, func())
+}
+
+func TestStore(t *testing.T, o *TestStoreOptions) {
+	db, clean := o.NewStoreFunc(t)
+	defer clean()
+
+	chunks := getChunks(o.ChunkCount)
+
+	if o.Cleaned {
+		t.Run("clean", func(t *testing.T) {
+			sem := make(chan struct{}, *concurrencyFlag)
+			var wg sync.WaitGroup
+
+			wg.Add(o.ChunkCount)
+			for _, ch := range chunks {
+				sem <- struct{}{}
+
+				go func(ch chunk.Chunk) {
+					defer func() {
+						<-sem
+						wg.Done()
+					}()
+
+					if err := db.Put(ch); err != nil {
+						panic(err)
+					}
+				}(ch)
+			}
+			wg.Wait()
+
+			wg = sync.WaitGroup{}
+
+			wg.Add(o.ChunkCount)
+			for _, ch := range chunks {
+				sem <- struct{}{}
+
+				go func(ch chunk.Chunk) {
+					defer func() {
+						<-sem
+						wg.Done()
+					}()
+
+					if err := db.Delete(ch.Address()); err != nil {
+						panic(err)
+					}
+				}(ch)
+			}
+			wg.Wait()
+		})
+	}
+
+	rand.Shuffle(o.ChunkCount, func(i, j int) {
+		chunks[i], chunks[j] = chunks[j], chunks[i]
+	})
+
+	var deletedChunks sync.Map
+
+	t.Run("write", func(t *testing.T) {
+		sem := make(chan struct{}, *concurrencyFlag)
+		var wg sync.WaitGroup
+		var wantCount int
+		var wantCountMu sync.Mutex
+		wg.Add(o.ChunkCount)
+		for i, ch := range chunks {
+			sem <- struct{}{}
+
+			go func(i int, ch chunk.Chunk) {
+				defer func() {
+					<-sem
+					wg.Done()
+				}()
+
+				if err := db.Put(ch); err != nil {
+					panic(err)
+				}
+				if o.DeleteSplit > 0 && i%o.DeleteSplit == 0 {
+					if err := db.Delete(ch.Address()); err != nil {
+						panic(err)
+					}
+					deletedChunks.Store(string(ch.Address()), nil)
+				} else {
+					wantCountMu.Lock()
+					wantCount++
+					wantCountMu.Unlock()
+				}
+			}(i, ch)
+		}
+		wg.Wait()
+	})
+
+	rand.Shuffle(o.ChunkCount, func(i, j int) {
+		chunks[i], chunks[j] = chunks[j], chunks[i]
+	})
+
+	t.Run("read", func(t *testing.T) {
+		sem := make(chan struct{}, *concurrencyFlag)
+		var wg sync.WaitGroup
+
+		wg.Add(o.ChunkCount)
+		for i, ch := range chunks {
+			sem <- struct{}{}
+
+			go func(i int, ch chunk.Chunk) {
+				defer func() {
+					<-sem
+					wg.Done()
+				}()
+
+				got, err := db.Get(ch.Address())
+
+				if _, ok := deletedChunks.Load(string(ch.Address())); ok {
+					if err != chunk.ErrChunkNotFound {
+						panic(fmt.Errorf("got error %v, want %v", err, chunk.ErrChunkNotFound))
+					}
+				} else {
+					if err != nil {
+						panic(fmt.Errorf("chunk %v %s: %v", i, ch.Address().Hex(), err))
+					}
+					if !bytes.Equal(got.Address(), ch.Address()) {
+						panic(fmt.Errorf("got chunk %v address %x, want %x", i, got.Address(), ch.Address()))
+					}
+					if !bytes.Equal(got.Data(), ch.Data()) {
+						panic(fmt.Errorf("got chunk %v data %x, want %x", i, got.Data(), ch.Data()))
+					}
+				}
+			}(i, ch)
+		}
+		wg.Wait()
+	})
+}
+
+func TestIterator(t *testing.T, newStoreFunc func(t *testing.T) (fcds.Interface, func())) {
+	chunkCount := 1000
+
+	db, clean := newStoreFunc(t)
+	defer clean()
+
+	chunks := getChunks(chunkCount)
+
+	for _, ch := range chunks {
+		if err := db.Put(ch); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	gotCount, err := db.Count()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotCount != chunkCount {
+		t.Fatalf("got %v count, want %v", gotCount, chunkCount)
+	}
+
+	var iteratedCount int
+	if err := db.Iterate(func(ch chunk.Chunk) (stop bool, err error) {
+		for _, c := range chunks {
+			if bytes.Equal(c.Address(), ch.Address()) {
+				if !bytes.Equal(c.Data(), ch.Data()) {
+					t.Fatalf("invalid data in iterator for key %s", c.Address())
+				}
+				iteratedCount++
+				return false, nil
+			}
+		}
+		return false, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if iteratedCount != chunkCount {
+		t.Fatalf("iterated on %v chunks, want %v", iteratedCount, chunkCount)
+	}
+}
+
+func NewFCDSStore(t *testing.T, path string, metaStore fcds.MetaStore) (s *fcds.Store, clean func()) {
+	t.Helper()
+
+	path, err := ioutil.TempDir("", "swarm-fcds")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s, err = fcds.NewStore(path, chunk.DefaultSize, metaStore, *noCacheFlag)
+	if err != nil {
+		os.RemoveAll(path)
+		t.Fatal(err)
+	}
+	return s, func() {
+		s.Close()
+		os.RemoveAll(path)
+	}
+}
+
+var chunkCache []chunk.Chunk
+
+func getChunks(count int) []chunk.Chunk {
+	l := len(chunkCache)
+	if l == 0 {
+		chunkCache = make([]chunk.Chunk, count)
+		for i := 0; i < count; i++ {
+			chunkCache[i] = GenerateTestRandomChunk()
+		}
+		return chunkCache
+	}
+	if l < count {
+		for i := 0; i < count-l; i++ {
+			chunkCache = append(chunkCache, GenerateTestRandomChunk())
+		}
+		return chunkCache
+	}
+	return chunkCache[:count]
+}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func GenerateTestRandomChunk() chunk.Chunk {
+	data := make([]byte, chunk.DefaultSize)
+	rand.Read(data)
+	key := make([]byte, 32)
+	rand.Read(key)
+	return chunk.NewChunk(key, data)
+}

--- a/storage/fcds/test/store.go
+++ b/storage/fcds/test/store.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/ethersphere/swarm/chunk"
 	chunktesting "github.com/ethersphere/swarm/chunk/testing"
@@ -297,7 +298,7 @@ func NewFCDSStore(t *testing.T, path string, metaStore fcds.MetaStore) (s *fcds.
 		t.Fatal(err)
 	}
 
-	s, err = fcds.New(path, chunk.DefaultSize, metaStore, fcds.WithCache(!*noCacheFlag))
+	s, err = fcds.New(path, chunk.DefaultSize, metaStore, fcds.WithCache(!*noCacheFlag, time.Hour))
 	if err != nil {
 		os.RemoveAll(path)
 		t.Fatal(err)

--- a/storage/fcds/test/store.go
+++ b/storage/fcds/test/store.go
@@ -297,7 +297,7 @@ func NewFCDSStore(t *testing.T, path string, metaStore fcds.MetaStore) (s *fcds.
 		t.Fatal(err)
 	}
 
-	s, err = fcds.NewStore(path, chunk.DefaultSize, metaStore, !*noCacheFlag)
+	s, err = fcds.New(path, chunk.DefaultSize, metaStore, !*noCacheFlag)
 	if err != nil {
 		os.RemoveAll(path)
 		t.Fatal(err)

--- a/storage/fcds/test/store.go
+++ b/storage/fcds/test/store.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/ethersphere/swarm/chunk"
 	chunktesting "github.com/ethersphere/swarm/chunk/testing"
@@ -298,7 +297,7 @@ func NewFCDSStore(t *testing.T, path string, metaStore fcds.MetaStore) (s *fcds.
 		t.Fatal(err)
 	}
 
-	s, err = fcds.New(path, chunk.DefaultSize, metaStore, fcds.WithCache(!*noCacheFlag, time.Hour))
+	s, err = fcds.New(path, chunk.DefaultSize, metaStore, fcds.WithCache(!*noCacheFlag))
 	if err != nil {
 		os.RemoveAll(path)
 		t.Fatal(err)

--- a/storage/fcds/test/store.go
+++ b/storage/fcds/test/store.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"sync"
@@ -292,12 +291,7 @@ func RunIterator(t *testing.T, newStoreFunc func(t *testing.T) (fcds.Storer, fun
 func NewFCDSStore(t *testing.T, path string, metaStore fcds.MetaStore) (s *fcds.Store, clean func()) {
 	t.Helper()
 
-	path, err := ioutil.TempDir("", "swarm-fcds")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	s, err = fcds.New(path, chunk.DefaultSize, metaStore, fcds.WithCache(!*noCacheFlag))
+	s, err := fcds.New(path, chunk.DefaultSize, metaStore, fcds.WithCache(!*noCacheFlag))
 	if err != nil {
 		os.RemoveAll(path)
 		t.Fatal(err)

--- a/storage/fcds/test/store.go
+++ b/storage/fcds/test/store.go
@@ -44,7 +44,7 @@ func Main(m *testing.M) {
 }
 
 // RunAll runs all available tests for a Store implementation.
-func RunAll(t *testing.T, newStoreFunc func(t *testing.T) (fcds.Interface, func())) {
+func RunAll(t *testing.T, newStoreFunc func(t *testing.T) (fcds.Storer, func())) {
 
 	t.Run("empty", func(t *testing.T) {
 		RunStore(t, &RunStoreOptions{
@@ -106,7 +106,7 @@ func RunAll(t *testing.T, newStoreFunc func(t *testing.T) (fcds.Interface, func(
 
 // RunStoreOptions define parameters for Store test function.
 type RunStoreOptions struct {
-	NewStoreFunc func(t *testing.T) (fcds.Interface, func())
+	NewStoreFunc func(t *testing.T) (fcds.Storer, func())
 	ChunkCount   int
 	DeleteSplit  int
 	Cleaned      bool
@@ -245,7 +245,7 @@ func RunStore(t *testing.T, o *RunStoreOptions) {
 }
 
 // RunIterator validates behaviour of Iterate and Count methods on a Store.
-func RunIterator(t *testing.T, newStoreFunc func(t *testing.T) (fcds.Interface, func())) {
+func RunIterator(t *testing.T, newStoreFunc func(t *testing.T) (fcds.Storer, func())) {
 	chunkCount := 1000
 
 	db, clean := newStoreFunc(t)

--- a/storage/fcds/test/store.go
+++ b/storage/fcds/test/store.go
@@ -297,7 +297,7 @@ func NewFCDSStore(t *testing.T, path string, metaStore fcds.MetaStore) (s *fcds.
 		t.Fatal(err)
 	}
 
-	s, err = fcds.New(path, chunk.DefaultSize, metaStore, !*noCacheFlag)
+	s, err = fcds.New(path, chunk.DefaultSize, metaStore, fcds.WithCache(!*noCacheFlag))
 	if err != nil {
 		os.RemoveAll(path)
 		t.Fatal(err)

--- a/storage/localstore/export.go
+++ b/storage/localstore/export.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/ethersphere/swarm/chunk"
 	"github.com/ethersphere/swarm/log"
-	"github.com/ethersphere/swarm/shed"
 )
 
 const (
@@ -58,23 +57,25 @@ func (db *DB) Export(w io.Writer) (count int64, err error) {
 		return 0, err
 	}
 
-	err = db.retrievalDataIndex.Iterate(func(item shed.Item) (stop bool, err error) {
+	err = db.data.Iterate(func(ch chunk.Chunk) (stop bool, err error) {
+
+		data := ch.Data()
 
 		hdr := &tar.Header{
-			Name: hex.EncodeToString(item.Address),
+			Name: hex.EncodeToString(ch.Address()),
 			Mode: 0644,
-			Size: int64(len(item.Data)),
+			Size: int64(len(data)),
 		}
 
 		if err := tw.WriteHeader(hdr); err != nil {
 			return false, err
 		}
-		if _, err := tw.Write(item.Data); err != nil {
+		if _, err := tw.Write(data); err != nil {
 			return false, err
 		}
 		count++
 		return false, nil
-	}, nil)
+	})
 
 	return count, err
 }

--- a/storage/localstore/export.go
+++ b/storage/localstore/export.go
@@ -171,7 +171,9 @@ func (db *DB) Import(r io.Reader, legacy bool) (count int64, err error) {
 				}
 				select {
 				case errC <- err:
+					return
 				case <-ctx.Done():
+					return
 				}
 			}
 			// get the export file format version
@@ -180,7 +182,9 @@ func (db *DB) Import(r io.Reader, legacy bool) (count int64, err error) {
 				if err != nil {
 					select {
 					case errC <- err:
+						return
 					case <-ctx.Done():
+						return
 					}
 				}
 				version = string(data)
@@ -206,7 +210,9 @@ func (db *DB) Import(r io.Reader, legacy bool) (count int64, err error) {
 					if err := db.setPin(batch, addr, counter); err != nil {
 						select {
 						case errC <- err:
+							return
 						case <-ctx.Done():
+							return
 						}
 					}
 				}
@@ -214,14 +220,18 @@ func (db *DB) Import(r io.Reader, legacy bool) (count int64, err error) {
 				if err := scanner.Err(); err != nil {
 					select {
 					case errC <- err:
+						return
 					case <-ctx.Done():
+						return
 					}
 				}
 
 				if err := db.shed.WriteBatch(batch); err != nil {
 					select {
 					case errC <- err:
+						return
 					case <-ctx.Done():
+						return
 					}
 				}
 				continue
@@ -242,7 +252,9 @@ func (db *DB) Import(r io.Reader, legacy bool) (count int64, err error) {
 			if err != nil {
 				select {
 				case errC <- err:
+					return
 				case <-ctx.Done():
+					return
 				}
 			}
 			key := chunk.Address(keybytes)

--- a/storage/localstore/export.go
+++ b/storage/localstore/export.go
@@ -190,8 +190,8 @@ func (db *DB) Import(r io.Reader, legacy bool) (count int64, err error) {
 			if strings.HasPrefix(hdr.Name, tagsFilenamePrefix) {
 				// All chunks are put before tag files are iterated on
 				// because of tagsFilenamePrefix starts with "t"
-				// which is ordered later then hex characters of chunk
-				// addresses.
+				// which is ordered later in the tar file then
+				// hex characters of chunk addresses.
 				//
 				// Wait for chunks to be stored before continuing.
 				wg.Wait()

--- a/storage/localstore/gc.go
+++ b/storage/localstore/gc.go
@@ -120,7 +120,6 @@ func (db *DB) collectGarbage() (collectedCount uint64, done bool, err error) {
 		metrics.GetOrRegisterGauge(metricName+".accessts", nil).Update(item.AccessTimestamp)
 
 		// delete from retrieve, pull, gc
-		//db.retrievalDataIndex.DeleteInBatch(batch, item)
 		addrs = append(addrs, item.Address)
 		db.metaIndex.DeleteInBatch(batch, item)
 		db.pullIndex.DeleteInBatch(batch, item)

--- a/storage/localstore/gc.go
+++ b/storage/localstore/gc.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethersphere/swarm/chunk"
 	"github.com/ethersphere/swarm/shed"
 	"github.com/syndtr/goleveldb/leveldb"
 )
@@ -108,6 +109,7 @@ func (db *DB) collectGarbage() (collectedCount uint64, done bool, err error) {
 	}
 	metrics.GetOrRegisterGauge(metricName+".gcsize", nil).Update(int64(gcSize))
 
+	var addrs []chunk.Address
 	done = true
 	err = db.gcIndex.Iterate(func(item shed.Item) (stop bool, err error) {
 		if gcSize-collectedCount <= target {
@@ -118,8 +120,9 @@ func (db *DB) collectGarbage() (collectedCount uint64, done bool, err error) {
 		metrics.GetOrRegisterGauge(metricName+".accessts", nil).Update(item.AccessTimestamp)
 
 		// delete from retrieve, pull, gc
-		db.retrievalDataIndex.DeleteInBatch(batch, item)
-		db.retrievalAccessIndex.DeleteInBatch(batch, item)
+		//db.retrievalDataIndex.DeleteInBatch(batch, item)
+		addrs = append(addrs, item.Address)
+		db.metaIndex.DeleteInBatch(batch, item)
 		db.pullIndex.DeleteInBatch(batch, item)
 		db.gcIndex.DeleteInBatch(batch, item)
 		collectedCount++
@@ -143,6 +146,12 @@ func (db *DB) collectGarbage() (collectedCount uint64, done bool, err error) {
 		metrics.GetOrRegisterCounter(metricName+".writebatch.err", nil).Inc(1)
 		return 0, false, err
 	}
+	for _, a := range addrs {
+		if err := db.data.Delete(a); err != nil {
+			metrics.GetOrRegisterCounter(metricName+".deletechunk.err", nil).Inc(1)
+			return 0, false, err
+		}
+	}
 	return collectedCount, done, nil
 }
 
@@ -162,18 +171,12 @@ func (db *DB) removeChunksInExcludeIndexFromGC() (err error) {
 	var gcSizeChange int64
 	err = db.gcExcludeIndex.Iterate(func(item shed.Item) (stop bool, err error) {
 		// Get access timestamp
-		retrievalAccessIndexItem, err := db.retrievalAccessIndex.Get(item)
+		metaIndexItem, err := db.metaIndex.Get(item)
 		if err != nil {
 			return false, err
 		}
-		item.AccessTimestamp = retrievalAccessIndexItem.AccessTimestamp
-
-		// Get the binId
-		retrievalDataIndexItem, err := db.retrievalDataIndex.Get(item)
-		if err != nil {
-			return false, err
-		}
-		item.BinID = retrievalDataIndexItem.BinID
+		item.AccessTimestamp = metaIndexItem.AccessTimestamp
+		item.BinID = metaIndexItem.BinID
 
 		// Check if this item is in gcIndex and remove it
 		ok, err := db.gcIndex.Has(item)

--- a/storage/localstore/localstore.go
+++ b/storage/localstore/localstore.go
@@ -230,7 +230,7 @@ func New(path string, baseKey []byte, o *Options) (db *DB, err error) {
 			filepath.Join(path, "data"),
 			chunk.DefaultSize+8, // chunk data has additional 8 bytes prepended
 			metaStore,
-			fcds.WithCache(true),
+			fcds.WithCache(true, time.Hour),
 		)
 		if err != nil {
 			return nil, err

--- a/storage/localstore/localstore.go
+++ b/storage/localstore/localstore.go
@@ -68,7 +68,7 @@ type DB struct {
 	schemaName shed.StringField
 
 	// chunk data storage
-	data fcds.Interface
+	data fcds.Storer
 	// bin index and timestamps index
 	metaIndex shed.Index
 	// legacy data index, used only in export for manual migration

--- a/storage/localstore/localstore.go
+++ b/storage/localstore/localstore.go
@@ -204,7 +204,7 @@ func New(path string, baseKey []byte, o *Options) (db *DB, err error) {
 	}
 	if schemaName == "" {
 		// initial new localstore run
-		err := db.schemaName.Put(DbSchemaCurrent)
+		err := db.schemaName.Put(dbSchemaCurrent)
 		if err != nil {
 			return nil, err
 		}

--- a/storage/localstore/localstore.go
+++ b/storage/localstore/localstore.go
@@ -222,16 +222,22 @@ func New(path string, baseKey []byte, o *Options) (db *DB, err error) {
 		return nil, err
 	}
 
-	metaStore, err := fcdsleveldb.NewMetaStore(filepath.Join(path, "meta"))
-	if err != nil {
-		return nil, err
-	}
 	if o.MockStore == nil {
-		db.data, err = fcds.NewStore(path, chunk.DefaultSize+8, metaStore, false)
+		metaStore, err := fcdsleveldb.NewMetaStore(filepath.Join(path, "meta"))
+		if err != nil {
+			return nil, err
+		}
+		db.data, err = fcds.NewStore(
+			filepath.Join(path, "data"),
+			chunk.DefaultSize+8, // chunk data has additional 8 bytes prepended
+			metaStore,
+			true, // enable offset cache
+		)
 		if err != nil {
 			return nil, err
 		}
 	} else {
+		// Mock store is provided, use mock FCDS.
 		db.data = fcdsmock.NewStore(o.MockStore)
 	}
 	// Index storing bin id, store and access timestamp for a particular address.

--- a/storage/localstore/localstore.go
+++ b/storage/localstore/localstore.go
@@ -226,7 +226,7 @@ func New(path string, baseKey []byte, o *Options) (db *DB, err error) {
 		if err != nil {
 			return nil, err
 		}
-		db.data, err = fcds.NewStore(
+		db.data, err = fcds.New(
 			filepath.Join(path, "data"),
 			chunk.DefaultSize+8, // chunk data has additional 8 bytes prepended
 			metaStore,
@@ -237,7 +237,7 @@ func New(path string, baseKey []byte, o *Options) (db *DB, err error) {
 		}
 	} else {
 		// Mock store is provided, use mock FCDS.
-		db.data = fcdsmock.NewStore(o.MockStore)
+		db.data = fcdsmock.New(o.MockStore)
 	}
 	// Index storing bin id, store and access timestamp for a particular address.
 	// It is needed in order to update gc index keys for iteration order.

--- a/storage/localstore/localstore.go
+++ b/storage/localstore/localstore.go
@@ -230,7 +230,7 @@ func New(path string, baseKey []byte, o *Options) (db *DB, err error) {
 			filepath.Join(path, "data"),
 			chunk.DefaultSize+8, // chunk data has additional 8 bytes prepended
 			metaStore,
-			fcds.WithCache(true, time.Hour),
+			fcds.WithCache(true),
 		)
 		if err != nil {
 			return nil, err

--- a/storage/localstore/localstore.go
+++ b/storage/localstore/localstore.go
@@ -230,7 +230,7 @@ func New(path string, baseKey []byte, o *Options) (db *DB, err error) {
 			filepath.Join(path, "data"),
 			chunk.DefaultSize+8, // chunk data has additional 8 bytes prepended
 			metaStore,
-			true, // enable offset cache
+			fcds.WithCache(true),
 		)
 		if err != nil {
 			return nil, err

--- a/storage/localstore/migration.go
+++ b/storage/localstore/migration.go
@@ -48,6 +48,9 @@ func (e *BreakingMigrationError) Error() string {
 	return "breaking migration"
 }
 
+// Migrate checks the schema name in storage dir and compares it
+// with the expected schema name to construct a series of data migrations
+// if they are required.
 func (db *DB) Migrate() (err error) {
 	schemaName, err := db.schemaName.Get()
 	if err != nil {

--- a/storage/localstore/migration.go
+++ b/storage/localstore/migration.go
@@ -225,9 +225,9 @@ func migrateSanctuary(db *DB) error {
 
 func migrateDiwali(db *DB) error {
 	return NewBreakingMigrationError(fmt.Sprintf(`
-Swarm chunk storage layer is changed.
+Swarm chunk storage layer has changed.
 
-You can choose if you want to do a manual migration or to discard current data.
+You can choose either to manually migrate the data in your local store to the new data store or to discard the data altogether.
 
 Preserving data requires additional storage roughly the size of the data directory and may take longer time depending on storage performance.
 

--- a/storage/localstore/migration_test.go
+++ b/storage/localstore/migration_test.go
@@ -17,6 +17,7 @@
 package localstore
 
 import (
+	"errors"
 	"io"
 	"io/ioutil"
 	"log"
@@ -24,7 +25,6 @@ import (
 	"os"
 	"path"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/ethersphere/swarm/chunk"
@@ -77,6 +77,9 @@ func TestOneMigration(t *testing.T) {
 	// start the existing localstore and expect the migration to run
 	db, err = New(dir, baseKey, nil)
 	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Migrate(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -163,6 +166,9 @@ func TestManyMigrations(t *testing.T) {
 	// start the existing localstore and expect the migration to run
 	db, err = New(dir, baseKey, nil)
 	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Migrate(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -421,8 +427,12 @@ func TestMigrationFailFrom(t *testing.T) {
 
 	// start the existing localstore and expect the migration to run
 	db, err = New(dir, baseKey, nil)
-	if !strings.Contains(err.Error(), errMissingCurrentSchema.Error()) {
-		t.Fatalf("expected errCannotFindSchema but got %v", err)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.Migrate(); !errors.Is(err, errMissingCurrentSchema) {
+		t.Fatalf("got error %v, want %v", err, errMissingCurrentSchema)
 	}
 
 	if shouldNotRun {
@@ -480,8 +490,12 @@ func TestMigrationFailTo(t *testing.T) {
 
 	// start the existing localstore and expect the migration to run
 	db, err = New(dir, baseKey, nil)
-	if !strings.Contains(err.Error(), errMissingTargetSchema.Error()) {
-		t.Fatalf("expected errMissingTargetSchema but got %v", err)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.Migrate(); !errors.Is(err, errMissingTargetSchema) {
+		t.Fatalf("got error %v, want %v", err, errMissingTargetSchema)
 	}
 
 	if shouldNotRun {
@@ -531,8 +545,8 @@ func TestMigrateSanctuaryFixture(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if schemaName != dbSchemaCurrent {
-		t.Fatalf("schema name mismatch, want '%s' got '%s'", dbSchemaCurrent, schemaName)
+	if schemaName != dbSchemaSanctuary {
+		t.Fatalf("schema name mismatch, want '%s' got '%s'", dbSchemaSanctuary, schemaName)
 	}
 
 	err = db.Close()

--- a/storage/localstore/mode_get.go
+++ b/storage/localstore/mode_get.go
@@ -58,19 +58,19 @@ func (db *DB) Get(ctx context.Context, mode chunk.ModeGet, addr chunk.Address) (
 // get returns Item from the retrieval index
 // and updates other indexes.
 func (db *DB) get(mode chunk.ModeGet, addr chunk.Address) (out shed.Item, err error) {
-	item := addressToItem(addr)
-
-	out, err = db.retrievalDataIndex.Get(item)
+	c, err := db.data.Get(addr)
 	if err != nil {
 		return out, err
 	}
+	out.Address = addr
+	out.Data = c.Data()
 	switch mode {
 	// update the access timestamp and gc index
 	case chunk.ModeGetRequest:
 		db.updateGCItems(out)
 
 	case chunk.ModeGetPin:
-		pinnedItem, err := db.pinIndex.Get(item)
+		pinnedItem, err := db.pinIndex.Get(addressToItem(addr))
 		if err != nil {
 			return out, err
 		}
@@ -133,9 +133,11 @@ func (db *DB) updateGC(item shed.Item) (err error) {
 
 	// update accessTimeStamp in retrieve, gc
 
-	i, err := db.retrievalAccessIndex.Get(item)
+	i, err := db.metaIndex.Get(item)
 	switch err {
 	case nil:
+		item.BinID = i.BinID
+		item.StoreTimestamp = i.StoreTimestamp
 		item.AccessTimestamp = i.AccessTimestamp
 	case leveldb.ErrNotFound:
 		// no chunk accesses
@@ -152,10 +154,9 @@ func (db *DB) updateGC(item shed.Item) (err error) {
 	// update access timestamp
 	item.AccessTimestamp = now()
 	// update retrieve access index
-	db.retrievalAccessIndex.PutInBatch(batch, item)
+	db.metaIndex.PutInBatch(batch, item)
 	// add new entry to gc index
 	db.gcIndex.PutInBatch(batch, item)
-
 	return db.shed.WriteBatch(batch)
 }
 

--- a/storage/localstore/mode_get_multi.go
+++ b/storage/localstore/mode_get_multi.go
@@ -61,11 +61,16 @@ func (db *DB) GetMulti(ctx context.Context, mode chunk.ModeGet, addrs ...chunk.A
 // and updates other indexes.
 func (db *DB) getMulti(mode chunk.ModeGet, addrs ...chunk.Address) (out []shed.Item, err error) {
 	out = make([]shed.Item, len(addrs))
-	for i, addr := range addrs {
-		out[i].Address = addr
+	for i, a := range addrs {
+		c, err := db.data.Get(a)
+		if err != nil {
+			return nil, err
+		}
+		out[i].Address = a
+		out[i].Data = c.Data()
 	}
 
-	err = db.retrievalDataIndex.Fill(out)
+	err = db.metaIndex.Fill(out)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/localstore/mode_has.go
+++ b/storage/localstore/mode_has.go
@@ -31,7 +31,7 @@ func (db *DB) Has(ctx context.Context, addr chunk.Address) (bool, error) {
 	metrics.GetOrRegisterCounter(metricName, nil).Inc(1)
 	defer totalTimeMetric(metricName, time.Now())
 
-	has, err := db.retrievalDataIndex.Has(addressToItem(addr))
+	has, err := db.data.Has(addr)
 	if err != nil {
 		metrics.GetOrRegisterCounter(metricName+".error", nil).Inc(1)
 	}
@@ -46,9 +46,14 @@ func (db *DB) HasMulti(ctx context.Context, addrs ...chunk.Address) ([]bool, err
 	metrics.GetOrRegisterCounter(metricName, nil).Inc(1)
 	defer totalTimeMetric(metricName, time.Now())
 
-	have, err := db.retrievalDataIndex.HasMulti(addressesToItems(addrs...)...)
-	if err != nil {
-		metrics.GetOrRegisterCounter(metricName+".error", nil).Inc(1)
+	have := make([]bool, len(addrs))
+	for i, a := range addrs {
+		has, err := db.data.Has(a)
+		if err != nil {
+			metrics.GetOrRegisterCounter(metricName+".error", nil).Inc(1)
+			return nil, err
+		}
+		have[i] = has
 	}
-	return have, err
+	return have, nil
 }

--- a/storage/localstore/mode_put.go
+++ b/storage/localstore/mode_put.go
@@ -141,9 +141,11 @@ func (db *DB) put(mode chunk.ModePut, chs ...chunk.Chunk) (exist []bool, err err
 		return nil, err
 	}
 
-	for _, ch := range chs {
-		if err := db.data.Put(ch); err != nil {
-			return nil, err
+	for i, ch := range chs {
+		if !exist[i] {
+			if err := db.data.Put(ch); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/storage/localstore/mode_set.go
+++ b/storage/localstore/mode_set.go
@@ -54,6 +54,7 @@ func (db *DB) set(mode chunk.ModeSet, addrs ...chunk.Address) (err error) {
 	defer db.batchMu.Unlock()
 
 	batch := new(leveldb.Batch)
+	var removeChunks bool
 
 	// variables that provide information for operations
 	// to be done after write batch function successfully executes
@@ -96,6 +97,7 @@ func (db *DB) set(mode chunk.ModeSet, addrs ...chunk.Address) (err error) {
 			}
 			gcSizeChange += c
 		}
+		removeChunks = true
 
 	case chunk.ModeSetPin:
 		for _, addr := range addrs {
@@ -125,6 +127,15 @@ func (db *DB) set(mode chunk.ModeSet, addrs ...chunk.Address) (err error) {
 	if err != nil {
 		return err
 	}
+
+	if removeChunks {
+		for _, a := range addrs {
+			if err := db.data.Delete(a); err != nil {
+				return err
+			}
+		}
+	}
+
 	for po := range triggerPullFeed {
 		db.triggerPullSubscriptions(po)
 	}
@@ -138,14 +149,14 @@ func (db *DB) setAccess(batch *leveldb.Batch, binIDs map[uint8]uint64, addr chun
 
 	item := addressToItem(addr)
 
-	// need to get access timestamp here as it is not
-	// provided by the access function, and it is not
-	// a property of a chunk provided to Accessor.Put.
-	i, err := db.retrievalDataIndex.Get(item)
+	i, err := db.metaIndex.Get(item)
 	switch err {
 	case nil:
-		item.StoreTimestamp = i.StoreTimestamp
 		item.BinID = i.BinID
+		item.StoreTimestamp = i.StoreTimestamp
+		item.AccessTimestamp = i.AccessTimestamp
+		db.gcIndex.DeleteInBatch(batch, item)
+		gcSizeChange--
 	case leveldb.ErrNotFound:
 		db.pushIndex.DeleteInBatch(batch, item)
 		item.StoreTimestamp = now()
@@ -156,20 +167,7 @@ func (db *DB) setAccess(batch *leveldb.Batch, binIDs map[uint8]uint64, addr chun
 	default:
 		return 0, err
 	}
-
-	i, err = db.retrievalAccessIndex.Get(item)
-	switch err {
-	case nil:
-		item.AccessTimestamp = i.AccessTimestamp
-		db.gcIndex.DeleteInBatch(batch, item)
-		gcSizeChange--
-	case leveldb.ErrNotFound:
-		// the chunk is not accessed before
-	default:
-		return 0, err
-	}
 	item.AccessTimestamp = now()
-	db.retrievalAccessIndex.PutInBatch(batch, item)
 	db.pullIndex.PutInBatch(batch, item)
 	db.gcIndex.PutInBatch(batch, item)
 	gcSizeChange++
@@ -191,20 +189,16 @@ func (db *DB) setSync(batch *leveldb.Batch, addr chunk.Address, mode chunk.ModeS
 	// provided by the access function, and it is not
 	// a property of a chunk provided to Accessor.Put.
 
-	i, err := db.retrievalDataIndex.Get(item)
+	i, err := db.metaIndex.Get(item)
 	if err != nil {
 		if err == leveldb.ErrNotFound {
-			// chunk is not found,
-			// no need to update gc index
-			// just delete from the push index
-			// if it is there
-			db.pushIndex.DeleteInBatch(batch, item)
 			return 0, nil
 		}
 		return 0, err
 	}
-	item.StoreTimestamp = i.StoreTimestamp
 	item.BinID = i.BinID
+	item.StoreTimestamp = i.StoreTimestamp
+	item.AccessTimestamp = i.AccessTimestamp
 
 	switch mode {
 	case chunk.ModeSetSyncPull:
@@ -276,19 +270,12 @@ func (db *DB) setSync(batch *leveldb.Batch, addr chunk.Address, mode chunk.ModeS
 		db.pushIndex.DeleteInBatch(batch, item)
 	}
 
-	i, err = db.retrievalAccessIndex.Get(item)
-	switch err {
-	case nil:
-		item.AccessTimestamp = i.AccessTimestamp
+	if item.AccessTimestamp > 0 {
 		db.gcIndex.DeleteInBatch(batch, item)
 		gcSizeChange--
-	case leveldb.ErrNotFound:
-		// the chunk is not accessed before
-	default:
-		return 0, err
 	}
 	item.AccessTimestamp = now()
-	db.retrievalAccessIndex.PutInBatch(batch, item)
+	db.metaIndex.PutInBatch(batch, item)
 
 	// Add in gcIndex only if this chunk is not pinned
 	ok, err := db.pinIndex.Has(item)
@@ -312,23 +299,18 @@ func (db *DB) setRemove(batch *leveldb.Batch, addr chunk.Address) (gcSizeChange 
 	// need to get access timestamp here as it is not
 	// provided by the access function, and it is not
 	// a property of a chunk provided to Accessor.Put.
-	i, err := db.retrievalAccessIndex.Get(item)
+	i, err := db.metaIndex.Get(item)
 	switch err {
 	case nil:
+		item.BinID = i.BinID
+		item.StoreTimestamp = i.StoreTimestamp
 		item.AccessTimestamp = i.AccessTimestamp
 	case leveldb.ErrNotFound:
 	default:
 		return 0, err
 	}
-	i, err = db.retrievalDataIndex.Get(item)
-	if err != nil {
-		return 0, err
-	}
-	item.StoreTimestamp = i.StoreTimestamp
-	item.BinID = i.BinID
 
-	db.retrievalDataIndex.DeleteInBatch(batch, item)
-	db.retrievalAccessIndex.DeleteInBatch(batch, item)
+	db.metaIndex.DeleteInBatch(batch, item)
 	db.pullIndex.DeleteInBatch(batch, item)
 	db.gcIndex.DeleteInBatch(batch, item)
 	// a check is needed for decrementing gcSize

--- a/storage/localstore/mode_set.go
+++ b/storage/localstore/mode_set.go
@@ -101,7 +101,7 @@ func (db *DB) set(mode chunk.ModeSet, addrs ...chunk.Address) (err error) {
 
 	case chunk.ModeSetPin:
 		for _, addr := range addrs {
-			err := db.setPin(batch, addr)
+			err := db.setPin(batch, addr, 1)
 			if err != nil {
 				return err
 			}
@@ -326,7 +326,7 @@ func (db *DB) setRemove(batch *leveldb.Batch, addr chunk.Address) (gcSizeChange 
 // setPin increments pin counter for the chunk by updating
 // pin index and sets the chunk to be excluded from garbage collection.
 // Provided batch is updated.
-func (db *DB) setPin(batch *leveldb.Batch, addr chunk.Address) (err error) {
+func (db *DB) setPin(batch *leveldb.Batch, addr chunk.Address, count uint64) (err error) {
 	item := addressToItem(addr)
 
 	// Get the existing pin counter of the chunk
@@ -346,8 +346,8 @@ func (db *DB) setPin(batch *leveldb.Batch, addr chunk.Address) (err error) {
 		existingPinCounter = pinnedChunk.PinCounter
 	}
 
-	// Otherwise increase the existing counter by 1
-	item.PinCounter = existingPinCounter + 1
+	// Otherwise increase the existing counter by the pin count
+	item.PinCounter = existingPinCounter + count
 	db.pinIndex.PutInBatch(batch, item)
 
 	return nil

--- a/storage/localstore/mode_set_test.go
+++ b/storage/localstore/mode_set_test.go
@@ -333,22 +333,23 @@ func TestModeSetRemove(t *testing.T) {
 
 			t.Run("retrieve indexes", func(t *testing.T) {
 				for _, ch := range chunks {
-					wantErr := leveldb.ErrNotFound
-					_, err := db.retrievalDataIndex.Get(addressToItem(ch.Address()))
+					wantErr := chunk.ErrChunkNotFound
+					_, err := db.data.Get(ch.Address())
 					if err != wantErr {
 						t.Errorf("got error %v, want %v", err, wantErr)
 					}
 
 					// access index should not be set
-					_, err = db.retrievalAccessIndex.Get(addressToItem(ch.Address()))
+					_, err = db.metaIndex.Get(addressToItem(ch.Address()))
+					wantErr = leveldb.ErrNotFound
 					if err != wantErr {
 						t.Errorf("got error %v, want %v", err, wantErr)
 					}
 				}
 
-				t.Run("retrieve data index count", newItemsCountTest(db.retrievalDataIndex, 0))
+				t.Run("retrieve data index count", newDataCountTest(db, 0))
 
-				t.Run("retrieve access index count", newItemsCountTest(db.retrievalAccessIndex, 0))
+				t.Run("retrieve access index count", newItemsCountTest(db.metaIndex, 0))
 			})
 
 			for _, ch := range chunks {

--- a/storage/localstore/subscription_pull_test.go
+++ b/storage/localstore/subscription_pull_test.go
@@ -569,7 +569,7 @@ func readPullSubscriptionBin(ctx context.Context, db *DB, bin uint8, ch <-chan c
 				if !bytes.Equal(got.Address, addr) {
 					err = fmt.Errorf("got chunk bin id %v in bin %v %v, want %v", i, bin, got.Address.Hex(), addr.Hex())
 				} else {
-					want, err := db.retrievalDataIndex.Get(shed.Item{
+					want, err := db.metaIndex.Get(shed.Item{
 						Address: addr,
 					})
 					if err != nil {

--- a/storage/localstore/subscription_push.go
+++ b/storage/localstore/subscription_push.go
@@ -72,13 +72,13 @@ func (db *DB) SubscribePush(ctx context.Context) (c <-chan chunk.Chunk, stop fun
 				var count int
 				err := db.pushIndex.Iterate(func(item shed.Item) (stop bool, err error) {
 					// get chunk data
-					dataItem, err := db.retrievalDataIndex.Get(item)
+					c, err := db.data.Get(item.Address)
 					if err != nil {
 						return true, err
 					}
 
 					select {
-					case chunks <- chunk.NewChunk(dataItem.Address, dataItem.Data).WithTagID(item.Tag):
+					case chunks <- chunk.NewChunk(c.Address(), c.Data()).WithTagID(item.Tag):
 						count++
 						// set next iteration start item
 						// when its chunk is successfully sent to channel

--- a/swarm.go
+++ b/swarm.go
@@ -232,6 +232,9 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 	if err != nil {
 		return nil, err
 	}
+	if err := localStore.Migrate(); err != nil {
+		return nil, err
+	}
 	lstore := chunk.NewValidatorStore(
 		localStore,
 		storage.NewContentAddressValidator(storage.MakeHashFunc(storage.DefaultHash)),

--- a/swarm.go
+++ b/swarm.go
@@ -198,9 +198,7 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 
 	// check that we are not in the old database schema
 	// if so - fail and exit
-	isLegacy := localstore.IsLegacyDatabase(config.ChunkDbPath)
-
-	if isLegacy {
+	if localstore.IsLegacyDatabase(config.ChunkDbPath) {
 		return nil, errors.New("Legacy database format detected! Please read the migration announcement at: https://github.com/ethersphere/swarm/blob/master/docs/Migration-v0.3-to-v0.4.md")
 	}
 


### PR DESCRIPTION
This PR changes the chunk data disk persistence structure. It is based on previous experiment https://github.com/janos/forky where multiple approaches were tried out. The most performant was chosen and added to swarm as `storage/fcds` package.

This PR includes additional changes required for new storage to be used and optionally manually  migrated.

FCDS is integrated into `storage/localstore` without breaking changes to the package API. That involves:
- removing usage of retrievalDataIndex, except to provide export functionality for older db schema
- replacing retrievalAccessIndex with metaIndex that contains storage timestamp, access timestamp and bin id

At the roundtable discussion, it was decided to have an optional manual data migration. To achieve this,
instructions with steps are printed when the new swarm version is started with older data format. LocalStore
migrations are adjusted to make this functionality. Some issues to `getMigrations` function are discovered
that are fixed and tested in this pr through additional tests. Schema name variables are now unexported
and names from the legacy ldbstore removed from migrations as they are not needed to be there.

In order for migration to be complete, import and export localstore functions needed to handle pinning
information. This functionality is added.


## Measurements

Measurements are performed locally on 4 core MacBook Pro mid 2014.
Every run on a clean swarm data directory by uploading files with random data.

### Local test1 - 1GB size - 5x speedup

```
time ./swarm.master up test1
c4e105675ab10acc907ac4e966aa0359eb0accc5fe5bd03dc15d8161e5fa1dda
./swarm.master up test1  0.98s user 1.85s system 1% cpu 3:52.39 total

time ./swarm.fcds up test1
c4e105675ab10acc907ac4e966aa0359eb0accc5fe5bd03dc15d8161e5fa1dda
./swarm.forky up test1  1.01s user 1.94s system 6% cpu 46.629 total
```

### Local test4 - 4GB size - 6.5x speedup

```
time ./swarm.master up test4
b2c1bae070933e5c46d1f839340e2ea33c77469e1c8210691cbe0ed79b211506
./swarm.master up test4  3.91s user 7.37s system 0% cpu 26:27.17 total

time ./swarm.fcds up test4
b2c1bae070933e5c46d1f839340e2ea33c77469e1c8210691cbe0ed79b211506
./swarm.forky up test4  4.30s user 8.50s system 5% cpu 4:06.79 total
```

### Smoke tests on cluster

Smoke tests were run multiple times for validation and to measure performance. However, the performance
gain is related to the number of cpus that ec2 node has and how many swarm nodes are running on the same ec2 node.

These are results from running one swarm node on 2 core c5.large https://snapshot.raintank.io/dashboard/snapshot/dD0JQruCpHpOjvKqwR6YN3ay3GmONLyr.
If there are two swarm processes on the same node, upload speed is about the half. It is noticeable that
garbage collection influences performance and this is the area where further adjustments can be made.