### PR TITLE
api/http/langos: fix TestHTTPMultipleRangeResponse test

### DIFF
--- a/api/http/langos/http_test.go
+++ b/api/http/langos/http_test.go
@@ -115,7 +115,7 @@ func TestHTTPMultipleRangeResponse(t *testing.T) {
 			for i := rand.Intn(5); i >= 0; i-- {
 				var beginning int
 				if l := len(ranges); l > 0 {
-					beginning = ranges[l-1][1]
+					beginning = ranges[l-1][1] + 1
 				}
 				if beginning >= dataSize {
 					break


### PR DESCRIPTION
This PR fixes langos TestHTTPMultipleRangeResponse test by preventing to create multi range HTTP requests that have the same end value for n-th range as the start value for n+1 range. It is possible that such ranges are merged into one if they are of length 1.

The test was run several hundred times locally to validate that it does not flake anymore.