### PR TITLE
forward: Kademlia forwarder peer query service

### DIFF
--- a/network/forward/forward.go
+++ b/network/forward/forward.go
@@ -1,0 +1,1 @@
+package forward

--- a/network/forward/forward.go
+++ b/network/forward/forward.go
@@ -1,6 +1,7 @@
 package forward
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -8,15 +9,67 @@ import (
 	"github.com/ethersphere/swarm/network"
 )
 
+var (
+	NoMorePeers = errors.New("no more peers")
+)
+
+// Session encapsulates one single peer iteration query
 type Session struct {
-	kademlia        *network.KademliaLoadBalancer
-	pivot           []byte
+	kademlia        *network.KademliaLoadBalancer // kademlia backend
+	base            []byte                        //
 	id              int
 	capabilityIndex string
 	nextC           chan struct{}
-	getC            chan *ForwardPeer
+	getC            chan *network.Peer
 }
 
+// Id returns the session id
+func (s *Session) Id() int {
+	return s.id
+}
+
+// Get returns up to numPeers peers from the current position of the iterator
+// If no further peers are available a NoMorePeers error will be returned
+func (s *Session) Get(numPeers int) ([]*network.Peer, error) {
+	var result []*network.Peer
+	select {
+	case <-s.getC:
+		return result, NoMorePeers
+	default:
+	}
+	for i := 0; i < numPeers; i++ {
+		s.nextC <- struct{}{}
+		p, ok := <-s.getC
+		if !ok {
+			break
+		}
+		result = append(result, p)
+	}
+	return result, nil
+}
+
+// starts the iterator and blocks for request for next peer through Get()
+func (s *Session) load() error {
+	err := s.kademlia.EachBinFiltered(s.base, s.capabilityIndex, func(bin network.LBBin) bool {
+		for _, p := range bin.LBPeers {
+			_, ok := <-s.nextC
+			if !ok {
+				return false
+			}
+			s.getC <- p.Peer
+		}
+		return true
+	})
+	close(s.getC)
+	return err
+}
+
+// frees resources
+func (s *Session) destroy() {
+	close(s.nextC)
+}
+
+// SessionManager is the Session object factory
 type SessionManager struct {
 	sessions map[int]*Session
 	kademlia *network.KademliaLoadBalancer
@@ -24,6 +77,9 @@ type SessionManager struct {
 	mu       sync.Mutex
 }
 
+// NewSessionManager is the SessionManager constructor
+// Sessions created with the SessionManager will use the provided kademlia backend
+// TODO: argument should be network.KademliaBackend, but needs KademliaLoadBalancer to implement this
 func NewSessionManager(kademlia *network.KademliaLoadBalancer) *SessionManager {
 	return &SessionManager{
 		sessions: make(map[int]*Session),
@@ -31,32 +87,36 @@ func NewSessionManager(kademlia *network.KademliaLoadBalancer) *SessionManager {
 	}
 }
 
-func (m *SessionManager) add(s *Session) *Session {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.lastId++
-	log.Trace("adding session", "id", m.lastId)
-	s.id = m.lastId
-	m.sessions[m.lastId] = s
-	return s
-}
-
-func (m *SessionManager) New(capabilityIndex string, pivot []byte) *Session {
+// New creates a new Session object with the given capabilityindex and base address
+// if capabilityIndex is empty, the global kademlia database will be used
+// if base is nil, the kademlia base address will be used as comparator for the iteration
+func (m *SessionManager) New(capabilityIndex string, base []byte) *Session {
 	s := &Session{
 		capabilityIndex: capabilityIndex,
 		kademlia:        m.kademlia,
 		nextC:           make(chan struct{}),
-		getC:            make(chan *ForwardPeer),
+		getC:            make(chan *network.Peer),
 	}
-	if pivot == nil {
-		s.pivot = m.kademlia.BaseAddr()
+	if base == nil {
+		s.base = m.kademlia.BaseAddr()
 	} else {
-		s.pivot = pivot
+		s.base = base
 	}
 	go s.load()
 	return m.add(s)
 }
 
+// Reap frees the Session object resources and removes it from the session index
+func (m *SessionManager) Reap(sessionId int) {
+	s, ok := m.sessions[sessionId]
+	if !ok {
+		return
+	}
+	s.destroy()
+}
+
+// ToContext creates a SessionContext from the existing Session matching the provided id
+// if the session does not exist an error is returned
 func (m *SessionManager) ToContext(id int) (*SessionContext, error) {
 	s, ok := m.sessions[id]
 	if !ok {
@@ -65,10 +125,13 @@ func (m *SessionManager) ToContext(id int) (*SessionContext, error) {
 	return &SessionContext{
 		CapabilityIndex: s.capabilityIndex,
 		SessionId:       s.id,
-		Address:         s.pivot,
+		Address:         s.base,
 	}, nil
 }
 
+// FromContext retrieves or creates a Session from a provided context
+// If the context has the "id" value set, the corresponding Session is returned, or error if it does not exist
+// Otherwise, a new Session is created and returned, optionally with the "address" and/or "capability" values provided in the context
 func (m *SessionManager) FromContext(sctx *SessionContext) (*Session, error) {
 
 	sessionId, ok := sctx.Value("id").(int)
@@ -85,34 +148,13 @@ func (m *SessionManager) FromContext(sctx *SessionContext) (*Session, error) {
 	return m.New(capabilityIndex, addr), nil
 }
 
-func (s *Session) Get(numPeers int) ([]*ForwardPeer, error) {
-	var result []*ForwardPeer
-	for i := 0; i < numPeers; i++ {
-		s.nextC <- struct{}{}
-		p, ok := <-s.getC
-		if !ok {
-			break
-		}
-		result = append(result, p)
-	}
-	return result, nil
-}
-
-func (s *Session) load() error {
-	err := s.kademlia.EachBinFiltered(s.pivot, s.capabilityIndex, func(bin network.LBBin) bool {
-		for _, p := range bin.LBPeers {
-			_, ok := <-s.nextC
-			if !ok {
-				return false
-			}
-			s.getC <- &ForwardPeer{Peer: p.Peer}
-		}
-		return true
-	})
-	close(s.getC)
-	return err
-}
-
-func (s *Session) Close() {
-	close(s.nextC)
+// adds a new session to the sessionmanager
+func (m *SessionManager) add(s *Session) *Session {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.lastId++
+	log.Trace("adding session", "id", m.lastId)
+	s.id = m.lastId
+	m.sessions[m.lastId] = s
+	return s
 }

--- a/network/forward/forward.go
+++ b/network/forward/forward.go
@@ -1,1 +1,35 @@
 package forward
+
+import (
+	"context"
+
+	"github.com/ethersphere/swarm/log"
+	"github.com/ethersphere/swarm/network"
+)
+
+type Session struct {
+	sessionContext context.Context
+	kademlia       *network.Kademlia
+	pivot          []byte
+}
+
+func New(sctx context.Context, kad *network.Kademlia) *Session {
+	s := &Session{
+		sessionContext: sctx,
+		kademlia:       kad,
+	}
+	addr := sctx.Value("address")
+	log.Trace("addr", "addr", addr)
+	if addr == nil {
+		s.pivot = kad.BaseAddr()
+	} else {
+		s.pivot = addr.([]byte)
+	}
+	return s
+}
+
+func (s *Session) Get(numPeers int) ([]ForwardPeer, error) {
+	var result []ForwardPeer
+
+	return result, nil
+}

--- a/network/forward/forward.go
+++ b/network/forward/forward.go
@@ -1,30 +1,35 @@
 package forward
 
 import (
-	"context"
-
-	"github.com/ethersphere/swarm/log"
 	"github.com/ethersphere/swarm/network"
 )
 
 type Session struct {
-	sessionContext context.Context
-	kademlia       *network.Kademlia
-	pivot          []byte
+	kademlia        *network.Kademlia
+	pivot           []byte
+	id              int
+	capabilityIndex string
 }
 
-func New(sctx context.Context, kad *network.Kademlia) *Session {
+func NewFromContext(sctx *SessionContext, kad *network.Kademlia) *Session {
 	s := &Session{
-		sessionContext: sctx,
-		kademlia:       kad,
+		kademlia: kad,
 	}
+
+	s.id = sctx.Value("id").(int)
+
 	addr := sctx.Value("address")
-	log.Trace("addr", "addr", addr)
 	if addr == nil {
 		s.pivot = kad.BaseAddr()
 	} else {
 		s.pivot = addr.([]byte)
 	}
+
+	capabilityIndex := sctx.Value("capability")
+	if capabilityIndex != nil {
+		s.capabilityIndex = capabilityIndex.(string)
+	}
+
 	return s
 }
 

--- a/network/forward/forward.go
+++ b/network/forward/forward.go
@@ -1,6 +1,7 @@
 package forward
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/ethersphere/swarm/network"
@@ -43,27 +44,43 @@ func (m *SessionManager) New(kad *network.Kademlia, capabilityIndex string, pivo
 	return m.add(s)
 }
 
-//func NewFromContext(sctx *SessionContext, kad *network.Kademlia) *Session {
-//	s := &Session{
-//		kademlia: kad,
-//	}
-//
-//	s.id = sctx.Value("id").(int)
-//
-//	addr := sctx.Value("address")
-//	if addr == nil {
-//		s.pivot = kad.BaseAddr()
-//	} else {
-//		s.pivot = addr.([]byte)
-//	}
-//
-//	capabilityIndex := sctx.Value("capability")
-//	if capabilityIndex != nil {
-//		s.capabilityIndex = capabilityIndex.(string)
-//	}
-//
-//	return s
-//}
+func (m *SessionManager) ToContext(id int) (*SessionContext, error) {
+	if id >= len(m.sessions) {
+		return nil, fmt.Errorf("No such session %d (max %d)", id, len(m.sessions))
+	}
+	s := m.sessions[id]
+	return &SessionContext{
+		CapabilityIndex: s.capabilityIndex,
+		SessionId:       s.id,
+		Address:         s.pivot,
+	}, nil
+}
+
+func (m *SessionManager) FromContext(sctx *SessionContext) (*Session, error) {
+
+	sessionId := sctx.Value("id")
+	if sessionId != nil {
+		id := sessionId.(int)
+		if id < len(m.sessions) {
+			return m.sessions[id], nil
+		}
+	}
+	return nil, nil
+	//
+	//	addr := sctx.Value("address")
+	//	if addr == nil {
+	//		s.pivot = kad.BaseAddr()
+	//	} else {
+	//		s.pivot = addr.([]byte)
+	//	}
+	//
+	//	capabilityIndex := sctx.Value("capability")
+	//	if capabilityIndex != nil {
+	//		s.capabilityIndex = capabilityIndex.(string)
+	//	}
+	//
+	//	return s
+}
 
 func (s *Session) Get(numPeers int) ([]ForwardPeer, error) {
 	var result []ForwardPeer

--- a/network/forward/forward.go
+++ b/network/forward/forward.go
@@ -4,6 +4,11 @@ import (
 	"github.com/ethersphere/swarm/network"
 )
 
+var (
+	sessionId = 0
+	sessions  []*Session
+)
+
 type Session struct {
 	kademlia        *network.Kademlia
 	pivot           []byte
@@ -11,27 +16,42 @@ type Session struct {
 	capabilityIndex string
 }
 
-func NewFromContext(sctx *SessionContext, kad *network.Kademlia) *Session {
+func New(kad *network.Kademlia, capabilityIndex string, pivot []byte) *Session {
 	s := &Session{
-		kademlia: kad,
+		kademlia:        kad,
+		id:              sessionId,
+		capabilityIndex: capabilityIndex,
 	}
-
-	s.id = sctx.Value("id").(int)
-
-	addr := sctx.Value("address")
-	if addr == nil {
+	if pivot == nil {
 		s.pivot = kad.BaseAddr()
 	} else {
-		s.pivot = addr.([]byte)
+		s.pivot = pivot
 	}
-
-	capabilityIndex := sctx.Value("capability")
-	if capabilityIndex != nil {
-		s.capabilityIndex = capabilityIndex.(string)
-	}
-
+	sessionId++
 	return s
 }
+
+//func NewFromContext(sctx *SessionContext, kad *network.Kademlia) *Session {
+//	s := &Session{
+//		kademlia: kad,
+//	}
+//
+//	s.id = sctx.Value("id").(int)
+//
+//	addr := sctx.Value("address")
+//	if addr == nil {
+//		s.pivot = kad.BaseAddr()
+//	} else {
+//		s.pivot = addr.([]byte)
+//	}
+//
+//	capabilityIndex := sctx.Value("capability")
+//	if capabilityIndex != nil {
+//		s.capabilityIndex = capabilityIndex.(string)
+//	}
+//
+//	return s
+//}
 
 func (s *Session) Get(numPeers int) ([]ForwardPeer, error) {
 	var result []ForwardPeer

--- a/network/forward/forward.go
+++ b/network/forward/forward.go
@@ -16,11 +16,11 @@ var (
 // Session encapsulates one single peer iteration query
 type Session struct {
 	kademlia        *network.KademliaLoadBalancer // kademlia backend
-	base            []byte                        //
-	id              int
-	capabilityIndex string
-	nextC           chan struct{}
-	getC            chan *network.Peer
+	base            []byte                        // base address to use for iteration
+	id              int                           // id of session
+	capabilityIndex string                        // kademlia capabilityIndex in use
+	nextC           chan struct{}                 // triggered to output one single peer from iterator
+	getC            chan *network.Peer            // receives peer from iterator
 }
 
 // Id returns the session id
@@ -71,10 +71,10 @@ func (s *Session) destroy() {
 
 // SessionManager is the Session object factory
 type SessionManager struct {
-	sessions map[int]*Session
-	kademlia *network.KademliaLoadBalancer
-	lastId   int // starts at 1 to make create from context easier
-	mu       sync.Mutex
+	kademlia *network.KademliaLoadBalancer // underlying kademlia backend
+	sessions map[int]*Session              // index of active sessions, mapped by session id
+	lastId   int                           // last assigned id for session, starts at 1 to make create from context easier
+	mu       sync.Mutex                    // protects sessions map
 }
 
 // NewSessionManager is the SessionManager constructor

--- a/network/forward/forward_test.go
+++ b/network/forward/forward_test.go
@@ -20,26 +20,29 @@ func TestNew(t *testing.T) {
 	kadParams := network.NewKadParams()
 	kad := network.NewKademlia(addr, kadParams)
 
-	sessionId = 42
-	fwdBase := New(kad, "", nil)
+	mgr := NewSessionManager()
+	fwdBase := mgr.New(kad, "", nil)
 	if !bytes.Equal(fwdBase.pivot, addr) {
 		t.Fatalf("pivot base; expected %x, got %x", addr, fwdBase.pivot)
 	}
-	if fwdBase.id != 42 {
+	if fwdBase.id != 0 {
 		t.Fatalf("sessionId; expected %d, got %d", 42, fwdBase.id)
 	}
 
 	bytesNear := pot.NewAddressFromString("00000001")
 	capabilityIndex := "foo"
-	fwdExplicit := New(kad, capabilityIndex, bytesNear)
+	fwdExplicit := mgr.New(kad, capabilityIndex, bytesNear)
 	if !bytes.Equal(fwdExplicit.pivot, bytesNear) {
 		t.Fatalf("pivot explicit; expected %x, got %x", bytesNear, fwdExplicit.pivot)
 	}
-	if fwdExplicit.id != 43 {
+	if fwdExplicit.id != 1 {
 		t.Fatalf("sessionId; expected %d, got %d", 43, fwdExplicit.id)
 	}
 	if fwdExplicit.capabilityIndex != capabilityIndex {
 		t.Fatalf("capabilityindex, expected %s, got %s", capabilityIndex, fwdExplicit.capabilityIndex)
+	}
+	if len(mgr.sessions) != 2 {
+		t.Fatalf("sessions array; expected %d, got %d", 2, len(mgr.sessions))
 	}
 }
 

--- a/network/forward/forward_test.go
+++ b/network/forward/forward_test.go
@@ -1,0 +1,32 @@
+package forward
+
+import (
+	"testing"
+
+	"github.com/ethersphere/swarm/network"
+	"github.com/ethersphere/swarm/network/capability"
+	"github.com/ethersphere/swarm/pot"
+)
+
+func TestGet(t *testing.T) {
+	addr := make([]byte, 32)
+	kadParams := network.NewKadParams()
+	kad := network.NewKademlia(addr, kadParams)
+	cp := capability.NewCapability(4, 2)
+	kad.RegisterCapabilityIndex("foo", *cp)
+	sctx := NewSessionContext("foo")
+	fwd := New(sctx)
+
+	bytesFar := pot.NewAddressFromString("10000000")
+	bytesNear := pot.NewAddressFromString("00000001")
+	addrFar := network.NewBzzAddr(bytesFar, []byte{})
+	addrNear := network.NewBzzAddr(bytesNear, []byte{})
+	addrFar.Capabilities.Add(cp)
+	addrNear.Capabilities.Add(cp)
+	peerFar := network.NewPeer(&network.BzzPeer{BzzAddr: addrFar}, kad)
+	peerNear := network.NewPeer(&network.BzzPeer{BzzAddr: addrNear}, kad)
+	kad.Register(addrFar)
+	kad.Register(addrNear)
+	kad.On(peerFar)
+	kad.On(peerNear)
+}

--- a/network/forward/forward_test.go
+++ b/network/forward/forward_test.go
@@ -46,6 +46,43 @@ func TestNew(t *testing.T) {
 	}
 }
 
+func TestManagerContext(t *testing.T) {
+	addr := make([]byte, 32)
+	addr[31] = 0x01
+	kadParams := network.NewKadParams()
+	kad := network.NewKademlia(addr, kadParams)
+
+	mgr := NewSessionManager()
+	_ = mgr.New(kad, "", nil)
+	fwdOne := mgr.New(kad, "", nil)
+	sctx := NewSessionContext(fwdOne.id, "", nil)
+	fwdRetrieved, err := mgr.FromContext(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fwdRetrieved != fwdOne {
+		t.Fatalf("fromcontext; expected %p, got %p", fwdOne, fwdRetrieved)
+	}
+
+	newAddr := make([]byte, 32)
+	newAddr[31] = 0x02
+	fwdTwo := mgr.New(kad, "foo", newAddr)
+	sctx, err = mgr.ToContext(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fwdTwo.id != sctx.SessionId {
+		t.Fatalf("to context id; expected %d, got %d", fwdTwo.id, sctx.SessionId)
+	}
+	if fwdTwo.capabilityIndex != sctx.CapabilityIndex {
+		t.Fatalf("to context id; expected %s, got %s", fwdTwo.capabilityIndex, sctx.CapabilityIndex)
+	}
+	if !bytes.Equal(fwdTwo.pivot, sctx.Address) {
+		t.Fatalf("to context id; expected %x, got %x", fwdTwo.pivot, sctx.Address)
+	}
+
+}
+
 //func TestGet() {
 //addr := make([]byte, 32)
 //	kadParams := network.NewKadParams()

--- a/network/forward/forward_test.go
+++ b/network/forward/forward_test.go
@@ -20,17 +20,31 @@ func TestNew(t *testing.T) {
 	kadParams := network.NewKadParams()
 	kad := network.NewKademlia(addr, kadParams)
 
+	sessionId = 42
 	sctx := NewSessionContext()
-	fwdBase := New(sctx, kad)
+	fwdBase := NewFromContext(sctx, kad)
 	if !bytes.Equal(fwdBase.pivot, addr) {
 		t.Fatalf("pivot base; expected %x, got %x", addr, fwdBase.pivot)
 	}
+	if fwdBase.id != 42 {
+		t.Fatalf("sessionId; expected %d, got %d", 42, fwdBase.id)
+	}
 
 	bytesNear := pot.NewAddressFromString("00000001")
+	capabilityIndex := "foo"
+	sctx = NewSessionContext()
+	sctx.SetCapability(capabilityIndex)
 	sctx.SetAddress(bytesNear)
-	fwdExplicit := New(sctx, kad)
+	fwdExplicit := NewFromContext(sctx, kad)
 	if !bytes.Equal(fwdExplicit.pivot, bytesNear) {
 		t.Fatalf("pivot explicit; expected %x, got %x", bytesNear, fwdExplicit.pivot)
+	}
+
+	if sctx.CapabilityIndex != capabilityIndex {
+		t.Fatalf("capability; expected %s, got %s", capabilityIndex, fwdExplicit.capabilityIndex)
+	}
+	if fwdExplicit.id != 43 {
+		t.Fatalf("sessionId; expected %d, got %d", 43, fwdExplicit.id)
 	}
 }
 

--- a/network/forward/forward_test.go
+++ b/network/forward/forward_test.go
@@ -1,32 +1,69 @@
 package forward
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/ethersphere/swarm/network"
-	"github.com/ethersphere/swarm/network/capability"
 	"github.com/ethersphere/swarm/pot"
+	"github.com/ethersphere/swarm/testutil"
 )
 
-func TestGet(t *testing.T) {
+func init() {
+	testutil.Init()
+}
+
+func TestNew(t *testing.T) {
+
 	addr := make([]byte, 32)
+	addr[31] = 0x01
 	kadParams := network.NewKadParams()
 	kad := network.NewKademlia(addr, kadParams)
-	cp := capability.NewCapability(4, 2)
-	kad.RegisterCapabilityIndex("foo", *cp)
-	sctx := NewSessionContext("foo")
-	fwd := New(sctx)
 
-	bytesFar := pot.NewAddressFromString("10000000")
+	sctx := NewSessionContext()
+	fwdBase := New(sctx, kad)
+	if !bytes.Equal(fwdBase.pivot, addr) {
+		t.Fatalf("pivot base; expected %x, got %x", addr, fwdBase.pivot)
+	}
+
 	bytesNear := pot.NewAddressFromString("00000001")
-	addrFar := network.NewBzzAddr(bytesFar, []byte{})
-	addrNear := network.NewBzzAddr(bytesNear, []byte{})
-	addrFar.Capabilities.Add(cp)
-	addrNear.Capabilities.Add(cp)
-	peerFar := network.NewPeer(&network.BzzPeer{BzzAddr: addrFar}, kad)
-	peerNear := network.NewPeer(&network.BzzPeer{BzzAddr: addrNear}, kad)
-	kad.Register(addrFar)
-	kad.Register(addrNear)
-	kad.On(peerFar)
-	kad.On(peerNear)
+	sctx.SetAddress(bytesNear)
+	fwdExplicit := New(sctx, kad)
+	if !bytes.Equal(fwdExplicit.pivot, bytesNear) {
+		t.Fatalf("pivot explicit; expected %x, got %x", bytesNear, fwdExplicit.pivot)
+	}
 }
+
+//func TestGet() {
+//addr := make([]byte, 32)
+//	kadParams := network.NewKadParams()
+//	kad := network.NewKademlia(addr, kadParams)
+//	cp := capability.NewCapability(4, 2)
+//	kad.RegisterCapabilityIndex("foo", *cp)
+//
+//	bytesFar := pot.NewAddressFromString("10000000")
+//	bytesNear := pot.NewAddressFromString("00000001")
+//	addrFar := network.NewBzzAddr(bytesFar, []byte{})
+//	addrNear := network.NewBzzAddr(bytesNear, []byte{})
+//	addrFar.Capabilities.Add(cp)
+//	addrNear.Capabilities.Add(cp)
+//	peerFar := network.NewPeer(&network.BzzPeer{BzzAddr: addrFar}, kad)
+//	peerNear := network.NewPeer(&network.BzzPeer{BzzAddr: addrNear}, kad)
+//	kad.Register(addrFar)
+//	kad.Register(addrNear)
+//	kad.On(peerFar)
+//	kad.On(peerNear)
+//
+//
+//resultNear, err := fwdBase.Get(1)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//	if len(resultNear) != 1 {
+//		t.Fatalf("peer missing, expected %d, got %d", 1, len(resultNear))
+//	}
+//	if !bytes.Equal(resultNear[0].Address(), addrNear.Address()) {
+//		t.Fatalf("peer mismatch, expected %x, got %x", addrNear.Address(), resultNear[0].Address())
+//	}
+
+//}

--- a/network/forward/forward_test.go
+++ b/network/forward/forward_test.go
@@ -21,8 +21,7 @@ func TestNew(t *testing.T) {
 	kad := network.NewKademlia(addr, kadParams)
 
 	sessionId = 42
-	sctx := NewSessionContext()
-	fwdBase := NewFromContext(sctx, kad)
+	fwdBase := New(kad, "", nil)
 	if !bytes.Equal(fwdBase.pivot, addr) {
 		t.Fatalf("pivot base; expected %x, got %x", addr, fwdBase.pivot)
 	}
@@ -32,19 +31,15 @@ func TestNew(t *testing.T) {
 
 	bytesNear := pot.NewAddressFromString("00000001")
 	capabilityIndex := "foo"
-	sctx = NewSessionContext()
-	sctx.SetCapability(capabilityIndex)
-	sctx.SetAddress(bytesNear)
-	fwdExplicit := NewFromContext(sctx, kad)
+	fwdExplicit := New(kad, capabilityIndex, bytesNear)
 	if !bytes.Equal(fwdExplicit.pivot, bytesNear) {
 		t.Fatalf("pivot explicit; expected %x, got %x", bytesNear, fwdExplicit.pivot)
 	}
-
-	if sctx.CapabilityIndex != capabilityIndex {
-		t.Fatalf("capability; expected %s, got %s", capabilityIndex, fwdExplicit.capabilityIndex)
-	}
 	if fwdExplicit.id != 43 {
 		t.Fatalf("sessionId; expected %d, got %d", 43, fwdExplicit.id)
+	}
+	if fwdExplicit.capabilityIndex != capabilityIndex {
+		t.Fatalf("capabilityindex, expected %s, got %s", capabilityIndex, fwdExplicit.capabilityIndex)
 	}
 }
 

--- a/network/forward/types.go
+++ b/network/forward/types.go
@@ -1,0 +1,29 @@
+package forward
+
+var (
+	sessionId = 0
+)
+
+type ForwardPeer struct {
+}
+
+type SessionInterface interface {
+	Subscribe() <-chan ForwardPeer
+	Get(numberOfPeers int) ([]ForwardPeer, error)
+	Close()
+}
+
+// also implements context.Context
+type SessionContext struct {
+	CapabilityIndex string
+	SessionId       int
+}
+
+func NewSessionContext(cpidx string) SessionContext {
+	sctx := SessionContext{
+		CapabilityIndex: cpidx,
+		SessionId:       sessionId,
+	}
+	sessionId++
+	return sctx
+}

--- a/network/forward/types.go
+++ b/network/forward/types.go
@@ -27,7 +27,7 @@ type SessionContext struct {
 	Address         []byte
 }
 
-func newSessionContext(capabilityIndex string, sessionId int, addr []byte) *SessionContext {
+func NewSessionContext(sessionId int, capabilityIndex string, addr []byte) *SessionContext {
 	return &SessionContext{
 		CapabilityIndex: capabilityIndex,
 		SessionId:       sessionId,

--- a/network/forward/types.go
+++ b/network/forward/types.go
@@ -11,7 +11,7 @@ var (
 )
 
 type ForwardPeer struct {
-	*network.BzzPeer
+	*network.Peer
 }
 
 type SessionInterface interface {

--- a/network/forward/types.go
+++ b/network/forward/types.go
@@ -27,10 +27,9 @@ type SessionContext struct {
 	Address         []byte
 }
 
-func NewSessionContext(sessionId int, capabilityIndex string, addr []byte) *SessionContext {
+func NewSessionContext(capabilityIndex string, addr []byte) *SessionContext {
 	return &SessionContext{
 		CapabilityIndex: capabilityIndex,
-		SessionId:       sessionId,
 		Address:         addr,
 	}
 }

--- a/network/forward/types.go
+++ b/network/forward/types.go
@@ -27,11 +27,6 @@ type SessionContext struct {
 	Address         []byte
 }
 
-func NewSessionContext() *SessionContext {
-	sctx := newSessionContext("", sessionId, nil)
-	return sctx
-}
-
 func newSessionContext(capabilityIndex string, sessionId int, addr []byte) *SessionContext {
 	return &SessionContext{
 		CapabilityIndex: capabilityIndex,

--- a/network/forward/types.go
+++ b/network/forward/types.go
@@ -7,8 +7,7 @@ import (
 )
 
 var (
-	sessionId = 0
-	zeroTime  = time.Unix(0, 0)
+	zeroTime = time.Unix(0, 0)
 )
 
 type ForwardPeer struct {
@@ -30,7 +29,6 @@ type SessionContext struct {
 
 func NewSessionContext() *SessionContext {
 	sctx := newSessionContext("", sessionId, nil)
-	sessionId++
 	return sctx
 }
 

--- a/network/forward/types.go
+++ b/network/forward/types.go
@@ -65,6 +65,11 @@ func (c *SessionContext) Value(k interface{}) interface{} {
 			return nil
 		}
 		return c.Address
+	case "capability":
+		if c.CapabilityIndex == "" {
+			return nil
+		}
+		return c.CapabilityIndex
 	case "id":
 		return c.SessionId
 	}
@@ -73,4 +78,8 @@ func (c *SessionContext) Value(k interface{}) interface{} {
 
 func (c *SessionContext) SetAddress(addr []byte) {
 	c.Address = addr
+}
+
+func (c *SessionContext) SetCapability(capabilityIndex string) {
+	c.CapabilityIndex = capabilityIndex
 }

--- a/network/forward/types.go
+++ b/network/forward/types.go
@@ -10,42 +10,43 @@ var (
 	zeroTime = time.Unix(0, 0)
 )
 
-type ForwardPeer struct {
-	*network.Peer
-}
-
+// SessionInterface provides an interface for an individual session object
 type SessionInterface interface {
-	Subscribe() <-chan ForwardPeer
-	Get(numberOfPeers int) ([]ForwardPeer, error)
-	Close()
+	Subscribe() <-chan *network.Peer
+	Get(numberOfPeers int) ([]*network.Peer, error)
 }
 
-// also implements context.Context
+// SessionContext is a context.Context that can be used to reference existing sessions or create new sessions
 type SessionContext struct {
 	CapabilityIndex string
 	SessionId       int
 	Address         []byte
 }
 
-func NewSessionContext(capabilityIndex string, addr []byte) *SessionContext {
+// NewSessionContext creates a new SessionContext with the provided capabilityIndex and base address
+func NewSessionContext(capabilityIndex string, base []byte) *SessionContext {
 	return &SessionContext{
 		CapabilityIndex: capabilityIndex,
-		Address:         addr,
+		Address:         base,
 	}
 }
 
+// Deadline implements context.Context
 func (c *SessionContext) Deadline() (time.Time, bool) {
 	return zeroTime, false
 }
 
+// Done implements context.Context
 func (c *SessionContext) Done() <-chan struct{} {
 	return nil
 }
 
+// Err implements context.Context
 func (c *SessionContext) Err() error {
 	return nil
 }
 
+// Value implements context.Context
 func (c *SessionContext) Value(k interface{}) interface{} {
 	ks, ok := k.(string)
 	if !ok {
@@ -66,12 +67,4 @@ func (c *SessionContext) Value(k interface{}) interface{} {
 		return c.SessionId
 	}
 	return nil
-}
-
-func (c *SessionContext) SetAddress(addr []byte) {
-	c.Address = addr
-}
-
-func (c *SessionContext) SetCapability(capabilityIndex string) {
-	c.CapabilityIndex = capabilityIndex
 }

--- a/network/forward/types.go
+++ b/network/forward/types.go
@@ -1,10 +1,18 @@
 package forward
 
+import (
+	"time"
+
+	"github.com/ethersphere/swarm/network"
+)
+
 var (
 	sessionId = 0
+	zeroTime  = time.Unix(0, 0)
 )
 
 type ForwardPeer struct {
+	*network.BzzPeer
 }
 
 type SessionInterface interface {
@@ -17,13 +25,52 @@ type SessionInterface interface {
 type SessionContext struct {
 	CapabilityIndex string
 	SessionId       int
+	Address         []byte
 }
 
-func NewSessionContext(cpidx string) SessionContext {
-	sctx := SessionContext{
-		CapabilityIndex: cpidx,
-		SessionId:       sessionId,
-	}
+func NewSessionContext() *SessionContext {
+	sctx := newSessionContext("", sessionId, nil)
 	sessionId++
 	return sctx
+}
+
+func newSessionContext(capabilityIndex string, sessionId int, addr []byte) *SessionContext {
+	return &SessionContext{
+		CapabilityIndex: capabilityIndex,
+		SessionId:       sessionId,
+		Address:         addr,
+	}
+}
+
+func (c *SessionContext) Deadline() (time.Time, bool) {
+	return zeroTime, false
+}
+
+func (c *SessionContext) Done() <-chan struct{} {
+	return nil
+}
+
+func (c *SessionContext) Err() error {
+	return nil
+}
+
+func (c *SessionContext) Value(k interface{}) interface{} {
+	ks, ok := k.(string)
+	if !ok {
+		return nil
+	}
+	switch ks {
+	case "address":
+		if c.Address == nil {
+			return nil
+		}
+		return c.Address
+	case "id":
+		return c.SessionId
+	}
+	return nil
+}
+
+func (c *SessionContext) SetAddress(addr []byte) {
+	c.Address = addr
 }

--- a/network/kademlia_load_balancer.go
+++ b/network/kademlia_load_balancer.go
@@ -24,6 +24,7 @@ import (
 )
 
 // KademliaBackend is the required interface of KademliaLoadBalancer.
+// TODO: Consider if KademliaLoadBalancer itself should implement KademliaBackend
 type KademliaBackend interface {
 	SubscribeToPeerChanges() *pubsubchannel.Subscription
 	BaseAddr() []byte
@@ -122,6 +123,11 @@ func (klb *KademliaLoadBalancer) EachBinDesc(base []byte, consumeBin LBBinConsum
 		peers := klb.peerBinToPeerList(peerBin)
 		return consumeBin(LBBin{LBPeers: peers, ProximityOrder: peerBin.ProximityOrder})
 	})
+}
+
+// BaseAddr returns the base address of the underlying kademlia backend
+func (klb *KademliaLoadBalancer) BaseAddr() []byte {
+	return klb.kademlia.BaseAddr()
 }
 
 func (klb *KademliaLoadBalancer) peerBinToPeerList(bin *PeerBin) []LBPeer {

--- a/pot/address.go
+++ b/pot/address.go
@@ -79,6 +79,10 @@ func (a Address) Bytes() []byte {
 	return a[:]
 }
 
+func (a Address) Address() []byte {
+	return a[:]
+}
+
 // Distance returns the distance between address x and address y as a (comparable) big integer using the distance metric defined in the swarm specification
 // Fails if not all addresses are of equal length
 func Distance(x, y []byte) (*big.Int, error) {


### PR DESCRIPTION
This PR is the first step of implementing the component described in https://github.com/ethersphere/SWIPs/pull/35

It introduces a new package `network/forward`, which contains:

* `Session` - represents a single peer query
* `SessionManager` - index of existing sessions, used for queries that should be kept alive
* `SessionContext` - specialized `context.Context` object intended for use in multiple RPC API calls for the same session

The goal of the PR is to set up the framework for the package, and enable the simplest mode of operation; static, synchronous retrieval of peers from the given kademlia backend.