### PR TITLE
kademlia: use IsSameAs instead of Match for capability index comparison

### DIFF
--- a/network/kademlia.go
+++ b/network/kademlia.go
@@ -170,7 +170,6 @@ func (k *Kademlia) addToCapabilityIndex(p interface{}) {
 			if idxItem.Id != vCap.Id {
 				continue
 			}
-
 			if vCap.IsSameAs(idxItem.Capability) {
 				log.Trace("Added peer to capability index", "conn", ok, "s", s, "v", vCap, "p", p)
 				if ok {

--- a/network/kademlia.go
+++ b/network/kademlia.go
@@ -170,7 +170,8 @@ func (k *Kademlia) addToCapabilityIndex(p interface{}) {
 			if idxItem.Id != vCap.Id {
 				continue
 			}
-			if vCap.Match(idxItem.Capability) {
+
+			if vCap.IsSameAs(idxItem.Capability) {
 				log.Trace("Added peer to capability index", "conn", ok, "s", s, "v", vCap, "p", p)
 				if ok {
 					k.capabilityIndex[s].conns, _, _ = pot.Add(idxItem.conns, newEntryFromPeer(ePeer), Pof)

--- a/network/kademlia_test.go
+++ b/network/kademlia_test.go
@@ -1080,7 +1080,7 @@ func TestCapabilityNeighbourhoodDepth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if depth != 2 {
-		t.Fatalf("cap 'one' expected depth 2, was %d", depth)
+	if depth != 0 {
+		t.Fatalf("cap 'one' expected depth 0, was %d", depth)
 	}
 }


### PR DESCRIPTION
Fixes a bug where full node gets added to the light node capability index because it satisfies the comparison in the capabilities `Match` function (because light nodes will always be fulfilling a subset of full node capabilities).
Instead, `IsSameAs` should be used when doing the comparison