### PR TITLE
swap: refactor cashout logic to cashout processor

### DIFF
--- a/contracts/swap/swap.go
+++ b/contracts/swap/swap.go
@@ -49,7 +49,7 @@ type Contract interface {
 	Withdraw(auth *bind.TransactOpts, amount *big.Int) (*types.Receipt, error)
 	// Deposit sends a raw transaction to the chequebook, triggering the fallback—depositing amount
 	Deposit(auth *bind.TransactOpts, amout *big.Int) (*types.Receipt, error)
-	// CashChequeBeneficiaryStart sends the transaction to a cash a cheque as the beneficiary
+	// CashChequeBeneficiaryStart sends the transaction to cash a cheque as the beneficiary
 	CashChequeBeneficiaryStart(opts *bind.TransactOpts, beneficiary common.Address, cumulativePayout *big.Int, ownerSig []byte) (*types.Transaction, error)
 	// CashChequeBeneficiaryResult processes the receipt from a CashChequeBeneficiary transaction
 	CashChequeBeneficiaryResult(receipt *types.Receipt) *CashChequeResult

--- a/contracts/swap/swap.go
+++ b/contracts/swap/swap.go
@@ -142,7 +142,7 @@ func (s simpleContract) Deposit(auth *bind.TransactOpts, amount *big.Int) (*type
 	return WaitFunc(auth.Context, s.backend, tx)
 }
 
-// CashChequeBeneficiaryStart sends the transaction to a cash a cheque as the beneficiary
+// CashChequeBeneficiaryStart sends the transaction to cash a cheque as the beneficiary
 func (s simpleContract) CashChequeBeneficiaryStart(opts *bind.TransactOpts, beneficiary common.Address, cumulativePayout *big.Int, ownerSig []byte) (*types.Transaction, error) {
 	tx, err := s.instance.CashChequeBeneficiary(opts, beneficiary, cumulativePayout, ownerSig)
 	if err != nil {

--- a/swap/cashout.go
+++ b/swap/cashout.go
@@ -1,3 +1,18 @@
+// Copyright 2020 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
 package swap
 
 import (

--- a/swap/cashout.go
+++ b/swap/cashout.go
@@ -26,6 +26,9 @@ import (
 	contract "github.com/ethersphere/swarm/contracts/swap"
 )
 
+// CashChequeBeneficiaryTransactionCost is the expected gas cost of a CashChequeBeneficiary transaction
+const CashChequeBeneficiaryTransactionCost = 50000
+
 // CashoutProcessor holds all relevant fields needed for processing cashouts
 type CashoutProcessor struct {
 	backend    contract.Backend  // ethereum backend to use
@@ -93,7 +96,7 @@ func (c *CashoutProcessor) estimatePayout(ctx context.Context, cheque *Cheque) (
 		return 0, 0, err
 	}
 
-	transactionCosts = gasPrice.Uint64() * 50000 // cashing a cheque is approximately 50000 gas
+	transactionCosts = gasPrice.Uint64() * CashChequeBeneficiaryTransactionCost
 
 	if paidOut.Cmp(big.NewInt(int64(cheque.CumulativePayout))) > 0 {
 		return 0, transactionCosts, nil

--- a/swap/cashout_test.go
+++ b/swap/cashout_test.go
@@ -1,0 +1,194 @@
+// Copyright 2020 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package swap
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	contract "github.com/ethersphere/swarm/contracts/swap"
+)
+
+func newSignedTestCheque(testChequeContract common.Address, beneficiaryAddress common.Address, cumulativePayout *big.Int, signingKey *ecdsa.PrivateKey) (*Cheque, error) {
+	cheque := &Cheque{
+		ChequeParams: ChequeParams{
+			Contract:         testChequeContract,
+			CumulativePayout: cumulativePayout.Uint64(),
+			Beneficiary:      beneficiaryAddress,
+		},
+		Honey: cumulativePayout.Uint64(),
+	}
+
+	sig, err := cheque.Sign(signingKey)
+	if err != nil {
+		return nil, err
+	}
+	cheque.Signature = sig
+	return cheque, nil
+}
+
+// TestContractIntegration tests a end-to-end cheque interaction.
+// First a simulated backend is created, then we deploy the issuer's swap contract.
+// We issue a test cheque with the beneficiary address and on the issuer's contract,
+// and immediately try to cash-in the cheque
+// afterwards it attempts to cash-in a bouncing cheque
+func TestContractIntegration(t *testing.T) {
+	backend := newTestBackend(t)
+	reset := setupContractTest()
+	defer reset()
+
+	payout := big.NewInt(42)
+
+	chequebook, err := testDeployWithPrivateKey(context.Background(), backend, ownerKey, ownerAddress, payout)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cheque, err := newSignedTestCheque(chequebook.ContractParams().ContractAddress, beneficiaryAddress, payout, ownerKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	opts := bind.NewKeyedTransactor(beneficiaryKey)
+
+	tx, err := chequebook.CashChequeBeneficiaryStart(opts, beneficiaryAddress, payout, cheque.Signature)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	receipt, err := contract.WaitForTransactionByHash(context.Background(), backend, tx.Hash())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cashResult := chequebook.CashChequeBeneficiaryResult(receipt)
+	if receipt.Status != 1 {
+		t.Fatalf("Bad status %d", receipt.Status)
+	}
+	if cashResult.Bounced {
+		t.Fatal("cashing bounced")
+	}
+
+	// check state, check that cheque is indeed there
+	result, err := chequebook.PaidOut(nil, beneficiaryAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Uint64() != cheque.CumulativePayout {
+		t.Fatalf("Wrong cumulative payout %d", result)
+	}
+	log.Debug("cheques result", "result", result)
+
+	// create a cheque that will bounce
+	bouncingCheque, err := newSignedTestCheque(chequebook.ContractParams().ContractAddress, beneficiaryAddress, payout.Add(payout, big.NewInt(int64(10000*RetrieveRequestPrice))), ownerKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tx, err = chequebook.CashChequeBeneficiaryStart(opts, beneficiaryAddress, big.NewInt(int64(bouncingCheque.CumulativePayout)), bouncingCheque.Signature)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	receipt, err = contract.WaitForTransactionByHash(context.Background(), backend, tx.Hash())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Status != 1 {
+		t.Fatalf("Bad status %d", receipt.Status)
+	}
+
+	cashResult = chequebook.CashChequeBeneficiaryResult(receipt)
+	if !cashResult.Bounced {
+		t.Fatal("cheque did not bounce")
+	}
+
+}
+
+func TestCashCheque(t *testing.T) {
+	backend := newTestBackend(t)
+	reset := setupContractTest()
+	defer reset()
+
+	cashoutProcessor := newCashoutProcessor(backend, ownerKey)
+	payout := big.NewInt(42)
+
+	chequebook, err := testDeployWithPrivateKey(context.Background(), backend, ownerKey, ownerAddress, payout)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCheque, err := newSignedTestCheque(chequebook.ContractParams().ContractAddress, ownerAddress, payout, ownerKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = cashoutProcessor.cashCheque(context.Background(), &CashoutRequest{
+		Cheque:      *testCheque,
+		Destination: ownerAddress,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	paidOut, err := chequebook.PaidOut(nil, ownerAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if paidOut.Cmp(big.NewInt(int64(testCheque.CumulativePayout))) != 0 {
+		t.Fatalf("paidOut does not equal the CumulativePayout: paidOut=%v expected=%v", paidOut, testCheque.CumulativePayout)
+	}
+}
+
+func TestEstimatePayout(t *testing.T) {
+	backend := newTestBackend(t)
+	reset := setupContractTest()
+	defer reset()
+
+	cashoutProcessor := newCashoutProcessor(backend, ownerKey)
+	payout := big.NewInt(42)
+
+	chequebook, err := testDeployWithPrivateKey(context.Background(), backend, ownerKey, ownerAddress, payout)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCheque, err := newSignedTestCheque(chequebook.ContractParams().ContractAddress, ownerAddress, payout, ownerKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedPayout, transactionCost, err := cashoutProcessor.estimatePayout(context.Background(), testCheque)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if expectedPayout != payout.Uint64() {
+		t.Fatalf("unexpected expectedPayout: got %d, wanted: %d", expectedPayout, payout.Uint64())
+	}
+
+	// the gas price in the simulated backend is 1 therefore the total transactionCost should be 50000 * 1 = 50000
+	if transactionCost != 50000 {
+		t.Fatalf("unexpected transactionCost: got %d, wanted: %d", transactionCost, 0)
+	}
+}

--- a/swap/cashout_test.go
+++ b/swap/cashout_test.go
@@ -190,7 +190,7 @@ func TestEstimatePayout(t *testing.T) {
 	}
 
 	// the gas price in the simulated backend is 1 therefore the total transactionCost should be 50000 * 1 = 50000
-	if transactionCost != 50000 {
+	if transactionCost != CashChequeBeneficiaryTransactionCost {
 		t.Fatalf("unexpected transactionCost: got %d, wanted: %d", transactionCost, 0)
 	}
 }

--- a/swap/cashout_test.go
+++ b/swap/cashout_test.go
@@ -124,6 +124,7 @@ func TestContractIntegration(t *testing.T) {
 
 }
 
+// TestCashCheque creates a valid cheque and feeds it to cashoutProcessor.cashCheque
 func TestCashCheque(t *testing.T) {
 	backend := newTestBackend(t)
 	reset := setupContractTest()
@@ -160,6 +161,7 @@ func TestCashCheque(t *testing.T) {
 	}
 }
 
+// TestEstimatePayout creates a valid cheque and feeds it to cashoutProcessor.estimatePayout
 func TestEstimatePayout(t *testing.T) {
 	backend := newTestBackend(t)
 	reset := setupContractTest()

--- a/swap/config.go
+++ b/swap/config.go
@@ -34,5 +34,6 @@ const (
 	// The smart-contract allows for setting this variable differently per beneficiary
 	defaultHarddepositTimeoutDuration = 24 * time.Hour
 	// Until we deploy swap officially, it's only allowed to be enabled under a specific network ID (use the --bzznetworkid flag to set it)
-	AllowedNetworkID = 5
+	AllowedNetworkID          = 5
+	DefaultTransactionTimeout = 10 * time.Minute
 )

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -66,6 +66,7 @@ type Swap struct {
 	contract          contract.Contract          // reference to the smart contract
 	chequebookFactory contract.SimpleSwapFactory // the chequebook factory used
 	honeyPriceOracle  HoneyOracle                // oracle which resolves the price of honey (in Wei)
+	cashoutProcessor  *CashoutProcessor          // processor for cashing out
 }
 
 // Owner encapsulates information related to accessing the contract
@@ -144,6 +145,7 @@ func newSwapInstance(stateStore state.Store, owner *Owner, backend contract.Back
 		chequebookFactory: chequebookFactory,
 		honeyPriceOracle:  NewHoneyPriceOracle(),
 		chainID:           chainID,
+		cashoutProcessor:  newCashoutProcessor(backend, owner.privateKey),
 	}
 }
 
@@ -433,27 +435,14 @@ func (s *Swap) handleEmitChequeMsg(ctx context.Context, p *Peer, msg *EmitCheque
 		return err
 	}
 
-	otherSwap, err := contract.InstanceAt(cheque.Contract, s.backend)
+	expectedPayout, transactionCosts, err := s.cashoutProcessor.estimatePayout(context.TODO(), cheque)
 	if err != nil {
-		log.Error("error getting contract", "err", err)
 		return err
 	}
 
-	gasPrice, err := s.backend.SuggestGasPrice(context.TODO())
-	if err != nil {
-		return err
-	}
-	transactionCosts := gasPrice.Uint64() * 50000 // cashing a cheque is approximately 50000 gas
-	paidOut, err := otherSwap.PaidOut(nil, cheque.Beneficiary)
-	if err != nil {
-		return err
-	}
 	// do a payout transaction if we get 2 times the gas costs
-	if (cheque.CumulativePayout - paidOut.Uint64()) > 2*transactionCosts {
-		opts := bind.NewKeyedTransactor(s.owner.privateKey)
-		opts.Context = ctx
-		// cash cheque in async, otherwise this blocks here until the TX is mined
-		go defaultCashCheque(s, otherSwap, opts, cheque)
+	if expectedPayout > 2*transactionCosts {
+		go defaultCashCheque(s, cheque)
 	}
 
 	return err
@@ -489,26 +478,15 @@ func (s *Swap) handleConfirmChequeMsg(ctx context.Context, p *Peer, msg *Confirm
 
 // cashCheque should be called async as it blocks until the transaction(s) are mined
 // The function cashes the cheque by sending it to the blockchain
-func cashCheque(s *Swap, otherSwap contract.Contract, opts *bind.TransactOpts, cheque *Cheque) {
-	// blocks here, as we are waiting for the transaction to be mined
-	result, receipt, err := otherSwap.CashChequeBeneficiary(opts, s.GetParams().ContractAddress, big.NewInt(int64(cheque.CumulativePayout)), cheque.Signature)
+func cashCheque(s *Swap, cheque *Cheque) {
+	err := s.cashoutProcessor.cashCheque(context.Background(), &CashoutRequest{
+		Cheque:      *cheque,
+		Destination: s.GetParams().ContractAddress,
+	})
+
 	if err != nil {
-		// TODO: do something with the error
-		// and we actually need to log this error as we are in an async routine; nobody is handling this error for now
-		swapLog.Error("error cashing cheque", "err", err)
-		return
+		swapLog.Error(err.Error())
 	}
-
-	metrics.GetOrRegisterCounter("swap.cheques.cashed.honey", nil).Inc(result.TotalPayout.Int64())
-
-	if result.Bounced {
-		metrics.GetOrRegisterCounter("swap.cheques.cashed.bounced", nil).Inc(1)
-		swapLog.Warn("cheque bounced", "tx", receipt.TxHash)
-		return
-		// TODO: do something here
-	}
-
-	swapLog.Debug("cash tx mined", "receipt", receipt)
 }
 
 // processAndVerifyCheque verifies the cheque and compares it with the last received cheque

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -485,6 +485,7 @@ func cashCheque(s *Swap, cheque *Cheque) {
 	})
 
 	if err != nil {
+		metrics.GetOrRegisterCounter("swap.cheques.cashed.errors", nil).Inc(1)
 		swapLog.Error(err.Error())
 	}
 }

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -51,8 +51,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/simulations/adapters"
 	"github.com/ethereum/go-ethereum/rpc"
 	contractFactory "github.com/ethersphere/go-sw3/contracts-v0-2-0/simpleswapfactory"
-	"github.com/ethersphere/swarm/contracts/swap"
-	contract "github.com/ethersphere/swarm/contracts/swap"
 	cswap "github.com/ethersphere/swarm/contracts/swap"
 	"github.com/ethersphere/swarm/p2p/protocols"
 	"github.com/ethersphere/swarm/state"
@@ -512,7 +510,7 @@ func TestStartChequebookFailure(t *testing.T) {
 			name: "with wrong pass in",
 			configure: func(config *chequebookConfig) {
 				config.passIn = common.HexToAddress("0x4405415b2B8c9F9aA83E151637B8370000000000") // address without deployed chequebook
-				config.expectedError = fmt.Errorf("contract validation for %v failed: %v", config.passIn.Hex(), swap.ErrNotDeployedByFactory)
+				config.expectedError = fmt.Errorf("contract validation for %v failed: %v", config.passIn.Hex(), cswap.ErrNotDeployedByFactory)
 			},
 			check: func(t *testing.T, config *chequebookConfig) {
 				// create SWAP
@@ -1173,7 +1171,7 @@ func testWaitForTx(ctx context.Context, backend cswap.Backend, tx *types.Transac
 }
 
 // deploy for testing (needs simulated backend commit)
-func testDeployWithPrivateKey(ctx context.Context, backend swap.Backend, privateKey *ecdsa.PrivateKey, ownerAddress common.Address, depositAmount *big.Int) (contract.Contract, error) {
+func testDeployWithPrivateKey(ctx context.Context, backend cswap.Backend, privateKey *ecdsa.PrivateKey, ownerAddress common.Address, depositAmount *big.Int) (cswap.Contract, error) {
 	opts := bind.NewKeyedTransactor(privateKey)
 	opts.Context = ctx
 

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -1152,105 +1152,6 @@ func TestFactoryVerifySelf(t *testing.T) {
 	}
 }
 
-// TestContractIntegration tests a end-to-end cheque interaction.
-// First a simulated backend is created, then we deploy the issuer's swap contract.
-// We issue a test cheque with the beneficiary address and on the issuer's contract,
-// and immediately try to cash-in the cheque
-// afterwards it attempts to cash-in a bouncing cheque
-func TestContractIntegration(t *testing.T) {
-	log.Debug("creating test swap")
-
-	issuerSwap, clean := newTestSwap(t, ownerKey, nil)
-	defer clean()
-
-	issuerSwap.owner.address = ownerAddress
-	issuerSwap.owner.privateKey = ownerKey
-
-	log.Debug("deploy issuer swap")
-
-	cheque := newTestCheque()
-
-	ctx := context.TODO()
-	err := testDeploy(ctx, issuerSwap, big.NewInt(int64(cheque.CumulativePayout)))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	log.Debug("deployed. signing cheque")
-	cheque.ChequeParams.Contract = issuerSwap.GetParams().ContractAddress
-	cheque.Signature, err = cheque.Sign(issuerSwap.owner.privateKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	log.Debug("sending cheque...")
-
-	// setup the wait for mined transaction function for testing
-	cleanup := setupContractTest()
-	defer cleanup()
-
-	opts := bind.NewKeyedTransactor(beneficiaryKey)
-	opts.Context = ctx
-
-	log.Debug("cash-in the cheque")
-
-	tx, err := issuerSwap.contract.CashChequeBeneficiaryStart(opts, beneficiaryAddress, big.NewInt(int64(cheque.CumulativePayout)), cheque.Signature)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	receipt, err := contract.WaitForTransactionByHash(ctx, issuerSwap.backend, tx.Hash())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cashResult := issuerSwap.contract.CashChequeBeneficiaryResult(receipt)
-	if receipt.Status != 1 {
-		t.Fatalf("Bad status %d", receipt.Status)
-	}
-	if cashResult.Bounced {
-		t.Fatal("cashing bounced")
-	}
-
-	// check state, check that cheque is indeed there
-	result, err := issuerSwap.contract.PaidOut(nil, beneficiaryAddress)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if result.Uint64() != cheque.CumulativePayout {
-		t.Fatalf("Wrong cumulative payout %d", result)
-	}
-	log.Debug("cheques result", "result", result)
-
-	// create a cheque that will bounce
-	bouncingCheque := newTestCheque()
-	bouncingCheque.ChequeParams.Contract = issuerSwap.GetParams().ContractAddress
-	bouncingCheque.CumulativePayout = bouncingCheque.CumulativePayout + 10000*RetrieveRequestPrice
-	bouncingCheque.Signature, err = bouncingCheque.Sign(issuerSwap.owner.privateKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	log.Debug("try to cash-in the bouncing cheque")
-	tx, err = issuerSwap.contract.CashChequeBeneficiaryStart(opts, beneficiaryAddress, big.NewInt(int64(bouncingCheque.CumulativePayout)), bouncingCheque.Signature)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	receipt, err = contract.WaitForTransactionByHash(ctx, issuerSwap.backend, tx.Hash())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if receipt.Status != 1 {
-		t.Fatalf("Bad status %d", receipt.Status)
-	}
-
-	cashResult = issuerSwap.contract.CashChequeBeneficiaryResult(receipt)
-	if !cashResult.Bounced {
-		t.Fatal("cheque did not bounce")
-	}
-}
-
 // when testing, we don't need to wait for a transaction to be mined
 func testWaitForTx(ctx context.Context, backend cswap.Backend, tx *types.Transaction) (*types.Receipt, error) {
 
@@ -1272,51 +1173,57 @@ func testWaitForTx(ctx context.Context, backend cswap.Backend, tx *types.Transac
 }
 
 // deploy for testing (needs simulated backend commit)
-func testDeploy(ctx context.Context, swap *Swap, depositAmount *big.Int) (err error) {
-	opts := bind.NewKeyedTransactor(swap.owner.privateKey)
+func testDeployWithPrivateKey(ctx context.Context, backend swap.Backend, privateKey *ecdsa.PrivateKey, ownerAddress common.Address, depositAmount *big.Int) (contract.Contract, error) {
+	opts := bind.NewKeyedTransactor(privateKey)
 	opts.Context = ctx
 
 	var stb *swapTestBackend
 	var ok bool
-	if stb, ok = swap.backend.(*swapTestBackend); !ok {
-		return errors.New("not the expected test backend")
+	if stb, ok = backend.(*swapTestBackend); !ok {
+		return nil, errors.New("not the expected test backend")
 	}
 
 	factory, err := cswap.FactoryAt(stb.factoryAddress, stb)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// setup the wait for mined transaction function for testing
 	cleanup := setupContractTest()
 	defer cleanup()
-	swap.contract, err = factory.DeploySimpleSwap(opts, swap.owner.address, big.NewInt(int64(defaultHarddepositTimeoutDuration)))
+	contract, err := factory.DeploySimpleSwap(opts, ownerAddress, big.NewInt(int64(defaultHarddepositTimeoutDuration)))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	stb.Commit()
 
 	// send money into the new chequebook
 	token, err := contractFactory.NewERC20Mintable(stb.tokenAddress, stb)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	tx, err := token.Mint(bind.NewKeyedTransactor(ownerKey), swap.contract.ContractParams().ContractAddress, depositAmount)
+	tx, err := token.Mint(bind.NewKeyedTransactor(ownerKey), contract.ContractParams().ContractAddress, depositAmount)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	stb.Commit()
 	receipt, err := stb.TransactionReceipt(ctx, tx.Hash())
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if receipt.Status != 1 {
-		return errors.New("token transfer reverted")
+		return nil, errors.New("token transfer reverted")
 	}
 
-	return nil
+	return contract, nil
+}
+
+// deploy for testing (needs simulated backend commit)
+func testDeploy(ctx context.Context, swap *Swap, depositAmount *big.Int) (err error) {
+	swap.contract, err = testDeployWithPrivateKey(ctx, swap.backend, swap.owner.privateKey, swap.owner.address, depositAmount)
+	return err
 }
 
 // newTestSwapAndPeer is a helper function to create a swap and a peer instance that fit together


### PR DESCRIPTION
This PR moves most of the cashout related logic into its own file (`cashout.go`) and onto its own receiver (`CashoutProcessor`) and splits `CashChequeBeneficiary` (in the `contract` package) into `CashChequeBeneficiaryStart` and `CashChequeBeneficiaryResult`.

This by itself does not change any functionality. The changes made here are primarily to make implementing a proper cashout queue easier (as the PR for that was getting out of hand in terms of complexity). The `CashoutProcessor` was introduced as the responsibilities of the `Swap` struct are already huge and cashing is orthogonal to the rest of the swap logic.

This PR introduces several structs and passes them around instead of individual parameters. The reasoning behind this is that in a later PR this structs will be persisted to the local store to allow queueing wand waiting fo cashouts across client restarts.

In addition this PR also:
* puts the payout and cost estimation into its own `estimatePayout` function
* introduces a maximum wait time for a transaction (`DefaultTransactionTimeout`)
* introduces a test helper `testDeployWithPrivateKey` to make tests which don't need the full swap easier
* introduces a test helper `newSignedTestCheque` to make creating signed cheques for tests easier