### PR TITLE
contract/ens: use new ens contract address

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -100,7 +100,7 @@ func NewConfig() *Config {
 		SwapLogPath:             "",
 		HiveParams:              network.NewHiveParams(),
 		Pss:                     pss.NewParams(),
-		EnsRoot:                 ens.TestNetAddress,
+		EnsRoot:                 ens.Address,
 		EnsAPIs:                 nil,
 		RnsAPI:                  "",
 		Path:                    node.DefaultDataDir(),

--- a/contracts/ens/ens.go
+++ b/contracts/ens/ens.go
@@ -34,8 +34,7 @@ import (
 )
 
 var (
-	MainNetAddress           = common.HexToAddress("0x314159265dD8dbb310642f98f50C066173C1259b")
-	TestNetAddress           = common.HexToAddress("0x112234455c3a32fd11230c42e7bccd4a84e02010")
+	Address                  = common.HexToAddress("0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e")
 	contentHash_Interface_Id [4]byte
 )
 


### PR DESCRIPTION
This PR is changing ENS contract address to the new one based on the guide https://docs.ens.domains/ens-migration/guide-for-dapp-developers.

All networks have the same contract address, so some of the code is simplified.

This PR is an alternative to https://github.com/ethersphere/swarm/pull/2084.