### PR TITLE
swap: pass the context to waitForTx directly

### DIFF
--- a/contracts/swap/factory.go
+++ b/contracts/swap/factory.go
@@ -83,7 +83,7 @@ func (sf simpleSwapFactory) DeploySimpleSwap(auth *bind.TransactOpts, issuer com
 		return nil, err
 	}
 
-	receipt, err := WaitFunc(auth, sf.backend, tx)
+	receipt, err := WaitFunc(auth.Context, sf.backend, tx)
 	if err != nil {
 		return nil, err
 	}

--- a/contracts/swap/swap.go
+++ b/contracts/swap/swap.go
@@ -106,7 +106,7 @@ func (s simpleContract) Withdraw(auth *bind.TransactOpts, amount *big.Int) (*typ
 	if err != nil {
 		return nil, err
 	}
-	return WaitFunc(auth, s.backend, tx)
+	return WaitFunc(auth.Context, s.backend, tx)
 }
 
 // Deposit sends an amount in ERC20 token to the chequebook and blocks until the transaction is mined
@@ -136,7 +136,7 @@ func (s simpleContract) Deposit(auth *bind.TransactOpts, amount *big.Int) (*type
 	if err != nil {
 		return nil, err
 	}
-	return WaitFunc(auth, s.backend, tx)
+	return WaitFunc(auth.Context, s.backend, tx)
 }
 
 // CashChequeBeneficiary cashes the cheque on the blockchain and blocks until the transaction is mined.
@@ -145,7 +145,7 @@ func (s simpleContract) CashChequeBeneficiary(opts *bind.TransactOpts, beneficia
 	if err != nil {
 		return nil, nil, err
 	}
-	receipt, err := WaitFunc(opts, s.backend, tx)
+	receipt, err := WaitFunc(opts.Context, s.backend, tx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -225,9 +225,9 @@ func (s simpleContract) PaidOut(opts *bind.CallOpts, addr common.Address) (*big.
 var WaitFunc = waitForTx
 
 // waitForTx waits for transaction to be mined and returns the receipt
-func waitForTx(auth *bind.TransactOpts, backend Backend, tx *types.Transaction) (*types.Receipt, error) {
+func waitForTx(ctx context.Context, backend Backend, tx *types.Transaction) (*types.Receipt, error) {
 	// it blocks here until tx is mined
-	receipt, err := bind.WaitMined(auth.Context, backend, tx)
+	receipt, err := bind.WaitMined(ctx, backend, tx)
 	if err != nil {
 		return nil, err
 	}

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -1245,7 +1245,7 @@ func TestContractIntegration(t *testing.T) {
 }
 
 // when testing, we don't need to wait for a transaction to be mined
-func testWaitForTx(auth *bind.TransactOpts, backend cswap.Backend, tx *types.Transaction) (*types.Receipt, error) {
+func testWaitForTx(ctx context.Context, backend cswap.Backend, tx *types.Transaction) (*types.Receipt, error) {
 
 	var stb *swapTestBackend
 	var ok bool
@@ -1254,7 +1254,7 @@ func testWaitForTx(auth *bind.TransactOpts, backend cswap.Backend, tx *types.Tra
 	}
 	stb.Commit()
 
-	receipt, err := backend.TransactionReceipt(context.TODO(), tx.Hash())
+	receipt, err := backend.TransactionReceipt(ctx, tx.Hash())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Instead of having a `auth *bind.TransactOpts` as the first argument for `waitForTx`, this PR passes the context (which is the only field used of the opts) directly.

This allows using `waitForTx` in contexts where there is no transaction without having to wrap the context in a dummy `bind.TransactOpts`.