### PR TITLE
bmt: fix data races in Hasher

### DIFF
--- a/bmt/bmt.go
+++ b/bmt/bmt.go
@@ -334,11 +334,14 @@ func (h *Hasher) BlockSize() int {
 // Implements hash.Hash in file.SectionWriter
 func (h *Hasher) Sum(b []byte) (s []byte) {
 	t := h.getTree()
+	h.mtx.Lock()
 	if h.size == 0 && t.offset == 0 {
+		h.mtx.Unlock()
 		h.releaseTree()
 		//return h.pool.zerohashes[h.pool.Depth]
 		return h.GetZeroHash()
 	}
+	h.mtx.Unlock()
 	// write the last section with final flag set to true
 	go h.WriteSection(t.cursor, t.section, true, true)
 	// wait for the result
@@ -360,7 +363,9 @@ func (h *Hasher) Write(b []byte) (int, error) {
 	if l == 0 || l > h.pool.Size {
 		return 0, nil
 	}
+	h.mtx.Lock()
 	h.size += len(b)
+	h.mtx.Unlock()
 	t := h.getTree()
 	secsize := 2 * h.pool.SegmentSize
 	// calculate length of missing bit to complete current open section


### PR DESCRIPTION
This PR fixes two data races found in bmt hasher.

Fixes are minimal, but maybe locking can be improved a bit more.

```
==================
WARNING: DATA RACE
Write at 0x00c000080418 by goroutine 87:
  github.com/ethersphere/swarm/bmt.(*Hasher).WriteSection()
      /Users/janos/go/src/github.com/ethersphere/swarm/bmt/bmt.go:445 +0x71

Previous read at 0x00c000080418 by goroutine 39:
  github.com/ethersphere/swarm/bmt.(*Hasher).Sum()
      /Users/janos/go/src/github.com/ethersphere/swarm/bmt/bmt.go:338 +0xae
  github.com/ethersphere/swarm/bmt.syncHash()
      /Users/janos/go/src/github.com/ethersphere/swarm/bmt/bmt_test.go:454 +0xd9
  github.com/ethersphere/swarm/bmt.testHasherCorrectness()
      /Users/janos/go/src/github.com/ethersphere/swarm/bmt/bmt_test.go:318 +0x32b
  github.com/ethersphere/swarm/bmt.TestSyncHasherCorrectness.func1()
      /Users/janos/go/src/github.com/ethersphere/swarm/bmt/bmt_test.go:163 +0x2ed
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Goroutine 87 (running) created at:
  github.com/ethersphere/swarm/bmt.(*Hasher).Write()
      /Users/janos/go/src/github.com/ethersphere/swarm/bmt/bmt.go:398 +0x3f9
  github.com/ethersphere/swarm/bmt.syncHash()
      /Users/janos/go/src/github.com/ethersphere/swarm/bmt/bmt_test.go:453 +0xba
  github.com/ethersphere/swarm/bmt.testHasherCorrectness()
      /Users/janos/go/src/github.com/ethersphere/swarm/bmt/bmt_test.go:318 +0x32b
  github.com/ethersphere/swarm/bmt.TestSyncHasherCorrectness.func1()
      /Users/janos/go/src/github.com/ethersphere/swarm/bmt/bmt_test.go:163 +0x2ed
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199

Goroutine 39 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:960 +0x651
  github.com/ethersphere/swarm/bmt.TestSyncHasherCorrectness()
      /Users/janos/go/src/github.com/ethersphere/swarm/bmt/bmt_test.go:154 +0x163
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199
==================
```

```
==================
WARNING: DATA RACE
Read at 0x00c0000868d8 by goroutine 170:
  github.com/ethersphere/swarm/bmt.(*Hasher).WriteSection()
      /Users/janos/go/src/github.com/ethersphere/swarm/bmt/bmt.go:445 +0x55

Previous write at 0x00c0000868d8 by goroutine 166:
  github.com/ethersphere/swarm/bmt.(*Hasher).Write()
      /Users/janos/go/src/github.com/ethersphere/swarm/bmt/bmt.go:367 +0x9e
  github.com/ethersphere/swarm/bmt.TestBMTWriterBuffers.func1.1()
      /Users/janos/go/src/github.com/ethersphere/swarm/bmt/bmt_test.go:262 +0x23a
  github.com/ethersphere/swarm/bmt.TestBMTWriterBuffers.func1.2()
      /Users/janos/go/src/github.com/ethersphere/swarm/bmt/bmt_test.go:280 +0x34

Goroutine 170 (running) created at:
  github.com/ethersphere/swarm/bmt.(*Hasher).Write()
      /Users/janos/go/src/github.com/ethersphere/swarm/bmt/bmt.go:398 +0x3f9
  github.com/ethersphere/swarm/bmt.TestBMTWriterBuffers.func1.1()
      /Users/janos/go/src/github.com/ethersphere/swarm/bmt/bmt_test.go:262 +0x23a
  github.com/ethersphere/swarm/bmt.TestBMTWriterBuffers.func1.2()
      /Users/janos/go/src/github.com/ethersphere/swarm/bmt/bmt_test.go:280 +0x34

Goroutine 166 (running) created at:
  github.com/ethersphere/swarm/bmt.TestBMTWriterBuffers.func1()
      /Users/janos/go/src/github.com/ethersphere/swarm/bmt/bmt_test.go:279 +0x5ca
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199
==================
```