### PR TITLE
state, swap: add batch support to state store

### DIFF
--- a/state/dbstore.go
+++ b/state/dbstore.go
@@ -134,13 +134,13 @@ func (s *DBStore) Close() error {
 	return s.db.Close()
 }
 
-// StoreBatch is a wrapper around a leveldb batch that takes care of the proper encoding
+// StoreBatch is a wrapper around a leveldb batch that takes care of the proper encoding.
 type StoreBatch struct {
 	leveldb.Batch
 }
 
-// Put encodes the value and puts a corresponding Put operation into the underlying batch
-// This only returns an error if the encoding failed
+// Put encodes the value and puts a corresponding Put operation into the underlying batch.
+// This only returns an error if the encoding failed.
 func (b *StoreBatch) Put(key string, i interface{}) (err error) {
 	var bytes []byte
 	if marshaler, ok := i.(encoding.BinaryMarshaler); ok {
@@ -156,12 +156,12 @@ func (b *StoreBatch) Put(key string, i interface{}) (err error) {
 	return nil
 }
 
-// Delete adds a delete operation to the underlying batch
+// Delete adds a delete operation to the underlying batch.
 func (b *StoreBatch) Delete(key string) {
 	b.Batch.Delete([]byte(key))
 }
 
-// WriteBatch executes the batch on the underlying database
+// WriteBatch executes the batch on the underlying database.
 func (s *DBStore) WriteBatch(batch *StoreBatch) error {
 	return s.db.Write(&batch.Batch, nil)
 }

--- a/state/dbstore_test.go
+++ b/state/dbstore_test.go
@@ -227,6 +227,7 @@ func testStoreBatch(t *testing.T, store Store) {
 
 	batch = new(StoreBatch)
 	batch.Delete("key1")
+	batch.Delete("key2")
 
 	err = store.WriteBatch(batch)
 	if err != nil {
@@ -236,5 +237,10 @@ func testStoreBatch(t *testing.T, store Store) {
 	err = store.Get("key1", &result)
 	if err != ErrNotFound {
 		t.Fatal("expected key1 to be deleted")
+	}
+
+	err = store.Get("key2", &result)
+	if err != ErrNotFound {
+		t.Fatal("expected key2 to be deleted")
 	}
 }

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -465,15 +465,24 @@ func (s *Swap) handleConfirmChequeMsg(ctx context.Context, p *Peer, msg *Confirm
 		return fmt.Errorf("ignoring confirm msg, unexpected cheque, confirm message cheque %s, expected %s", cheque, p.getPendingCheque())
 	}
 
-	err := p.setLastSentCheque(cheque)
+	batch := new(state.StoreBatch)
+	err := batch.Put(sentChequeKey(p.ID()), cheque)
 	if err != nil {
-		return protocols.Break(fmt.Errorf("setLastSentCheque failed: %w", err))
+		return protocols.Break(fmt.Errorf("encoding cheque failed: %w", err))
 	}
 
-	err = p.setPendingCheque(nil)
+	err = batch.Put(pendingChequeKey(p.ID()), nil)
 	if err != nil {
-		return protocols.Break(fmt.Errorf("setPendingCheque failed: %w", err))
+		return protocols.Break(fmt.Errorf("encoding pending cheque failed: %w", err))
 	}
+
+	err = s.store.WriteBatch(batch)
+	if err != nil {
+		return protocols.Break(fmt.Errorf("could not write cheque to database: %w", err))
+	}
+
+	p.lastSentCheque = cheque
+	p.pendingCheque = nil
 
 	return nil
 }


### PR DESCRIPTION
This PR adds support for batch writes to the state store. It introduces a `StoreBatch` struct which wraps around a `leveldb.Batch`. 
Unlike the `leveldb.Batch`, the `Put` function here encodes the value the same way as the stores `Put` function before adding it to the batch and accepts the key as string. Same for `Delete`.

This was added to allow atomic updates to multiple keys which can eliminate many error edge cases that currently exist in the `Swap` codebase. In this PR this change is only made in one place for demonstration purposes. The functionality will be heavily used in another PR currently in progress.