### PR TITLE
swap: pass depositAmount to testDeploy

### DIFF
--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -190,6 +190,8 @@ func newSharedBackendSwaps(t *testing.T, nodeCount int) (*swapSimulationParams, 
 	alloc := core.GenesisAlloc{}
 	stores := make(map[int]*state.DBStore)
 
+	ethFundingAmount := big.NewInt(9000000000000000000)
+
 	// for each node, generate keys, a GenesisAccount and a state store
 	for i := 0; i < nodeCount; i++ {
 		key, err := crypto.GenerateKey()
@@ -198,7 +200,7 @@ func newSharedBackendSwaps(t *testing.T, nodeCount int) (*swapSimulationParams, 
 		}
 		keys[i] = key
 		addrs[i] = crypto.PubkeyToAddress(key.PublicKey)
-		alloc[addrs[i]] = core.GenesisAccount{Balance: big.NewInt(9000000000000000000)}
+		alloc[addrs[i]] = core.GenesisAccount{Balance: ethFundingAmount}
 		dir, err := ioutil.TempDir("", fmt.Sprintf("swap_test_store_%x", addrs[i].Hex()))
 		if err != nil {
 			return nil, err
@@ -211,7 +213,7 @@ func newSharedBackendSwaps(t *testing.T, nodeCount int) (*swapSimulationParams, 
 		stores[i] = stateStore
 	}
 
-	alloc[ownerAddress] = core.GenesisAccount{Balance: big.NewInt(9000000000000000000)}
+	alloc[ownerAddress] = core.GenesisAccount{Balance: ethFundingAmount}
 
 	// then create the single SimulatedBackend
 	gasLimit := uint64(8000000000)

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -664,12 +664,14 @@ func TestResetBalance(t *testing.T) {
 	defer clean1()
 	defer clean2()
 
+	testAmount := int64(DefaultPaymentThreshold + 42)
+
 	ctx := context.Background()
 	err := testDeploy(ctx, creditorSwap, big.NewInt(0))
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = testDeploy(ctx, debitorSwap, big.NewInt(int64(DefaultPaymentThreshold)+42))
+	err = testDeploy(ctx, debitorSwap, big.NewInt(testAmount))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -689,7 +691,6 @@ func TestResetBalance(t *testing.T) {
 	}
 
 	// set balances arbitrarily
-	testAmount := int64(DefaultPaymentThreshold + 42)
 	debitor.setBalance(testAmount)
 	creditor.setBalance(-testAmount)
 
@@ -1550,8 +1551,10 @@ func TestSwapLogToFile(t *testing.T) {
 	}
 	defer clean()
 
+	testAmount := int64(DefaultPaymentThreshold + 42)
+
 	ctx := context.Background()
-	err = testDeploy(ctx, creditorSwap, big.NewInt(int64(DefaultPaymentThreshold)+42))
+	err = testDeploy(ctx, creditorSwap, big.NewInt(testAmount))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1575,7 +1578,6 @@ func TestSwapLogToFile(t *testing.T) {
 	}
 
 	// set balances arbitrarily
-	testAmount := int64(DefaultPaymentThreshold + 42)
 	debitor.setBalance(testAmount)
 	creditor.setBalance(-testAmount)
 


### PR DESCRIPTION
This PR removes the magical deployment deposit constant and lets each call of testDeploy decide the value individually. Deposits where chosen to the minimum amount required in each test.

To make things easier this PR also changes the way test deposits are made. Previously they were funded by the swap owner address (requiring token prefunding of that account also). Now they are always minted on demand by the token owner (the global `ownerKey`).

closes #1928