### PR TITLE
p2p/protocols: change sequence of message accounting

### DIFF
--- a/p2p/protocols/protocol.go
+++ b/p2p/protocols/protocol.go
@@ -277,15 +277,18 @@ func (p *Peer) Send(ctx context.Context, msg interface{}) error {
 		}
 		size = len(r)
 	}
+
+	err = p2p.Send(p.rw, code, wmsg)
+	if err != nil {
+		return nil
+	}
+
 	// if the accounting hook is set, call it
 	if p.spec.Hook != nil {
 		err = p.spec.Hook.Send(p, uint32(size), msg)
-		if err != nil {
-			return err
-		}
 	}
 
-	return p2p.Send(p.rw, code, wmsg)
+	return err
 }
 
 // handleIncoming(code)

--- a/p2p/protocols/protocol.go
+++ b/p2p/protocols/protocol.go
@@ -280,7 +280,7 @@ func (p *Peer) Send(ctx context.Context, msg interface{}) error {
 
 	err = p2p.Send(p.rw, code, wmsg)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	// if the accounting hook is set, call it


### PR DESCRIPTION
This PR introduces a change in the sequence of message accounting.
Previously, when a message was marked as accounted via its pricing interface, it would be accounted for **before sending**.

This had negative side effects in that if sending a message crossed the payment threshold, a node would send the corresponding cheque **first**, which could bring a node into debt before the actual message would be arriving.

Related issues:  
* https://github.com/ethersphere/swarm/pull/1983
* https://github.com/ethersphere/swarm/pull/1925

This PR changes the sequence, first the message is sent, and only if it succeeded, the message is accounted for.