### PR TITLE
swap: unify variable types, pt. 2

### DIFF
--- a/contracts/swap/swap.go
+++ b/contracts/swap/swap.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	contract "github.com/ethersphere/go-sw3/contracts-v0-2-0/erc20simpleswap"
+	"github.com/ethersphere/swarm/uint256"
 )
 
 var (
@@ -50,7 +51,7 @@ type Contract interface {
 	// Deposit sends a raw transaction to the chequebook, triggering the fallback—depositing amount
 	Deposit(auth *bind.TransactOpts, amout *big.Int) (*types.Receipt, error)
 	// CashChequeBeneficiaryStart sends the transaction to cash a cheque as the beneficiary
-	CashChequeBeneficiaryStart(opts *bind.TransactOpts, beneficiary common.Address, cumulativePayout *big.Int, ownerSig []byte) (*types.Transaction, error)
+	CashChequeBeneficiaryStart(opts *bind.TransactOpts, beneficiary common.Address, cumulativePayout *uint256.Uint256, ownerSig []byte) (*types.Transaction, error)
 	// CashChequeBeneficiaryResult processes the receipt from a CashChequeBeneficiary transaction
 	CashChequeBeneficiaryResult(receipt *types.Receipt) *CashChequeResult
 	// LiquidBalance returns the LiquidBalance (total balance in ERC20-token - total hard deposits in ERC20-token) of the chequebook
@@ -143,8 +144,9 @@ func (s simpleContract) Deposit(auth *bind.TransactOpts, amount *big.Int) (*type
 }
 
 // CashChequeBeneficiaryStart sends the transaction to cash a cheque as the beneficiary
-func (s simpleContract) CashChequeBeneficiaryStart(opts *bind.TransactOpts, beneficiary common.Address, cumulativePayout *big.Int, ownerSig []byte) (*types.Transaction, error) {
-	tx, err := s.instance.CashChequeBeneficiary(opts, beneficiary, cumulativePayout, ownerSig)
+func (s simpleContract) CashChequeBeneficiaryStart(opts *bind.TransactOpts, beneficiary common.Address, cumulativePayout *uint256.Uint256, ownerSig []byte) (*types.Transaction, error) {
+	payout := cumulativePayout.Value()
+	tx, err := s.instance.CashChequeBeneficiary(opts, beneficiary, &payout, ownerSig)
 	if err != nil {
 		return nil, err
 	}

--- a/swap/cashout.go
+++ b/swap/cashout.go
@@ -111,12 +111,11 @@ func (c *CashoutProcessor) estimatePayout(ctx context.Context, cheque *Cheque) (
 		return nil, nil, err
 	}
 
-	cumulativePayout := cheque.CumulativePayout
-	if paidOut.Cmp(cumulativePayout) > 0 {
+	if paidOut.Cmp(cheque.CumulativePayout) > 0 {
 		return uint256.New(), transactionCosts, nil
 	}
 
-	expectedPayout, err = uint256.New().Sub(cumulativePayout, paidOut)
+	expectedPayout, err = uint256.New().Sub(cheque.CumulativePayout, paidOut)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/swap/cashout.go
+++ b/swap/cashout.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/metrics"
 	contract "github.com/ethersphere/swarm/contracts/swap"
+	"github.com/ethersphere/swarm/uint256"
 )
 
 // CashChequeBeneficiaryTransactionCost is the expected gas cost of a CashChequeBeneficiary transaction
@@ -80,23 +81,31 @@ func (c *CashoutProcessor) cashCheque(ctx context.Context, request *CashoutReque
 }
 
 // estimatePayout estimates the payout for a given cheque as well as the transaction cost
-func (c *CashoutProcessor) estimatePayout(ctx context.Context, cheque *Cheque) (expectedPayout uint64, transactionCosts uint64, err error) {
+func (c *CashoutProcessor) estimatePayout(ctx context.Context, cheque *Cheque) (expectedPayout uint64, transactionCosts *uint256.Uint256, err error) {
 	otherSwap, err := contract.InstanceAt(cheque.Contract, c.backend)
 	if err != nil {
-		return 0, 0, err
+		return 0, nil, err
 	}
 
 	paidOut, err := otherSwap.PaidOut(&bind.CallOpts{Context: ctx}, cheque.Beneficiary)
 	if err != nil {
-		return 0, 0, err
+		return 0, nil, err
 	}
 
-	gasPrice, err := c.backend.SuggestGasPrice(ctx)
+	suggestedGasPrice, err := c.backend.SuggestGasPrice(ctx)
 	if err != nil {
-		return 0, 0, err
+		return 0, nil, err
 	}
 
-	transactionCosts = gasPrice.Uint64() * CashChequeBeneficiaryTransactionCost
+	gasPrice, err := uint256.New().Set(*suggestedGasPrice)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	transactionCosts, err = uint256.New().Mul(gasPrice, uint256.FromUint64(CashChequeBeneficiaryTransactionCost))
+	if err != nil {
+		return 0, nil, err
+	}
 
 	cumulativePayout := cheque.CumulativePayout.Value()
 	if paidOut.Cmp(&cumulativePayout) > 0 {

--- a/swap/cashout.go
+++ b/swap/cashout.go
@@ -67,8 +67,7 @@ func (c *CashoutProcessor) cashCheque(ctx context.Context, request *CashoutReque
 		return err
 	}
 
-	cumulativePayout := cheque.CumulativePayout.Value()
-	tx, err := otherSwap.CashChequeBeneficiaryStart(opts, request.Destination, &cumulativePayout, cheque.Signature)
+	tx, err := otherSwap.CashChequeBeneficiaryStart(opts, request.Destination, cheque.CumulativePayout, cheque.Signature)
 	if err != nil {
 		return err
 	}

--- a/swap/cashout_test.go
+++ b/swap/cashout_test.go
@@ -182,6 +182,6 @@ func TestEstimatePayout(t *testing.T) {
 
 	// the gas price in the simulated backend is 1 therefore the total transactionCost should be 50000 * 1 = 50000
 	if !transactionCost.Equals(uint256.FromUint64(CashChequeBeneficiaryTransactionCost)) {
-		t.Fatalf("unexpected transactionCost: got %v, wanted: %d", transactionCost, 0)
+		t.Fatalf("unexpected transaction cost: got %v, wanted: %d", transactionCost, 0)
 	}
 }

--- a/swap/cashout_test.go
+++ b/swap/cashout_test.go
@@ -84,7 +84,7 @@ func TestContractIntegration(t *testing.T) {
 	log.Debug("cheques result", "result", result)
 
 	// create a cheque that will bounce
-	_, err = payout.Add(payout, uint256.FromUint64(uint64(10000*RetrieveRequestPrice)))
+	_, err = payout.Add(payout, uint256.FromUint64(10000*RetrieveRequestPrice))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/swap/cashout_test.go
+++ b/swap/cashout_test.go
@@ -18,7 +18,6 @@ package swap
 
 import (
 	"context"
-	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -37,7 +36,7 @@ func TestContractIntegration(t *testing.T) {
 	reset := setupContractTest()
 	defer reset()
 
-	payout := big.NewInt(42)
+	payout := uint256.FromUint64(42)
 
 	chequebook, err := testDeployWithPrivateKey(context.Background(), backend, ownerKey, ownerAddress, payout)
 	if err != nil {
@@ -85,13 +84,17 @@ func TestContractIntegration(t *testing.T) {
 	log.Debug("cheques result", "result", result)
 
 	// create a cheque that will bounce
-	bouncingCheque, err := newSignedTestCheque(chequebook.ContractParams().ContractAddress, beneficiaryAddress, payout.Add(payout, big.NewInt(int64(10000*RetrieveRequestPrice))), ownerKey)
+	_, err = payout.Add(payout, uint256.FromUint64(uint64(10000*RetrieveRequestPrice)))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	cumulativePayout := bouncingCheque.CumulativePayout.Value()
-	tx, err = chequebook.CashChequeBeneficiaryStart(opts, beneficiaryAddress, &cumulativePayout, bouncingCheque.Signature)
+	bouncingCheque, err := newSignedTestCheque(chequebook.ContractParams().ContractAddress, beneficiaryAddress, payout, ownerKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tx, err = chequebook.CashChequeBeneficiaryStart(opts, beneficiaryAddress, bouncingCheque.CumulativePayout, bouncingCheque.Signature)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +121,7 @@ func TestCashCheque(t *testing.T) {
 	defer reset()
 
 	cashoutProcessor := newCashoutProcessor(backend, ownerKey)
-	payout := big.NewInt(42)
+	payout := uint256.FromUint64(42)
 
 	chequebook, err := testDeployWithPrivateKey(context.Background(), backend, ownerKey, ownerAddress, payout)
 	if err != nil {
@@ -156,7 +159,7 @@ func TestEstimatePayout(t *testing.T) {
 	defer reset()
 
 	cashoutProcessor := newCashoutProcessor(backend, ownerKey)
-	payout := big.NewInt(42)
+	payout := uint256.FromUint64(42)
 
 	chequebook, err := testDeployWithPrivateKey(context.Background(), backend, ownerKey, ownerAddress, payout)
 	if err != nil {
@@ -173,12 +176,12 @@ func TestEstimatePayout(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if expectedPayout != payout.Uint64() {
-		t.Fatalf("unexpected expectedPayout: got %d, wanted: %d", expectedPayout, payout.Uint64())
+	if !expectedPayout.Equals(payout) {
+		t.Fatalf("unexpected expectedPayout: got %v, wanted: %v", expectedPayout, payout)
 	}
 
 	// the gas price in the simulated backend is 1 therefore the total transactionCost should be 50000 * 1 = 50000
-	if transactionCost != CashChequeBeneficiaryTransactionCost {
-		t.Fatalf("unexpected transactionCost: got %d, wanted: %d", transactionCost, 0)
+	if !transactionCost.Equals(uint256.FromUint64(CashChequeBeneficiaryTransactionCost)) {
+		t.Fatalf("unexpected transactionCost: got %v, wanted: %d", transactionCost, 0)
 	}
 }

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"math/big"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -51,7 +50,7 @@ type swapTester struct {
 }
 
 // creates a new protocol tester for swap with a deployed chequebook
-func newSwapTester(t *testing.T, backend *swapTestBackend, depositAmount *big.Int) (*swapTester, func(), error) {
+func newSwapTester(t *testing.T, backend *swapTestBackend, depositAmount *uint256.Uint256) (*swapTester, func(), error) {
 	swap, clean := newTestSwap(t, ownerKey, backend)
 
 	err := testDeploy(context.Background(), swap, depositAmount)
@@ -136,7 +135,7 @@ func correctSwapHandshakeMsg(swap *Swap) *HandshakeMsg {
 // TestHandshake tests the correct handshake scenario
 func TestHandshake(t *testing.T) {
 	// setup the protocolTester, which will allow protocol testing by sending messages
-	protocolTester, clean, err := newSwapTester(t, nil, big.NewInt(0))
+	protocolTester, clean, err := newSwapTester(t, nil, uint256.FromUint64(0))
 	defer clean()
 	if err != nil {
 		t.Fatal(err)
@@ -154,7 +153,7 @@ func TestHandshake(t *testing.T) {
 // TestHandshakeInvalidChainID tests that a handshake with the wrong chain id is rejected
 func TestHandshakeInvalidChainID(t *testing.T) {
 	// setup the protocolTester, which will allow protocol testing by sending messages
-	protocolTester, clean, err := newSwapTester(t, nil, big.NewInt(0))
+	protocolTester, clean, err := newSwapTester(t, nil, uint256.FromUint64(0))
 	defer clean()
 	if err != nil {
 		t.Fatal(err)
@@ -176,7 +175,7 @@ func TestHandshakeInvalidChainID(t *testing.T) {
 // TestHandshakeEmptyContract tests that a handshake with an empty contract address is rejected
 func TestHandshakeEmptyContract(t *testing.T) {
 	// setup the protocolTester, which will allow protocol testing by sending messages
-	protocolTester, clean, err := newSwapTester(t, nil, big.NewInt(0))
+	protocolTester, clean, err := newSwapTester(t, nil, uint256.FromUint64(0))
 	defer clean()
 	if err != nil {
 		t.Fatal(err)
@@ -198,7 +197,7 @@ func TestHandshakeEmptyContract(t *testing.T) {
 // TestHandshakeInvalidContract tests that a handshake with an address that's not a valid chequebook
 func TestHandshakeInvalidContract(t *testing.T) {
 	// setup the protocolTester, which will allow protocol testing by sending messages
-	protocolTester, clean, err := newSwapTester(t, nil, big.NewInt(0))
+	protocolTester, clean, err := newSwapTester(t, nil, uint256.FromUint64(0))
 	defer clean()
 	if err != nil {
 		t.Fatal(err)
@@ -224,7 +223,7 @@ func TestHandshakeInvalidContract(t *testing.T) {
 func TestEmitCheque(t *testing.T) {
 	testBackend := newTestBackend(t)
 
-	protocolTester, clean, err := newSwapTester(t, testBackend, big.NewInt(0))
+	protocolTester, clean, err := newSwapTester(t, testBackend, uint256.FromUint64(0))
 	defer clean()
 	if err != nil {
 		t.Fatal(err)
@@ -249,7 +248,7 @@ func TestEmitCheque(t *testing.T) {
 	balance := uint256.FromUint64(100001)
 	balanceValue := balance.Value()
 
-	if err := testDeploy(context.Background(), debitorSwap, &balanceValue); err != nil {
+	if err := testDeploy(context.Background(), debitorSwap, balance); err != nil {
 		t.Fatal(err)
 	}
 
@@ -334,7 +333,7 @@ func TestEmitCheque(t *testing.T) {
 func TestTriggerPaymentThreshold(t *testing.T) {
 	testBackend := newTestBackend(t)
 	log.Debug("create test swap")
-	protocolTester, clean, err := newSwapTester(t, testBackend, big.NewInt(int64(DefaultPaymentThreshold)*2))
+	protocolTester, clean, err := newSwapTester(t, testBackend, uint256.FromUint64(DefaultPaymentThreshold*2))
 	defer clean()
 	if err != nil {
 		t.Fatal(err)

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -160,7 +160,7 @@ func newSimServiceMap(params *swapSimulationParams) map[string]simulation.Servic
 			ts.spec.Hook = protocols.NewAccounting(balance)
 			ts.swap = balance
 			// deploy the accounting to the `SimulatedBackend`
-			err = testDeploy(context.Background(), balance, uint256.FromUint64(100000*uint64(RetrieveRequestPrice)))
+			err = testDeploy(context.Background(), balance, uint256.FromUint64(100000*RetrieveRequestPrice))
 			if err != nil {
 				return nil, nil, err
 			}

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -160,7 +160,7 @@ func newSimServiceMap(params *swapSimulationParams) map[string]simulation.Servic
 			ts.spec.Hook = protocols.NewAccounting(balance)
 			ts.swap = balance
 			// deploy the accounting to the `SimulatedBackend`
-			err = testDeploy(context.Background(), balance, big.NewInt(100000*int64(RetrieveRequestPrice)))
+			err = testDeploy(context.Background(), balance, uint256.FromUint64(100000*uint64(RetrieveRequestPrice)))
 			if err != nil {
 				return nil, nil, err
 			}

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -439,9 +439,8 @@ func (s *Swap) handleEmitChequeMsg(ctx context.Context, p *Peer, msg *EmitCheque
 	}
 
 	payout := uint256.FromUint64(expectedPayout)
-	costs := uint256.FromUint64(transactionCosts)
 	costsMultiplier := uint256.FromUint64(2)
-	costThreshold, err := uint256.New().Mul(costs, costsMultiplier)
+	costThreshold, err := uint256.New().Mul(transactionCosts, costsMultiplier)
 	if err != nil {
 		return err
 	}

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -438,7 +438,6 @@ func (s *Swap) handleEmitChequeMsg(ctx context.Context, p *Peer, msg *EmitCheque
 		return protocols.Break(err)
 	}
 
-	payout := uint256.FromUint64(expectedPayout)
 	costsMultiplier := uint256.FromUint64(2)
 	costThreshold, err := uint256.New().Mul(transactionCosts, costsMultiplier)
 	if err != nil {
@@ -446,7 +445,7 @@ func (s *Swap) handleEmitChequeMsg(ctx context.Context, p *Peer, msg *EmitCheque
 	}
 
 	// do a payout transaction if we get 2 times the gas costs
-	if payout.Cmp(costThreshold) == 1 {
+	if expectedPayout.Cmp(costThreshold) == 1 {
 		go defaultCashCheque(s, cheque)
 	}
 

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -1344,6 +1344,9 @@ func TestAvailableBalance(t *testing.T) {
 	}
 	// verify available balance
 	expectedBalance, err := uint256.New().Sub(netDeposit, uint256.FromUint64(chequeAmount))
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !availableBalance.Equals(expectedBalance) {
 		t.Fatalf("available balance not equal to deposited minus withdraw. available balance: %v, expected balance: %v", availableBalance, expectedBalance)
 	}

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -434,7 +434,7 @@ func TestStartChequebookFailure(t *testing.T) {
 				swap, clean := newTestSwap(t, ownerKey, config.testBackend)
 				defer clean()
 				// deploy a chequebook
-				err := testDeploy(context.TODO(), swap, big.NewInt(0))
+				err := testDeploy(context.TODO(), swap, uint256.FromUint64(0))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -493,7 +493,7 @@ func TestStartChequebookSuccess(t *testing.T) {
 				defer clean()
 
 				// deploy a chequebook
-				err := testDeploy(context.TODO(), swap, big.NewInt(0))
+				err := testDeploy(context.TODO(), swap, uint256.FromUint64(0))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -519,7 +519,7 @@ func TestStartChequebookSuccess(t *testing.T) {
 				defer clean()
 
 				// deploy a chequebook
-				err := testDeploy(context.TODO(), swap, big.NewInt(0))
+				err := testDeploy(context.TODO(), swap, uint256.FromUint64(0))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -551,7 +551,7 @@ func TestStartChequebookSuccess(t *testing.T) {
 func TestDisconnectThreshold(t *testing.T) {
 	swap, clean := newTestSwap(t, ownerKey, nil)
 	defer clean()
-	testDeploy(context.Background(), swap, big.NewInt(0))
+	testDeploy(context.Background(), swap, uint256.FromUint64(0))
 
 	testPeer := newDummyPeer()
 	swap.addPeer(testPeer.Peer, swap.owner.address, swap.GetParams().ContractAddress)
@@ -577,7 +577,7 @@ func TestDisconnectThreshold(t *testing.T) {
 func TestPaymentThreshold(t *testing.T) {
 	swap, clean := newTestSwap(t, ownerKey, nil)
 	defer clean()
-	testDeploy(context.Background(), swap, big.NewInt(int64(DefaultPaymentThreshold)))
+	testDeploy(context.Background(), swap, uint256.FromUint64(DefaultPaymentThreshold))
 	testPeer := newDummyPeerWithSpec(Spec)
 	swap.addPeer(testPeer.Peer, swap.owner.address, swap.GetParams().ContractAddress)
 	if err := swap.Add(-int64(DefaultPaymentThreshold), testPeer.Peer); err != nil {
@@ -607,14 +607,14 @@ func TestResetBalance(t *testing.T) {
 	defer clean1()
 	defer clean2()
 
-	testAmount := int64(DefaultPaymentThreshold + 42)
+	testAmount := uint64(DefaultPaymentThreshold + 42)
 
 	ctx := context.Background()
-	err := testDeploy(ctx, creditorSwap, big.NewInt(0))
+	err := testDeploy(ctx, creditorSwap, uint256.FromUint64(0))
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = testDeploy(ctx, debitorSwap, big.NewInt(testAmount))
+	err = testDeploy(ctx, debitorSwap, uint256.FromUint64(testAmount))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -634,8 +634,8 @@ func TestResetBalance(t *testing.T) {
 	}
 
 	// set balances arbitrarily
-	debitor.setBalance(testAmount)
-	creditor.setBalance(-testAmount)
+	debitor.setBalance(int64(testAmount))
+	creditor.setBalance(int64(-testAmount))
 
 	// setup the wait for mined transaction function for testing
 	cleanup := setupContractTest()
@@ -889,7 +889,7 @@ func TestVerifyContract(t *testing.T) {
 	defer clean()
 
 	// deploy a new swap contract
-	err := testDeploy(context.TODO(), swap, big.NewInt(0))
+	err := testDeploy(context.TODO(), swap, uint256.FromUint64(0))
 	if err != nil {
 		t.Fatalf("Error in deploy: %v", err)
 	}
@@ -1194,14 +1194,14 @@ func TestSwapLogToFile(t *testing.T) {
 	}
 	defer clean()
 
-	testAmount := int64(DefaultPaymentThreshold + 42)
+	testAmount := uint64(DefaultPaymentThreshold + 42)
 
 	ctx := context.Background()
-	err = testDeploy(ctx, creditorSwap, big.NewInt(testAmount))
+	err = testDeploy(ctx, creditorSwap, uint256.FromUint64(testAmount))
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = testDeploy(ctx, debitorSwap, big.NewInt(0))
+	err = testDeploy(ctx, debitorSwap, uint256.FromUint64(0))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1221,8 +1221,8 @@ func TestSwapLogToFile(t *testing.T) {
 	}
 
 	// set balances arbitrarily
-	debitor.setBalance(testAmount)
-	creditor.setBalance(-testAmount)
+	debitor.setBalance(int64(testAmount))
+	creditor.setBalance(int64(-testAmount))
 
 	// setup the wait for mined transaction function for testing
 	cleanup := setupContractTest()
@@ -1282,7 +1282,7 @@ func TestAvailableBalance(t *testing.T) {
 	cleanup := setupContractTest()
 	defer cleanup()
 
-	depositAmount := big.NewInt(9000 * int64(RetrieveRequestPrice))
+	depositAmount := uint256.FromUint64(9000 * uint64(RetrieveRequestPrice))
 
 	// deploy a chequebook
 	err := testDeploy(context.TODO(), swap, depositAmount)
@@ -1300,15 +1300,20 @@ func TestAvailableBalance(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !availableBalance.Equals(uint256.FromUint64(depositAmount.Uint64())) {
-		t.Fatalf("availableBalance not equal to deposited amount. availableBalance: %v, depositAmount: %d", availableBalance, depositAmount)
+	if !availableBalance.Equals(depositAmount) {
+		t.Fatalf("availableBalance not equal to deposited amount. available balance: %v, deposit amount: %v", availableBalance, depositAmount)
 	}
 	// withdraw 50
-	withdrawAmount := big.NewInt(50)
-	netDeposit := depositAmount.Uint64() - withdrawAmount.Uint64()
+	withdrawAmount := uint256.FromUint64(50)
+	netDeposit, err := uint256.New().Sub(depositAmount, withdrawAmount)
+	if err != nil {
+		t.Fatal(err)
+	}
+	withdraw := withdrawAmount.Value()
+
 	opts := bind.NewKeyedTransactor(swap.owner.privateKey)
 	opts.Context = context.TODO()
-	rec, err := swap.contract.Withdraw(opts, withdrawAmount)
+	rec, err := swap.contract.Withdraw(opts, &withdraw)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1321,14 +1326,14 @@ func TestAvailableBalance(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !availableBalance.Equals(uint256.FromUint64(netDeposit)) {
-		t.Fatalf("availableBalance not equal to deposited minus withdraw. availableBalance: %v, deposit minus withdrawn: %d", availableBalance, depositAmount.Uint64()-withdrawAmount.Uint64())
+	if !availableBalance.Equals(netDeposit) {
+		t.Fatalf("availableBalance not equal to deposited minus withdraw. available balance: %v, deposit minus withdrawn: %v", availableBalance, netDeposit)
 	}
 
 	// send a cheque worth 42
-	chequeAmount := int64(42)
+	chequeAmount := uint64(42)
 	// create a dummy peer. Note: the peer's contract address and the peers address are resp the swap contract and the swap owner
-	peer.setBalance(-chequeAmount)
+	peer.setBalance(int64(-chequeAmount))
 	if err = peer.sendCheque(); err != nil {
 		t.Fatal(err)
 	}
@@ -1338,9 +1343,9 @@ func TestAvailableBalance(t *testing.T) {
 		t.Fatal(err)
 	}
 	// verify available balance
-	expectedBalance := netDeposit - uint64(chequeAmount)
-	if !availableBalance.Equals(uint256.FromUint64(expectedBalance)) {
-		t.Fatalf("availableBalance not equal to deposited minus withdraw. availableBalance: %v, deposit minus withdrawn: %d", availableBalance, depositAmount.Uint64()-withdrawAmount.Uint64())
+	expectedBalance, err := uint256.New().Sub(netDeposit, uint256.FromUint64(chequeAmount))
+	if !availableBalance.Equals(expectedBalance) {
+		t.Fatalf("availableBalance not equal to deposited minus withdraw. available balance: %v, expected balance: %v", availableBalance, expectedBalance)
 	}
 
 }

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -1301,7 +1301,7 @@ func TestAvailableBalance(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !availableBalance.Equals(depositAmount) {
-		t.Fatalf("availableBalance not equal to deposited amount. available balance: %v, deposit amount: %v", availableBalance, depositAmount)
+		t.Fatalf("availabl balance not equal to deposited amount. available balance: %v, deposit amount: %v", availableBalance, depositAmount)
 	}
 	// withdraw 50
 	withdrawAmount := uint256.FromUint64(50)
@@ -1327,7 +1327,7 @@ func TestAvailableBalance(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !availableBalance.Equals(netDeposit) {
-		t.Fatalf("availableBalance not equal to deposited minus withdraw. available balance: %v, deposit minus withdrawn: %v", availableBalance, netDeposit)
+		t.Fatalf("available balance not equal to deposited minus withdraw. available balance: %v, deposit minus withdrawn: %v", availableBalance, netDeposit)
 	}
 
 	// send a cheque worth 42
@@ -1345,7 +1345,7 @@ func TestAvailableBalance(t *testing.T) {
 	// verify available balance
 	expectedBalance, err := uint256.New().Sub(netDeposit, uint256.FromUint64(chequeAmount))
 	if !availableBalance.Equals(expectedBalance) {
-		t.Fatalf("availableBalance not equal to deposited minus withdraw. available balance: %v, expected balance: %v", availableBalance, expectedBalance)
+		t.Fatalf("available balance not equal to deposited minus withdraw. available balance: %v, expected balance: %v", availableBalance, expectedBalance)
 	}
 
 }

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -1301,7 +1301,7 @@ func TestAvailableBalance(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !availableBalance.Equals(depositAmount) {
-		t.Fatalf("availabl balance not equal to deposited amount. available balance: %v, deposit amount: %v", availableBalance, depositAmount)
+		t.Fatalf("available balance not equal to deposited amount. available balance: %v, deposit amount: %v", availableBalance, depositAmount)
 	}
 	// withdraw 50
 	withdrawAmount := uint256.FromUint64(50)

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -607,7 +607,7 @@ func TestResetBalance(t *testing.T) {
 	defer clean1()
 	defer clean2()
 
-	testAmount := uint64(DefaultPaymentThreshold + 42)
+	testAmount := DefaultPaymentThreshold + 42
 
 	ctx := context.Background()
 	err := testDeploy(ctx, creditorSwap, uint256.FromUint64(0))
@@ -1194,7 +1194,7 @@ func TestSwapLogToFile(t *testing.T) {
 	}
 	defer clean()
 
-	testAmount := uint64(DefaultPaymentThreshold + 42)
+	testAmount := DefaultPaymentThreshold + 42
 
 	ctx := context.Background()
 	err = testDeploy(ctx, creditorSwap, uint256.FromUint64(testAmount))
@@ -1282,7 +1282,7 @@ func TestAvailableBalance(t *testing.T) {
 	cleanup := setupContractTest()
 	defer cleanup()
 
-	depositAmount := uint256.FromUint64(9000 * uint64(RetrieveRequestPrice))
+	depositAmount := uint256.FromUint64(9000 * RetrieveRequestPrice)
 
 	// deploy a chequebook
 	err := testDeploy(context.TODO(), swap, depositAmount)


### PR DESCRIPTION
This PR is part 2 of implementing issue #1581, which aims at unifying variable types between the SWAP smart contracts and the related code on the go side.

The strategy is to work with the `Uint256` type right up until calling the contract bindings. Only then should the code work with the `big.Int` type.

The following functions have had their signature modified to work with the `Uint256` type:
- `CashChequeBeneficiaryStart`
- `estimatePayout`
- `newSignedTestCheque`
- `testDeployWithPrivateKey`
- `testDeploy`
- `newSwapTester`

Other functions which call these have had their bodies updated as a result.