### PR TITLE
network, storage: fix usage of base logger

### DIFF
--- a/network/retrieval/peer.go
+++ b/network/retrieval/peer.go
@@ -40,7 +40,7 @@ type Peer struct {
 func NewPeer(peer *network.BzzPeer, baseKey *network.BzzAddr) *Peer {
 	return &Peer{
 		BzzPeer:    peer,
-		logger:     log.NewBaseAddressLogger("base", baseKey.ShortString(), "peer", peer.BzzAddr.ShortString()),
+		logger:     log.NewBaseAddressLogger(baseKey.ShortString(), "peer", peer.BzzAddr.ShortString()),
 		retrievals: make(map[uint]chunk.Address),
 	}
 }

--- a/network/retrieval/retrieve.go
+++ b/network/retrieval/retrieve.go
@@ -113,7 +113,7 @@ func New(kad *network.Kademlia, ns *storage.NetStore, baseKey *network.BzzAddr, 
 		kademliaLB:  network.NewKademliaLoadBalancer(kad, false),
 		peers:       make(map[enode.ID]*Peer),
 		spec:        spec,
-		logger:      log.NewBaseAddressLogger("base", baseKey.ShortString()),
+		logger:      log.NewBaseAddressLogger(baseKey.ShortString()),
 		quit:        make(chan struct{}),
 	}
 	if balance != nil && !reflect.ValueOf(balance).IsNil() {

--- a/network/stream/sync_provider.go
+++ b/network/stream/sync_provider.go
@@ -85,7 +85,7 @@ func NewSyncProvider(ns *storage.NetStore, kad *network.Kademlia, baseAddr *netw
 		quit:                    make(chan struct{}),
 		cache:                   c,
 		setCache:                sc,
-		logger:                  log.NewBaseAddressLogger("base", baseAddr.ShortString()),
+		logger:                  log.NewBaseAddressLogger(baseAddr.ShortString()),
 		binZeroSem:              make(chan struct{}, maxBinZeroSyncPeers),
 	}
 }

--- a/storage/netstore.go
+++ b/storage/netstore.go
@@ -109,7 +109,7 @@ func NewNetStore(store chunk.Store, baseAddr *network.BzzAddr) *NetStore {
 		fetchers: fetchers,
 		Store:    store,
 		LocalID:  baseAddr.ID(),
-		logger:   log.NewBaseAddressLogger("base", baseAddr.ShortString()),
+		logger:   log.NewBaseAddressLogger(baseAddr.ShortString()),
 	}
 }
 


### PR DESCRIPTION
base logger was invoked with `base` string, but `base` string was already hardcoded in the base address logger constructor, resulting in errors while logger due to even number of parameters, and broken formatting of the addresses