### PR TITLE
Protocol msg pauser

### DIFF
--- a/network/stream/common_test.go
+++ b/network/stream/common_test.go
@@ -275,7 +275,7 @@ type syncPauser struct {
 	mu  sync.RWMutex
 }
 
-func (p *syncPauser) pause() {
+func (p *syncPauser) Pause() {
 	p.mu.Lock()
 	if p.c == nil {
 		p.c = sync.NewCond(&p.cMu)
@@ -283,7 +283,7 @@ func (p *syncPauser) pause() {
 	p.mu.Unlock()
 }
 
-func (p *syncPauser) resume() {
+func (p *syncPauser) Resume() {
 	p.c.L.Lock()
 	p.c.Broadcast()
 	p.c.L.Unlock()
@@ -292,7 +292,7 @@ func (p *syncPauser) resume() {
 	p.mu.Unlock()
 }
 
-func (p *syncPauser) wait() {
+func (p *syncPauser) Wait() {
 	p.mu.RLock()
 	if p.c != nil {
 		p.c.L.Lock()

--- a/network/stream/stream.go
+++ b/network/stream/stream.go
@@ -131,7 +131,8 @@ func New(intervalsStore state.Store, address *network.BzzAddr, providers ...Stre
 // Run is being dispatched when 2 nodes connect
 func (r *Registry) Run(bp *network.BzzPeer) error {
 	sp := newPeer(bp, r.address, r.intervalsStore, r.providers)
-	sp.Peer.MsgPauserEnabled = true
+	// enable msg pauser for stream protocol, this is used only in tests
+	sp.Peer.EnableMsgPauser()
 	r.addPeer(sp)
 	defer r.removePeer(sp)
 

--- a/network/stream/stream.go
+++ b/network/stream/stream.go
@@ -94,7 +94,7 @@ var (
 	}
 
 	// pause the msgHandler execution, used only for tests
-	MessagePauser protocols.TestMsgPauser = nil
+	handleMsgPauser protocols.MsgPauser = nil
 )
 
 // Registry is the base type that handles all client/server operations on a node
@@ -135,7 +135,7 @@ func New(intervalsStore state.Store, address *network.BzzAddr, providers ...Stre
 func (r *Registry) Run(bp *network.BzzPeer) error {
 	sp := newPeer(bp, r.address, r.intervalsStore, r.providers)
 	// enable msg pauser for stream protocol, this is used only in tests
-	sp.Peer.SetMsgPauser(MessagePauser)
+	sp.Peer.SetMsgPauser(handleMsgPauser)
 	r.addPeer(sp)
 	defer r.removePeer(sp)
 

--- a/network/stream/stream.go
+++ b/network/stream/stream.go
@@ -92,6 +92,9 @@ var (
 			WantedHashes{},
 		},
 	}
+
+	// pause the msgHandler execution, used only for tests
+	MessagePauser protocols.TestMsgPauser = nil
 )
 
 // Registry is the base type that handles all client/server operations on a node
@@ -132,7 +135,7 @@ func New(intervalsStore state.Store, address *network.BzzAddr, providers ...Stre
 func (r *Registry) Run(bp *network.BzzPeer) error {
 	sp := newPeer(bp, r.address, r.intervalsStore, r.providers)
 	// enable msg pauser for stream protocol, this is used only in tests
-	sp.Peer.EnableMsgPauser()
+	sp.Peer.SetMsgPauser(MessagePauser)
 	r.addPeer(sp)
 	defer r.removePeer(sp)
 

--- a/network/stream/stream.go
+++ b/network/stream/stream.go
@@ -131,6 +131,7 @@ func New(intervalsStore state.Store, address *network.BzzAddr, providers ...Stre
 // Run is being dispatched when 2 nodes connect
 func (r *Registry) Run(bp *network.BzzPeer) error {
 	sp := newPeer(bp, r.address, r.intervalsStore, r.providers)
+	sp.Peer.MsgPauserEnabled = true
 	r.addPeer(sp)
 	defer r.removePeer(sp)
 
@@ -142,16 +143,6 @@ func (r *Registry) Run(bp *network.BzzPeer) error {
 // HandleMsg is the main message handler for the stream protocol
 func (r *Registry) HandleMsg(p *Peer) func(context.Context, interface{}) error {
 	return func(ctx context.Context, msg interface{}) error {
-		// handleMsgPauser should not be nil only in tests.
-		// It does not use mutex lock protection and because of that
-		// it must be set before the Registry is constructed and
-		// reset when it is closed, in tests.
-		// Production performance impact can be considered as
-		// neglectable as nil check is a ns order operation.
-		if handleMsgPauser != nil {
-			handleMsgPauser.wait()
-		}
-
 		switch msg := msg.(type) {
 		case *StreamInfoReq:
 			return r.serverHandleStreamInfoReq(ctx, p, msg)
@@ -211,16 +202,6 @@ func (r *Registry) HandleMsg(p *Peer) func(context.Context, interface{}) error {
 			return nil
 		}
 	}
-}
-
-// Used to pause any message handling in tests for
-// synchronizing desired states.
-var handleMsgPauser pauser
-
-type pauser interface {
-	pause()
-	resume()
-	wait()
 }
 
 // serverHandleStreamInfoReq handles the StreamInfoReq message on the server side (Peer is the client)

--- a/network/stream/syncing_test.go
+++ b/network/stream/syncing_test.go
@@ -47,9 +47,8 @@ var timeout = 90 * time.Second
 func TestTwoNodesSyncWithGaps(t *testing.T) {
 	// construct a pauser before simulation is started and reset it to nil after all streams are closed
 	// to avoid the need for protecting handleMsgPauser with a lock in production code.
-	protocols.HandleMsgPauser = new(syncPauser)
-	defer func() { protocols.HandleMsgPauser = nil }()
-
+	MessagePauser = new(syncPauser)
+	defer func() { MessagePauser = nil }()
 	removeChunks := func(t *testing.T, ctx context.Context, store chunk.Store, gaps [][2]uint64, chunks []chunk.Address) (removedCount uint64) {
 		t.Helper()
 
@@ -199,14 +198,14 @@ func TestTwoNodesSyncWithGaps(t *testing.T) {
 			if tc.liveChunkCount > 0 {
 				// pause syncing so that the chunks in the live gap
 				// are not synced before they are removed
-				protocols.HandleMsgPauser.Pause()
+				MessagePauser.Pause()
 
 				chunks = append(chunks, mustUploadChunks(ctx, t, uploadStore, tc.liveChunkCount)...)
 
 				removedCount += removeChunks(t, ctx, uploadStore, tc.liveGaps, chunks)
 
 				// resume syncing
-				protocols.HandleMsgPauser.Resume()
+				MessagePauser.Resume()
 
 				err = waitChunks(syncStore, tc.chunkCount+tc.liveChunkCount-removedCount, time.Minute)
 				if err != nil {

--- a/network/stream/syncing_test.go
+++ b/network/stream/syncing_test.go
@@ -47,8 +47,8 @@ var timeout = 90 * time.Second
 func TestTwoNodesSyncWithGaps(t *testing.T) {
 	// construct a pauser before simulation is started and reset it to nil after all streams are closed
 	// to avoid the need for protecting handleMsgPauser with a lock in production code.
-	handleMsgPauser = new(syncPauser)
-	defer func() { handleMsgPauser = nil }()
+	protocols.HandleMsgPauser = new(syncPauser)
+	defer func() { protocols.HandleMsgPauser = nil }()
 
 	removeChunks := func(t *testing.T, ctx context.Context, store chunk.Store, gaps [][2]uint64, chunks []chunk.Address) (removedCount uint64) {
 		t.Helper()
@@ -199,14 +199,14 @@ func TestTwoNodesSyncWithGaps(t *testing.T) {
 			if tc.liveChunkCount > 0 {
 				// pause syncing so that the chunks in the live gap
 				// are not synced before they are removed
-				handleMsgPauser.pause()
+				protocols.HandleMsgPauser.Pause()
 
 				chunks = append(chunks, mustUploadChunks(ctx, t, uploadStore, tc.liveChunkCount)...)
 
 				removedCount += removeChunks(t, ctx, uploadStore, tc.liveGaps, chunks)
 
 				// resume syncing
-				handleMsgPauser.resume()
+				protocols.HandleMsgPauser.Resume()
 
 				err = waitChunks(syncStore, tc.chunkCount+tc.liveChunkCount-removedCount, time.Minute)
 				if err != nil {

--- a/p2p/protocols/protocol.go
+++ b/p2p/protocols/protocol.go
@@ -112,9 +112,9 @@ func errorf(code int, format string, params ...interface{}) *Error {
 	}
 }
 
-// TestMsgPauser can be used to pause run execution
+// MsgPauser can be used to pause run execution
 // IMPORTANT: should be used only for tests
-type TestMsgPauser interface {
+type MsgPauser interface {
 	Pause()
 	Resume()
 	Wait()
@@ -213,9 +213,9 @@ type Peer struct {
 	encode          func(context.Context, interface{}) (interface{}, int, error)
 	decode          func(p2p.Msg) (context.Context, []byte, error)
 	wg              sync.WaitGroup
-	running         bool          // if running is true async go routines are dispatched in the event loop
-	mtx             sync.RWMutex  // guards running
-	handleMsgPauser TestMsgPauser //  message pauser, should be used only in tests
+	running         bool         // if running is true async go routines are dispatched in the event loop
+	mtx             sync.RWMutex // guards running
+	handleMsgPauser MsgPauser    //  message pauser, should be used only in tests
 }
 
 // NewPeer constructs a new peer
@@ -388,7 +388,7 @@ func (p *Peer) Send(ctx context.Context, msg interface{}) error {
 
 // SetMsgPauser sets message pauser for this peer
 // IMPORTANT: to be used only for testing
-func (p *Peer) SetMsgPauser(pauser TestMsgPauser) {
+func (p *Peer) SetMsgPauser(pauser MsgPauser) {
 	p.handleMsgPauser = pauser
 }
 

--- a/p2p/protocols/protocol.go
+++ b/p2p/protocols/protocol.go
@@ -217,7 +217,7 @@ type Peer struct {
 	wg               sync.WaitGroup
 	running          bool         // if running is true async go routines are dispatched in the event loop
 	mtx              sync.RWMutex // guards running
-	MsgPauserEnabled bool         // enables message message pauser, use only in tests
+	msgPauserEnabled bool         // enables message message pauser, set to true only in tests if needed
 }
 
 // NewPeer constructs a new peer
@@ -274,7 +274,7 @@ func (p *Peer) run(handler func(ctx context.Context, msg interface{}) error) fun
 			// reset when it is closed, in tests.
 			// Production performance impact can be considered as
 			// neglectable as nil check is a ns order operation.
-			if HandleMsgPauser != nil && p.MsgPauserEnabled {
+			if HandleMsgPauser != nil && p.msgPauserEnabled {
 				HandleMsgPauser.Wait()
 			}
 
@@ -386,6 +386,12 @@ func (p *Peer) Send(ctx context.Context, msg interface{}) error {
 	}
 
 	return p2p.Send(p.rw, code, wmsg)
+}
+
+// EnableMsgPauser enables message pausing for this peer
+// IMPORTANT: to be used only for testing
+func (p *Peer) EnableMsgPauser() {
+	p.msgPauserEnabled = true
 }
 
 // receive is a sync call that handles incoming message with provided message handler


### PR DESCRIPTION
Hacky solution for message pauser that is used only in testing. When protocol handlers were moved to async, this changed msg pauser in stream to behave a bit differently. This is a fast and hacky way of achieving the similar functionality from protocol as well. Let me know what you think, we can also abort it if you think it is not necessary or if we should invest more time and implement it better.