### PR TITLE
api: do not try to resolve swarm hashes over ens

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -251,10 +251,10 @@ func TestAPIResolve(t *testing.T) {
 			expectErr: errors.New(`no DNS to resolve name: "swarm.eth"`),
 		},
 		{
-			desc:   "DNS configured, hash address, hash resolves, returns resolved address",
+			desc:   "DNS not configured, hash address, hash resolves, returns hash",
 			dns:    doesResolve,
 			addr:   hashAddr,
-			result: resolvedAddr,
+			result: hashAddr,
 		},
 		{
 			desc:      "DNS configured, immutable hash address, hash resolves, returns hash address",


### PR DESCRIPTION
This PR changes how API.Resolve handles input in a way not to try to resolve swarm hashes. This may be one of the reasons why we have a large number of ENS resolution attempts on production cluster.