### PR TITLE
swap, uint256: unify variable types, pt. 1

### DIFF
--- a/swap/api.go
+++ b/swap/api.go
@@ -67,7 +67,8 @@ func (s *Swap) AvailableBalance() (*Uint256, error) {
 	}
 
 	// Compute the total worth of cheques sent and how much of of this is cashed
-	var sentChequesWorth, cashedChequesWorth *big.Int
+	sentChequesWorth := new(big.Int)
+	cashedChequesWorth := new(big.Int)
 	for _, peerCheques := range cheques {
 		var sentCheque *Cheque
 		if peerCheques.PendingCheque != nil {

--- a/swap/api.go
+++ b/swap/api.go
@@ -54,17 +54,17 @@ func NewAPI(s *Swap) *API {
 
 // AvailableBalance returns the total balance of the chequebook against which new cheques can be written
 func (s *Swap) AvailableBalance() (*Uint256, error) {
-	var liquidBalance, zero *Uint256
+	var liquidBalance *Uint256
 	// get the LiquidBalance of the chequebook
 	contractLiquidBalance, err := s.contract.LiquidBalance(nil)
 	if err != nil {
-		return zero, err
+		return &Uint256{}, err
 	}
 
 	// get all cheques
 	cheques, err := s.Cheques()
 	if err != nil {
-		return zero, err
+		return &Uint256{}, err
 	}
 
 	// Compute the total worth of cheques sent and how much of of this is cashed
@@ -82,7 +82,7 @@ func (s *Swap) AvailableBalance() (*Uint256, error) {
 		sentChequesWorth.Add(sentChequesWorth, sentCheque.ChequeParams.CumulativePayout.Value())
 		paidOut, err := s.contract.PaidOut(nil, sentCheque.ChequeParams.Beneficiary)
 		if err != nil {
-			return zero, err
+			return &Uint256{}, err
 		}
 		cashedChequesWorth.Add(cashedChequesWorth, paidOut)
 	}
@@ -93,7 +93,7 @@ func (s *Swap) AvailableBalance() (*Uint256, error) {
 
 	err = liquidBalance.Set(tentativeLiquidBalance)
 	if err != nil {
-		return zero, err
+		return &Uint256{}, err
 	}
 	return liquidBalance, nil
 }

--- a/swap/api.go
+++ b/swap/api.go
@@ -57,13 +57,13 @@ func (s *Swap) AvailableBalance() (*Uint256, error) {
 	// get the LiquidBalance of the chequebook
 	contractLiquidBalance, err := s.contract.LiquidBalance(nil)
 	if err != nil {
-		return NewUint256(), err
+		return nil, err
 	}
 
 	// get all cheques
 	cheques, err := s.Cheques()
 	if err != nil {
-		return NewUint256(), err
+		return nil, err
 	}
 
 	// Compute the total worth of cheques sent and how much of of this is cashed
@@ -81,7 +81,7 @@ func (s *Swap) AvailableBalance() (*Uint256, error) {
 		sentChequesWorth.Add(sentChequesWorth, sentCheque.ChequeParams.CumulativePayout.Value)
 		paidOut, err := s.contract.PaidOut(nil, sentCheque.ChequeParams.Beneficiary)
 		if err != nil {
-			return NewUint256(), err
+			return nil, err
 		}
 		cashedChequesWorth.Add(cashedChequesWorth, paidOut)
 	}

--- a/swap/api.go
+++ b/swap/api.go
@@ -54,7 +54,6 @@ func NewAPI(s *Swap) *API {
 
 // AvailableBalance returns the total balance of the chequebook against which new cheques can be written
 func (s *Swap) AvailableBalance() (*Uint256, error) {
-	var liquidBalance *Uint256
 	// get the LiquidBalance of the chequebook
 	contractLiquidBalance, err := s.contract.LiquidBalance(nil)
 	if err != nil {
@@ -89,11 +88,7 @@ func (s *Swap) AvailableBalance() (*Uint256, error) {
 	totalChequesWorth := new(big.Int).Sub(cashedChequesWorth, sentChequesWorth)
 	tentativeLiquidBalance := new(big.Int).Add(contractLiquidBalance, totalChequesWorth)
 
-	err = liquidBalance.Set(tentativeLiquidBalance)
-	if err != nil {
-		return &Uint256{}, err
-	}
-	return liquidBalance, nil
+	return (&Uint256{}).Set(tentativeLiquidBalance)
 }
 
 // PeerBalance returns the balance for a given peer

--- a/swap/api.go
+++ b/swap/api.go
@@ -78,7 +78,8 @@ func (s *Swap) AvailableBalance() (*Uint256, error) {
 		} else {
 			continue
 		}
-		sentChequesWorth.Add(sentChequesWorth, sentCheque.ChequeParams.CumulativePayout.Value)
+		cumulativePayout := sentCheque.ChequeParams.CumulativePayout.Value()
+		sentChequesWorth.Add(sentChequesWorth, &cumulativePayout)
 		paidOut, err := s.contract.PaidOut(nil, sentCheque.ChequeParams.Beneficiary)
 		if err != nil {
 			return nil, err
@@ -89,7 +90,7 @@ func (s *Swap) AvailableBalance() (*Uint256, error) {
 	totalChequesWorth := new(big.Int).Sub(cashedChequesWorth, sentChequesWorth)
 	tentativeLiquidBalance := new(big.Int).Add(contractLiquidBalance, totalChequesWorth)
 
-	return NewUint256().Set(tentativeLiquidBalance)
+	return NewUint256().Set(*tentativeLiquidBalance)
 }
 
 // PeerBalance returns the balance for a given peer

--- a/swap/api.go
+++ b/swap/api.go
@@ -77,7 +77,7 @@ func (s *Swap) AvailableBalance() (*Uint256, error) {
 		} else {
 			continue
 		}
-		sentChequesWorth.Add(sentChequesWorth, sentCheque.ChequeParams.CumulativePayout.Value())
+		sentChequesWorth.Add(sentChequesWorth, sentCheque.ChequeParams.CumulativePayout.Value)
 		paidOut, err := s.contract.PaidOut(nil, sentCheque.ChequeParams.Beneficiary)
 		if err != nil {
 			return NewUint256(), err

--- a/swap/api.go
+++ b/swap/api.go
@@ -68,8 +68,7 @@ func (s *Swap) AvailableBalance() (*Uint256, error) {
 	}
 
 	// Compute the total worth of cheques sent and how much of of this is cashed
-	var sentChequesWorth *big.Int
-	var cashedChequesWorth *big.Int
+	var sentChequesWorth, cashedChequesWorth *big.Int
 	for _, peerCheques := range cheques {
 		var sentCheque *Cheque
 		if peerCheques.PendingCheque != nil {
@@ -87,9 +86,8 @@ func (s *Swap) AvailableBalance() (*Uint256, error) {
 		cashedChequesWorth.Add(cashedChequesWorth, paidOut)
 	}
 
-	var totalChequesWorth, tentativeLiquidBalance *big.Int
-	totalChequesWorth.Sub(cashedChequesWorth, sentChequesWorth)
-	tentativeLiquidBalance.Add(contractLiquidBalance, totalChequesWorth)
+	totalChequesWorth := new(big.Int).Sub(cashedChequesWorth, sentChequesWorth)
+	tentativeLiquidBalance := new(big.Int).Add(contractLiquidBalance, totalChequesWorth)
 
 	err = liquidBalance.Set(tentativeLiquidBalance)
 	if err != nil {

--- a/swap/api.go
+++ b/swap/api.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 	contract "github.com/ethersphere/swarm/contracts/swap"
 	"github.com/ethersphere/swarm/state"
+	"github.com/ethersphere/swarm/uint256"
 )
 
 // APIs is a node.Service interface method
@@ -24,7 +25,7 @@ func (s *Swap) APIs() []rpc.API {
 }
 
 type swapAPI interface {
-	AvailableBalance() (*Uint256, error)
+	AvailableBalance() (*uint256.Uint256, error)
 	PeerBalance(peer enode.ID) (int64, error)
 	Balances() (map[enode.ID]int64, error)
 	PeerCheques(peer enode.ID) (PeerCheques, error)
@@ -53,7 +54,7 @@ func NewAPI(s *Swap) *API {
 }
 
 // AvailableBalance returns the total balance of the chequebook against which new cheques can be written
-func (s *Swap) AvailableBalance() (*Uint256, error) {
+func (s *Swap) AvailableBalance() (*uint256.Uint256, error) {
 	// get the LiquidBalance of the chequebook
 	contractLiquidBalance, err := s.contract.LiquidBalance(nil)
 	if err != nil {
@@ -90,7 +91,7 @@ func (s *Swap) AvailableBalance() (*Uint256, error) {
 	totalChequesWorth := new(big.Int).Sub(cashedChequesWorth, sentChequesWorth)
 	tentativeLiquidBalance := new(big.Int).Add(contractLiquidBalance, totalChequesWorth)
 
-	return NewUint256().Set(*tentativeLiquidBalance)
+	return uint256.New().Set(*tentativeLiquidBalance)
 }
 
 // PeerBalance returns the balance for a given peer

--- a/swap/api.go
+++ b/swap/api.go
@@ -57,13 +57,13 @@ func (s *Swap) AvailableBalance() (*Uint256, error) {
 	// get the LiquidBalance of the chequebook
 	contractLiquidBalance, err := s.contract.LiquidBalance(nil)
 	if err != nil {
-		return &Uint256{}, err
+		return NewUint256(), err
 	}
 
 	// get all cheques
 	cheques, err := s.Cheques()
 	if err != nil {
-		return &Uint256{}, err
+		return NewUint256(), err
 	}
 
 	// Compute the total worth of cheques sent and how much of of this is cashed
@@ -80,7 +80,7 @@ func (s *Swap) AvailableBalance() (*Uint256, error) {
 		sentChequesWorth.Add(sentChequesWorth, sentCheque.ChequeParams.CumulativePayout.Value())
 		paidOut, err := s.contract.PaidOut(nil, sentCheque.ChequeParams.Beneficiary)
 		if err != nil {
-			return &Uint256{}, err
+			return NewUint256(), err
 		}
 		cashedChequesWorth.Add(cashedChequesWorth, paidOut)
 	}
@@ -88,7 +88,7 @@ func (s *Swap) AvailableBalance() (*Uint256, error) {
 	totalChequesWorth := new(big.Int).Sub(cashedChequesWorth, sentChequesWorth)
 	tentativeLiquidBalance := new(big.Int).Add(contractLiquidBalance, totalChequesWorth)
 
-	return (&Uint256{}).Set(tentativeLiquidBalance)
+	return NewUint256().Set(tentativeLiquidBalance)
 }
 
 // PeerBalance returns the balance for a given peer

--- a/swap/cashout_test.go
+++ b/swap/cashout_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/log"
 	contract "github.com/ethersphere/swarm/contracts/swap"
+	"github.com/ethersphere/swarm/uint256"
 )
 
 // TestContractIntegration tests a end-to-end cheque interaction.
@@ -73,7 +74,7 @@ func TestContractIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	paidOut, err := NewUint256().Set(*result)
+	paidOut, err := uint256.New().Set(*result)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swap/cheque.go
+++ b/swap/cheque.go
@@ -137,14 +137,14 @@ func (cheque *Cheque) verifyChequeAgainstLast(lastCheque *Cheque, expectedAmount
 
 	if lastCheque != nil {
 		if cheque.CumulativePayout.Cmp(lastCheque.CumulativePayout) < 1 {
-			return &Uint256{}, fmt.Errorf("wrong cheque parameters: expected cumulative payout larger than %d, was: %d", lastCheque.CumulativePayout, cheque.CumulativePayout)
+			return NewUint256(), fmt.Errorf("wrong cheque parameters: expected cumulative payout larger than %d, was: %d", lastCheque.CumulativePayout, cheque.CumulativePayout)
 		}
 
 		actualAmount.Sub(actualAmount, lastCheque.CumulativePayout)
 	}
 
 	if expectedAmount != actualAmount {
-		return &Uint256{}, fmt.Errorf("unexpected amount for honey, expected %d was %d", expectedAmount, actualAmount)
+		return NewUint256(), fmt.Errorf("unexpected amount for honey, expected %d was %d", expectedAmount, actualAmount)
 	}
 
 	return actualAmount, nil

--- a/swap/cheque.go
+++ b/swap/cheque.go
@@ -96,7 +96,7 @@ func (cheque *Cheque) Equal(other *Cheque) bool {
 		return false
 	}
 
-	if cheque.CumulativePayout != other.CumulativePayout {
+	if !cheque.CumulativePayout.Equals(other.CumulativePayout) {
 		return false
 	}
 
@@ -143,7 +143,7 @@ func (cheque *Cheque) verifyChequeAgainstLast(lastCheque *Cheque, expectedAmount
 		actualAmount.Sub(actualAmount, lastCheque.CumulativePayout)
 	}
 
-	if expectedAmount.Cmp(actualAmount) != 0 {
+	if !expectedAmount.Equals(actualAmount) {
 		return NewUint256(), fmt.Errorf("unexpected amount for honey, expected %v was %v", expectedAmount, actualAmount)
 	}
 

--- a/swap/cheque.go
+++ b/swap/cheque.go
@@ -30,7 +30,10 @@ func (cheque *ChequeParams) encodeForSignature() []byte {
 	cumulativePayoutBytes := make([]byte, 32)
 	// we need to write the last 8 bytes as we write a uint64 into a 32-byte array
 	// encoded in BigEndian because EVM uses BigEndian encoding
-	copy(cumulativePayoutBytes[:32], cheque.CumulativePayout.Value().Bytes())
+	if cheque.CumulativePayout.Value() != nil {
+		chequePayoutBytes := cheque.CumulativePayout.Value().Bytes()
+		copy(cumulativePayoutBytes[32-len(chequePayoutBytes):], chequePayoutBytes)
+	}
 	// construct the actual cheque
 	input := cheque.Contract.Bytes()
 	input = append(input, cheque.Beneficiary.Bytes()...)

--- a/swap/cheque.go
+++ b/swap/cheque.go
@@ -30,9 +30,10 @@ func (cheque *ChequeParams) encodeForSignature() []byte {
 	cumulativePayoutBytes := make([]byte, 32)
 	// we need to write the last 8 bytes as we write a uint64 into a 32-byte array
 	// encoded in BigEndian because EVM uses BigEndian encoding
-	chequePayoutBytes := cheque.CumulativePayout.Value().Bytes()
-	copy(cumulativePayoutBytes[32-len(chequePayoutBytes):], chequePayoutBytes)
-
+	if cheque.CumulativePayout.Value() != nil {
+		chequePayoutBytes := cheque.CumulativePayout.Value().Bytes()
+		copy(cumulativePayoutBytes[32-len(chequePayoutBytes):], chequePayoutBytes)
+	}
 	// construct the actual cheque
 	input := cheque.Contract.Bytes()
 	input = append(input, cheque.Beneficiary.Bytes()...)

--- a/swap/cheque.go
+++ b/swap/cheque.go
@@ -137,7 +137,7 @@ func (cheque *Cheque) verifyChequeAgainstLast(lastCheque *Cheque, expectedAmount
 			return &Uint256{}, fmt.Errorf("wrong cheque parameters: expected cumulative payout larger than %d, was: %d", lastCheque.CumulativePayout, cheque.CumulativePayout)
 		}
 
-		actualAmount.Sub(lastCheque.CumulativePayout)
+		actualAmount.Sub(actualAmount, lastCheque.CumulativePayout)
 	}
 
 	if expectedAmount != actualAmount {

--- a/swap/cheque.go
+++ b/swap/cheque.go
@@ -30,10 +30,9 @@ func (cheque *ChequeParams) encodeForSignature() []byte {
 	cumulativePayoutBytes := make([]byte, 32)
 	// we need to write the last 8 bytes as we write a uint64 into a 32-byte array
 	// encoded in BigEndian because EVM uses BigEndian encoding
-	if cheque.CumulativePayout.Value != nil {
-		chequePayoutBytes := cheque.CumulativePayout.Value.Bytes()
-		copy(cumulativePayoutBytes[32-len(chequePayoutBytes):], chequePayoutBytes)
-	}
+	chequePayoutBytes := cheque.CumulativePayout.Value.Bytes()
+	copy(cumulativePayoutBytes[32-len(chequePayoutBytes):], chequePayoutBytes)
+
 	// construct the actual cheque
 	input := cheque.Contract.Bytes()
 	input = append(input, cheque.Beneficiary.Bytes()...)

--- a/swap/cheque.go
+++ b/swap/cheque.go
@@ -137,19 +137,19 @@ func (cheque *Cheque) verifyChequeAgainstLast(lastCheque *Cheque, expectedAmount
 
 	if lastCheque != nil {
 		if cheque.CumulativePayout.Cmp(lastCheque.CumulativePayout) < 1 {
-			return NewUint256(), fmt.Errorf("wrong cheque parameters: expected cumulative payout larger than %d, was: %d", lastCheque.CumulativePayout, cheque.CumulativePayout)
+			return NewUint256(), fmt.Errorf("wrong cheque parameters: expected cumulative payout larger than %v, was: %v", lastCheque.CumulativePayout, cheque.CumulativePayout)
 		}
 
 		actualAmount.Sub(actualAmount, lastCheque.CumulativePayout)
 	}
 
 	if expectedAmount != actualAmount {
-		return NewUint256(), fmt.Errorf("unexpected amount for honey, expected %d was %d", expectedAmount, actualAmount)
+		return NewUint256(), fmt.Errorf("unexpected amount for honey, expected %v was %v", expectedAmount, actualAmount)
 	}
 
 	return actualAmount, nil
 }
 
 func (cheque *Cheque) String() string {
-	return fmt.Sprintf("Contract: %x Beneficiary: %x CumulativePayout: %d Honey: %d", cheque.Contract, cheque.Beneficiary, cheque.CumulativePayout, cheque.Honey)
+	return fmt.Sprintf("Contract: %x Beneficiary: %x CumulativePayout: %v Honey: %d", cheque.Contract, cheque.Beneficiary, cheque.CumulativePayout, cheque.Honey)
 }

--- a/swap/cheque.go
+++ b/swap/cheque.go
@@ -30,8 +30,8 @@ func (cheque *ChequeParams) encodeForSignature() []byte {
 	cumulativePayoutBytes := make([]byte, 32)
 	// we need to write the last 8 bytes as we write a uint64 into a 32-byte array
 	// encoded in BigEndian because EVM uses BigEndian encoding
-	if cheque.CumulativePayout.Value() != nil {
-		chequePayoutBytes := cheque.CumulativePayout.Value().Bytes()
+	if cheque.CumulativePayout.Value != nil {
+		chequePayoutBytes := cheque.CumulativePayout.Value.Bytes()
 		copy(cumulativePayoutBytes[32-len(chequePayoutBytes):], chequePayoutBytes)
 	}
 	// construct the actual cheque
@@ -143,7 +143,7 @@ func (cheque *Cheque) verifyChequeAgainstLast(lastCheque *Cheque, expectedAmount
 		actualAmount.Sub(actualAmount, lastCheque.CumulativePayout)
 	}
 
-	if expectedAmount != actualAmount {
+	if expectedAmount.Cmp(actualAmount) != 0 {
 		return NewUint256(), fmt.Errorf("unexpected amount for honey, expected %v was %v", expectedAmount, actualAmount)
 	}
 

--- a/swap/cheque.go
+++ b/swap/cheque.go
@@ -130,19 +130,19 @@ func (cheque *Cheque) verifyChequeProperties(p *Peer, expectedBeneficiary common
 
 // verifyChequeAgainstLast verifies that the amount is higher than in the previous cheque and the increase is as expected
 // returns the actual amount received in this cheque
-func (cheque *Cheque) verifyChequeAgainstLast(lastCheque *Cheque, expectedAmount uint64) (uint64, error) {
+func (cheque *Cheque) verifyChequeAgainstLast(lastCheque *Cheque, expectedAmount *Uint256) (*Uint256, error) {
 	actualAmount := cheque.CumulativePayout
 
 	if lastCheque != nil {
-		if cheque.CumulativePayout <= lastCheque.CumulativePayout {
-			return 0, fmt.Errorf("wrong cheque parameters: expected cumulative payout larger than %d, was: %d", lastCheque.CumulativePayout, cheque.CumulativePayout)
+		if cheque.CumulativePayout.Cmp(lastCheque.CumulativePayout) < 1 {
+			return &Uint256{}, fmt.Errorf("wrong cheque parameters: expected cumulative payout larger than %d, was: %d", lastCheque.CumulativePayout, cheque.CumulativePayout)
 		}
 
-		actualAmount -= lastCheque.CumulativePayout
+		actualAmount.Sub(lastCheque.CumulativePayout)
 	}
 
 	if expectedAmount != actualAmount {
-		return 0, fmt.Errorf("unexpected amount for honey, expected %d was %d", expectedAmount, actualAmount)
+		return &Uint256{}, fmt.Errorf("unexpected amount for honey, expected %d was %d", expectedAmount, actualAmount)
 	}
 
 	return actualAmount, nil

--- a/swap/cheque.go
+++ b/swap/cheque.go
@@ -136,14 +136,14 @@ func (cheque *Cheque) verifyChequeAgainstLast(lastCheque *Cheque, expectedAmount
 
 	if lastCheque != nil {
 		if cheque.CumulativePayout.Cmp(lastCheque.CumulativePayout) < 1 {
-			return NewUint256(), fmt.Errorf("wrong cheque parameters: expected cumulative payout larger than %v, was: %v", lastCheque.CumulativePayout, cheque.CumulativePayout)
+			return nil, fmt.Errorf("wrong cheque parameters: expected cumulative payout larger than %v, was: %v", lastCheque.CumulativePayout, cheque.CumulativePayout)
 		}
 
 		actualAmount.Sub(actualAmount, lastCheque.CumulativePayout)
 	}
 
 	if !expectedAmount.Equals(actualAmount) {
-		return NewUint256(), fmt.Errorf("unexpected amount for honey, expected %v was %v", expectedAmount, actualAmount)
+		return nil, fmt.Errorf("unexpected amount for honey, expected %v was %v", expectedAmount, actualAmount)
 	}
 
 	return actualAmount, nil

--- a/swap/cheque.go
+++ b/swap/cheque.go
@@ -19,7 +19,6 @@ package swap
 import (
 	"bytes"
 	"crypto/ecdsa"
-	"encoding/binary"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -31,7 +30,7 @@ func (cheque *ChequeParams) encodeForSignature() []byte {
 	cumulativePayoutBytes := make([]byte, 32)
 	// we need to write the last 8 bytes as we write a uint64 into a 32-byte array
 	// encoded in BigEndian because EVM uses BigEndian encoding
-	binary.BigEndian.PutUint64(cumulativePayoutBytes[24:], cheque.CumulativePayout)
+	copy(cumulativePayoutBytes[:32], cheque.CumulativePayout.Value().Bytes())
 	// construct the actual cheque
 	input := cheque.Contract.Bytes()
 	input = append(input, cheque.Beneficiary.Bytes()...)

--- a/swap/cheque.go
+++ b/swap/cheque.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethersphere/swarm/uint256"
 )
 
 // encodeForSignature encodes the cheque params in the format used in the signing procedure
@@ -132,8 +133,8 @@ func (cheque *Cheque) verifyChequeProperties(p *Peer, expectedBeneficiary common
 
 // verifyChequeAgainstLast verifies that the amount is higher than in the previous cheque and the increase is as expected
 // returns the actual amount received in this cheque
-func (cheque *Cheque) verifyChequeAgainstLast(lastCheque *Cheque, expectedAmount *Uint256) (*Uint256, error) {
-	actualAmount := NewUint256().Copy(cheque.CumulativePayout)
+func (cheque *Cheque) verifyChequeAgainstLast(lastCheque *Cheque, expectedAmount *uint256.Uint256) (*uint256.Uint256, error) {
+	actualAmount := uint256.New().Copy(cheque.CumulativePayout)
 
 	if lastCheque != nil {
 		if cheque.CumulativePayout.Cmp(lastCheque.CumulativePayout) < 1 {

--- a/swap/cheque.go
+++ b/swap/cheque.go
@@ -30,10 +30,9 @@ func (cheque *ChequeParams) encodeForSignature() []byte {
 	cumulativePayoutBytes := make([]byte, 32)
 	// we need to write the last 8 bytes as we write a uint64 into a 32-byte array
 	// encoded in BigEndian because EVM uses BigEndian encoding
-	if cheque.CumulativePayout.Value() != nil {
-		chequePayoutBytes := cheque.CumulativePayout.Value().Bytes()
-		copy(cumulativePayoutBytes[32-len(chequePayoutBytes):], chequePayoutBytes)
-	}
+	chequePayoutBytes := cheque.CumulativePayout.Value().Bytes()
+	copy(cumulativePayoutBytes[32-len(chequePayoutBytes):], chequePayoutBytes)
+
 	// construct the actual cheque
 	input := cheque.Contract.Bytes()
 	input = append(input, cheque.Beneficiary.Bytes()...)

--- a/swap/cheque.go
+++ b/swap/cheque.go
@@ -133,7 +133,7 @@ func (cheque *Cheque) verifyChequeProperties(p *Peer, expectedBeneficiary common
 // verifyChequeAgainstLast verifies that the amount is higher than in the previous cheque and the increase is as expected
 // returns the actual amount received in this cheque
 func (cheque *Cheque) verifyChequeAgainstLast(lastCheque *Cheque, expectedAmount *Uint256) (*Uint256, error) {
-	actualAmount := cheque.CumulativePayout
+	actualAmount := NewUint256().Copy(cheque.CumulativePayout)
 
 	if lastCheque != nil {
 		if cheque.CumulativePayout.Cmp(lastCheque.CumulativePayout) < 1 {

--- a/swap/cheque.go
+++ b/swap/cheque.go
@@ -30,7 +30,8 @@ func (cheque *ChequeParams) encodeForSignature() []byte {
 	cumulativePayoutBytes := make([]byte, 32)
 	// we need to write the last 8 bytes as we write a uint64 into a 32-byte array
 	// encoded in BigEndian because EVM uses BigEndian encoding
-	chequePayoutBytes := cheque.CumulativePayout.Value.Bytes()
+	cumulativePayout := cheque.CumulativePayout.Value()
+	chequePayoutBytes := (&cumulativePayout).Bytes()
 	copy(cumulativePayoutBytes[32-len(chequePayoutBytes):], chequePayoutBytes)
 
 	// construct the actual cheque

--- a/swap/common_test.go
+++ b/swap/common_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethersphere/swarm/network"
 	"github.com/ethersphere/swarm/p2p/protocols"
 	"github.com/ethersphere/swarm/state"
+	"github.com/ethersphere/swarm/uint256"
 )
 
 // swapTestBackend encapsulates the SimulatedBackend and can offer
@@ -167,7 +168,7 @@ func newTestCheque() *Cheque {
 	cheque := &Cheque{
 		ChequeParams: ChequeParams{
 			Contract:         testChequeContract,
-			CumulativePayout: Uint64ToUint256(42),
+			CumulativePayout: uint256.FromUint64(42),
 			Beneficiary:      beneficiaryAddress,
 		},
 		Honey: uint64(42),
@@ -180,7 +181,7 @@ func newSignedTestCheque(testChequeContract common.Address, beneficiaryAddress c
 	cheque := &Cheque{
 		ChequeParams: ChequeParams{
 			Contract:         testChequeContract,
-			CumulativePayout: Uint64ToUint256(cumulativePayout.Uint64()),
+			CumulativePayout: uint256.FromUint64(cumulativePayout.Uint64()),
 			Beneficiary:      beneficiaryAddress,
 		},
 		Honey: cumulativePayout.Uint64(),
@@ -201,7 +202,7 @@ func newRandomTestCheque() *Cheque {
 	cheque := &Cheque{
 		ChequeParams: ChequeParams{
 			Contract:         testChequeContract,
-			CumulativePayout: Uint64ToUint256(amount),
+			CumulativePayout: uint256.FromUint64(amount),
 			Beneficiary:      beneficiaryAddress,
 		},
 		Honey: amount,

--- a/swap/peer.go
+++ b/swap/peer.go
@@ -167,8 +167,7 @@ func (p *Peer) createCheque() (*Cheque, error) {
 		return nil, fmt.Errorf("error getting price from oracle: %v", err)
 	}
 
-	var amount *Uint256
-	amount.FromUint64(price)
+	amount := Uint64ToUint256(price)
 
 	cumulativePayout := p.getLastSentCumulativePayout()
 	err = cumulativePayout.Add(amount)

--- a/swap/peer.go
+++ b/swap/peer.go
@@ -121,7 +121,7 @@ func (p *Peer) getLastSentCumulativePayout() *Uint256 {
 	if lastCheque != nil {
 		return lastCheque.CumulativePayout
 	}
-	return &Uint256{}
+	return NewUint256()
 }
 
 // the caller is expected to hold p.lock

--- a/swap/peer.go
+++ b/swap/peer.go
@@ -169,14 +169,14 @@ func (p *Peer) createCheque() (*Cheque, error) {
 	castedPrice := Uint64ToUint256(price)
 
 	cumulativePayout := p.getLastSentCumulativePayout()
-	_, err = cumulativePayout.Add(cumulativePayout, castedPrice)
+	newCumulativePayout, err := NewUint256().Add(cumulativePayout, castedPrice)
 	if err != nil {
 		return nil, err
 	}
 
 	cheque = &Cheque{
 		ChequeParams: ChequeParams{
-			CumulativePayout: cumulativePayout,
+			CumulativePayout: newCumulativePayout,
 			Contract:         p.swap.GetParams().ContractAddress,
 			Beneficiary:      p.beneficiary,
 		},

--- a/swap/peer.go
+++ b/swap/peer.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/big"
 	"strconv"
 	"sync"
 
@@ -169,10 +168,7 @@ func (p *Peer) createCheque() (*Cheque, error) {
 	}
 
 	var amount *Uint256
-	err = amount.Set(new(big.Int).SetUint64(price)) // cast uint64 to big.Int and then fit into Uint256
-	if err != nil {
-		return nil, err
-	}
+	amount.FromUint64(price)
 
 	cumulativePayout := p.getLastSentCumulativePayout()
 	err = cumulativePayout.Add(amount)

--- a/swap/peer.go
+++ b/swap/peer.go
@@ -166,11 +166,10 @@ func (p *Peer) createCheque() (*Cheque, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error getting price from oracle: %v", err)
 	}
-
-	amount := Uint64ToUint256(price)
+	castedPrice := (&Uint256{}).FromUint64(price)
 
 	cumulativePayout := p.getLastSentCumulativePayout()
-	err = cumulativePayout.Add(amount)
+	_, err = cumulativePayout.Add(cumulativePayout, castedPrice)
 	if err != nil {
 		return nil, err
 	}

--- a/swap/peer.go
+++ b/swap/peer.go
@@ -166,7 +166,7 @@ func (p *Peer) createCheque() (*Cheque, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error getting price from oracle: %v", err)
 	}
-	castedPrice := (&Uint256{}).FromUint64(price)
+	castedPrice := Uint64ToUint256(price)
 
 	cumulativePayout := p.getLastSentCumulativePayout()
 	_, err = cumulativePayout.Add(cumulativePayout, castedPrice)

--- a/swap/peer.go
+++ b/swap/peer.go
@@ -162,14 +162,14 @@ func (p *Peer) createCheque() (*Cheque, error) {
 	// the balance should be negative here, we take the absolute value:
 	honey := uint64(-p.getBalance())
 
-	price, err := p.swap.honeyPriceOracle.GetPrice(honey)
+	oraclePrice, err := p.swap.honeyPriceOracle.GetPrice(honey)
 	if err != nil {
 		return nil, fmt.Errorf("error getting price from oracle: %v", err)
 	}
-	castedPrice := Uint64ToUint256(price)
+	price := Uint64ToUint256(oraclePrice)
 
 	cumulativePayout := p.getLastSentCumulativePayout()
-	newCumulativePayout, err := NewUint256().Add(cumulativePayout, castedPrice)
+	newCumulativePayout, err := NewUint256().Add(cumulativePayout, price)
 	if err != nil {
 		return nil, err
 	}

--- a/swap/peer.go
+++ b/swap/peer.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethersphere/swarm/p2p/protocols"
+	"github.com/ethersphere/swarm/uint256"
 )
 
 // ErrDontOwe indictates that no balance is actially owned
@@ -116,12 +117,12 @@ func (p *Peer) setPendingCheque(cheque *Cheque) error {
 
 // getLastSentCumulativePayout returns the cumulative payout of the last sent cheque or 0 if there is none
 // the caller is expected to hold p.lock
-func (p *Peer) getLastSentCumulativePayout() *Uint256 {
+func (p *Peer) getLastSentCumulativePayout() *uint256.Uint256 {
 	lastCheque := p.getLastSentCheque()
 	if lastCheque != nil {
 		return lastCheque.CumulativePayout
 	}
-	return NewUint256()
+	return uint256.New()
 }
 
 // the caller is expected to hold p.lock
@@ -166,10 +167,10 @@ func (p *Peer) createCheque() (*Cheque, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error getting price from oracle: %v", err)
 	}
-	price := Uint64ToUint256(oraclePrice)
+	price := uint256.FromUint64(oraclePrice)
 
 	cumulativePayout := p.getLastSentCumulativePayout()
-	newCumulativePayout, err := NewUint256().Add(cumulativePayout, price)
+	newCumulativePayout, err := uint256.New().Add(cumulativePayout, price)
 	if err != nil {
 		return nil, err
 	}

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -245,7 +245,7 @@ func TestEmitCheque(t *testing.T) {
 	// gasPrice on testBackend == 1
 	// estimated gas costs == 50000
 	// cheque should be sent if the accumulated amount of uncashed cheques is worth more than 100000
-	balance := (&Uint256{}).FromUint64(uint64(100001))
+	balance := Uint64ToUint256(uint64(100001))
 
 	if err := testDeploy(context.Background(), debitorSwap, balance.Value()); err != nil {
 		t.Fatal(err)
@@ -380,7 +380,7 @@ func TestTriggerPaymentThreshold(t *testing.T) {
 		t.Fatal("Expected pending cheque")
 	}
 
-	if pending.CumulativePayout.Cmp((&Uint256{}).FromUint64(expectedAmount)) != 0 {
+	if pending.CumulativePayout.Cmp(Uint64ToUint256(expectedAmount)) != 0 {
 		t.Fatalf("Expected cheque cumulative payout to be %d, but is %d", expectedAmount, pending.CumulativePayout)
 	}
 

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -246,8 +246,9 @@ func TestEmitCheque(t *testing.T) {
 	// estimated gas costs == 50000
 	// cheque should be sent if the accumulated amount of uncashed cheques is worth more than 100000
 	balance := Uint64ToUint256(100001)
+	balanceValue := balance.Value()
 
-	if err := testDeploy(context.Background(), debitorSwap, balance.Value); err != nil {
+	if err := testDeploy(context.Background(), debitorSwap, &balanceValue); err != nil {
 		t.Fatal(err)
 	}
 
@@ -260,7 +261,7 @@ func TestEmitCheque(t *testing.T) {
 
 	debitor := creditorSwap.getPeer(protocolTester.Nodes[0].ID())
 	// set balance artificially
-	if err = debitor.setBalance(balance.Value.Int64()); err != nil {
+	if err = debitor.setBalance(balanceValue.Int64()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -275,7 +276,7 @@ func TestEmitCheque(t *testing.T) {
 			Beneficiary:      creditorSwap.owner.address,
 			CumulativePayout: balance,
 		},
-		Honey: balance.Value.Uint64(),
+		Honey: balanceValue.Uint64(),
 	}
 	cheque.Signature, err = cheque.Sign(debitorSwap.owner.privateKey)
 	if err != nil {

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -245,9 +245,10 @@ func TestEmitCheque(t *testing.T) {
 	// gasPrice on testBackend == 1
 	// estimated gas costs == 50000
 	// cheque should be sent if the accumulated amount of uncashed cheques is worth more than 100000
-	balance := uint64(100001)
+	var balance *Uint256
+	balance.FromUint64(uint64(100001))
 
-	if err := testDeploy(context.Background(), debitorSwap, big.NewInt(int64(balance))); err != nil {
+	if err := testDeploy(context.Background(), debitorSwap, balance.Value()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -260,7 +261,7 @@ func TestEmitCheque(t *testing.T) {
 
 	debitor := creditorSwap.getPeer(protocolTester.Nodes[0].ID())
 	// set balance artificially
-	if err = debitor.setBalance(int64(balance)); err != nil {
+	if err = debitor.setBalance(balance.Value().Int64()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -275,7 +276,7 @@ func TestEmitCheque(t *testing.T) {
 			Beneficiary:      creditorSwap.owner.address,
 			CumulativePayout: balance,
 		},
-		Honey: balance,
+		Honey: balance.Value().Uint64(),
 	}
 	cheque.Signature, err = cheque.Sign(debitorSwap.owner.privateKey)
 	if err != nil {
@@ -380,7 +381,7 @@ func TestTriggerPaymentThreshold(t *testing.T) {
 		t.Fatal("Expected pending cheque")
 	}
 
-	if pending.CumulativePayout != expectedAmount {
+	if pending.CumulativePayout.Cmp((&Uint256{}).FromUint64(expectedAmount)) != 0 {
 		t.Fatalf("Expected cheque cumulative payout to be %d, but is %d", expectedAmount, pending.CumulativePayout)
 	}
 

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -245,7 +245,7 @@ func TestEmitCheque(t *testing.T) {
 	// gasPrice on testBackend == 1
 	// estimated gas costs == 50000
 	// cheque should be sent if the accumulated amount of uncashed cheques is worth more than 100000
-	balance := Uint64ToUint256(uint64(100001))
+	balance := Uint64ToUint256(100001)
 
 	if err := testDeploy(context.Background(), debitorSwap, balance.Value()); err != nil {
 		t.Fatal(err)

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -245,8 +245,7 @@ func TestEmitCheque(t *testing.T) {
 	// gasPrice on testBackend == 1
 	// estimated gas costs == 50000
 	// cheque should be sent if the accumulated amount of uncashed cheques is worth more than 100000
-	var balance *Uint256
-	balance.FromUint64(uint64(100001))
+	balance := (&Uint256{}).FromUint64(uint64(100001))
 
 	if err := testDeploy(context.Background(), debitorSwap, balance.Value()); err != nil {
 		t.Fatal(err)

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -380,7 +380,7 @@ func TestTriggerPaymentThreshold(t *testing.T) {
 		t.Fatal("Expected pending cheque")
 	}
 
-	if pending.CumulativePayout.Cmp(Uint64ToUint256(expectedAmount)) != 0 {
+	if !pending.CumulativePayout.Equals(Uint64ToUint256(expectedAmount)) {
 		t.Fatalf("Expected cheque cumulative payout to be %d, but is %v", expectedAmount, pending.CumulativePayout)
 	}
 

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -381,7 +381,7 @@ func TestTriggerPaymentThreshold(t *testing.T) {
 	}
 
 	if pending.CumulativePayout.Cmp(Uint64ToUint256(expectedAmount)) != 0 {
-		t.Fatalf("Expected cheque cumulative payout to be %d, but is %d", expectedAmount, pending.CumulativePayout)
+		t.Fatalf("Expected cheque cumulative payout to be %d, but is %v", expectedAmount, pending.CumulativePayout)
 	}
 
 	if pending.Honey != expectedAmount {

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 	contract "github.com/ethersphere/swarm/contracts/swap"
 	p2ptest "github.com/ethersphere/swarm/p2p/testing"
+	"github.com/ethersphere/swarm/uint256"
 	colorable "github.com/mattn/go-colorable"
 )
 
@@ -245,7 +246,7 @@ func TestEmitCheque(t *testing.T) {
 	// gasPrice on testBackend == 1
 	// estimated gas costs == 50000
 	// cheque should be sent if the accumulated amount of uncashed cheques is worth more than 100000
-	balance := Uint64ToUint256(100001)
+	balance := uint256.FromUint64(100001)
 	balanceValue := balance.Value()
 
 	if err := testDeploy(context.Background(), debitorSwap, &balanceValue); err != nil {
@@ -381,7 +382,7 @@ func TestTriggerPaymentThreshold(t *testing.T) {
 		t.Fatal("Expected pending cheque")
 	}
 
-	if !pending.CumulativePayout.Equals(Uint64ToUint256(expectedAmount)) {
+	if !pending.CumulativePayout.Equals(uint256.FromUint64(expectedAmount)) {
 		t.Fatalf("Expected cheque cumulative payout to be %d, but is %v", expectedAmount, pending.CumulativePayout)
 	}
 

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -247,7 +247,7 @@ func TestEmitCheque(t *testing.T) {
 	// cheque should be sent if the accumulated amount of uncashed cheques is worth more than 100000
 	balance := Uint64ToUint256(100001)
 
-	if err := testDeploy(context.Background(), debitorSwap, balance.Value()); err != nil {
+	if err := testDeploy(context.Background(), debitorSwap, balance.Value); err != nil {
 		t.Fatal(err)
 	}
 
@@ -260,7 +260,7 @@ func TestEmitCheque(t *testing.T) {
 
 	debitor := creditorSwap.getPeer(protocolTester.Nodes[0].ID())
 	// set balance artificially
-	if err = debitor.setBalance(balance.Value().Int64()); err != nil {
+	if err = debitor.setBalance(balance.Value.Int64()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -275,7 +275,7 @@ func TestEmitCheque(t *testing.T) {
 			Beneficiary:      creditorSwap.owner.address,
 			CumulativePayout: balance,
 		},
-		Honey: balance.Value().Uint64(),
+		Honey: balance.Value.Uint64(),
 	}
 	cheque.Signature, err = cheque.Sign(debitorSwap.owner.privateKey)
 	if err != nil {

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -368,10 +368,10 @@ func TestPingPongChequeSimulation(t *testing.T) {
 	}
 
 	expected := uint64(maxCheques) / 2 * (DefaultPaymentThreshold + 1)
-	if ch1.CumulativePayout != expected {
+	if ch1.CumulativePayout.Cmp((&Uint256{}).FromUint64(expected)) != 0 {
 		t.Fatalf("expected cumulative payout to be %d, but is %d", expected, ch1.CumulativePayout)
 	}
-	if ch2.CumulativePayout != expected {
+	if ch2.CumulativePayout.Cmp((&Uint256{}).FromUint64(expected)) != 0 {
 		t.Fatalf("expected cumulative payout to be %d, but is %d", expected, ch2.CumulativePayout)
 	}
 
@@ -509,7 +509,7 @@ func TestMultiChequeSimulation(t *testing.T) {
 	// check also the actual expected amount
 	expectedPayout = uint64(maxCheques) * (DefaultPaymentThreshold + 1)
 
-	if cheque2.CumulativePayout != expectedPayout {
+	if cheque2.CumulativePayout.Cmp((&Uint256{}).FromUint64(expectedPayout)) != 0 {
 		t.Fatalf("Expected %d in cumulative payout, got %d", expectedPayout, cheque1.CumulativePayout)
 	}
 
@@ -745,7 +745,7 @@ func waitForChequeProcessed(t *testing.T, backend *swapTestBackend, counter metr
 				p.lock.Lock()
 				lastPayout := p.getLastSentCumulativePayout()
 				p.lock.Unlock()
-				if lastPayout != expectedLastPayout {
+				if lastPayout.Cmp((&Uint256{}).FromUint64(expectedLastPayout)) != 0 {
 					time.Sleep(5 * time.Millisecond)
 					continue
 				} else {

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/ethersphere/swarm/network/simulation"
 	"github.com/ethersphere/swarm/p2p/protocols"
 	"github.com/ethersphere/swarm/state"
+	"github.com/ethersphere/swarm/uint256"
 )
 
 /*
@@ -368,10 +369,10 @@ func TestPingPongChequeSimulation(t *testing.T) {
 	}
 
 	expected := uint64(maxCheques) / 2 * (DefaultPaymentThreshold + 1)
-	if !ch1.CumulativePayout.Equals(Uint64ToUint256(expected)) {
+	if !ch1.CumulativePayout.Equals(uint256.FromUint64(expected)) {
 		t.Fatalf("expected cumulative payout to be %d, but is %v", expected, ch1.CumulativePayout)
 	}
-	if !ch2.CumulativePayout.Equals(Uint64ToUint256(expected)) {
+	if !ch2.CumulativePayout.Equals(uint256.FromUint64(expected)) {
 		t.Fatalf("expected cumulative payout to be %d, but is %v", expected, ch2.CumulativePayout)
 	}
 
@@ -509,7 +510,7 @@ func TestMultiChequeSimulation(t *testing.T) {
 	// check also the actual expected amount
 	expectedPayout = uint64(maxCheques) * (DefaultPaymentThreshold + 1)
 
-	if !cheque2.CumulativePayout.Equals(Uint64ToUint256(expectedPayout)) {
+	if !cheque2.CumulativePayout.Equals(uint256.FromUint64(expectedPayout)) {
 		t.Fatalf("Expected %d in cumulative payout, got %v", expectedPayout, cheque1.CumulativePayout)
 	}
 
@@ -745,7 +746,7 @@ func waitForChequeProcessed(t *testing.T, backend *swapTestBackend, counter metr
 				p.lock.Lock()
 				lastPayout := p.getLastSentCumulativePayout()
 				p.lock.Unlock()
-				if !lastPayout.Equals(Uint64ToUint256(expectedLastPayout)) {
+				if !lastPayout.Equals(uint256.FromUint64(expectedLastPayout)) {
 					time.Sleep(5 * time.Millisecond)
 					continue
 				} else {

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -369,10 +369,10 @@ func TestPingPongChequeSimulation(t *testing.T) {
 
 	expected := uint64(maxCheques) / 2 * (DefaultPaymentThreshold + 1)
 	if ch1.CumulativePayout.Cmp(Uint64ToUint256(expected)) != 0 {
-		t.Fatalf("expected cumulative payout to be %d, but is %d", expected, ch1.CumulativePayout)
+		t.Fatalf("expected cumulative payout to be %d, but is %v", expected, ch1.CumulativePayout)
 	}
 	if ch2.CumulativePayout.Cmp(Uint64ToUint256(expected)) != 0 {
-		t.Fatalf("expected cumulative payout to be %d, but is %d", expected, ch2.CumulativePayout)
+		t.Fatalf("expected cumulative payout to be %d, but is %v", expected, ch2.CumulativePayout)
 	}
 
 	log.Info("Simulation ended")
@@ -503,14 +503,14 @@ func TestMultiChequeSimulation(t *testing.T) {
 
 	// both cheques (at issuer and beneficiary) should have same cumulative value
 	if cheque1.CumulativePayout != cheque2.CumulativePayout {
-		t.Fatalf("Expected symmetric cheques payout, but they are not: %d vs %d", cheque1.CumulativePayout, cheque2.CumulativePayout)
+		t.Fatalf("Expected symmetric cheques payout, but they are not: %v vs %v", cheque1.CumulativePayout, cheque2.CumulativePayout)
 	}
 
 	// check also the actual expected amount
 	expectedPayout = uint64(maxCheques) * (DefaultPaymentThreshold + 1)
 
 	if cheque2.CumulativePayout.Cmp(Uint64ToUint256(expectedPayout)) != 0 {
-		t.Fatalf("Expected %d in cumulative payout, got %d", expectedPayout, cheque1.CumulativePayout)
+		t.Fatalf("Expected %d in cumulative payout, got %v", expectedPayout, cheque1.CumulativePayout)
 	}
 
 	log.Info("Simulation ended")

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -368,10 +368,10 @@ func TestPingPongChequeSimulation(t *testing.T) {
 	}
 
 	expected := uint64(maxCheques) / 2 * (DefaultPaymentThreshold + 1)
-	if ch1.CumulativePayout.Cmp(Uint64ToUint256(expected)) != 0 {
+	if !ch1.CumulativePayout.Equals(Uint64ToUint256(expected)) {
 		t.Fatalf("expected cumulative payout to be %d, but is %v", expected, ch1.CumulativePayout)
 	}
-	if ch2.CumulativePayout.Cmp(Uint64ToUint256(expected)) != 0 {
+	if !ch2.CumulativePayout.Equals(Uint64ToUint256(expected)) {
 		t.Fatalf("expected cumulative payout to be %d, but is %v", expected, ch2.CumulativePayout)
 	}
 
@@ -509,7 +509,7 @@ func TestMultiChequeSimulation(t *testing.T) {
 	// check also the actual expected amount
 	expectedPayout = uint64(maxCheques) * (DefaultPaymentThreshold + 1)
 
-	if cheque2.CumulativePayout.Cmp(Uint64ToUint256(expectedPayout)) != 0 {
+	if !cheque2.CumulativePayout.Equals(Uint64ToUint256(expectedPayout)) {
 		t.Fatalf("Expected %d in cumulative payout, got %v", expectedPayout, cheque1.CumulativePayout)
 	}
 
@@ -745,7 +745,7 @@ func waitForChequeProcessed(t *testing.T, backend *swapTestBackend, counter metr
 				p.lock.Lock()
 				lastPayout := p.getLastSentCumulativePayout()
 				p.lock.Unlock()
-				if lastPayout.Cmp(Uint64ToUint256(expectedLastPayout)) != 0 {
+				if !lastPayout.Equals(Uint64ToUint256(expectedLastPayout)) {
 					time.Sleep(5 * time.Millisecond)
 					continue
 				} else {

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -502,7 +502,7 @@ func TestMultiChequeSimulation(t *testing.T) {
 	}
 
 	// both cheques (at issuer and beneficiary) should have same cumulative value
-	if cheque1.CumulativePayout != cheque2.CumulativePayout {
+	if !cheque1.CumulativePayout.Equals(cheque2.CumulativePayout) {
 		t.Fatalf("Expected symmetric cheques payout, but they are not: %v vs %v", cheque1.CumulativePayout, cheque2.CumulativePayout)
 	}
 

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -368,10 +368,10 @@ func TestPingPongChequeSimulation(t *testing.T) {
 	}
 
 	expected := uint64(maxCheques) / 2 * (DefaultPaymentThreshold + 1)
-	if ch1.CumulativePayout.Cmp((&Uint256{}).FromUint64(expected)) != 0 {
+	if ch1.CumulativePayout.Cmp(Uint64ToUint256(expected)) != 0 {
 		t.Fatalf("expected cumulative payout to be %d, but is %d", expected, ch1.CumulativePayout)
 	}
-	if ch2.CumulativePayout.Cmp((&Uint256{}).FromUint64(expected)) != 0 {
+	if ch2.CumulativePayout.Cmp(Uint64ToUint256(expected)) != 0 {
 		t.Fatalf("expected cumulative payout to be %d, but is %d", expected, ch2.CumulativePayout)
 	}
 
@@ -509,7 +509,7 @@ func TestMultiChequeSimulation(t *testing.T) {
 	// check also the actual expected amount
 	expectedPayout = uint64(maxCheques) * (DefaultPaymentThreshold + 1)
 
-	if cheque2.CumulativePayout.Cmp((&Uint256{}).FromUint64(expectedPayout)) != 0 {
+	if cheque2.CumulativePayout.Cmp(Uint64ToUint256(expectedPayout)) != 0 {
 		t.Fatalf("Expected %d in cumulative payout, got %d", expectedPayout, cheque1.CumulativePayout)
 	}
 
@@ -745,7 +745,7 @@ func waitForChequeProcessed(t *testing.T, backend *swapTestBackend, counter metr
 				p.lock.Lock()
 				lastPayout := p.getLastSentCumulativePayout()
 				p.lock.Unlock()
-				if lastPayout.Cmp((&Uint256{}).FromUint64(expectedLastPayout)) != 0 {
+				if lastPayout.Cmp(Uint64ToUint256(expectedLastPayout)) != 0 {
 					time.Sleep(5 * time.Millisecond)
 					continue
 				} else {

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -509,7 +509,7 @@ func cashCheque(s *Swap, otherSwap contract.Contract, opts *bind.TransactOpts, c
 // if the cheque is valid it will also be saved as the new last cheque
 func (s *Swap) processAndVerifyCheque(cheque *Cheque, p *Peer) (*Uint256, error) {
 	if err := cheque.verifyChequeProperties(p, s.owner.address); err != nil {
-		return NewUint256(), err
+		return nil, err
 	}
 
 	lastCheque := p.getLastReceivedCheque()
@@ -517,12 +517,12 @@ func (s *Swap) processAndVerifyCheque(cheque *Cheque, p *Peer) (*Uint256, error)
 	// TODO: there should probably be a lock here?
 	expectedAmount, err := s.honeyPriceOracle.GetPrice(cheque.Honey)
 	if err != nil {
-		return NewUint256(), err
+		return nil, err
 	}
 
 	actualAmount, err := cheque.verifyChequeAgainstLast(lastCheque, Uint64ToUint256(expectedAmount))
 	if err != nil {
-		return NewUint256(), err
+		return nil, err
 	}
 
 	if err := p.setLastReceivedCheque(cheque); err != nil {

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -488,9 +488,9 @@ func cashCheque(s *Swap, otherSwap contract.Contract, opts *bind.TransactOpts, c
 
 // processAndVerifyCheque verifies the cheque and compares it with the last received cheque
 // if the cheque is valid it will also be saved as the new last cheque
-func (s *Swap) processAndVerifyCheque(cheque *Cheque, p *Peer) (uint64, error) {
+func (s *Swap) processAndVerifyCheque(cheque *Cheque, p *Peer) (*Uint256, error) {
 	if err := cheque.verifyChequeProperties(p, s.owner.address); err != nil {
-		return 0, err
+		return &Uint256{}, err
 	}
 
 	lastCheque := p.getLastReceivedCheque()
@@ -498,12 +498,12 @@ func (s *Swap) processAndVerifyCheque(cheque *Cheque, p *Peer) (uint64, error) {
 	// TODO: there should probably be a lock here?
 	expectedAmount, err := s.honeyPriceOracle.GetPrice(cheque.Honey)
 	if err != nil {
-		return 0, err
+		return &Uint256{}, err
 	}
 
-	actualAmount, err := cheque.verifyChequeAgainstLast(lastCheque, expectedAmount)
+	actualAmount, err := cheque.verifyChequeAgainstLast(lastCheque, Uint64ToUint256(expectedAmount))
 	if err != nil {
-		return 0, err
+		return &Uint256{}, err
 	}
 
 	if err := p.setLastReceivedCheque(cheque); err != nil {

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -420,7 +420,7 @@ func (s *Swap) handleEmitChequeMsg(ctx context.Context, p *Peer, msg *EmitCheque
 	}
 	transactionCosts := gasPrice.Uint64() * 50000 // cashing a cheque is approximately 50000 gas
 	castedTransactionCosts := Uint64ToUint256(transactionCosts)
-	costsMultiplier := Uint64ToUint256(2) // 2 as uint256
+	costsMultiplier := Uint64ToUint256(2)
 
 	costThreshold, err := NewUint256().Mul(castedTransactionCosts, costsMultiplier)
 	if err != nil {

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -432,7 +432,7 @@ func (s *Swap) handleEmitChequeMsg(ctx context.Context, p *Peer, msg *EmitCheque
 		return err
 	}
 
-	castedPaidOut, err := NewUint256().Set(paidOut)
+	castedPaidOut, err := NewUint256().Set(*paidOut)
 	if err != nil {
 		return err
 	}
@@ -485,7 +485,8 @@ func (s *Swap) handleConfirmChequeMsg(ctx context.Context, p *Peer, msg *Confirm
 // The function cashes the cheque by sending it to the blockchain
 func cashCheque(s *Swap, otherSwap contract.Contract, opts *bind.TransactOpts, cheque *Cheque) {
 	// blocks here, as we are waiting for the transaction to be mined
-	result, receipt, err := otherSwap.CashChequeBeneficiary(opts, s.GetParams().ContractAddress, cheque.CumulativePayout.Value, cheque.Signature)
+	cumulativePayout := cheque.CumulativePayout.Value()
+	result, receipt, err := otherSwap.CashChequeBeneficiary(opts, s.GetParams().ContractAddress, &cumulativePayout, cheque.Signature)
 	if err != nil {
 		// TODO: do something with the error
 		// and we actually need to log this error as we are in an async routine; nobody is handling this error for now

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -422,7 +422,7 @@ func (s *Swap) handleEmitChequeMsg(ctx context.Context, p *Peer, msg *EmitCheque
 	castedTransactionCosts := Uint64ToUint256(transactionCosts)
 	costsMultiplier := Uint64ToUint256(2) // 2 as uint256
 
-	costThreshold, err := (&Uint256{}).Mul(castedTransactionCosts, costsMultiplier)
+	costThreshold, err := NewUint256().Mul(castedTransactionCosts, costsMultiplier)
 	if err != nil {
 		return err
 	}
@@ -432,12 +432,12 @@ func (s *Swap) handleEmitChequeMsg(ctx context.Context, p *Peer, msg *EmitCheque
 		return err
 	}
 
-	castedPaidOut, err := (&Uint256{}).Set(paidOut)
+	castedPaidOut, err := NewUint256().Set(paidOut)
 	if err != nil {
 		return err
 	}
 
-	transactionProfit, err := (&Uint256{}).Sub(cheque.CumulativePayout, castedPaidOut)
+	transactionProfit, err := NewUint256().Sub(cheque.CumulativePayout, castedPaidOut)
 	if err != nil {
 		return err
 	}
@@ -509,7 +509,7 @@ func cashCheque(s *Swap, otherSwap contract.Contract, opts *bind.TransactOpts, c
 // if the cheque is valid it will also be saved as the new last cheque
 func (s *Swap) processAndVerifyCheque(cheque *Cheque, p *Peer) (*Uint256, error) {
 	if err := cheque.verifyChequeProperties(p, s.owner.address); err != nil {
-		return &Uint256{}, err
+		return NewUint256(), err
 	}
 
 	lastCheque := p.getLastReceivedCheque()
@@ -517,12 +517,12 @@ func (s *Swap) processAndVerifyCheque(cheque *Cheque, p *Peer) (*Uint256, error)
 	// TODO: there should probably be a lock here?
 	expectedAmount, err := s.honeyPriceOracle.GetPrice(cheque.Honey)
 	if err != nil {
-		return &Uint256{}, err
+		return NewUint256(), err
 	}
 
 	actualAmount, err := cheque.verifyChequeAgainstLast(lastCheque, Uint64ToUint256(expectedAmount))
 	if err != nil {
-		return &Uint256{}, err
+		return NewUint256(), err
 	}
 
 	if err := p.setLastReceivedCheque(cheque); err != nil {

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -443,7 +443,7 @@ func (s *Swap) handleEmitChequeMsg(ctx context.Context, p *Peer, msg *EmitCheque
 	}
 
 	// do a payout transaction if we get 2 times the gas costs
-	if transactionProfit.Cmp(costThreshold) >= 1 {
+	if transactionProfit.Cmp(costThreshold) >= 0 {
 		opts := bind.NewKeyedTransactor(s.owner.privateKey)
 		opts.Context = ctx
 		// cash cheque in async, otherwise this blocks here until the TX is mined

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -484,7 +484,7 @@ func (s *Swap) handleConfirmChequeMsg(ctx context.Context, p *Peer, msg *Confirm
 // The function cashes the cheque by sending it to the blockchain
 func cashCheque(s *Swap, otherSwap contract.Contract, opts *bind.TransactOpts, cheque *Cheque) {
 	// blocks here, as we are waiting for the transaction to be mined
-	result, receipt, err := otherSwap.CashChequeBeneficiary(opts, s.GetParams().ContractAddress, big.NewInt(int64(cheque.CumulativePayout)), cheque.Signature)
+	result, receipt, err := otherSwap.CashChequeBeneficiary(opts, s.GetParams().ContractAddress, cheque.CumulativePayout.Value(), cheque.Signature)
 	if err != nil {
 		// TODO: do something with the error
 		// and we actually need to log this error as we are in an async routine; nobody is handling this error for now

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -419,8 +419,8 @@ func (s *Swap) handleEmitChequeMsg(ctx context.Context, p *Peer, msg *EmitCheque
 		return err
 	}
 	transactionCosts := gasPrice.Uint64() * 50000 // cashing a cheque is approximately 50000 gas
-	castedTransactionCosts := (&Uint256{}).FromUint64(transactionCosts)
-	costsMultiplier := (&Uint256{}).FromUint64(uint64(2)) // 2 as uint256
+	castedTransactionCosts := Uint64ToUint256(transactionCosts)
+	costsMultiplier := Uint64ToUint256(uint64(2)) // 2 as uint256
 
 	costThreshold, err := (&Uint256{}).Mul(castedTransactionCosts, costsMultiplier)
 	if err != nil {
@@ -520,7 +520,7 @@ func (s *Swap) processAndVerifyCheque(cheque *Cheque, p *Peer) (*Uint256, error)
 		return &Uint256{}, err
 	}
 
-	actualAmount, err := cheque.verifyChequeAgainstLast(lastCheque, (&Uint256{}).FromUint64(expectedAmount))
+	actualAmount, err := cheque.verifyChequeAgainstLast(lastCheque, Uint64ToUint256(expectedAmount))
 	if err != nil {
 		return &Uint256{}, err
 	}

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -36,10 +36,10 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethersphere/swarm/contracts/swap"
 	contract "github.com/ethersphere/swarm/contracts/swap"
-
 	"github.com/ethersphere/swarm/network"
 	"github.com/ethersphere/swarm/p2p/protocols"
 	"github.com/ethersphere/swarm/state"
+	"github.com/ethersphere/swarm/uint256"
 )
 
 // ErrInvalidChequeSignature indicates the signature on the cheque was invalid
@@ -438,10 +438,10 @@ func (s *Swap) handleEmitChequeMsg(ctx context.Context, p *Peer, msg *EmitCheque
 		return protocols.Break(err)
 	}
 
-	payout := Uint64ToUint256(expectedPayout)
-	costs := Uint64ToUint256(transactionCosts)
-	costsMultiplier := Uint64ToUint256(2)
-	costThreshold, err := NewUint256().Mul(costs, costsMultiplier)
+	payout := uint256.FromUint64(expectedPayout)
+	costs := uint256.FromUint64(transactionCosts)
+	costsMultiplier := uint256.FromUint64(2)
+	costThreshold, err := uint256.New().Mul(costs, costsMultiplier)
 	if err != nil {
 		return err
 	}
@@ -496,7 +496,7 @@ func cashCheque(s *Swap, cheque *Cheque) {
 
 // processAndVerifyCheque verifies the cheque and compares it with the last received cheque
 // if the cheque is valid it will also be saved as the new last cheque
-func (s *Swap) processAndVerifyCheque(cheque *Cheque, p *Peer) (*Uint256, error) {
+func (s *Swap) processAndVerifyCheque(cheque *Cheque, p *Peer) (*uint256.Uint256, error) {
 	if err := cheque.verifyChequeProperties(p, s.owner.address); err != nil {
 		return nil, err
 	}
@@ -509,7 +509,7 @@ func (s *Swap) processAndVerifyCheque(cheque *Cheque, p *Peer) (*Uint256, error)
 		return nil, err
 	}
 
-	actualAmount, err := cheque.verifyChequeAgainstLast(lastCheque, Uint64ToUint256(expectedAmount))
+	actualAmount, err := cheque.verifyChequeAgainstLast(lastCheque, uint256.FromUint64(expectedAmount))
 	if err != nil {
 		return nil, err
 	}

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -448,9 +448,6 @@ func (s *Swap) handleEmitChequeMsg(ctx context.Context, p *Peer, msg *EmitCheque
 
 	// do a payout transaction if we get 2 times the gas costs
 	if payout.Cmp(costThreshold) == 1 {
-		opts := bind.NewKeyedTransactor(s.owner.privateKey)
-		opts.Context = ctx
-		// cash cheque in async, otherwise this blocks here until the TX is mined
 		go defaultCashCheque(s, cheque)
 	}
 

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -443,7 +443,7 @@ func (s *Swap) handleEmitChequeMsg(ctx context.Context, p *Peer, msg *EmitCheque
 	}
 
 	// do a payout transaction if we get 2 times the gas costs
-	if transactionProfit.Cmp(costThreshold) >= 0 {
+	if transactionProfit.Cmp(costThreshold) == 1 {
 		opts := bind.NewKeyedTransactor(s.owner.privateKey)
 		opts.Context = ctx
 		// cash cheque in async, otherwise this blocks here until the TX is mined

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -420,7 +420,7 @@ func (s *Swap) handleEmitChequeMsg(ctx context.Context, p *Peer, msg *EmitCheque
 	}
 	transactionCosts := gasPrice.Uint64() * 50000 // cashing a cheque is approximately 50000 gas
 	castedTransactionCosts := Uint64ToUint256(transactionCosts)
-	costsMultiplier := Uint64ToUint256(uint64(2)) // 2 as uint256
+	costsMultiplier := Uint64ToUint256(2) // 2 as uint256
 
 	costThreshold, err := (&Uint256{}).Mul(castedTransactionCosts, costsMultiplier)
 	if err != nil {

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -485,7 +485,7 @@ func (s *Swap) handleConfirmChequeMsg(ctx context.Context, p *Peer, msg *Confirm
 // The function cashes the cheque by sending it to the blockchain
 func cashCheque(s *Swap, otherSwap contract.Contract, opts *bind.TransactOpts, cheque *Cheque) {
 	// blocks here, as we are waiting for the transaction to be mined
-	result, receipt, err := otherSwap.CashChequeBeneficiary(opts, s.GetParams().ContractAddress, cheque.CumulativePayout.Value(), cheque.Signature)
+	result, receipt, err := otherSwap.CashChequeBeneficiary(opts, s.GetParams().ContractAddress, cheque.CumulativePayout.Value, cheque.Signature)
 	if err != nil {
 		// TODO: do something with the error
 		// and we actually need to log this error as we are in an async routine; nobody is handling this error for now

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -643,7 +643,7 @@ func TestPaymentThreshold(t *testing.T) {
 
 	var cheque *Cheque
 	_ = swap.store.Get(pendingChequeKey(testPeer.Peer.ID()), &cheque)
-	if cheque.CumulativePayout.Cmp(Uint64ToUint256(DefaultPaymentThreshold)) != 0 {
+	if !cheque.CumulativePayout.Equals(Uint64ToUint256(DefaultPaymentThreshold)) {
 		t.Fatal()
 	}
 }
@@ -1214,7 +1214,7 @@ func TestContractIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if castedResult.Cmp(cheque.CumulativePayout) != 0 {
+	if !castedResult.Equals(cheque.CumulativePayout) {
 		t.Fatalf("Wrong cumulative payout %d", result)
 	}
 	log.Debug("cheques result", "result", result)
@@ -1422,7 +1422,7 @@ func TestPeerVerifyChequeAgainstLast(t *testing.T) {
 		t.Fatalf("failed to verify cheque compared to old cheque: %v", err)
 	}
 
-	if actualAmount.Cmp(increase) != 0 {
+	if !actualAmount.Equals(increase) {
 		t.Fatalf("wrong actual amount, expected: %v, was: %v", increase, actualAmount)
 	}
 }
@@ -1641,7 +1641,7 @@ func TestPeerGetLastSentCumulativePayout(t *testing.T) {
 	_, peer, clean := newTestSwapAndPeer(t, ownerKey)
 	defer clean()
 
-	if peer.getLastSentCumulativePayout().Cmp(Uint64ToUint256(0)) != 0 {
+	if !peer.getLastSentCumulativePayout().Equals(Uint64ToUint256(0)) {
 		t.Fatalf("last cumulative payout should be 0 in the beginning, was %v", peer.getLastSentCumulativePayout())
 	}
 
@@ -1681,7 +1681,7 @@ func TestAvailableBalance(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if availableBalance.Cmp(Uint64ToUint256(depositAmount.Uint64())) != 0 {
+	if !availableBalance.Equals(Uint64ToUint256(depositAmount.Uint64())) {
 		t.Fatalf("availableBalance not equal to deposited amount. availableBalance: %v, depositAmount: %d", availableBalance, depositAmount)
 	}
 	// withdraw 50
@@ -1702,7 +1702,7 @@ func TestAvailableBalance(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if availableBalance.Cmp(Uint64ToUint256(netDeposit)) != 0 {
+	if !availableBalance.Equals(Uint64ToUint256(netDeposit)) {
 		t.Fatalf("availableBalance not equal to deposited minus withdraw. availableBalance: %v, deposit minus withdrawn: %d", availableBalance, depositAmount.Uint64()-withdrawAmount.Uint64())
 	}
 
@@ -1720,7 +1720,7 @@ func TestAvailableBalance(t *testing.T) {
 	}
 	// verify available balance
 	expectedBalance := netDeposit - uint64(chequeAmount)
-	if availableBalance.Cmp(Uint64ToUint256(expectedBalance)) != 0 {
+	if !availableBalance.Equals(Uint64ToUint256(expectedBalance)) {
 		t.Fatalf("availableBalance not equal to deposited minus withdraw. availableBalance: %v, deposit minus withdrawn: %d", availableBalance, depositAmount.Uint64()-withdrawAmount.Uint64())
 	}
 

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -1170,7 +1170,8 @@ func TestContractIntegration(t *testing.T) {
 	cheque := newTestCheque()
 
 	ctx := context.TODO()
-	err := testDeploy(ctx, issuerSwap, cheque.CumulativePayout.Value)
+	cumulativePayout := cheque.CumulativePayout.Value()
+	err := testDeploy(ctx, issuerSwap, &cumulativePayout)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1193,7 +1194,8 @@ func TestContractIntegration(t *testing.T) {
 
 	log.Debug("cash-in the cheque")
 
-	cashResult, receipt, err := issuerSwap.contract.CashChequeBeneficiary(opts, beneficiaryAddress, cheque.CumulativePayout.Value, cheque.Signature)
+	cumulativePayout = cheque.CumulativePayout.Value()
+	cashResult, receipt, err := issuerSwap.contract.CashChequeBeneficiary(opts, beneficiaryAddress, &cumulativePayout, cheque.Signature)
 
 	if err != nil {
 		t.Fatal(err)
@@ -1210,7 +1212,7 @@ func TestContractIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	castedResult, err := NewUint256().Set(result)
+	castedResult, err := NewUint256().Set(*result)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1232,7 +1234,8 @@ func TestContractIntegration(t *testing.T) {
 	}
 
 	log.Debug("try to cash-in the bouncing cheque")
-	cashResult, receipt, err = issuerSwap.contract.CashChequeBeneficiary(opts, beneficiaryAddress, bouncingCheque.CumulativePayout.Value, bouncingCheque.Signature)
+	cumulativePayout = bouncingCheque.CumulativePayout.Value()
+	cashResult, receipt, err = issuerSwap.contract.CashChequeBeneficiary(opts, beneficiaryAddress, &cumulativePayout, bouncingCheque.Signature)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -643,7 +643,7 @@ func TestPaymentThreshold(t *testing.T) {
 
 	var cheque *Cheque
 	_ = swap.store.Get(pendingChequeKey(testPeer.Peer.ID()), &cheque)
-	if cheque.CumulativePayout.Cmp((&Uint256{}).FromUint64(DefaultPaymentThreshold)) != 0 {
+	if cheque.CumulativePayout.Cmp(Uint64ToUint256(DefaultPaymentThreshold)) != 0 {
 		t.Fatal()
 	}
 }
@@ -953,7 +953,7 @@ func newTestCheque() *Cheque {
 	cheque := &Cheque{
 		ChequeParams: ChequeParams{
 			Contract:         testChequeContract,
-			CumulativePayout: (&Uint256{}).FromUint64(uint64(42)),
+			CumulativePayout: Uint64ToUint256(uint64(42)),
 			Beneficiary:      beneficiaryAddress,
 		},
 		Honey: uint64(42),
@@ -969,7 +969,7 @@ func newRandomTestCheque() *Cheque {
 	cheque := &Cheque{
 		ChequeParams: ChequeParams{
 			Contract:         testChequeContract,
-			CumulativePayout: (&Uint256{}).FromUint64(uint64(amount)),
+			CumulativePayout: Uint64ToUint256(uint64(amount)),
 			Beneficiary:      beneficiaryAddress,
 		},
 		Honey: uint64(amount),
@@ -1222,7 +1222,7 @@ func TestContractIntegration(t *testing.T) {
 	// create a cheque that will bounce
 	bouncingCheque := newTestCheque()
 	bouncingCheque.ChequeParams.Contract = issuerSwap.GetParams().ContractAddress
-	_, err = bouncingCheque.CumulativePayout.Add(bouncingCheque.CumulativePayout, (&Uint256{}).FromUint64(10000*RetrieveRequestPrice))
+	_, err = bouncingCheque.CumulativePayout.Add(bouncingCheque.CumulativePayout, Uint64ToUint256(10000*RetrieveRequestPrice))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1408,7 +1408,7 @@ func TestPeerVerifyChequePropertiesInvalidCheque(t *testing.T) {
 
 // TestPeerVerifyChequeAgainstLast tests that verifyChequeAgainstLast accepts a cheque with higher amount
 func TestPeerVerifyChequeAgainstLast(t *testing.T) {
-	increase := (&Uint256{}).FromUint64(uint64(10))
+	increase := Uint64ToUint256(uint64(10))
 	oldCheque := newTestCheque()
 	newCheque := newTestCheque()
 
@@ -1429,7 +1429,7 @@ func TestPeerVerifyChequeAgainstLast(t *testing.T) {
 
 // TestPeerVerifyChequeAgainstLastInvalid tests that verifyChequeAgainstLast rejects cheques with lower amount or an unexpected value
 func TestPeerVerifyChequeAgainstLastInvalid(t *testing.T) {
-	increase := (&Uint256{}).FromUint64(uint64(10))
+	increase := Uint64ToUint256(uint64(10))
 
 	// cheque with same or lower amount
 	oldCheque := newTestCheque()
@@ -1442,7 +1442,7 @@ func TestPeerVerifyChequeAgainstLastInvalid(t *testing.T) {
 	// cheque with amount != increase
 	oldCheque = newTestCheque()
 	newCheque = newTestCheque()
-	_, err := increase.Add(increase, (&Uint256{}).FromUint64(uint64(5)))
+	_, err := increase.Add(increase, Uint64ToUint256(uint64(5)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1482,7 +1482,7 @@ func TestPeerProcessAndVerifyCheque(t *testing.T) {
 
 	// create another cheque with higher amount
 	otherCheque := newTestCheque()
-	_, err = otherCheque.CumulativePayout.Add(cheque.CumulativePayout, (&Uint256{}).FromUint64(10))
+	_, err = otherCheque.CumulativePayout.Add(cheque.CumulativePayout, Uint64ToUint256(10))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1530,7 +1530,7 @@ func TestPeerProcessAndVerifyChequeInvalid(t *testing.T) {
 
 	// invalid cheque because amount is lower
 	otherCheque := newTestCheque()
-	_, err := otherCheque.CumulativePayout.Sub(cheque.CumulativePayout, (&Uint256{}).FromUint64(uint64(10)))
+	_, err := otherCheque.CumulativePayout.Sub(cheque.CumulativePayout, Uint64ToUint256(uint64(10)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1641,7 +1641,7 @@ func TestPeerGetLastSentCumulativePayout(t *testing.T) {
 	_, peer, clean := newTestSwapAndPeer(t, ownerKey)
 	defer clean()
 
-	if peer.getLastSentCumulativePayout().Cmp((&Uint256{}).FromUint64(uint64(0))) != 0 {
+	if peer.getLastSentCumulativePayout().Cmp(Uint64ToUint256(uint64(0))) != 0 {
 		t.Fatalf("last cumulative payout should be 0 in the beginning, was %d", peer.getLastSentCumulativePayout())
 	}
 
@@ -1681,7 +1681,7 @@ func TestAvailableBalance(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if availableBalance.Cmp((&Uint256{}).FromUint64(depositAmount.Uint64())) != 0 {
+	if availableBalance.Cmp(Uint64ToUint256(depositAmount.Uint64())) != 0 {
 		t.Fatalf("availableBalance not equal to deposited amount. availableBalance: %d, depositAmount: %d", availableBalance, depositAmount)
 	}
 	// withdraw 50
@@ -1702,7 +1702,7 @@ func TestAvailableBalance(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if availableBalance.Cmp((&Uint256{}).FromUint64(netDeposit)) != 0 {
+	if availableBalance.Cmp(Uint64ToUint256(netDeposit)) != 0 {
 		t.Fatalf("availableBalance not equal to deposited minus withdraw. availableBalance: %d, deposit minus withdrawn: %d", availableBalance, depositAmount.Uint64()-withdrawAmount.Uint64())
 	}
 
@@ -1720,7 +1720,7 @@ func TestAvailableBalance(t *testing.T) {
 	}
 	// verify available balance
 	expectedBalance := netDeposit - uint64(chequeAmount)
-	if availableBalance.Cmp((&Uint256{}).FromUint64(expectedBalance)) != 0 {
+	if availableBalance.Cmp(Uint64ToUint256(expectedBalance)) != 0 {
 		t.Fatalf("availableBalance not equal to deposited minus withdraw. availableBalance: %d, deposit minus withdrawn: %d", availableBalance, depositAmount.Uint64()-withdrawAmount.Uint64())
 	}
 

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -953,7 +953,7 @@ func newTestCheque() *Cheque {
 	cheque := &Cheque{
 		ChequeParams: ChequeParams{
 			Contract:         testChequeContract,
-			CumulativePayout: Uint64ToUint256(uint64(42)),
+			CumulativePayout: Uint64ToUint256(42),
 			Beneficiary:      beneficiaryAddress,
 		},
 		Honey: uint64(42),
@@ -1408,7 +1408,7 @@ func TestPeerVerifyChequePropertiesInvalidCheque(t *testing.T) {
 
 // TestPeerVerifyChequeAgainstLast tests that verifyChequeAgainstLast accepts a cheque with higher amount
 func TestPeerVerifyChequeAgainstLast(t *testing.T) {
-	increase := Uint64ToUint256(uint64(10))
+	increase := Uint64ToUint256(10)
 	oldCheque := newTestCheque()
 	newCheque := newTestCheque()
 
@@ -1429,7 +1429,7 @@ func TestPeerVerifyChequeAgainstLast(t *testing.T) {
 
 // TestPeerVerifyChequeAgainstLastInvalid tests that verifyChequeAgainstLast rejects cheques with lower amount or an unexpected value
 func TestPeerVerifyChequeAgainstLastInvalid(t *testing.T) {
-	increase := Uint64ToUint256(uint64(10))
+	increase := Uint64ToUint256(10)
 
 	// cheque with same or lower amount
 	oldCheque := newTestCheque()
@@ -1442,7 +1442,7 @@ func TestPeerVerifyChequeAgainstLastInvalid(t *testing.T) {
 	// cheque with amount != increase
 	oldCheque = newTestCheque()
 	newCheque = newTestCheque()
-	_, err := increase.Add(increase, Uint64ToUint256(uint64(5)))
+	_, err := increase.Add(increase, Uint64ToUint256(5))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1530,7 +1530,7 @@ func TestPeerProcessAndVerifyChequeInvalid(t *testing.T) {
 
 	// invalid cheque because amount is lower
 	otherCheque := newTestCheque()
-	_, err := otherCheque.CumulativePayout.Sub(cheque.CumulativePayout, Uint64ToUint256(uint64(10)))
+	_, err := otherCheque.CumulativePayout.Sub(cheque.CumulativePayout, Uint64ToUint256(10))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1641,7 +1641,7 @@ func TestPeerGetLastSentCumulativePayout(t *testing.T) {
 	_, peer, clean := newTestSwapAndPeer(t, ownerKey)
 	defer clean()
 
-	if peer.getLastSentCumulativePayout().Cmp(Uint64ToUint256(uint64(0))) != 0 {
+	if peer.getLastSentCumulativePayout().Cmp(Uint64ToUint256(0)) != 0 {
 		t.Fatalf("last cumulative payout should be 0 in the beginning, was %d", peer.getLastSentCumulativePayout())
 	}
 

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -1210,7 +1210,7 @@ func TestContractIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	castedResult, err := (&Uint256{}).Set(result)
+	castedResult, err := NewUint256().Set(result)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -1423,7 +1423,7 @@ func TestPeerVerifyChequeAgainstLast(t *testing.T) {
 	}
 
 	if actualAmount.Cmp(increase) != 0 {
-		t.Fatalf("wrong actual amount, expected: %d, was: %d", increase, actualAmount)
+		t.Fatalf("wrong actual amount, expected: %v, was: %v", increase, actualAmount)
 	}
 }
 
@@ -1472,12 +1472,12 @@ func TestPeerProcessAndVerifyCheque(t *testing.T) {
 	}
 
 	if actualAmount != cheque.CumulativePayout {
-		t.Fatalf("computed wrong actual amount: was %d, expected: %d", actualAmount, cheque.CumulativePayout)
+		t.Fatalf("computed wrong actual amount: was %v, expected: %v", actualAmount, cheque.CumulativePayout)
 	}
 
 	// verify that it was indeed saved
 	if peer.getLastReceivedCheque().CumulativePayout != cheque.CumulativePayout {
-		t.Fatalf("last received cheque has wrong cumulative payout, was: %d, expected: %d", peer.lastReceivedCheque.CumulativePayout, cheque.CumulativePayout)
+		t.Fatalf("last received cheque has wrong cumulative payout, was: %v, expected: %v", peer.lastReceivedCheque.CumulativePayout, cheque.CumulativePayout)
 	}
 
 	// create another cheque with higher amount
@@ -1495,7 +1495,7 @@ func TestPeerProcessAndVerifyCheque(t *testing.T) {
 
 	// verify that it was indeed saved
 	if peer.getLastReceivedCheque().CumulativePayout != otherCheque.CumulativePayout {
-		t.Fatalf("last received cheque has wrong cumulative payout, was: %d, expected: %d", peer.lastReceivedCheque.CumulativePayout, otherCheque.CumulativePayout)
+		t.Fatalf("last received cheque has wrong cumulative payout, was: %v, expected: %v", peer.lastReceivedCheque.CumulativePayout, otherCheque.CumulativePayout)
 	}
 }
 
@@ -1525,7 +1525,7 @@ func TestPeerProcessAndVerifyChequeInvalid(t *testing.T) {
 	}
 
 	if peer.getLastReceivedCheque().CumulativePayout != cheque.CumulativePayout {
-		t.Fatalf("last received cheque has wrong cumulative payout, was: %d, expected: %d", peer.lastReceivedCheque.CumulativePayout, cheque.CumulativePayout)
+		t.Fatalf("last received cheque has wrong cumulative payout, was: %v, expected: %v", peer.lastReceivedCheque.CumulativePayout, cheque.CumulativePayout)
 	}
 
 	// invalid cheque because amount is lower
@@ -1543,7 +1543,7 @@ func TestPeerProcessAndVerifyChequeInvalid(t *testing.T) {
 
 	// check that no invalid cheque was saved
 	if peer.getLastReceivedCheque().CumulativePayout != cheque.CumulativePayout {
-		t.Fatalf("last received cheque has wrong cumulative payout, was: %d, expected: %d", peer.lastReceivedCheque.CumulativePayout, cheque.CumulativePayout)
+		t.Fatalf("last received cheque has wrong cumulative payout, was: %v, expected: %v", peer.lastReceivedCheque.CumulativePayout, cheque.CumulativePayout)
 	}
 }
 
@@ -1642,7 +1642,7 @@ func TestPeerGetLastSentCumulativePayout(t *testing.T) {
 	defer clean()
 
 	if peer.getLastSentCumulativePayout().Cmp(Uint64ToUint256(0)) != 0 {
-		t.Fatalf("last cumulative payout should be 0 in the beginning, was %d", peer.getLastSentCumulativePayout())
+		t.Fatalf("last cumulative payout should be 0 in the beginning, was %v", peer.getLastSentCumulativePayout())
 	}
 
 	cheque := newTestCheque()
@@ -1651,7 +1651,7 @@ func TestPeerGetLastSentCumulativePayout(t *testing.T) {
 	}
 
 	if peer.getLastSentCumulativePayout() != cheque.CumulativePayout {
-		t.Fatalf("last cumulative payout should be the payout of the last sent cheque, was: %d, expected %d", peer.getLastSentCumulativePayout(), cheque.CumulativePayout)
+		t.Fatalf("last cumulative payout should be the payout of the last sent cheque, was: %v, expected %v", peer.getLastSentCumulativePayout(), cheque.CumulativePayout)
 	}
 }
 
@@ -1682,7 +1682,7 @@ func TestAvailableBalance(t *testing.T) {
 		t.Fatal(err)
 	}
 	if availableBalance.Cmp(Uint64ToUint256(depositAmount.Uint64())) != 0 {
-		t.Fatalf("availableBalance not equal to deposited amount. availableBalance: %d, depositAmount: %d", availableBalance, depositAmount)
+		t.Fatalf("availableBalance not equal to deposited amount. availableBalance: %v, depositAmount: %d", availableBalance, depositAmount)
 	}
 	// withdraw 50
 	withdrawAmount := big.NewInt(50)
@@ -1703,7 +1703,7 @@ func TestAvailableBalance(t *testing.T) {
 		t.Fatal(err)
 	}
 	if availableBalance.Cmp(Uint64ToUint256(netDeposit)) != 0 {
-		t.Fatalf("availableBalance not equal to deposited minus withdraw. availableBalance: %d, deposit minus withdrawn: %d", availableBalance, depositAmount.Uint64()-withdrawAmount.Uint64())
+		t.Fatalf("availableBalance not equal to deposited minus withdraw. availableBalance: %v, deposit minus withdrawn: %d", availableBalance, depositAmount.Uint64()-withdrawAmount.Uint64())
 	}
 
 	// send a cheque worth 42
@@ -1721,7 +1721,7 @@ func TestAvailableBalance(t *testing.T) {
 	// verify available balance
 	expectedBalance := netDeposit - uint64(chequeAmount)
 	if availableBalance.Cmp(Uint64ToUint256(expectedBalance)) != 0 {
-		t.Fatalf("availableBalance not equal to deposited minus withdraw. availableBalance: %d, deposit minus withdrawn: %d", availableBalance, depositAmount.Uint64()-withdrawAmount.Uint64())
+		t.Fatalf("availableBalance not equal to deposited minus withdraw. availableBalance: %v, deposit minus withdrawn: %d", availableBalance, depositAmount.Uint64()-withdrawAmount.Uint64())
 	}
 
 }

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -1471,12 +1471,12 @@ func TestPeerProcessAndVerifyCheque(t *testing.T) {
 		t.Fatalf("failed to process cheque: %s", err)
 	}
 
-	if actualAmount != cheque.CumulativePayout {
+	if !actualAmount.Equals(cheque.CumulativePayout) {
 		t.Fatalf("computed wrong actual amount: was %v, expected: %v", actualAmount, cheque.CumulativePayout)
 	}
 
 	// verify that it was indeed saved
-	if peer.getLastReceivedCheque().CumulativePayout != cheque.CumulativePayout {
+	if !peer.getLastReceivedCheque().CumulativePayout.Equals(cheque.CumulativePayout) {
 		t.Fatalf("last received cheque has wrong cumulative payout, was: %v, expected: %v", peer.lastReceivedCheque.CumulativePayout, cheque.CumulativePayout)
 	}
 
@@ -1494,7 +1494,7 @@ func TestPeerProcessAndVerifyCheque(t *testing.T) {
 	}
 
 	// verify that it was indeed saved
-	if peer.getLastReceivedCheque().CumulativePayout != otherCheque.CumulativePayout {
+	if !peer.getLastReceivedCheque().CumulativePayout.Equals(otherCheque.CumulativePayout) {
 		t.Fatalf("last received cheque has wrong cumulative payout, was: %v, expected: %v", peer.lastReceivedCheque.CumulativePayout, otherCheque.CumulativePayout)
 	}
 }

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -1442,12 +1442,12 @@ func TestPeerVerifyChequeAgainstLastInvalid(t *testing.T) {
 	// cheque with amount != increase
 	oldCheque = newTestCheque()
 	newCheque = newTestCheque()
-	_, err := increase.Add(increase, Uint64ToUint256(5))
+	cumulativePayoutIncrease, err := NewUint256().Add(increase, Uint64ToUint256(5))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = newCheque.CumulativePayout.Add(oldCheque.CumulativePayout, increase)
+	_, err = newCheque.CumulativePayout.Add(oldCheque.CumulativePayout, cumulativePayoutIncrease)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -1170,7 +1170,7 @@ func TestContractIntegration(t *testing.T) {
 	cheque := newTestCheque()
 
 	ctx := context.TODO()
-	err := testDeploy(ctx, issuerSwap, cheque.CumulativePayout.Value())
+	err := testDeploy(ctx, issuerSwap, cheque.CumulativePayout.Value)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1193,7 +1193,7 @@ func TestContractIntegration(t *testing.T) {
 
 	log.Debug("cash-in the cheque")
 
-	cashResult, receipt, err := issuerSwap.contract.CashChequeBeneficiary(opts, beneficiaryAddress, cheque.CumulativePayout.Value(), cheque.Signature)
+	cashResult, receipt, err := issuerSwap.contract.CashChequeBeneficiary(opts, beneficiaryAddress, cheque.CumulativePayout.Value, cheque.Signature)
 
 	if err != nil {
 		t.Fatal(err)
@@ -1232,7 +1232,7 @@ func TestContractIntegration(t *testing.T) {
 	}
 
 	log.Debug("try to cash-in the bouncing cheque")
-	cashResult, receipt, err = issuerSwap.contract.CashChequeBeneficiary(opts, beneficiaryAddress, bouncingCheque.CumulativePayout.Value(), bouncingCheque.Signature)
+	cashResult, receipt, err = issuerSwap.contract.CashChequeBeneficiary(opts, beneficiaryAddress, bouncingCheque.CumulativePayout.Value, bouncingCheque.Signature)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/ethersphere/swarm/p2p/protocols"
 	"github.com/ethersphere/swarm/state"
 	"github.com/ethersphere/swarm/testutil"
+	"github.com/ethersphere/swarm/uint256"
 )
 
 var (
@@ -585,7 +586,7 @@ func TestPaymentThreshold(t *testing.T) {
 
 	var cheque *Cheque
 	_ = swap.store.Get(pendingChequeKey(testPeer.Peer.ID()), &cheque)
-	if !cheque.CumulativePayout.Equals(Uint64ToUint256(DefaultPaymentThreshold)) {
+	if !cheque.CumulativePayout.Equals(uint256.FromUint64(DefaultPaymentThreshold)) {
 		t.Fatal()
 	}
 }
@@ -1026,7 +1027,7 @@ func TestPeerVerifyChequePropertiesInvalidCheque(t *testing.T) {
 
 // TestPeerVerifyChequeAgainstLast tests that verifyChequeAgainstLast accepts a cheque with higher amount
 func TestPeerVerifyChequeAgainstLast(t *testing.T) {
-	increase := Uint64ToUint256(10)
+	increase := uint256.FromUint64(10)
 	oldCheque := newTestCheque()
 	newCheque := newTestCheque()
 
@@ -1047,7 +1048,7 @@ func TestPeerVerifyChequeAgainstLast(t *testing.T) {
 
 // TestPeerVerifyChequeAgainstLastInvalid tests that verifyChequeAgainstLast rejects cheques with lower amount or an unexpected value
 func TestPeerVerifyChequeAgainstLastInvalid(t *testing.T) {
-	increase := Uint64ToUint256(10)
+	increase := uint256.FromUint64(10)
 
 	// cheque with same or lower amount
 	oldCheque := newTestCheque()
@@ -1060,7 +1061,7 @@ func TestPeerVerifyChequeAgainstLastInvalid(t *testing.T) {
 	// cheque with amount != increase
 	oldCheque = newTestCheque()
 	newCheque = newTestCheque()
-	cumulativePayoutIncrease, err := NewUint256().Add(increase, Uint64ToUint256(5))
+	cumulativePayoutIncrease, err := uint256.New().Add(increase, uint256.FromUint64(5))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1100,7 +1101,7 @@ func TestPeerProcessAndVerifyCheque(t *testing.T) {
 
 	// create another cheque with higher amount
 	otherCheque := newTestCheque()
-	_, err = otherCheque.CumulativePayout.Add(cheque.CumulativePayout, Uint64ToUint256(10))
+	_, err = otherCheque.CumulativePayout.Add(cheque.CumulativePayout, uint256.FromUint64(10))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1148,7 +1149,7 @@ func TestPeerProcessAndVerifyChequeInvalid(t *testing.T) {
 
 	// invalid cheque because amount is lower
 	otherCheque := newTestCheque()
-	_, err := otherCheque.CumulativePayout.Sub(cheque.CumulativePayout, Uint64ToUint256(10))
+	_, err := otherCheque.CumulativePayout.Sub(cheque.CumulativePayout, uint256.FromUint64(10))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1259,7 +1260,7 @@ func TestPeerGetLastSentCumulativePayout(t *testing.T) {
 	_, peer, clean := newTestSwapAndPeer(t, ownerKey)
 	defer clean()
 
-	if !peer.getLastSentCumulativePayout().Equals(Uint64ToUint256(0)) {
+	if !peer.getLastSentCumulativePayout().Equals(uint256.FromUint64(0)) {
 		t.Fatalf("last cumulative payout should be 0 in the beginning, was %v", peer.getLastSentCumulativePayout())
 	}
 
@@ -1299,7 +1300,7 @@ func TestAvailableBalance(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !availableBalance.Equals(Uint64ToUint256(depositAmount.Uint64())) {
+	if !availableBalance.Equals(uint256.FromUint64(depositAmount.Uint64())) {
 		t.Fatalf("availableBalance not equal to deposited amount. availableBalance: %v, depositAmount: %d", availableBalance, depositAmount)
 	}
 	// withdraw 50
@@ -1320,7 +1321,7 @@ func TestAvailableBalance(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !availableBalance.Equals(Uint64ToUint256(netDeposit)) {
+	if !availableBalance.Equals(uint256.FromUint64(netDeposit)) {
 		t.Fatalf("availableBalance not equal to deposited minus withdraw. availableBalance: %v, deposit minus withdrawn: %d", availableBalance, depositAmount.Uint64()-withdrawAmount.Uint64())
 	}
 
@@ -1338,7 +1339,7 @@ func TestAvailableBalance(t *testing.T) {
 	}
 	// verify available balance
 	expectedBalance := netDeposit - uint64(chequeAmount)
-	if !availableBalance.Equals(Uint64ToUint256(expectedBalance)) {
+	if !availableBalance.Equals(uint256.FromUint64(expectedBalance)) {
 		t.Fatalf("availableBalance not equal to deposited minus withdraw. availableBalance: %v, deposit minus withdrawn: %d", availableBalance, depositAmount.Uint64()-withdrawAmount.Uint64())
 	}
 

--- a/swap/types.go
+++ b/swap/types.go
@@ -66,10 +66,9 @@ func (u *Uint256) Value() *big.Int {
 	return u.value
 }
 
-// Uint64ToUint256 creates a Uint256 struct based on the given uint64 param
+// FromUint64 creates a Uint256 struct based on the given uint64 param
 // any uint64 is valid as a uint256
-func Uint64ToUint256(base uint64) *Uint256 {
-	var u *Uint256
+func (u *Uint256) FromUint64(base uint64) *Uint256 {
 	u.value = new(big.Int).SetUint64(base)
 	return u
 }

--- a/swap/types.go
+++ b/swap/types.go
@@ -17,6 +17,7 @@
 package swap
 
 import (
+	"errors"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -57,16 +58,25 @@ type Uint256 struct {
 	value big.Int
 }
 
-func (u *Uint256) min() *big.Int {
+func (u *Uint256) Set(value *big.Int) error {
+	if value.Cmp(u.Max()) == 1 {
+		return errors.New("overflow")
+	}
+	if value.Cmp(u.Min()) == -1 {
+		return errors.New("underflow")
+	}
+	return nil
+}
+
+func (u *Uint256) Min() *big.Int {
 	return big.NewInt(0)
 }
 
-func (u *Uint256) max() *big.Int {
+func (u *Uint256) Max() *big.Int {
 	max := new(big.Int)
-	max, success := max.SetString("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10)
+	max, success := max.SetString("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10) // 2^256 -1
 	if success {
 		return max
-	} else {
-		return new(big.Int)
 	}
+	return new(big.Int)
 }

--- a/swap/types.go
+++ b/swap/types.go
@@ -55,28 +55,25 @@ type ConfirmChequeMsg struct {
 
 // Uint256 represents an unsigned integer of 256 bits
 type Uint256 struct {
-	value big.Int
+	value *big.Int
 }
 
+var minUint256 = big.NewInt(0)
+var maxUint256, _ = new(big.Int).SetString("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10) // 2^256 -1
+
+// Value returns the underlying big int pointer for the Uint256 struct
+func (u *Uint256) Value() *big.Int {
+	return u.value
+}
+
+// Set assigns a new value to the underlying pointer within the unsigned 256-bit integer range
 func (u *Uint256) Set(value *big.Int) error {
-	if value.Cmp(u.Max()) == 1 {
+	if value.Cmp(minUint256) == 1 {
 		return errors.New("overflow")
 	}
-	if value.Cmp(u.Min()) == -1 {
+	if value.Cmp(maxUint256) == -1 {
 		return errors.New("underflow")
 	}
+	u.value = value
 	return nil
-}
-
-func (u *Uint256) Min() *big.Int {
-	return big.NewInt(0)
-}
-
-func (u *Uint256) Max() *big.Int {
-	max := new(big.Int)
-	max, success := max.SetString("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10) // 2^256 -1
-	if success {
-		return max
-	}
-	return new(big.Int)
 }

--- a/swap/types.go
+++ b/swap/types.go
@@ -91,3 +91,8 @@ func (u *Uint256) Sub(subtrahend *Uint256) error {
 	difference.Sub(u.Value(), subtrahend.Value()) // any uint256 is good enough for a big.Int
 	return u.Set(difference)
 }
+
+// Cmp calls the underlying Cmp method for the big.Int stored in a Uint256 struct
+func (u *Uint256) Cmp(v *Uint256) (r int) {
+	return u.Value().Cmp(v.Value())
+}

--- a/swap/types.go
+++ b/swap/types.go
@@ -66,7 +66,7 @@ var maxUint256 = new(big.Int).Sub(new(big.Int).Exp(big.NewInt(2), big.NewInt(256
 // NewUint256 creates a Uint256 struct with a minimum initial underlying value
 func NewUint256() *Uint256 {
 	u := new(Uint256)
-	u.value = *minUint256
+	u.value = *new(big.Int).Set(minUint256)
 	return u
 }
 
@@ -92,13 +92,13 @@ func (u *Uint256) Set(value big.Int) (*Uint256, error) {
 	if value.Cmp(minUint256) == -1 {
 		return nil, fmt.Errorf("cannot set Uint256 to %v as it underflows min value of %v", value, minUint256)
 	}
-	u.value = value
+	u.value = *new(big.Int).Set(&value)
 	return u, nil
 }
 
 // Copy sets the underlying value of u to a copy of the given Uint256 param, and returns the modified receiver struct
 func (u *Uint256) Copy(v *Uint256) *Uint256 {
-	u.value = v.value
+	u.value = *new(big.Int).Set(&v.value)
 	return u
 }
 

--- a/swap/types.go
+++ b/swap/types.go
@@ -59,7 +59,7 @@ type Uint256 struct {
 }
 
 var minUint256 = big.NewInt(0)
-var maxUint256, _ = new(big.Int).SetString("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10) // 2^256 - 1 (base 10)
+var maxUint256 = new(big.Int).Sub(new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil), big.NewInt(1)) // 2^256 - 1
 
 // Value returns the underlying big.Int pointer for the Uint256 struct
 func (u *Uint256) Value() *big.Int {

--- a/swap/types.go
+++ b/swap/types.go
@@ -132,23 +132,3 @@ func (u *Uint256) Mul(multiplicand, multiplier *Uint256) (*Uint256, error) {
 func (u *Uint256) String() string {
 	return u.Value.String()
 }
-
-// MarshalJSON specifies how to marshal a Uint256 struct so that it can be written to disk
-func (u Uint256) MarshalJSON() ([]byte, error) {
-	return []byte(u.Value.String()), nil
-}
-
-// UnmarshalJSON specifies how to unmarshal a Uint256 struct so that it can be reconstructed from disk
-func (u *Uint256) UnmarshalJSON(b []byte) error {
-	if string(b) == "null" {
-		return nil
-	}
-
-	var value big.Int
-	_, ok := value.SetString(string(b), 10)
-	if !ok {
-		return fmt.Errorf("not a valid integer value: %s", b)
-	}
-	u.Value = &value
-	return nil
-}

--- a/swap/types.go
+++ b/swap/types.go
@@ -121,6 +121,10 @@ func (u *Uint256) Cmp(v *Uint256) int {
 	return u.Value().Cmp(v.Value())
 }
 
+func (u *Uint256) String() string {
+	return u.Value().String()
+}
+
 // MarshalJSON specifies how to marshal a Uint256 struct so that it can be written to disk
 func (u Uint256) MarshalJSON() ([]byte, error) {
 	// take the underliyng big.Int value, cast it to string and return the resulting byte array

--- a/swap/types.go
+++ b/swap/types.go
@@ -17,7 +17,7 @@
 package swap
 
 import (
-	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -69,10 +69,10 @@ func (u *Uint256) Value() *big.Int {
 // Set assigns a new value to the underlying pointer within the unsigned 256-bit integer range
 func (u *Uint256) Set(value *big.Int) error {
 	if value.Cmp(minUint256) == 1 {
-		return errors.New("overflow")
+		return fmt.Errorf("cannot set uint256 to %v as it overflows max value of %v", value, maxUint256)
 	}
 	if value.Cmp(maxUint256) == -1 {
-		return errors.New("underflow")
+		return fmt.Errorf("cannot set uint256 to %v as it underflows min value of %v", value, minUint256)
 	}
 	u.value = value
 	return nil

--- a/swap/types.go
+++ b/swap/types.go
@@ -55,22 +55,17 @@ type ConfirmChequeMsg struct {
 
 // Uint256 represents an unsigned integer of 256 bits
 type Uint256 struct {
-	value *big.Int
+	Value *big.Int
 }
 
 var minUint256 = big.NewInt(0)
 var maxUint256 = new(big.Int).Sub(new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil), big.NewInt(1)) // 2^256 - 1
 
-// Value returns the underlying big.Int pointer for the Uint256 struct
-func (u *Uint256) Value() *big.Int {
-	return u.value
-}
-
 // NewUint256 creates a Uint256 struct with an initial underlying value of 0
 // no Uint256 should have a nil pointer as its value field
 func NewUint256() *Uint256 {
 	u := new(Uint256)
-	u.value = big.NewInt(0)
+	u.Value = big.NewInt(0)
 	return u
 }
 
@@ -78,7 +73,7 @@ func NewUint256() *Uint256 {
 // any uint64 is valid as a uint256
 func Uint64ToUint256(base uint64) *Uint256 {
 	u := NewUint256()
-	u.value = new(big.Int).SetUint64(base)
+	u.Value = new(big.Int).SetUint64(base)
 	return u
 }
 
@@ -91,44 +86,44 @@ func (u *Uint256) Set(value *big.Int) (*Uint256, error) {
 	if value.Cmp(minUint256) == -1 {
 		return NewUint256(), fmt.Errorf("cannot set uint256 to %v as it underflows min value of %v", value, minUint256)
 	}
-	u.value = value
+	u.Value = value
 	return u, nil
 }
 
 // Add sets u to augend + addend and returns u as the sum
 // returns an error when the result falls outside of the unsigned 256-bit integer range
 func (u *Uint256) Add(augend, addend *Uint256) (*Uint256, error) {
-	sum := new(big.Int).Add(augend.Value(), addend.Value())
+	sum := new(big.Int).Add(augend.Value, addend.Value)
 	return u.Set(sum)
 }
 
 // Sub sets u to minuend - subtrahend and returns u as the difference
 // returns an error when the result falls outside of the unsigned 256-bit integer range
 func (u *Uint256) Sub(minuend, subtrahend *Uint256) (*Uint256, error) {
-	difference := new(big.Int).Sub(minuend.Value(), subtrahend.Value())
+	difference := new(big.Int).Sub(minuend.Value, subtrahend.Value)
 	return u.Set(difference)
 }
 
 // Mul sets u to multiplicand * multiplier and returns u as the product
 // returns an error when the result falls outside of the unsigned 256-bit integer range
 func (u *Uint256) Mul(multiplicand, multiplier *Uint256) (*Uint256, error) {
-	product := new(big.Int).Mul(multiplicand.Value(), multiplier.Value())
+	product := new(big.Int).Mul(multiplicand.Value, multiplier.Value)
 	return u.Set(product)
 }
 
 // Cmp calls the underlying Cmp method for the big.Int stored in a Uint256 struct as its value field
 func (u *Uint256) Cmp(v *Uint256) int {
-	return u.Value().Cmp(v.Value())
+	return u.Value.Cmp(v.Value)
 }
 
 func (u *Uint256) String() string {
-	return u.Value().String()
+	return u.Value.String()
 }
 
 // MarshalJSON specifies how to marshal a Uint256 struct so that it can be written to disk
 func (u Uint256) MarshalJSON() ([]byte, error) {
 	// take the underliyng big.Int value, cast it to string and return the resulting byte array
-	return []byte(u.Value().String()), nil
+	return []byte(u.Value.String()), nil
 }
 
 // UnmarshalJSON specifies how to unmarshal a Uint256 struct so that it can be recovered from disk
@@ -142,6 +137,6 @@ func (u *Uint256) UnmarshalJSON(b []byte) error {
 	if !ok {
 		return fmt.Errorf("not a valid integer value: %s", b)
 	}
-	u.value = &value
+	u.Value = &value
 	return nil
 }

--- a/swap/types.go
+++ b/swap/types.go
@@ -74,37 +74,41 @@ func Uint64ToUint256(base uint64) *Uint256 {
 	return u
 }
 
-// Set assigns a new value to the underlying pointer within the unsigned 256-bit integer range
-func (u *Uint256) Set(value *big.Int) error {
+// Set creates a new Uint256 pointer and assignes the given param to its underlying value before returning it
+// returns an error when the result falls outside of the unsigned 256-bit integer range
+func (u *Uint256) Set(value *big.Int) (*Uint256, error) {
 	if value.Cmp(minUint256) == 1 {
-		return fmt.Errorf("cannot set uint256 to %v as it overflows max value of %v", value, maxUint256)
+		return &Uint256{}, fmt.Errorf("cannot set uint256 to %v as it overflows max value of %v", value, maxUint256)
 	}
 	if value.Cmp(maxUint256) == -1 {
-		return fmt.Errorf("cannot set uint256 to %v as it underflows min value of %v", value, minUint256)
+		return &Uint256{}, fmt.Errorf("cannot set uint256 to %v as it underflows min value of %v", value, minUint256)
 	}
 	u.value = value
-	return nil
+	return u, nil
 }
 
-// Add attempts to add the given unsigned 256-bit integer to another
-func (u *Uint256) Add(addend *Uint256) error {
-	sum := new(big.Int).Add(u.Value(), addend.Value())
+// Add sets u to augend + addend and returns u as the sum
+// returns an error when the result falls outside of the unsigned 256-bit integer range
+func (u *Uint256) Add(augend, addend *Uint256) (*Uint256, error) {
+	sum := new(big.Int).Add(augend.Value(), addend.Value())
 	return u.Set(sum)
 }
 
-// Sub attempts to subtract the given unsigned 256-bit integer from another
-func (u *Uint256) Sub(subtrahend *Uint256) error {
-	difference := new(big.Int).Sub(u.Value(), subtrahend.Value())
+// Sub sets u to minuend - subtrahend and returns u as the difference
+// returns an error when the result falls outside of the unsigned 256-bit integer range
+func (u *Uint256) Sub(minuend, subtrahend *Uint256) (*Uint256, error) {
+	difference := new(big.Int).Sub(minuend.Value(), subtrahend.Value())
 	return u.Set(difference)
 }
 
-// Mul attempts to multiply an unsigned 256-bit integer by another (given) one
-func (u *Uint256) Mul(multiplier *Uint256) error {
-	product := new(big.Int).Mul(u.Value(), multiplier.Value())
+// Mul sets u to multiplicand * multiplier and returns u as the product
+// returns an error when the result falls outside of the unsigned 256-bit integer range
+func (u *Uint256) Mul(multiplicand, multiplier *Uint256) (*Uint256, error) {
+	product := new(big.Int).Mul(multiplicand.Value(), multiplier.Value())
 	return u.Set(product)
 }
 
-// Cmp calls the underlying Cmp method for the big.Int stored in a Uint256 struct
-func (u *Uint256) Cmp(v *Uint256) (r int) {
+// Cmp calls the underlying Cmp method for the big.Int stored in a Uint256 struct as its value field
+func (u *Uint256) Cmp(v *Uint256) int {
 	return u.Value().Cmp(v.Value())
 }

--- a/swap/types.go
+++ b/swap/types.go
@@ -69,7 +69,7 @@ func (u *Uint256) Value() *big.Int {
 // Uint64ToUint256 creates a Uint256 struct based on the given uint64 param
 // any uint64 is valid as a uint256
 func Uint64ToUint256(base uint64) *Uint256 {
-	var u *Uint256
+	u := &Uint256{}
 	u.value = new(big.Int).SetUint64(base)
 	return u
 }

--- a/swap/types.go
+++ b/swap/types.go
@@ -66,9 +66,10 @@ func (u *Uint256) Value() *big.Int {
 	return u.value
 }
 
-// FromUint64 creates a Uint256 struct based on the given uint64 param
+// Uint64ToUint256 creates a Uint256 struct based on the given uint64 param
 // any uint64 is valid as a uint256
-func (u *Uint256) FromUint64(base uint64) *Uint256 {
+func Uint64ToUint256(base uint64) *Uint256 {
+	var u *Uint256
 	u.value = new(big.Int).SetUint64(base)
 	return u
 }

--- a/swap/types.go
+++ b/swap/types.go
@@ -59,7 +59,7 @@ type Uint256 struct {
 }
 
 var minUint256 = big.NewInt(0)
-var maxUint256, _ = new(big.Int).SetString("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10) // 2^256 -1
+var maxUint256, _ = new(big.Int).SetString("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10) // 2^256 - 1 (base 10)
 
 // Value returns the underlying big int pointer for the Uint256 struct
 func (u *Uint256) Value() *big.Int {
@@ -76,4 +76,18 @@ func (u *Uint256) Set(value *big.Int) error {
 	}
 	u.value = value
 	return nil
+}
+
+// Add attempts to add the given addend to an unsigned 256-bit integer
+func (u *Uint256) Add(addend *big.Int) error {
+	var summand *big.Int
+	summand.Add(u.Value(), addend)
+	return u.Set(summand)
+}
+
+// Sub attempts to subtract the given subtrahend to an unsigned 256-bit integer
+func (u *Uint256) Sub(subtrahend *big.Int) error {
+	var difference *big.Int
+	difference.Sub(u.Value(), subtrahend)
+	return u.Set(difference)
 }

--- a/swap/types.go
+++ b/swap/types.go
@@ -111,3 +111,22 @@ func (u *Uint256) Mul(multiplicand, multiplier *Uint256) (*Uint256, error) {
 func (u *Uint256) Cmp(v *Uint256) int {
 	return u.Value().Cmp(v.Value())
 }
+
+//source: https://stackoverflow.com/questions/53991835/how-to-marshal-and-unmarshal-big-int-in-json
+
+func (b Uint256) MarshalJSON() ([]byte, error) {
+	return []byte(b.Value().String()), nil
+}
+
+func (b *Uint256) UnmarshalJSON(p []byte) error {
+	if string(p) == "null" {
+		return nil
+	}
+	var z big.Int
+	_, ok := z.SetString(string(p), 10)
+	if !ok {
+		return fmt.Errorf("not a valid big integer: %s", p)
+	}
+	b.value = &z
+	return nil
+}

--- a/swap/types.go
+++ b/swap/types.go
@@ -65,7 +65,7 @@ var maxUint256 = new(big.Int).Sub(new(big.Int).Exp(big.NewInt(2), big.NewInt(256
 // no Uint256 should have a nil pointer as its value field
 func NewUint256() *Uint256 {
 	u := new(Uint256)
-	u.Value = big.NewInt(0)
+	u.Value = minUint256
 	return u
 }
 
@@ -81,10 +81,10 @@ func Uint64ToUint256(base uint64) *Uint256 {
 // returns an error when the result falls outside of the unsigned 256-bit integer range
 func (u *Uint256) Set(value *big.Int) (*Uint256, error) {
 	if value.Cmp(maxUint256) == 1 {
-		return NewUint256(), fmt.Errorf("cannot set Uint256 to %v as it overflows max value of %v", value, maxUint256)
+		return nil, fmt.Errorf("cannot set Uint256 to %v as it overflows max value of %v", value, maxUint256)
 	}
 	if value.Cmp(minUint256) == -1 {
-		return NewUint256(), fmt.Errorf("cannot set Uint256 to %v as it underflows min value of %v", value, minUint256)
+		return nil, fmt.Errorf("cannot set Uint256 to %v as it underflows min value of %v", value, minUint256)
 	}
 	u.Value = value
 	return u, nil

--- a/swap/types.go
+++ b/swap/types.go
@@ -66,10 +66,12 @@ func (u *Uint256) Value() *big.Int {
 	return u.value
 }
 
-// FromUint64 sets the value for an Uint256 based on the given uint64 param
-// any uint64 can be used as uint256
-func (u *Uint256) FromUint64(base uint64) {
+// Uint64ToUint256 creates a Uint256 struct based on the given uint64 param
+// any uint64 is valid as a uint256
+func Uint64ToUint256(base uint64) *Uint256 {
+	var u *Uint256
 	u.value = new(big.Int).SetUint64(base)
+	return u
 }
 
 // Set assigns a new value to the underlying pointer within the unsigned 256-bit integer range

--- a/swap/types.go
+++ b/swap/types.go
@@ -92,7 +92,7 @@ func (u *Uint256) Add(addend *big.Int) error {
 	return u.Set(summand)
 }
 
-// Sub attempts to subtract the given subtrahend to an unsigned 256-bit integer
+// Sub attempts to subtract the given subtrahend from an unsigned 256-bit integer
 func (u *Uint256) Sub(subtrahend *big.Int) error {
 	var difference *big.Int
 	difference.Sub(u.Value(), subtrahend)

--- a/swap/types.go
+++ b/swap/types.go
@@ -98,6 +98,12 @@ func (u *Uint256) Sub(subtrahend *Uint256) error {
 	return u.Set(difference)
 }
 
+// Mul attempts to multiply an unsigned 256-bit integer by another (given) one
+func (u *Uint256) Mul(multiplier *Uint256) error {
+	product := new(big.Int).Mul(u.Value(), multiplier.Value())
+	return u.Set(product)
+}
+
 // Cmp calls the underlying Cmp method for the big.Int stored in a Uint256 struct
 func (u *Uint256) Cmp(v *Uint256) (r int) {
 	return u.Value().Cmp(v.Value())

--- a/swap/types.go
+++ b/swap/types.go
@@ -66,10 +66,16 @@ func (u *Uint256) Value() *big.Int {
 	return u.value
 }
 
+func NewUint256() *Uint256 {
+	u := &Uint256{}
+	u.value = big.NewInt(0)
+	return u
+}
+
 // Uint64ToUint256 creates a Uint256 struct based on the given uint64 param
 // any uint64 is valid as a uint256
 func Uint64ToUint256(base uint64) *Uint256 {
-	u := &Uint256{}
+	u := NewUint256()
 	u.value = new(big.Int).SetUint64(base)
 	return u
 }
@@ -77,11 +83,11 @@ func Uint64ToUint256(base uint64) *Uint256 {
 // Set creates a new Uint256 pointer and assignes the given param to its underlying value before returning it
 // returns an error when the result falls outside of the unsigned 256-bit integer range
 func (u *Uint256) Set(value *big.Int) (*Uint256, error) {
-	if value.Cmp(minUint256) == 1 {
-		return &Uint256{}, fmt.Errorf("cannot set uint256 to %v as it overflows max value of %v", value, maxUint256)
+	if value.Cmp(maxUint256) == 1 {
+		return NewUint256(), fmt.Errorf("cannot set uint256 to %v as it overflows max value of %v", value, maxUint256)
 	}
-	if value.Cmp(maxUint256) == -1 {
-		return &Uint256{}, fmt.Errorf("cannot set uint256 to %v as it underflows min value of %v", value, minUint256)
+	if value.Cmp(minUint256) == -1 {
+		return NewUint256(), fmt.Errorf("cannot set uint256 to %v as it underflows min value of %v", value, minUint256)
 	}
 	u.value = value
 	return u, nil

--- a/swap/types.go
+++ b/swap/types.go
@@ -80,15 +80,13 @@ func (u *Uint256) Set(value *big.Int) error {
 
 // Add attempts to add the given unsigned 256-bit integer to another
 func (u *Uint256) Add(addend *Uint256) error {
-	var summand *big.Int
-	summand.Add(u.Value(), addend.Value()) // any uint256 is good enough for a big.Int
-	return u.Set(summand)
+	sum := new(big.Int).Add(u.Value(), addend.Value())
+	return u.Set(sum)
 }
 
 // Sub attempts to subtract the given unsigned 256-bit integer from another
 func (u *Uint256) Sub(subtrahend *Uint256) error {
-	var difference *big.Int
-	difference.Sub(u.Value(), subtrahend.Value()) // any uint256 is good enough for a big.Int
+	difference := new(big.Int).Sub(u.Value(), subtrahend.Value())
 	return u.Set(difference)
 }
 

--- a/swap/types.go
+++ b/swap/types.go
@@ -116,6 +116,12 @@ func (u *Uint256) Cmp(v *Uint256) int {
 	return u.Value.Cmp(v.Value)
 }
 
+// Equals returns true if the two Uint256 structs have the same underlying values, false otherwise
+func (u *Uint256) Equals(v *Uint256) bool {
+	return u.Cmp(v) == 0
+}
+
+// String returns the string representation for Uint256 structs
 func (u *Uint256) String() string {
 	return u.Value.String()
 }

--- a/swap/types.go
+++ b/swap/types.go
@@ -27,7 +27,7 @@ import (
 type ChequeParams struct {
 	Contract         common.Address // address of chequebook, needed to avoid cross-contract submission
 	Beneficiary      common.Address // address of the beneficiary, the contract which will redeem the cheque
-	CumulativePayout uint64         // cumulative amount of the cheque in currency
+	CumulativePayout *Uint256       // cumulative amount of the cheque in currency
 }
 
 // Cheque encapsulates the parameters and the signature
@@ -61,13 +61,6 @@ type Uint256 struct {
 var minUint256 = big.NewInt(0)
 var maxUint256, _ = new(big.Int).SetString("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10) // 2^256 - 1 (base 10)
 
-// NewUint256 returns a new Uint256 struct with a value based on the given uint64 param
-func NewUint256(i uint64) *Uint256 {
-	var u *Uint256
-	u.value = new(big.Int).SetUint64(i) // any uint64 is good enough for a uint256
-	return u
-}
-
 // Value returns the underlying big.Int pointer for the Uint256 struct
 func (u *Uint256) Value() *big.Int {
 	return u.value
@@ -85,16 +78,16 @@ func (u *Uint256) Set(value *big.Int) error {
 	return nil
 }
 
-// Add attempts to add the given addend to an unsigned 256-bit integer
-func (u *Uint256) Add(addend *big.Int) error {
+// Add attempts to add the given unsigned 256-bit integer to another
+func (u *Uint256) Add(addend *Uint256) error {
 	var summand *big.Int
-	summand.Add(u.Value(), addend)
+	summand.Add(u.Value(), addend.Value()) // any uint256 is good enough for a big.Int
 	return u.Set(summand)
 }
 
-// Sub attempts to subtract the given subtrahend from an unsigned 256-bit integer
-func (u *Uint256) Sub(subtrahend *big.Int) error {
+// Sub attempts to subtract the given unsigned 256-bit integer from another
+func (u *Uint256) Sub(subtrahend *Uint256) error {
 	var difference *big.Int
-	difference.Sub(u.Value(), subtrahend)
+	difference.Sub(u.Value(), subtrahend.Value()) // any uint256 is good enough for a big.Int
 	return u.Set(difference)
 }

--- a/swap/types.go
+++ b/swap/types.go
@@ -61,7 +61,7 @@ type Uint256 struct {
 var minUint256 = big.NewInt(0)
 var maxUint256, _ = new(big.Int).SetString("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10) // 2^256 - 1 (base 10)
 
-// NewUint256 returns a new Uint256 struct with a value of the given param
+// NewUint256 returns a new Uint256 struct with a value based on the given uint64 param
 func NewUint256(i uint64) *Uint256 {
 	var u *Uint256
 	u.value = new(big.Int).SetUint64(i) // any uint64 is good enough for a uint256

--- a/swap/types.go
+++ b/swap/types.go
@@ -17,6 +17,8 @@
 package swap
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -48,4 +50,23 @@ type EmitChequeMsg struct {
 // ConfirmChequeMsg is sent from the creditor to the debitor with the cheque to confirm successful processing
 type ConfirmChequeMsg struct {
 	Cheque *Cheque
+}
+
+// Uint256 represents an unsigned integer of 256 bits
+type Uint256 struct {
+	value big.Int
+}
+
+func (u *Uint256) min() *big.Int {
+	return big.NewInt(0)
+}
+
+func (u *Uint256) max() *big.Int {
+	max := new(big.Int)
+	max, success := max.SetString("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10)
+	if success {
+		return max
+	} else {
+		return new(big.Int)
+	}
 }

--- a/swap/types.go
+++ b/swap/types.go
@@ -69,7 +69,7 @@ func (u *Uint256) Value() *big.Int {
 // NewUint256 creates a Uint256 struct with an initial underlying value of 0
 // no Uint256 should have a nil pointer as its value field
 func NewUint256() *Uint256 {
-	u := &Uint256{}
+	u := new(Uint256)
 	u.value = big.NewInt(0)
 	return u
 }
@@ -121,21 +121,23 @@ func (u *Uint256) Cmp(v *Uint256) int {
 	return u.Value().Cmp(v.Value())
 }
 
-//source: https://stackoverflow.com/questions/53991835/how-to-marshal-and-unmarshal-big-int-in-json
-
-func (b Uint256) MarshalJSON() ([]byte, error) {
-	return []byte(b.Value().String()), nil
+// MarshalJSON specifies how to marshal a Uint256 struct so that it can be written to disk
+func (u Uint256) MarshalJSON() ([]byte, error) {
+	// take the underliyng big.Int value, cast it to string and return the resulting byte array
+	return []byte(u.Value().String()), nil
 }
 
-func (b *Uint256) UnmarshalJSON(p []byte) error {
-	if string(p) == "null" {
+// UnmarshalJSON specifies how to unmarshal a Uint256 struct so that it can be recovered from disk
+func (u *Uint256) UnmarshalJSON(b []byte) error {
+	if string(b) == "null" {
 		return nil
 	}
-	var z big.Int
-	_, ok := z.SetString(string(p), 10)
+
+	var value big.Int
+	_, ok := value.SetString(string(b), 10)
 	if !ok {
-		return fmt.Errorf("not a valid big integer: %s", p)
+		return fmt.Errorf("not a valid integer value: %s", b)
 	}
-	b.value = &z
+	u.value = &value
 	return nil
 }

--- a/swap/types.go
+++ b/swap/types.go
@@ -66,6 +66,8 @@ func (u *Uint256) Value() *big.Int {
 	return u.value
 }
 
+// NewUint256 creates a Uint256 struct with an initial underlying value of 0
+// no Uint256 should have a nil pointer as its value field
 func NewUint256() *Uint256 {
 	u := &Uint256{}
 	u.value = big.NewInt(0)

--- a/swap/types.go
+++ b/swap/types.go
@@ -61,7 +61,14 @@ type Uint256 struct {
 var minUint256 = big.NewInt(0)
 var maxUint256, _ = new(big.Int).SetString("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10) // 2^256 - 1 (base 10)
 
-// Value returns the underlying big int pointer for the Uint256 struct
+// NewUint256 returns a new Uint256 struct with a value of the given param
+func NewUint256(i uint64) *Uint256 {
+	var u *Uint256
+	u.value = new(big.Int).SetUint64(i) // any uint64 is good enough for a uint256
+	return u
+}
+
+// Value returns the underlying big.Int pointer for the Uint256 struct
 func (u *Uint256) Value() *big.Int {
 	return u.value
 }

--- a/swap/types.go
+++ b/swap/types.go
@@ -77,6 +77,13 @@ func Uint64ToUint256(base uint64) *Uint256 {
 	return u
 }
 
+// Copy creates a Uint256 struct with the same underlying value as the given param
+func (u *Uint256) Copy(v *Uint256) *Uint256 {
+	valueCopy := new(big.Int).Set(v.Value)
+	u.Value = valueCopy
+	return u
+}
+
 // Set creates a new Uint256 pointer and assignes the given param to its underlying value before returning it
 // returns an error when the result falls outside of the unsigned 256-bit integer range
 func (u *Uint256) Set(value *big.Int) (*Uint256, error) {

--- a/swap/types.go
+++ b/swap/types.go
@@ -66,6 +66,12 @@ func (u *Uint256) Value() *big.Int {
 	return u.value
 }
 
+// FromUint64 sets the value for an Uint256 based on the given uint64 param
+// any uint64 can be used as uint256
+func (u *Uint256) FromUint64(base uint64) {
+	u.value = new(big.Int).SetUint64(base)
+}
+
 // Set assigns a new value to the underlying pointer within the unsigned 256-bit integer range
 func (u *Uint256) Set(value *big.Int) error {
 	if value.Cmp(minUint256) == 1 {

--- a/swap/types.go
+++ b/swap/types.go
@@ -135,7 +135,6 @@ func (u *Uint256) String() string {
 
 // MarshalJSON specifies how to marshal a Uint256 struct so that it can be written to disk
 func (u Uint256) MarshalJSON() ([]byte, error) {
-	// take the underliyng big.Int value, cast it to string and return the resulting byte array
 	return []byte(u.Value.String()), nil
 }
 

--- a/swap/types.go
+++ b/swap/types.go
@@ -17,19 +17,15 @@
 package swap
 
 import (
-	"fmt"
-	"io"
-	"math/big"
-
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethersphere/swarm/uint256"
 )
 
 // ChequeParams encapsulate all cheque parameters
 type ChequeParams struct {
-	Contract         common.Address // address of chequebook, needed to avoid cross-contract submission
-	Beneficiary      common.Address // address of the beneficiary, the contract which will redeem the cheque
-	CumulativePayout *Uint256       // cumulative amount of the cheque in currency
+	Contract         common.Address   // address of chequebook, needed to avoid cross-contract submission
+	Beneficiary      common.Address   // address of the beneficiary, the contract which will redeem the cheque
+	CumulativePayout *uint256.Uint256 // cumulative amount of the cheque in currency
 }
 
 // Cheque encapsulates the parameters and the signature
@@ -53,121 +49,4 @@ type EmitChequeMsg struct {
 // ConfirmChequeMsg is sent from the creditor to the debitor with the cheque to confirm successful processing
 type ConfirmChequeMsg struct {
 	Cheque *Cheque
-}
-
-// Uint256 represents an unsigned integer of 256 bits
-type Uint256 struct {
-	value big.Int
-}
-
-var minUint256 = big.NewInt(0)
-var maxUint256 = new(big.Int).Sub(new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil), big.NewInt(1)) // 2^256 - 1
-
-// NewUint256 creates a Uint256 struct with a minimum initial underlying value
-func NewUint256() *Uint256 {
-	u := new(Uint256)
-	u.value = *new(big.Int).Set(minUint256)
-	return u
-}
-
-// Uint64ToUint256 creates a Uint256 struct based on the given uint64 param
-// any uint64 is valid as a Uint256
-func Uint64ToUint256(base uint64) *Uint256 {
-	u := NewUint256()
-	u.value = *new(big.Int).SetUint64(base)
-	return u
-}
-
-// Value returns the underlying private value for a Uint256 struct
-func (u *Uint256) Value() big.Int {
-	return u.value
-}
-
-// Set assigns the underlying value of the given Uint256 param to u, and returns the modified receiver struct
-// returns an error when the result falls outside of the unsigned 256-bit integer range
-func (u *Uint256) Set(value big.Int) (*Uint256, error) {
-	if value.Cmp(maxUint256) == 1 {
-		return nil, fmt.Errorf("cannot set Uint256 to %v as it overflows max value of %v", value, maxUint256)
-	}
-	if value.Cmp(minUint256) == -1 {
-		return nil, fmt.Errorf("cannot set Uint256 to %v as it underflows min value of %v", value, minUint256)
-	}
-	u.value = *new(big.Int).Set(&value)
-	return u, nil
-}
-
-// Copy sets the underlying value of u to a copy of the given Uint256 param, and returns the modified receiver struct
-func (u *Uint256) Copy(v *Uint256) *Uint256 {
-	u.value = *new(big.Int).Set(&v.value)
-	return u
-}
-
-// Cmp calls the underlying Cmp method for the big.Int stored in a Uint256 struct as its value field
-func (u *Uint256) Cmp(v *Uint256) int {
-	return u.value.Cmp(&v.value)
-}
-
-// Equals returns true if the two Uint256 structs have the same underlying values, false otherwise
-func (u *Uint256) Equals(v *Uint256) bool {
-	return u.Cmp(v) == 0
-}
-
-// Add sets u to augend + addend and returns u as the sum
-// returns an error when the result falls outside of the unsigned 256-bit integer range
-func (u *Uint256) Add(augend, addend *Uint256) (*Uint256, error) {
-	sum := new(big.Int).Add(&augend.value, &addend.value)
-	return u.Set(*sum)
-}
-
-// Sub sets u to minuend - subtrahend and returns u as the difference
-// returns an error when the result falls outside of the unsigned 256-bit integer range
-func (u *Uint256) Sub(minuend, subtrahend *Uint256) (*Uint256, error) {
-	difference := new(big.Int).Sub(&minuend.value, &subtrahend.value)
-	return u.Set(*difference)
-}
-
-// Mul sets u to multiplicand * multiplier and returns u as the product
-// returns an error when the result falls outside of the unsigned 256-bit integer range
-func (u *Uint256) Mul(multiplicand, multiplier *Uint256) (*Uint256, error) {
-	product := new(big.Int).Mul(&multiplicand.value, &multiplier.value)
-	return u.Set(*product)
-}
-
-// String returns the string representation for Uint256 structs
-func (u *Uint256) String() string {
-	return u.value.String()
-}
-
-// MarshalJSON implements the json.Marshaler interface
-// it specifies how to marshal a Uint256 struct so that it can be written to disk
-func (u Uint256) MarshalJSON() ([]byte, error) {
-	return []byte(u.value.String()), nil
-}
-
-// UnmarshalJSON implements the json.Unmarshaler interface
-// it specifies how to unmarshal a Uint256 struct so that it can be reconstructed from disk
-func (u *Uint256) UnmarshalJSON(b []byte) error {
-	if string(b) == "null" {
-		return nil
-	}
-
-	var value big.Int
-	_, ok := value.SetString(string(b), 10)
-	if !ok {
-		return fmt.Errorf("not a valid integer value: %s", b)
-	}
-	u.value = value
-	return nil
-}
-
-// EncodeRLP implements the rlp.Encoder interface
-// it makes sure the `value` field is encoded even though it is private
-func (u *Uint256) EncodeRLP(w io.Writer) error {
-	return rlp.Encode(w, &u.value)
-}
-
-// DecodeRLP implements the rlp.Decoder interface
-// it makes sure the `value` field is decoded even though it is private
-func (u *Uint256) DecodeRLP(s *rlp.Stream) error {
-	return s.Decode(&u.value)
 }

--- a/swap/types_test.go
+++ b/swap/types_test.go
@@ -1,0 +1,39 @@
+package swap
+
+import "testing"
+
+import "math/big"
+
+type Uint256TestCase struct {
+	name         string
+	baseInteger  *big.Int
+	expectsError bool
+}
+
+func TestNewUint256(t *testing.T) {
+	testCases := []Uint256TestCase{
+		{
+			name:         "base 0",
+			baseInteger:  big.NewInt(0),
+			expectsError: false,
+		},
+	}
+
+	testNewUint256(t, testCases)
+}
+
+func testNewUint256(t *testing.T, testCases []Uint256TestCase) {
+	t.Helper()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewUint256().Set(tc.baseInteger)
+			if tc.expectsError && err == nil {
+				t.Fatalf("expected error when creating new Uint256, but got none")
+			}
+			if !tc.expectsError && err != nil {
+				t.Fatalf("got unexpected error when creating new Uint256: %v", err)
+			}
+		})
+	}
+}

--- a/swap/types_test.go
+++ b/swap/types_test.go
@@ -1,8 +1,9 @@
 package swap
 
-import "testing"
-
-import "math/big"
+import (
+	"math/big"
+	"testing"
+)
 
 type Uint256TestCase struct {
 	name         string
@@ -16,6 +17,21 @@ func TestNewUint256(t *testing.T) {
 			name:         "base 0",
 			baseInteger:  big.NewInt(0),
 			expectsError: false,
+		},
+		{
+			name:         "base -1",
+			baseInteger:  big.NewInt(-1),
+			expectsError: true,
+		},
+		{
+			name:         "base -256",
+			baseInteger:  big.NewInt(-256),
+			expectsError: true,
+		},
+		{
+			name:         "base -2,147,483,648",
+			baseInteger:  big.NewInt(-2147483648),
+			expectsError: true,
 		},
 	}
 

--- a/swap/types_test.go
+++ b/swap/types_test.go
@@ -18,19 +18,46 @@ func TestNewUint256(t *testing.T) {
 			baseInteger:  big.NewInt(0),
 			expectsError: false,
 		},
+		// negative numbers
 		{
 			name:         "base -1",
 			baseInteger:  big.NewInt(-1),
 			expectsError: true,
 		},
 		{
-			name:         "base -256",
-			baseInteger:  big.NewInt(-256),
+			name:         "base -1 * 2^8",
+			baseInteger:  new(big.Int).Mul(new(big.Int).Exp(big.NewInt(2), big.NewInt(8), nil), big.NewInt(-1)),
 			expectsError: true,
 		},
 		{
-			name:         "base -2,147,483,648",
-			baseInteger:  big.NewInt(-2147483648),
+			name:         "base -1 * 2^64",
+			baseInteger:  new(big.Int).Mul(new(big.Int).Exp(big.NewInt(2), big.NewInt(64), nil), big.NewInt(-1)),
+			expectsError: true,
+		},
+		// positive numbers
+		{
+			name:         "base 1",
+			baseInteger:  big.NewInt(1),
+			expectsError: false,
+		},
+		{
+			name:         "base 2^8",
+			baseInteger:  new(big.Int).Exp(big.NewInt(2), big.NewInt(8), nil),
+			expectsError: false,
+		},
+		{
+			name:         "base 2^128",
+			baseInteger:  new(big.Int).Exp(big.NewInt(2), big.NewInt(128), nil),
+			expectsError: false,
+		},
+		{
+			name:         "base 2^256 - 1",
+			baseInteger:  new(big.Int).Sub(new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil), big.NewInt(1)),
+			expectsError: false,
+		},
+		{
+			name:         "base 2^256",
+			baseInteger:  new(big.Int).Add(new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil), big.NewInt(1)),
 			expectsError: true,
 		},
 	}

--- a/swap/types_test.go
+++ b/swap/types_test.go
@@ -1,6 +1,7 @@
 package swap
 
 import (
+	"crypto/rand"
 	"math/big"
 	"testing"
 )
@@ -11,7 +12,7 @@ type Uint256TestCase struct {
 	expectsError bool
 }
 
-func TestNewUint256(t *testing.T) {
+func TestSetUint256(t *testing.T) {
 	testCases := []Uint256TestCase{
 		{
 			name:         "base 0",
@@ -62,10 +63,10 @@ func TestNewUint256(t *testing.T) {
 		},
 	}
 
-	testNewUint256(t, testCases)
+	testSetUint256(t, testCases)
 }
 
-func testNewUint256(t *testing.T, testCases []Uint256TestCase) {
+func testSetUint256(t *testing.T, testCases []Uint256TestCase) {
 	t.Helper()
 
 	for _, tc := range testCases {
@@ -78,5 +79,31 @@ func testNewUint256(t *testing.T, testCases []Uint256TestCase) {
 				t.Fatalf("got unexpected error when creating new Uint256: %v", err)
 			}
 		})
+	}
+}
+
+func TestCopyUint256(t *testing.T) {
+	t.Helper()
+
+	r, err := rand.Int(rand.Reader, new(big.Int).Sub(maxUint256, minUint256)) // base for random
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	randomUint256 := new(big.Int).Add(r, minUint256) // random is within [minUint256, maxUint256]
+
+	u, err := NewUint256().Set(randomUint256)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewUint256().Copy(u)
+
+	if c.Cmp(u) != 0 {
+		t.Fatalf("copy of uint256 %v has an unequal value of %v", u, c)
+	}
+
+	if c == u {
+		t.Fatalf("copy of uint256 %v shares memory with its base", u)
 	}
 }

--- a/swap/types_test.go
+++ b/swap/types_test.go
@@ -2,11 +2,8 @@ package swap
 
 import (
 	"crypto/rand"
-	"io/ioutil"
 	"math/big"
 	"testing"
-
-	"github.com/ethersphere/swarm/state"
 )
 
 type Uint256TestCase struct {
@@ -15,6 +12,7 @@ type Uint256TestCase struct {
 	expectsError bool
 }
 
+// TestSetUint256 tests the creation of valid and invalid Uint256 structs by calling the Set function
 func TestSetUint256(t *testing.T) {
 	testCases := []Uint256TestCase{
 		{
@@ -85,6 +83,7 @@ func testSetUint256(t *testing.T, testCases []Uint256TestCase) {
 	}
 }
 
+// TestCopyUint256 tests the duplication of an existing Uint256 variable
 func TestCopyUint256(t *testing.T) {
 	r, err := randomUint256()
 	if err != nil {
@@ -112,36 +111,4 @@ func randomUint256() (*Uint256, error) {
 
 	u, err := NewUint256().Set(randomUint256)
 	return u, err
-}
-
-func TestUint256Store(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "uint256_test_store")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	stateStore, err := state.NewDBStore(testDir)
-	defer stateStore.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	r, err := randomUint256()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	k := r.String()
-
-	stateStore.Put(k, r)
-
-	var u *Uint256
-	err = stateStore.Get(k, &u)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !u.Equals(r) {
-		t.Fatalf("retrieved uint256 %v has an unequal balance to the original uint256 %v", u, r)
-	}
 }

--- a/swap/types_test.go
+++ b/swap/types_test.go
@@ -62,6 +62,11 @@ func TestSetUint256(t *testing.T) {
 			baseInteger:  new(big.Int).Add(new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil), big.NewInt(1)),
 			expectsError: true,
 		},
+		{
+			name:         "base 2^512",
+			baseInteger:  new(big.Int).Add(new(big.Int).Exp(big.NewInt(2), big.NewInt(512), nil), big.NewInt(1)),
+			expectsError: true,
+		},
 	}
 
 	testSetUint256(t, testCases)
@@ -72,12 +77,17 @@ func testSetUint256(t *testing.T, testCases []Uint256TestCase) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := NewUint256().Set(tc.baseInteger)
+			result, err := NewUint256().Set(tc.baseInteger)
 			if tc.expectsError && err == nil {
 				t.Fatalf("expected error when creating new Uint256, but got none")
 			}
-			if !tc.expectsError && err != nil {
-				t.Fatalf("got unexpected error when creating new Uint256: %v", err)
+			if !tc.expectsError {
+				if err != nil {
+					t.Fatalf("got unexpected error when creating new Uint256: %v", err)
+				}
+				if result.Value.Cmp(tc.baseInteger) != 0 {
+					t.Fatalf("expected value of %v, got %v instead", tc.baseInteger, result.Value)
+				}
 			}
 		})
 	}
@@ -109,6 +119,5 @@ func randomUint256() (*Uint256, error) {
 
 	randomUint256 := new(big.Int).Add(r, minUint256) // random is within [minUint256, maxUint256]
 
-	u, err := NewUint256().Set(randomUint256)
-	return u, err
+	return NewUint256().Set(randomUint256)
 }

--- a/swap/types_test.go
+++ b/swap/types_test.go
@@ -109,10 +109,6 @@ func TestCopyUint256(t *testing.T) {
 	if !c.Equals(r) {
 		t.Fatalf("copy of Uint256 %v has an unequal value of %v", r, c)
 	}
-
-	if c == r {
-		t.Fatalf("copy of Uint256 %v shares memory with its base", r)
-	}
 }
 
 func randomUint256() (*Uint256, error) {

--- a/uint256/uint256.go
+++ b/uint256/uint256.go
@@ -1,0 +1,142 @@
+// Copyright 2020 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package uint256
+
+import (
+	"fmt"
+	"io"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// Uint256 represents an unsigned integer of 256 bits
+type Uint256 struct {
+	value big.Int
+}
+
+var minUint256 = big.NewInt(0)
+var maxUint256 = new(big.Int).Sub(new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil), big.NewInt(1)) // 2^256 - 1
+
+// New creates a Uint256 struct with a minimum initial underlying value
+func New() *Uint256 {
+	u := new(Uint256)
+	u.value = *new(big.Int).Set(minUint256)
+	return u
+}
+
+// FromUint64 creates a Uint256 struct based on the given uint64 param
+// any uint64 is valid as a Uint256
+func FromUint64(base uint64) *Uint256 {
+	u := New()
+	u.value = *new(big.Int).SetUint64(base)
+	return u
+}
+
+// Value returns the underlying private value for a Uint256 struct
+func (u *Uint256) Value() big.Int {
+	return u.value
+}
+
+// Set assigns the underlying value of the given Uint256 param to u, and returns the modified receiver struct
+// returns an error when the result falls outside of the unsigned 256-bit integer range
+func (u *Uint256) Set(value big.Int) (*Uint256, error) {
+	if value.Cmp(maxUint256) == 1 {
+		return nil, fmt.Errorf("cannot set Uint256 to %v as it overflows max value of %v", value, maxUint256)
+	}
+	if value.Cmp(minUint256) == -1 {
+		return nil, fmt.Errorf("cannot set Uint256 to %v as it underflows min value of %v", value, minUint256)
+	}
+	u.value = *new(big.Int).Set(&value)
+	return u, nil
+}
+
+// Copy sets the underlying value of u to a copy of the given Uint256 param, and returns the modified receiver struct
+func (u *Uint256) Copy(v *Uint256) *Uint256 {
+	u.value = *new(big.Int).Set(&v.value)
+	return u
+}
+
+// Cmp calls the underlying Cmp method for the big.Int stored in a Uint256 struct as its value field
+func (u *Uint256) Cmp(v *Uint256) int {
+	return u.value.Cmp(&v.value)
+}
+
+// Equals returns true if the two Uint256 structs have the same underlying values, false otherwise
+func (u *Uint256) Equals(v *Uint256) bool {
+	return u.Cmp(v) == 0
+}
+
+// Add sets u to augend + addend and returns u as the sum
+// returns an error when the result falls outside of the unsigned 256-bit integer range
+func (u *Uint256) Add(augend, addend *Uint256) (*Uint256, error) {
+	sum := new(big.Int).Add(&augend.value, &addend.value)
+	return u.Set(*sum)
+}
+
+// Sub sets u to minuend - subtrahend and returns u as the difference
+// returns an error when the result falls outside of the unsigned 256-bit integer range
+func (u *Uint256) Sub(minuend, subtrahend *Uint256) (*Uint256, error) {
+	difference := new(big.Int).Sub(&minuend.value, &subtrahend.value)
+	return u.Set(*difference)
+}
+
+// Mul sets u to multiplicand * multiplier and returns u as the product
+// returns an error when the result falls outside of the unsigned 256-bit integer range
+func (u *Uint256) Mul(multiplicand, multiplier *Uint256) (*Uint256, error) {
+	product := new(big.Int).Mul(&multiplicand.value, &multiplier.value)
+	return u.Set(*product)
+}
+
+// String returns the string representation for Uint256 structs
+func (u *Uint256) String() string {
+	return u.value.String()
+}
+
+// MarshalJSON implements the json.Marshaler interface
+// it specifies how to marshal a Uint256 struct so that it can be written to disk
+func (u Uint256) MarshalJSON() ([]byte, error) {
+	return []byte(u.value.String()), nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface
+// it specifies how to unmarshal a Uint256 struct so that it can be reconstructed from disk
+func (u *Uint256) UnmarshalJSON(b []byte) error {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var value big.Int
+	_, ok := value.SetString(string(b), 10)
+	if !ok {
+		return fmt.Errorf("not a valid integer value: %s", b)
+	}
+	u.value = value
+	return nil
+}
+
+// EncodeRLP implements the rlp.Encoder interface
+// it makes sure the `value` field is encoded even though it is private
+func (u *Uint256) EncodeRLP(w io.Writer) error {
+	return rlp.Encode(w, &u.value)
+}
+
+// DecodeRLP implements the rlp.Decoder interface
+// it makes sure the `value` field is decoded even though it is private
+func (u *Uint256) DecodeRLP(s *rlp.Stream) error {
+	return s.Decode(&u.value)
+}

--- a/uint256/uint256.go
+++ b/uint256/uint256.go
@@ -125,8 +125,8 @@ func (u *Uint256) UnmarshalJSON(b []byte) error {
 	if !ok {
 		return fmt.Errorf("not a valid integer value: %s", b)
 	}
-	u.value = value
-	return nil
+	_, err := u.Set(value)
+	return err
 }
 
 // EncodeRLP implements the rlp.Encoder interface
@@ -138,5 +138,9 @@ func (u *Uint256) EncodeRLP(w io.Writer) error {
 // DecodeRLP implements the rlp.Decoder interface
 // it makes sure the `value` field is decoded even though it is private
 func (u *Uint256) DecodeRLP(s *rlp.Stream) error {
-	return s.Decode(&u.value)
+	if err := s.Decode(&u.value); err != nil {
+		return nil
+	}
+	_, err := u.Set(u.value)
+	return err
 }

--- a/uint256/uint256_test.go
+++ b/uint256/uint256_test.go
@@ -1,4 +1,20 @@
-package swap
+// Copyright 2020 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package uint256
 
 import (
 	"crypto/rand"
@@ -15,8 +31,8 @@ type Uint256TestCase struct {
 	expectsError bool
 }
 
-// TestSetUint256 tests the creation of valid and invalid Uint256 structs by calling the Set function
-func TestSetUint256(t *testing.T) {
+// TestSet tests the creation of valid and invalid Uint256 structs by calling the Set function
+func TestSet(t *testing.T) {
 	testCases := []Uint256TestCase{
 		{
 			name:         "base 0",
@@ -72,15 +88,15 @@ func TestSetUint256(t *testing.T) {
 		},
 	}
 
-	testSetUint256(t, testCases)
+	testSet(t, testCases)
 }
 
-func testSetUint256(t *testing.T, testCases []Uint256TestCase) {
+func testSet(t *testing.T, testCases []Uint256TestCase) {
 	t.Helper()
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := NewUint256().Set(*tc.baseInteger)
+			result, err := New().Set(*tc.baseInteger)
 			if tc.expectsError && err == nil {
 				t.Fatalf("expected error when creating new Uint256, but got none")
 			}
@@ -97,14 +113,14 @@ func testSetUint256(t *testing.T, testCases []Uint256TestCase) {
 	}
 }
 
-// TestCopyUint256 tests the duplication of an existing Uint256 variable
-func TestCopyUint256(t *testing.T) {
+// TestCopy tests the duplication of an existing Uint256 variable
+func TestCopy(t *testing.T) {
 	r, err := randomUint256()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	c := NewUint256().Copy(r)
+	c := New().Copy(r)
 
 	if !c.Equals(r) {
 		t.Fatalf("copy of Uint256 %v has an unequal value of %v", r, c)
@@ -119,11 +135,11 @@ func randomUint256() (*Uint256, error) {
 
 	randomUint256 := new(big.Int).Add(r, minUint256) // random is within [minUint256, maxUint256]
 
-	return NewUint256().Set(*randomUint256)
+	return New().Set(*randomUint256)
 }
 
-// TestUint256Store indirectly tests the marshaling and unmarshaling of a random Uint256 variable
-func TestUint256Store(t *testing.T) {
+// TestStore indirectly tests the marshaling and unmarshaling of a random Uint256 variable
+func TestStore(t *testing.T) {
 	testDir, err := ioutil.TempDir("", "uint256_test_store")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This PR is the first step in implementing issue #1581, which aims at unifying variable types between the SWAP smart contracts and the related code on the go side.

Changes:
- Adds the `Uint256` type. This struct is merely a wrapper around a `big.Int` field, but it operates through functions that change its underlying value while controlling over and underflows.
  - I expect the `Uint64ToUint256` function to be retired once the issue is fully implemented. We should eventually only convert to and from `big.Int` (which is required by the contract bindings) and `Uint256` (or corresponding) types. This should be achieved once all field types are unified.
- Changes the `CumulativePayout` `ChequeParams` field from the `uint64` type to the `*Uint256` type.
  - as a result, the code and/or signature for the `AvailableBalance`, `encodeForSignature`, `verifyChequeAgainstLast`, (`Cheque`'s) `String`, `getLastSentCumulativePayout`, `createCheque`, `handleEmitChequeMsg`, `cashCheque` and `processAndVerifyCheque` functions has been changed as well. 
- Update tests to conform with these changes.