### PR TITLE
tracing: fix Setup function

### DIFF
--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -41,10 +41,12 @@ type Options struct {
 
 func Setup(o Options) {
 	if !o.Enabled {
-		log.Info("Enabling opentracing")
-		Enabled = true
-		Closer = initTracer(o.Endpoint, o.Name)
+		return
 	}
+
+	log.Info("Enabling opentracing")
+	Enabled = true
+	Closer = initTracer(o.Endpoint, o.Name)
 }
 
 func initTracer(endpoint, svc string) (closer io.Closer) {


### PR DESCRIPTION
This PR fixes a regression from https://github.com/ethersphere/swarm/pull/2059 where an incorrect check on enabled is made in tracing Setup function, causing reversed behaviour and rlp message encoding errors.