### PR TITLE
stream: fix stream not wanted bug

### DIFF
--- a/network/stream/stream.go
+++ b/network/stream/stream.go
@@ -479,7 +479,7 @@ func (r *Registry) clientHandleOfferedHashes(ctx context.Context, p *Peer, msg *
 	if !provider.WantStream(p, w.stream) {
 		wantedHashesMsg.BitVector = []byte{}
 		if err := p.Send(ctx, wantedHashesMsg); err != nil {
-			protocols.Break(fmt.Errorf("sending empty wanted hashes:  %w", err))
+			return protocols.Break(fmt.Errorf("sending empty wanted hashes:  %w", err))
 		}
 		return nil
 	}

--- a/network/stream/stream.go
+++ b/network/stream/stream.go
@@ -481,6 +481,7 @@ func (r *Registry) clientHandleOfferedHashes(ctx context.Context, p *Peer, msg *
 		if err := p.Send(ctx, wantedHashesMsg); err != nil {
 			protocols.Break(fmt.Errorf("sending empty wanted hashes:  %w", err))
 		}
+		return nil
 	}
 
 	want, err := bv.New(lenHashes / HashSize)
@@ -571,6 +572,7 @@ func (r *Registry) clientHandleOfferedHashes(ctx context.Context, p *Peer, msg *
 		if provider.WantStream(p, w.stream) {
 			return protocols.Break(errors.New("batch has timed out"))
 		}
+		return nil
 	case <-r.quit:
 		return nil
 	case <-p.quit:


### PR DESCRIPTION
This PR fixes a bug where a stream that is no longer wanted would result in two `WantedHashes` messages sent to the upstream peer.
Certain side effect observed is that the downstream peer would still try to seal the batch in any case, and this in turn causes some other data races on the server side.