### PR TITLE
version, changelog: v0.5.6 unstable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## v0.5.6 (Unreleased)
+
 ## v0.5.5 (January 29, 2020)
 
 ### Notes

--- a/version/version.go
+++ b/version/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 0        // Major version component of the current release
-	VersionMinor = 5        // Minor version component of the current release
-	VersionPatch = 5        // Patch version component of the current release
-	VersionMeta  = "stable" // Version metadata to append to the version string
+	VersionMajor = 0          // Major version component of the current release
+	VersionMinor = 5          // Minor version component of the current release
+	VersionPatch = 6          // Patch version component of the current release
+	VersionMeta  = "unstable" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
bump to `0.5.6-unstable`