### PR TITLE
swap: make Uint256 value field private and non-pointer

### DIFF
--- a/swap/api.go
+++ b/swap/api.go
@@ -78,7 +78,7 @@ func (s *Swap) AvailableBalance() (*Uint256, error) {
 		} else {
 			continue
 		}
-		sentChequesWorth.Add(sentChequesWorth, sentCheque.ChequeParams.CumulativePayout.Value)
+		sentChequesWorth.Add(sentChequesWorth, &sentCheque.ChequeParams.CumulativePayout.Value)
 		paidOut, err := s.contract.PaidOut(nil, sentCheque.ChequeParams.Beneficiary)
 		if err != nil {
 			return nil, err

--- a/swap/api.go
+++ b/swap/api.go
@@ -78,7 +78,8 @@ func (s *Swap) AvailableBalance() (*Uint256, error) {
 		} else {
 			continue
 		}
-		sentChequesWorth.Add(sentChequesWorth, sentCheque.ChequeParams.CumulativePayout.Value())
+		cumulativePayout := sentCheque.ChequeParams.CumulativePayout.Value()
+		sentChequesWorth.Add(sentChequesWorth, &cumulativePayout)
 		paidOut, err := s.contract.PaidOut(nil, sentCheque.ChequeParams.Beneficiary)
 		if err != nil {
 			return nil, err
@@ -89,7 +90,7 @@ func (s *Swap) AvailableBalance() (*Uint256, error) {
 	totalChequesWorth := new(big.Int).Sub(cashedChequesWorth, sentChequesWorth)
 	tentativeLiquidBalance := new(big.Int).Add(contractLiquidBalance, totalChequesWorth)
 
-	return NewUint256().Set(tentativeLiquidBalance)
+	return NewUint256().Set(*tentativeLiquidBalance)
 }
 
 // PeerBalance returns the balance for a given peer

--- a/swap/api.go
+++ b/swap/api.go
@@ -78,7 +78,7 @@ func (s *Swap) AvailableBalance() (*Uint256, error) {
 		} else {
 			continue
 		}
-		sentChequesWorth.Add(sentChequesWorth, &sentCheque.ChequeParams.CumulativePayout.Value)
+		sentChequesWorth.Add(sentChequesWorth, sentCheque.ChequeParams.CumulativePayout.Value())
 		paidOut, err := s.contract.PaidOut(nil, sentCheque.ChequeParams.Beneficiary)
 		if err != nil {
 			return nil, err

--- a/swap/cheque.go
+++ b/swap/cheque.go
@@ -30,7 +30,8 @@ func (cheque *ChequeParams) encodeForSignature() []byte {
 	cumulativePayoutBytes := make([]byte, 32)
 	// we need to write the last 8 bytes as we write a uint64 into a 32-byte array
 	// encoded in BigEndian because EVM uses BigEndian encoding
-	chequePayoutBytes := cheque.CumulativePayout.Value().Bytes()
+	cumulativePayout := cheque.CumulativePayout.Value()
+	chequePayoutBytes := (&cumulativePayout).Bytes()
 	copy(cumulativePayoutBytes[32-len(chequePayoutBytes):], chequePayoutBytes)
 
 	// construct the actual cheque

--- a/swap/cheque.go
+++ b/swap/cheque.go
@@ -30,7 +30,7 @@ func (cheque *ChequeParams) encodeForSignature() []byte {
 	cumulativePayoutBytes := make([]byte, 32)
 	// we need to write the last 8 bytes as we write a uint64 into a 32-byte array
 	// encoded in BigEndian because EVM uses BigEndian encoding
-	chequePayoutBytes := cheque.CumulativePayout.Value.Bytes()
+	chequePayoutBytes := cheque.CumulativePayout.Value().Bytes()
 	copy(cumulativePayoutBytes[32-len(chequePayoutBytes):], chequePayoutBytes)
 
 	// construct the actual cheque

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -247,7 +247,7 @@ func TestEmitCheque(t *testing.T) {
 	// cheque should be sent if the accumulated amount of uncashed cheques is worth more than 100000
 	balance := Uint64ToUint256(100001)
 
-	if err := testDeploy(context.Background(), debitorSwap, &balance.Value); err != nil {
+	if err := testDeploy(context.Background(), debitorSwap, balance.Value()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -260,7 +260,7 @@ func TestEmitCheque(t *testing.T) {
 
 	debitor := creditorSwap.getPeer(protocolTester.Nodes[0].ID())
 	// set balance artificially
-	if err = debitor.setBalance(balance.Value.Int64()); err != nil {
+	if err = debitor.setBalance(balance.Value().Int64()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -275,7 +275,7 @@ func TestEmitCheque(t *testing.T) {
 			Beneficiary:      creditorSwap.owner.address,
 			CumulativePayout: balance,
 		},
-		Honey: balance.Value.Uint64(),
+		Honey: balance.Value().Uint64(),
 	}
 	cheque.Signature, err = cheque.Sign(debitorSwap.owner.privateKey)
 	if err != nil {

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -246,8 +246,9 @@ func TestEmitCheque(t *testing.T) {
 	// estimated gas costs == 50000
 	// cheque should be sent if the accumulated amount of uncashed cheques is worth more than 100000
 	balance := Uint64ToUint256(100001)
+	balanceValue := balance.Value()
 
-	if err := testDeploy(context.Background(), debitorSwap, balance.Value()); err != nil {
+	if err := testDeploy(context.Background(), debitorSwap, &balanceValue); err != nil {
 		t.Fatal(err)
 	}
 
@@ -260,7 +261,7 @@ func TestEmitCheque(t *testing.T) {
 
 	debitor := creditorSwap.getPeer(protocolTester.Nodes[0].ID())
 	// set balance artificially
-	if err = debitor.setBalance(balance.Value().Int64()); err != nil {
+	if err = debitor.setBalance(balanceValue.Int64()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -275,7 +276,7 @@ func TestEmitCheque(t *testing.T) {
 			Beneficiary:      creditorSwap.owner.address,
 			CumulativePayout: balance,
 		},
-		Honey: balance.Value().Uint64(),
+		Honey: balanceValue.Uint64(),
 	}
 	cheque.Signature, err = cheque.Sign(debitorSwap.owner.privateKey)
 	if err != nil {

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -247,7 +247,7 @@ func TestEmitCheque(t *testing.T) {
 	// cheque should be sent if the accumulated amount of uncashed cheques is worth more than 100000
 	balance := Uint64ToUint256(100001)
 
-	if err := testDeploy(context.Background(), debitorSwap, balance.Value); err != nil {
+	if err := testDeploy(context.Background(), debitorSwap, &balance.Value); err != nil {
 		t.Fatal(err)
 	}
 

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -485,7 +485,7 @@ func (s *Swap) handleConfirmChequeMsg(ctx context.Context, p *Peer, msg *Confirm
 // The function cashes the cheque by sending it to the blockchain
 func cashCheque(s *Swap, otherSwap contract.Contract, opts *bind.TransactOpts, cheque *Cheque) {
 	// blocks here, as we are waiting for the transaction to be mined
-	result, receipt, err := otherSwap.CashChequeBeneficiary(opts, s.GetParams().ContractAddress, &cheque.CumulativePayout.Value, cheque.Signature)
+	result, receipt, err := otherSwap.CashChequeBeneficiary(opts, s.GetParams().ContractAddress, cheque.CumulativePayout.Value(), cheque.Signature)
 	if err != nil {
 		// TODO: do something with the error
 		// and we actually need to log this error as we are in an async routine; nobody is handling this error for now

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -485,7 +485,7 @@ func (s *Swap) handleConfirmChequeMsg(ctx context.Context, p *Peer, msg *Confirm
 // The function cashes the cheque by sending it to the blockchain
 func cashCheque(s *Swap, otherSwap contract.Contract, opts *bind.TransactOpts, cheque *Cheque) {
 	// blocks here, as we are waiting for the transaction to be mined
-	result, receipt, err := otherSwap.CashChequeBeneficiary(opts, s.GetParams().ContractAddress, cheque.CumulativePayout.Value, cheque.Signature)
+	result, receipt, err := otherSwap.CashChequeBeneficiary(opts, s.GetParams().ContractAddress, &cheque.CumulativePayout.Value, cheque.Signature)
 	if err != nil {
 		// TODO: do something with the error
 		// and we actually need to log this error as we are in an async routine; nobody is handling this error for now

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -432,7 +432,7 @@ func (s *Swap) handleEmitChequeMsg(ctx context.Context, p *Peer, msg *EmitCheque
 		return err
 	}
 
-	castedPaidOut, err := NewUint256().Set(paidOut)
+	castedPaidOut, err := NewUint256().Set(*paidOut)
 	if err != nil {
 		return err
 	}
@@ -485,7 +485,8 @@ func (s *Swap) handleConfirmChequeMsg(ctx context.Context, p *Peer, msg *Confirm
 // The function cashes the cheque by sending it to the blockchain
 func cashCheque(s *Swap, otherSwap contract.Contract, opts *bind.TransactOpts, cheque *Cheque) {
 	// blocks here, as we are waiting for the transaction to be mined
-	result, receipt, err := otherSwap.CashChequeBeneficiary(opts, s.GetParams().ContractAddress, cheque.CumulativePayout.Value(), cheque.Signature)
+	cumulativePayout := cheque.CumulativePayout.Value()
+	result, receipt, err := otherSwap.CashChequeBeneficiary(opts, s.GetParams().ContractAddress, &cumulativePayout, cheque.Signature)
 	if err != nil {
 		// TODO: do something with the error
 		// and we actually need to log this error as we are in an async routine; nobody is handling this error for now

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -1170,7 +1170,8 @@ func TestContractIntegration(t *testing.T) {
 	cheque := newTestCheque()
 
 	ctx := context.TODO()
-	err := testDeploy(ctx, issuerSwap, cheque.CumulativePayout.Value())
+	cumulativePayout := cheque.CumulativePayout.Value()
+	err := testDeploy(ctx, issuerSwap, &cumulativePayout)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1193,7 +1194,8 @@ func TestContractIntegration(t *testing.T) {
 
 	log.Debug("cash-in the cheque")
 
-	cashResult, receipt, err := issuerSwap.contract.CashChequeBeneficiary(opts, beneficiaryAddress, cheque.CumulativePayout.Value(), cheque.Signature)
+	cumulativePayout = cheque.CumulativePayout.Value()
+	cashResult, receipt, err := issuerSwap.contract.CashChequeBeneficiary(opts, beneficiaryAddress, &cumulativePayout, cheque.Signature)
 
 	if err != nil {
 		t.Fatal(err)
@@ -1210,7 +1212,7 @@ func TestContractIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	castedResult, err := NewUint256().Set(result)
+	castedResult, err := NewUint256().Set(*result)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1232,7 +1234,8 @@ func TestContractIntegration(t *testing.T) {
 	}
 
 	log.Debug("try to cash-in the bouncing cheque")
-	cashResult, receipt, err = issuerSwap.contract.CashChequeBeneficiary(opts, beneficiaryAddress, bouncingCheque.CumulativePayout.Value(), bouncingCheque.Signature)
+	cumulativePayout = bouncingCheque.CumulativePayout.Value()
+	cashResult, receipt, err = issuerSwap.contract.CashChequeBeneficiary(opts, beneficiaryAddress, &cumulativePayout, bouncingCheque.Signature)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -1170,7 +1170,7 @@ func TestContractIntegration(t *testing.T) {
 	cheque := newTestCheque()
 
 	ctx := context.TODO()
-	err := testDeploy(ctx, issuerSwap, cheque.CumulativePayout.Value)
+	err := testDeploy(ctx, issuerSwap, &cheque.CumulativePayout.Value)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1193,7 +1193,7 @@ func TestContractIntegration(t *testing.T) {
 
 	log.Debug("cash-in the cheque")
 
-	cashResult, receipt, err := issuerSwap.contract.CashChequeBeneficiary(opts, beneficiaryAddress, cheque.CumulativePayout.Value, cheque.Signature)
+	cashResult, receipt, err := issuerSwap.contract.CashChequeBeneficiary(opts, beneficiaryAddress, &cheque.CumulativePayout.Value, cheque.Signature)
 
 	if err != nil {
 		t.Fatal(err)
@@ -1232,7 +1232,7 @@ func TestContractIntegration(t *testing.T) {
 	}
 
 	log.Debug("try to cash-in the bouncing cheque")
-	cashResult, receipt, err = issuerSwap.contract.CashChequeBeneficiary(opts, beneficiaryAddress, bouncingCheque.CumulativePayout.Value, bouncingCheque.Signature)
+	cashResult, receipt, err = issuerSwap.contract.CashChequeBeneficiary(opts, beneficiaryAddress, &bouncingCheque.CumulativePayout.Value, bouncingCheque.Signature)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -1170,7 +1170,7 @@ func TestContractIntegration(t *testing.T) {
 	cheque := newTestCheque()
 
 	ctx := context.TODO()
-	err := testDeploy(ctx, issuerSwap, &cheque.CumulativePayout.Value)
+	err := testDeploy(ctx, issuerSwap, cheque.CumulativePayout.Value())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1193,7 +1193,7 @@ func TestContractIntegration(t *testing.T) {
 
 	log.Debug("cash-in the cheque")
 
-	cashResult, receipt, err := issuerSwap.contract.CashChequeBeneficiary(opts, beneficiaryAddress, &cheque.CumulativePayout.Value, cheque.Signature)
+	cashResult, receipt, err := issuerSwap.contract.CashChequeBeneficiary(opts, beneficiaryAddress, cheque.CumulativePayout.Value(), cheque.Signature)
 
 	if err != nil {
 		t.Fatal(err)
@@ -1232,7 +1232,7 @@ func TestContractIntegration(t *testing.T) {
 	}
 
 	log.Debug("try to cash-in the bouncing cheque")
-	cashResult, receipt, err = issuerSwap.contract.CashChequeBeneficiary(opts, beneficiaryAddress, &bouncingCheque.CumulativePayout.Value, bouncingCheque.Signature)
+	cashResult, receipt, err = issuerSwap.contract.CashChequeBeneficiary(opts, beneficiaryAddress, bouncingCheque.CumulativePayout.Value(), bouncingCheque.Signature)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swap/types.go
+++ b/swap/types.go
@@ -98,8 +98,7 @@ func (u *Uint256) Set(value big.Int) (*Uint256, error) {
 
 // Copy sets the underlying value of u to a copy of the given Uint256 param, and returns the modified receiver struct
 func (u *Uint256) Copy(v *Uint256) *Uint256 {
-	valueCopy := new(big.Int).Set(&v.value)
-	u.value = *valueCopy
+	u.value = v.value
 	return u
 }
 

--- a/swap/types.go
+++ b/swap/types.go
@@ -18,9 +18,11 @@ package swap
 
 import (
 	"fmt"
+	"io"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
 // ChequeParams encapsulate all cheque parameters
@@ -156,4 +158,12 @@ func (u *Uint256) UnmarshalJSON(b []byte) error {
 	}
 	u.value = value
 	return nil
+}
+
+func (u *Uint256) EncodeRLP(w io.Writer) error {
+	return rlp.Encode(w, &u.value)
+}
+
+func (u *Uint256) DecodeRLP(s *rlp.Stream) error {
+	return s.Decode(&u.value)
 }

--- a/swap/types.go
+++ b/swap/types.go
@@ -63,7 +63,7 @@ type Uint256 struct {
 var minUint256 = big.NewInt(0)
 var maxUint256 = new(big.Int).Sub(new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil), big.NewInt(1)) // 2^256 - 1
 
-// NewUint256 creates a Uint256 struct with an initial underlying value of 0
+// NewUint256 creates a Uint256 struct with a minimum initial underlying value
 func NewUint256() *Uint256 {
 	u := new(Uint256)
 	u.value = *minUint256

--- a/swap/types.go
+++ b/swap/types.go
@@ -137,3 +137,23 @@ func (u *Uint256) Mul(multiplicand, multiplier *Uint256) (*Uint256, error) {
 func (u *Uint256) String() string {
 	return u.value.String()
 }
+
+// MarshalJSON specifies how to marshal a Uint256 struct so that it can be written to disk
+func (u Uint256) MarshalJSON() ([]byte, error) {
+	return []byte(u.Value().String()), nil
+}
+
+// UnmarshalJSON specifies how to unmarshal a Uint256 struct so that it can be reconstructed from disk
+func (u *Uint256) UnmarshalJSON(b []byte) error {
+	if string(b) == "null" {
+		return nil
+	}
+
+	var value big.Int
+	_, ok := value.SetString(string(b), 10)
+	if !ok {
+		return fmt.Errorf("not a valid integer value: %s", b)
+	}
+	u.value = value
+	return nil
+}

--- a/swap/types.go
+++ b/swap/types.go
@@ -140,12 +140,14 @@ func (u *Uint256) String() string {
 	return u.value.String()
 }
 
-// MarshalJSON specifies how to marshal a Uint256 struct so that it can be written to disk
+// MarshalJSON implements the json.Marshaler interface
+// it specifies how to marshal a Uint256 struct so that it can be written to disk
 func (u Uint256) MarshalJSON() ([]byte, error) {
 	return []byte(u.Value().String()), nil
 }
 
-// UnmarshalJSON specifies how to unmarshal a Uint256 struct so that it can be reconstructed from disk
+// UnmarshalJSON implements the json.Unmarshaler interface
+// it specifies how to unmarshal a Uint256 struct so that it can be reconstructed from disk
 func (u *Uint256) UnmarshalJSON(b []byte) error {
 	if string(b) == "null" {
 		return nil
@@ -160,10 +162,14 @@ func (u *Uint256) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// EncodeRLP implements the rlp.Encoder interface
+// it makes sure the `value` field is encoded even though it is private
 func (u *Uint256) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, &u.value)
 }
 
+// DecodeRLP implements the rlp.Decoder interface
+// it makes sure the `value` field is decoded even though it is private
 func (u *Uint256) DecodeRLP(s *rlp.Stream) error {
 	return s.Decode(&u.value)
 }

--- a/swap/types.go
+++ b/swap/types.go
@@ -55,7 +55,7 @@ type ConfirmChequeMsg struct {
 
 // Uint256 represents an unsigned integer of 256 bits
 type Uint256 struct {
-	Value big.Int
+	value big.Int
 }
 
 var minUint256 = big.NewInt(0)
@@ -65,7 +65,7 @@ var maxUint256 = new(big.Int).Sub(new(big.Int).Exp(big.NewInt(2), big.NewInt(256
 // no Uint256 should have a nil pointer as its value field
 func NewUint256() *Uint256 {
 	u := new(Uint256)
-	u.Value = *minUint256
+	u.value = *minUint256
 	return u
 }
 
@@ -73,8 +73,13 @@ func NewUint256() *Uint256 {
 // any uint64 is valid as a Uint256
 func Uint64ToUint256(base uint64) *Uint256 {
 	u := NewUint256()
-	u.Value = *new(big.Int).SetUint64(base)
+	u.value = *new(big.Int).SetUint64(base)
 	return u
+}
+
+// Value returns the underlying private value for a Uint256 struct
+func (u *Uint256) Value() *big.Int {
+	return &u.value
 }
 
 // Set assigns the underlying value of the given Uint256 param to u, and returns the modified receiver struct
@@ -86,20 +91,20 @@ func (u *Uint256) Set(value *big.Int) (*Uint256, error) {
 	if value.Cmp(minUint256) == -1 {
 		return nil, fmt.Errorf("cannot set Uint256 to %v as it underflows min value of %v", value, minUint256)
 	}
-	u.Value = *value
+	u.value = *value
 	return u, nil
 }
 
 // Copy sets the underlying value of u to a copy of the given Uint256 param, and returns the modified receiver struct
 func (u *Uint256) Copy(v *Uint256) *Uint256 {
-	valueCopy := new(big.Int).Set(&v.Value)
-	u.Value = *valueCopy
+	valueCopy := new(big.Int).Set(v.Value())
+	u.value = *valueCopy
 	return u
 }
 
 // Cmp calls the underlying Cmp method for the big.Int stored in a Uint256 struct as its value field
 func (u *Uint256) Cmp(v *Uint256) int {
-	return u.Value.Cmp(&v.Value)
+	return u.value.Cmp(v.Value())
 }
 
 // Equals returns true if the two Uint256 structs have the same underlying values, false otherwise
@@ -110,25 +115,25 @@ func (u *Uint256) Equals(v *Uint256) bool {
 // Add sets u to augend + addend and returns u as the sum
 // returns an error when the result falls outside of the unsigned 256-bit integer range
 func (u *Uint256) Add(augend, addend *Uint256) (*Uint256, error) {
-	sum := new(big.Int).Add(&augend.Value, &addend.Value)
+	sum := new(big.Int).Add(augend.Value(), addend.Value())
 	return u.Set(sum)
 }
 
 // Sub sets u to minuend - subtrahend and returns u as the difference
 // returns an error when the result falls outside of the unsigned 256-bit integer range
 func (u *Uint256) Sub(minuend, subtrahend *Uint256) (*Uint256, error) {
-	difference := new(big.Int).Sub(&minuend.Value, &subtrahend.Value)
+	difference := new(big.Int).Sub(minuend.Value(), subtrahend.Value())
 	return u.Set(difference)
 }
 
 // Mul sets u to multiplicand * multiplier and returns u as the product
 // returns an error when the result falls outside of the unsigned 256-bit integer range
 func (u *Uint256) Mul(multiplicand, multiplier *Uint256) (*Uint256, error) {
-	product := new(big.Int).Mul(&multiplicand.Value, &multiplier.Value)
+	product := new(big.Int).Mul(multiplicand.Value(), multiplier.Value())
 	return u.Set(product)
 }
 
 // String returns the string representation for Uint256 structs
 func (u *Uint256) String() string {
-	return u.Value.String()
+	return u.value.String()
 }

--- a/swap/types.go
+++ b/swap/types.go
@@ -55,7 +55,7 @@ type ConfirmChequeMsg struct {
 
 // Uint256 represents an unsigned integer of 256 bits
 type Uint256 struct {
-	Value *big.Int
+	Value big.Int
 }
 
 var minUint256 = big.NewInt(0)
@@ -65,7 +65,7 @@ var maxUint256 = new(big.Int).Sub(new(big.Int).Exp(big.NewInt(2), big.NewInt(256
 // no Uint256 should have a nil pointer as its value field
 func NewUint256() *Uint256 {
 	u := new(Uint256)
-	u.Value = minUint256
+	u.Value = *minUint256
 	return u
 }
 
@@ -73,7 +73,7 @@ func NewUint256() *Uint256 {
 // any uint64 is valid as a Uint256
 func Uint64ToUint256(base uint64) *Uint256 {
 	u := NewUint256()
-	u.Value = new(big.Int).SetUint64(base)
+	u.Value = *new(big.Int).SetUint64(base)
 	return u
 }
 
@@ -86,20 +86,20 @@ func (u *Uint256) Set(value *big.Int) (*Uint256, error) {
 	if value.Cmp(minUint256) == -1 {
 		return nil, fmt.Errorf("cannot set Uint256 to %v as it underflows min value of %v", value, minUint256)
 	}
-	u.Value = value
+	u.Value = *value
 	return u, nil
 }
 
 // Copy sets the underlying value of u to a copy of the given Uint256 param, and returns the modified receiver struct
 func (u *Uint256) Copy(v *Uint256) *Uint256 {
-	valueCopy := new(big.Int).Set(v.Value)
-	u.Value = valueCopy
+	valueCopy := new(big.Int).Set(&v.Value)
+	u.Value = *valueCopy
 	return u
 }
 
 // Cmp calls the underlying Cmp method for the big.Int stored in a Uint256 struct as its value field
 func (u *Uint256) Cmp(v *Uint256) int {
-	return u.Value.Cmp(v.Value)
+	return u.Value.Cmp(&v.Value)
 }
 
 // Equals returns true if the two Uint256 structs have the same underlying values, false otherwise
@@ -110,21 +110,21 @@ func (u *Uint256) Equals(v *Uint256) bool {
 // Add sets u to augend + addend and returns u as the sum
 // returns an error when the result falls outside of the unsigned 256-bit integer range
 func (u *Uint256) Add(augend, addend *Uint256) (*Uint256, error) {
-	sum := new(big.Int).Add(augend.Value, addend.Value)
+	sum := new(big.Int).Add(&augend.Value, &addend.Value)
 	return u.Set(sum)
 }
 
 // Sub sets u to minuend - subtrahend and returns u as the difference
 // returns an error when the result falls outside of the unsigned 256-bit integer range
 func (u *Uint256) Sub(minuend, subtrahend *Uint256) (*Uint256, error) {
-	difference := new(big.Int).Sub(minuend.Value, subtrahend.Value)
+	difference := new(big.Int).Sub(&minuend.Value, &subtrahend.Value)
 	return u.Set(difference)
 }
 
 // Mul sets u to multiplicand * multiplier and returns u as the product
 // returns an error when the result falls outside of the unsigned 256-bit integer range
 func (u *Uint256) Mul(multiplicand, multiplier *Uint256) (*Uint256, error) {
-	product := new(big.Int).Mul(multiplicand.Value, multiplier.Value)
+	product := new(big.Int).Mul(&multiplicand.Value, &multiplier.Value)
 	return u.Set(product)
 }
 

--- a/swap/types.go
+++ b/swap/types.go
@@ -64,7 +64,6 @@ var minUint256 = big.NewInt(0)
 var maxUint256 = new(big.Int).Sub(new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil), big.NewInt(1)) // 2^256 - 1
 
 // NewUint256 creates a Uint256 struct with an initial underlying value of 0
-// no Uint256 should have a nil pointer as its value field
 func NewUint256() *Uint256 {
 	u := new(Uint256)
 	u.value = *minUint256
@@ -80,33 +79,33 @@ func Uint64ToUint256(base uint64) *Uint256 {
 }
 
 // Value returns the underlying private value for a Uint256 struct
-func (u *Uint256) Value() *big.Int {
-	return &u.value
+func (u *Uint256) Value() big.Int {
+	return u.value
 }
 
 // Set assigns the underlying value of the given Uint256 param to u, and returns the modified receiver struct
 // returns an error when the result falls outside of the unsigned 256-bit integer range
-func (u *Uint256) Set(value *big.Int) (*Uint256, error) {
+func (u *Uint256) Set(value big.Int) (*Uint256, error) {
 	if value.Cmp(maxUint256) == 1 {
 		return nil, fmt.Errorf("cannot set Uint256 to %v as it overflows max value of %v", value, maxUint256)
 	}
 	if value.Cmp(minUint256) == -1 {
 		return nil, fmt.Errorf("cannot set Uint256 to %v as it underflows min value of %v", value, minUint256)
 	}
-	u.value = *value
+	u.value = value
 	return u, nil
 }
 
 // Copy sets the underlying value of u to a copy of the given Uint256 param, and returns the modified receiver struct
 func (u *Uint256) Copy(v *Uint256) *Uint256 {
-	valueCopy := new(big.Int).Set(v.Value())
+	valueCopy := new(big.Int).Set(&v.value)
 	u.value = *valueCopy
 	return u
 }
 
 // Cmp calls the underlying Cmp method for the big.Int stored in a Uint256 struct as its value field
 func (u *Uint256) Cmp(v *Uint256) int {
-	return u.Value().Cmp(v.Value())
+	return u.value.Cmp(&v.value)
 }
 
 // Equals returns true if the two Uint256 structs have the same underlying values, false otherwise
@@ -117,33 +116,33 @@ func (u *Uint256) Equals(v *Uint256) bool {
 // Add sets u to augend + addend and returns u as the sum
 // returns an error when the result falls outside of the unsigned 256-bit integer range
 func (u *Uint256) Add(augend, addend *Uint256) (*Uint256, error) {
-	sum := new(big.Int).Add(augend.Value(), addend.Value())
-	return u.Set(sum)
+	sum := new(big.Int).Add(&augend.value, &addend.value)
+	return u.Set(*sum)
 }
 
 // Sub sets u to minuend - subtrahend and returns u as the difference
 // returns an error when the result falls outside of the unsigned 256-bit integer range
 func (u *Uint256) Sub(minuend, subtrahend *Uint256) (*Uint256, error) {
-	difference := new(big.Int).Sub(minuend.Value(), subtrahend.Value())
-	return u.Set(difference)
+	difference := new(big.Int).Sub(&minuend.value, &subtrahend.value)
+	return u.Set(*difference)
 }
 
 // Mul sets u to multiplicand * multiplier and returns u as the product
 // returns an error when the result falls outside of the unsigned 256-bit integer range
 func (u *Uint256) Mul(multiplicand, multiplier *Uint256) (*Uint256, error) {
-	product := new(big.Int).Mul(multiplicand.Value(), multiplier.Value())
-	return u.Set(product)
+	product := new(big.Int).Mul(&multiplicand.value, &multiplier.value)
+	return u.Set(*product)
 }
 
 // String returns the string representation for Uint256 structs
 func (u *Uint256) String() string {
-	return u.Value().String()
+	return u.value.String()
 }
 
 // MarshalJSON implements the json.Marshaler interface
 // it specifies how to marshal a Uint256 struct so that it can be written to disk
 func (u Uint256) MarshalJSON() ([]byte, error) {
-	return []byte(u.Value().String()), nil
+	return []byte(u.value.String()), nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface

--- a/swap/types.go
+++ b/swap/types.go
@@ -106,7 +106,7 @@ func (u *Uint256) Copy(v *Uint256) *Uint256 {
 
 // Cmp calls the underlying Cmp method for the big.Int stored in a Uint256 struct as its value field
 func (u *Uint256) Cmp(v *Uint256) int {
-	return u.value.Cmp(v.Value())
+	return u.Value().Cmp(v.Value())
 }
 
 // Equals returns true if the two Uint256 structs have the same underlying values, false otherwise
@@ -137,7 +137,7 @@ func (u *Uint256) Mul(multiplicand, multiplier *Uint256) (*Uint256, error) {
 
 // String returns the string representation for Uint256 structs
 func (u *Uint256) String() string {
-	return u.value.String()
+	return u.Value().String()
 }
 
 // MarshalJSON implements the json.Marshaler interface

--- a/swap/types_test.go
+++ b/swap/types_test.go
@@ -106,11 +106,11 @@ func TestCopyUint256(t *testing.T) {
 	c := NewUint256().Copy(r)
 
 	if !c.Equals(r) {
-		t.Fatalf("copy of uint256 %v has an unequal value of %v", r, c)
+		t.Fatalf("copy of Uint256 %v has an unequal value of %v", r, c)
 	}
 
 	if c == r {
-		t.Fatalf("copy of uint256 %v shares memory with its base", r)
+		t.Fatalf("copy of Uint256 %v shares memory with its base", r)
 	}
 }
 
@@ -125,6 +125,7 @@ func randomUint256() (*Uint256, error) {
 	return NewUint256().Set(randomUint256)
 }
 
+// TestUint256Store indirectly tests the marshaling and unmarshaling of a random Uint256 variable
 func TestUint256Store(t *testing.T) {
 	testDir, err := ioutil.TempDir("", "uint256_test_store")
 	if err != nil {
@@ -153,6 +154,6 @@ func TestUint256Store(t *testing.T) {
 	}
 
 	if !u.Equals(r) {
-		t.Fatalf("retrieved uint256 %v has an unequal balance to the original uint256 %v", u, r)
+		t.Fatalf("retrieved Uint256 %v has an unequal balance to the original Uint256 %v", u, r)
 	}
 }

--- a/swap/types_test.go
+++ b/swap/types_test.go
@@ -85,8 +85,8 @@ func testSetUint256(t *testing.T, testCases []Uint256TestCase) {
 				if err != nil {
 					t.Fatalf("got unexpected error when creating new Uint256: %v", err)
 				}
-				if result.Value.Cmp(tc.baseInteger) != 0 {
-					t.Fatalf("expected value of %v, got %v instead", tc.baseInteger, result.Value)
+				if result.Value().Cmp(tc.baseInteger) != 0 {
+					t.Fatalf("expected value of %v, got %v instead", tc.baseInteger, result.value)
 				}
 			}
 		})

--- a/swap/types_test.go
+++ b/swap/types_test.go
@@ -80,7 +80,7 @@ func testSetUint256(t *testing.T, testCases []Uint256TestCase) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := NewUint256().Set(tc.baseInteger)
+			result, err := NewUint256().Set(*tc.baseInteger)
 			if tc.expectsError && err == nil {
 				t.Fatalf("expected error when creating new Uint256, but got none")
 			}
@@ -88,7 +88,8 @@ func testSetUint256(t *testing.T, testCases []Uint256TestCase) {
 				if err != nil {
 					t.Fatalf("got unexpected error when creating new Uint256: %v", err)
 				}
-				if result.Value().Cmp(tc.baseInteger) != 0 {
+				resultValue := result.Value()
+				if (&resultValue).Cmp(tc.baseInteger) != 0 {
 					t.Fatalf("expected value of %v, got %v instead", tc.baseInteger, result.value)
 				}
 			}
@@ -122,7 +123,7 @@ func randomUint256() (*Uint256, error) {
 
 	randomUint256 := new(big.Int).Add(r, minUint256) // random is within [minUint256, maxUint256]
 
-	return NewUint256().Set(randomUint256)
+	return NewUint256().Set(*randomUint256)
 }
 
 // TestUint256Store indirectly tests the marshaling and unmarshaling of a random Uint256 variable


### PR DESCRIPTION
Starting out from #2063, this PR:
- Changes the type of the `Uint256` `Value` field to `big.Int` (instead of `*big.Int`).
- Changes the `Uint256` `Value` field to private (i.e. `value`).
- Adds the `Value` function so that the underlying `value` can be obtained.
- Changes the `Set` function so that the received parameter is of the `big.Int` type (instead of `*big.Int`).
- Adds the `MarshalJSON` and `UnmarshalJSON` functions so that `value` can be stored in and recovered from disk, despite no longer being a pointer.
- Adds the `EncodeRLP` and `DecodeRLP` functions so that `value` can be transferred to other peers through messages, despite no longer being a public field.