### PR TITLE
P2p validate accounting

### DIFF
--- a/p2p/protocols/accounting.go
+++ b/p2p/protocols/accounting.go
@@ -122,8 +122,7 @@ func SetupAccountingMetrics(reportInterval time.Duration, path string) *Accounti
 	return NewAccountingMetrics(metrics.AccountingRegistry, reportInterval, path)
 }
 
-// Send takes a peer, a size and a msg and
-//   - credits/debits local node using balance interface
+// Apply takes a peer, the signed cost for the local node and the msg size and credits/debits local node using balance interface
 func (ah *Accounting) Apply(peer *Peer, costToLocalNode int64, size uint32) error {
 	// do the accounting
 	err := ah.Add(costToLocalNode, peer)
@@ -132,7 +131,9 @@ func (ah *Accounting) Apply(peer *Peer, costToLocalNode int64, size uint32) erro
 	return err
 }
 
-//   - calculates the cost for the local node sending a msg of size to peer querying the message for its price
+// Validate calculates the cost for the local node sending or receiving a msg to/from a peer querying the message for its price.
+// It returns either the signed cost for the local node as int64 or an error, signaling that the accounting operation would fail
+// (no change has been applied at this point)
 func (ah *Accounting) Validate(peer *Peer, size uint32, msg interface{}, payer Payer) (int64, error) {
 	// get the price for a message (by querying the message type via the PricedMessage interface)
 	var pricedMessage PricedMessage

--- a/p2p/protocols/accounting_simulation_test.go
+++ b/p2p/protocols/accounting_simulation_test.go
@@ -71,7 +71,6 @@ func TestAccountingSimulation(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 	SetupAccountingMetrics(1*time.Second, filepath.Join(dir, "metrics.db"))
-	//define the node.Service for this test
 	services := adapters.Services{
 		"accounting": func(ctx *adapters.ServiceContext) (node.Service, error) {
 			return bal.newNode(), nil
@@ -88,6 +87,10 @@ func TestAccountingSimulation(t *testing.T) {
 	go func() {
 		// wait for all of them to arrive
 		bal.wg.Wait()
+		// as now actual accounting happens **after** message handling, we need to
+		// wait a short bit to make sure that all messages have been accounted
+		// (not sleeping here results in a message off by one)
+		time.Sleep(50 * time.Millisecond)
 		// then trigger a check
 		// the selected node for the trigger is irrelevant,
 		// we just want to trigger the end of the simulation

--- a/p2p/protocols/accounting_simulation_test.go
+++ b/p2p/protocols/accounting_simulation_test.go
@@ -200,9 +200,8 @@ func (m *matrix) symmetric() error {
 type balances struct {
 	i int
 	*matrix
-	id2n    map[enode.ID]int
-	wg      *sync.WaitGroup
-	allMsgs int
+	id2n map[enode.ID]int
+	wg   *sync.WaitGroup
 }
 
 func newBalances(n int) *balances {

--- a/p2p/protocols/accounting_simulation_test.go
+++ b/p2p/protocols/accounting_simulation_test.go
@@ -229,6 +229,10 @@ type testNode struct {
 	peerCount int
 }
 
+func (t *testNode) Check(a int64, p *Peer) error {
+	return nil
+}
+
 // do the accounting for the peer's test protocol
 // testNode implements protocols.Balance
 func (t *testNode) Add(a int64, p *Peer) error {

--- a/p2p/protocols/accounting_test.go
+++ b/p2p/protocols/accounting_test.go
@@ -173,17 +173,24 @@ func TestBalance(t *testing.T) {
 }
 
 func checkAccountingTestCases(t *testing.T, cases []testCase, acc *Accounting, peer *Peer, balance *dummyBalance, send bool) {
+	t.Helper()
 	for _, c := range cases {
 		var err error
-		var expectedResult int64
+		var expectedResult, cost int64
 		//reset balance before every check
 		balance.amount = 0
 		if send {
-			cost, _ := acc.Validate(peer, c.size, c.msg, Sender)
+			cost, err = acc.Validate(peer, c.size, c.msg, Sender)
+			if err != nil {
+				t.Fatal(err)
+			}
 			err = acc.Apply(peer, cost, c.size)
 			expectedResult = c.sendResult
 		} else {
-			cost, _ := acc.Validate(peer, c.size, c.msg, Receiver)
+			cost, err = acc.Validate(peer, c.size, c.msg, Receiver)
+			if err != nil {
+				t.Fatal(err)
+			}
 			err = acc.Apply(peer, cost, c.size)
 			expectedResult = c.recvResult
 		}

--- a/p2p/protocols/accounting_test.go
+++ b/p2p/protocols/accounting_test.go
@@ -96,6 +96,11 @@ func (m *zeroPriceMsg) Price() *Price {
 }
 
 //dummy accounting implementation, only stores values for later check
+func (d *dummyBalance) Check(amount int64, peer *Peer) error {
+	return nil
+}
+
+//dummy accounting implementation, only stores values for later check
 func (d *dummyBalance) Add(amount int64, peer *Peer) error {
 	d.amount = amount
 	d.peer = peer
@@ -174,10 +179,12 @@ func checkAccountingTestCases(t *testing.T, cases []testCase, acc *Accounting, p
 		//reset balance before every check
 		balance.amount = 0
 		if send {
-			err = acc.Send(peer, c.size, c.msg)
+			cost, _ := acc.Validate(peer, c.size, c.msg, Sender)
+			err = acc.Apply(peer, cost, c.size)
 			expectedResult = c.sendResult
 		} else {
-			err = acc.Receive(peer, c.size, c.msg)
+			cost, _ := acc.Validate(peer, c.size, c.msg, Receiver)
+			err = acc.Apply(peer, cost, c.size)
 			expectedResult = c.recvResult
 		}
 

--- a/p2p/protocols/protocol.go
+++ b/p2p/protocols/protocol.go
@@ -277,15 +277,18 @@ func (p *Peer) Send(ctx context.Context, msg interface{}) error {
 		}
 		size = len(r)
 	}
+
+	err = p2p.Send(p.rw, code, wmsg)
+	if err != nil {
+		return nil
+	}
+
 	// if the accounting hook is set, call it
 	if p.spec.Hook != nil {
 		err = p.spec.Hook.Send(p, uint32(size), msg)
-		if err != nil {
-			return err
-		}
 	}
 
-	return p2p.Send(p.rw, code, wmsg)
+	return err
 }
 
 // handleIncoming(code)

--- a/p2p/protocols/protocol.go
+++ b/p2p/protocols/protocol.go
@@ -280,7 +280,7 @@ func (p *Peer) Send(ctx context.Context, msg interface{}) error {
 
 	err = p2p.Send(p.rw, code, wmsg)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	// if the accounting hook is set, call it

--- a/p2p/protocols/protocol_test.go
+++ b/p2p/protocols/protocol_test.go
@@ -209,26 +209,25 @@ type dummyMsg struct {
 	Content string
 }
 
-func (d *dummyHook) Send(peer *Peer, size uint32, msg interface{}) error {
+func (d *dummyHook) Validate(peer *Peer, size uint32, msg interface{}, payer Payer) (int64, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-
 	d.peer = peer
 	d.size = size
 	d.msg = msg
-	d.send = true
-	return d.err
+	if payer == Sender {
+		d.send = true
+	} else {
+		d.send = false
+		d.waitC <- struct{}{}
+	}
+	return 0, d.err
 }
 
-func (d *dummyHook) Receive(peer *Peer, size uint32, msg interface{}) error {
+func (d *dummyHook) Apply(peer *Peer, cost int64, size uint32) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	d.peer = peer
-	d.size = size
-	d.msg = msg
-	d.send = false
-	d.waitC <- struct{}{}
 	return d.err
 }
 


### PR DESCRIPTION
After the roundtable of today, 17.12.2019, one suggestion as on how to handle accounting was made: that a *dry-run* is performed of the accounting before actually applying ("writing") the accounting.

This PR is a proposal on how to do this.

Before any message operation (sending, receiving), a `Check` function checks that the actual accounting operation would not result in any error which should prevent the operation to take place.
Only if the `Check` returns without an error, the operation is performed and then the accounting is applied (`Apply`).

A lock is now applied on the protocols `Peer` during this function group, allowing for some kind of atomicity / transactional-like handling.

This PR **OR** https://github.com/ethersphere/swarm/pull/2049 should be merged.