### PR TITLE
cmd/swarm, internal/debug: decouple cli library from internal/debug

### DIFF
--- a/cmd/swarm/debug.go
+++ b/cmd/swarm/debug.go
@@ -1,0 +1,83 @@
+// Copyright 2019 The Swarm Authors
+// This file is part of The Swarm.
+//
+// The Swarm is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with The Swarm. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"runtime"
+
+	"gopkg.in/urfave/cli.v1"
+)
+
+var (
+	verbosityFlag = cli.IntFlag{
+		Name:  "verbosity",
+		Usage: "Logging verbosity: 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail",
+		Value: 3,
+	}
+	vmoduleFlag = cli.StringFlag{
+		Name:  "vmodule",
+		Usage: "Per-module verbosity: comma-separated list of <pattern>=<level> (e.g. eth/*=5,p2p=4)",
+		Value: "",
+	}
+	backtraceAtFlag = cli.StringFlag{
+		Name:  "backtrace",
+		Usage: "Request a stack trace at a specific logging statement (e.g. \"block.go:271\")",
+		Value: "",
+	}
+	debugFlag = cli.BoolFlag{
+		Name:  "debug",
+		Usage: "Prepends log messages with call-site location (file and line number)",
+	}
+	pprofFlag = cli.BoolFlag{
+		Name:  "pprof",
+		Usage: "Enable the pprof HTTP server",
+	}
+	pprofPortFlag = cli.IntFlag{
+		Name:  "pprofport",
+		Usage: "pprof HTTP server listening port",
+		Value: 6060,
+	}
+	pprofAddrFlag = cli.StringFlag{
+		Name:  "pprofaddr",
+		Usage: "pprof HTTP server listening interface",
+		Value: "127.0.0.1",
+	}
+	memprofilerateFlag = cli.IntFlag{
+		Name:  "memprofilerate",
+		Usage: "Turn on memory profiling with the given rate",
+		Value: runtime.MemProfileRate,
+	}
+	blockprofilerateFlag = cli.IntFlag{
+		Name:  "blockprofilerate",
+		Usage: "Turn on block profiling with the given rate",
+	}
+	cpuprofileFlag = cli.StringFlag{
+		Name:  "cpuprofile",
+		Usage: "Write CPU profile to the given file",
+	}
+	traceFlag = cli.StringFlag{
+		Name:  "trace",
+		Usage: "Write execution trace to the given file",
+	}
+)
+
+// debugFlags holds all command-line flags required for debugging.
+var debugFlags = []cli.Flag{
+	verbosityFlag, vmoduleFlag, backtraceAtFlag, debugFlag,
+	pprofFlag, pprofAddrFlag, pprofPortFlag,
+	memprofilerateFlag, blockprofilerateFlag, cpuprofileFlag, traceFlag,
+}

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -224,12 +224,24 @@ func init() {
 		utils.WSAllowedOriginsFlag,
 	}
 	app.Flags = append(app.Flags, rpcFlags...)
-	app.Flags = append(app.Flags, debug.Flags...)
+	app.Flags = append(app.Flags, debugFlags...)
 	app.Flags = append(app.Flags, swarmmetrics.Flags...)
 	app.Flags = append(app.Flags, tracing.Flags...)
 	app.Before = func(ctx *cli.Context) error {
 		runtime.GOMAXPROCS(runtime.NumCPU())
-		if err := debug.Setup(ctx, ""); err != nil {
+		if err := debug.Setup(debug.Options{
+			Debug:            ctx.GlobalBool(debugFlag.Name),
+			Verbosity:        ctx.GlobalInt(verbosityFlag.Name),
+			Vmodule:          ctx.GlobalString(vmoduleFlag.Name),
+			BacktraceAt:      ctx.GlobalString(backtraceAtFlag.Name),
+			MemProfileRate:   ctx.GlobalInt(memprofilerateFlag.Name),
+			BlockProfileRate: ctx.GlobalInt(blockprofilerateFlag.Name),
+			TraceFile:        ctx.GlobalString(traceFlag.Name),
+			CPUProfileFile:   ctx.GlobalString(cpuprofileFlag.Name),
+			PprofEnabled:     ctx.GlobalBool(pprofFlag.Name),
+			PprofAddr:        ctx.GlobalString(pprofAddrFlag.Name),
+			PprofPort:        ctx.GlobalInt(pprofPortFlag.Name),
+		}); err != nil {
 			return err
 		}
 		swarmmetrics.Setup(ctx)


### PR DESCRIPTION
This PR decouples cli library from internal/debug metrics. Package internal/debug defines and uses cli flags for configuration making it highly coupled to the main package with hard requirement on the specific cli library. This change removes that coupling allowing switching to a different cli library in the main package.

This PR is a preparation for using cobra/viper in swarm main package.