### PR TITLE
swap: fix various data races

### DIFF
--- a/contracts/swap/swap.go
+++ b/contracts/swap/swap.go
@@ -133,6 +133,7 @@ func (s simpleContract) Deposit(auth *bind.TransactOpts, amount *big.Int) (*type
 // CashChequeBeneficiaryStart sends the transaction to cash a cheque as the beneficiary
 func (s simpleContract) CashChequeBeneficiaryStart(opts *bind.TransactOpts, beneficiary common.Address, cumulativePayout *uint256.Uint256, ownerSig []byte) (*types.Transaction, error) {
 	payout := cumulativePayout.Value()
+	// send a copy of cumulativePayout to instance as it modifies the supplied big int internally
 	tx, err := s.instance.CashChequeBeneficiary(opts, beneficiary, big.NewInt(0).Set(&payout), ownerSig)
 	if err != nil {
 		return nil, err

--- a/contracts/swap/swap.go
+++ b/contracts/swap/swap.go
@@ -133,7 +133,7 @@ func (s simpleContract) Deposit(auth *bind.TransactOpts, amount *big.Int) (*type
 // CashChequeBeneficiaryStart sends the transaction to cash a cheque as the beneficiary
 func (s simpleContract) CashChequeBeneficiaryStart(opts *bind.TransactOpts, beneficiary common.Address, cumulativePayout *uint256.Uint256, ownerSig []byte) (*types.Transaction, error) {
 	payout := cumulativePayout.Value()
-	tx, err := s.instance.CashChequeBeneficiary(opts, beneficiary, &payout, ownerSig)
+	tx, err := s.instance.CashChequeBeneficiary(opts, beneficiary, big.NewInt(0).Set(&payout), ownerSig)
 	if err != nil {
 		return nil, err
 	}

--- a/swap/api.go
+++ b/swap/api.go
@@ -144,10 +144,10 @@ func (s *Swap) PeerCheques(peer enode.ID) (PeerCheques, error) {
 	swapPeer := s.getPeer(peer)
 	if swapPeer != nil {
 		swapPeer.lock.Lock()
-		defer swapPeer.lock.Unlock()
 		pendingCheque = swapPeer.getPendingCheque()
 		sentCheque = swapPeer.getLastSentCheque()
 		receivedCheque = swapPeer.getLastReceivedCheque()
+		swapPeer.lock.Unlock()
 	} else {
 		errPendingCheque := s.store.Get(pendingChequeKey(peer), &pendingCheque)
 		if errPendingCheque != nil && errPendingCheque != state.ErrNotFound {

--- a/swap/api.go
+++ b/swap/api.go
@@ -97,6 +97,8 @@ func (s *Swap) AvailableBalance() (*uint256.Uint256, error) {
 // PeerBalance returns the balance for a given peer
 func (s *Swap) PeerBalance(peer enode.ID) (balance int64, err error) {
 	if swapPeer := s.getPeer(peer); swapPeer != nil {
+		swapPeer.lock.Lock()
+		defer swapPeer.lock.Unlock()
 		return swapPeer.getBalance(), nil
 	}
 	err = s.store.Get(balanceKey(peer), &balance)
@@ -141,6 +143,8 @@ func (s *Swap) PeerCheques(peer enode.ID) (PeerCheques, error) {
 
 	swapPeer := s.getPeer(peer)
 	if swapPeer != nil {
+		swapPeer.lock.Lock()
+		defer swapPeer.lock.Unlock()
 		pendingCheque = swapPeer.getPendingCheque()
 		sentCheque = swapPeer.getLastSentCheque()
 		receivedCheque = swapPeer.getLastReceivedCheque()

--- a/swap/common_test.go
+++ b/swap/common_test.go
@@ -67,6 +67,7 @@ func newTestBackend(t *testing.T) *swapTestBackend {
 		TestBackend:    backend,
 		factoryAddress: factoryAddress,
 		tokenAddress:   tokenAddress,
+		cashDone:       make(chan struct{}),
 	}
 }
 

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -236,8 +236,6 @@ func TestEmitCheque(t *testing.T) {
 	// setup the wait for mined transaction function for testing
 	cleanup := setupContractTest()
 	defer cleanup()
-	// now we need to create the channel...
-	testBackend.cashDone = make(chan struct{})
 
 	log.Debug("deploy to simulated backend")
 
@@ -319,7 +317,7 @@ func TestEmitCheque(t *testing.T) {
 
 	// we wait until the cashCheque is actually terminated (ensures proper nonce count)
 	select {
-	case <-creditorSwap.backend.(*swapTestBackend).cashDone:
+	case <-testBackend.cashDone:
 		log.Debug("cash transaction completed and committed")
 	case <-time.After(4 * time.Second):
 		t.Fatalf("Timeout waiting for cash transaction to complete")

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -432,7 +432,10 @@ loop:
 		case <-ctx.Done():
 			t.Fatal("Expected one cheque, but there is none")
 		default:
-			if creditor.getLastSentCheque() != nil {
+			creditor.lock.Lock()
+			lastSentCheque := creditor.getLastSentCheque()
+			creditor.lock.Unlock()
+			if lastSentCheque != nil {
 				break loop
 			}
 			time.Sleep(10 * time.Millisecond)

--- a/swap/protocol_test.go
+++ b/swap/protocol_test.go
@@ -317,7 +317,7 @@ func TestEmitCheque(t *testing.T) {
 		t.Fatalf("Expected cheque %v at creditor, but it was %v:", cheque, recvCheque)
 	}
 
-	// we wait until the cashCheque is actually terminated (ensures proper nounce count)
+	// we wait until the cashCheque is actually terminated (ensures proper nonce count)
 	select {
 	case <-creditorSwap.backend.(*swapTestBackend).cashDone:
 		log.Debug("cash transaction completed and committed")

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -234,7 +234,12 @@ func newSharedBackendSwaps(t *testing.T, nodeCount int) (*swapSimulationParams, 
 	}
 	defaultBackend.Commit()
 
-	testBackend := &swapTestBackend{TestBackend: mock.NewTestBackend(defaultBackend), factoryAddress: factoryAddress, tokenAddress: tokenAddress}
+	testBackend := &swapTestBackend{
+		TestBackend:    mock.NewTestBackend(defaultBackend),
+		factoryAddress: factoryAddress,
+		tokenAddress:   tokenAddress,
+		cashDone:       make(chan struct{}),
+	}
 	// finally, create all Swap instances for each node, which share the same backend
 	var owner *Owner
 	defParams := newDefaultParams(t)
@@ -270,8 +275,6 @@ func TestMultiChequeSimulation(t *testing.T) {
 	cleanup := setupContractTest()
 	defer cleanup()
 
-	params.backend.cashDone = make(chan struct{}, 1)
-	defer close(params.backend.cashDone)
 	// initialize the simulation
 	sim := simulation.NewBzzInProc(newSimServiceMap(params), false)
 	defer sim.Close()

--- a/swap/simulations_test.go
+++ b/swap/simulations_test.go
@@ -315,13 +315,17 @@ func TestMultiChequeSimulation(t *testing.T) {
 		// the node has all other peers in its peer list
 		debitorSvc.swap.peersLock.Lock()
 		debSwapLen = len(debitorSvc.swap.peers)
-		debLen = len(debitorSvc.peers)
 		debitorSvc.swap.peersLock.Unlock()
+		debitorSvc.lock.Lock()
+		debLen = len(debitorSvc.peers)
+		debitorSvc.lock.Unlock()
 
 		creditorSvc.swap.peersLock.Lock()
 		credSwapLen = len(creditorSvc.swap.peers)
-		credLen = len(creditorSvc.peers)
 		creditorSvc.swap.peersLock.Unlock()
+		creditorSvc.lock.Lock()
+		credLen = len(creditorSvc.peers)
+		creditorSvc.lock.Unlock()
 
 		if debLen == 1 && credLen == 1 && debSwapLen == 1 && credSwapLen == 1 {
 			break

--- a/swap/swap.go
+++ b/swap/swap.go
@@ -505,6 +505,7 @@ func cashCheque(s *Swap, cheque *Cheque) {
 
 // processAndVerifyCheque verifies the cheque and compares it with the last received cheque
 // if the cheque is valid it will also be saved as the new last cheque
+// the caller is expected to hold p.lock
 func (s *Swap) processAndVerifyCheque(cheque *Cheque, p *Peer) (*uint256.Uint256, error) {
 	if err := cheque.verifyChequeProperties(p, s.owner.address); err != nil {
 		return nil, err

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -667,8 +667,7 @@ func TestResetBalance(t *testing.T) {
 	msg := &EmitChequeMsg{
 		Cheque: cheque,
 	}
-	// now we need to create the channel...
-	testBackend.cashDone = make(chan struct{})
+
 	// ...and trigger message handling on the receiver side (creditor)
 	// remember that debitor is the model of the remote node for the creditor...
 	err = creditorSwap.handleEmitChequeMsg(ctx, debitor, msg)
@@ -737,9 +736,6 @@ func TestDebtCheques(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	testBackend.cashDone = make(chan struct{})
-	defer close(testBackend.cashDone)
 
 	// simulate cheque handling
 	err = creditorSwap.handleEmitChequeMsg(ctx, debitorPeer, &EmitChequeMsg{

--- a/swap/swap_test.go
+++ b/swap/swap_test.go
@@ -675,7 +675,7 @@ func TestResetBalance(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// ...on which we wait until the cashCheque is actually terminated (ensures proper nounce count)
+	// ...on which we wait until the cashCheque is actually terminated (ensures proper nonce count)
 	select {
 	case <-testBackend.cashDone:
 		log.Debug("cash transaction completed and committed")
@@ -750,7 +750,7 @@ func TestDebtCheques(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// ...on which we wait until the cashCheque is actually terminated (ensures proper nounce count)
+	// ...on which we wait until the cashCheque is actually terminated (ensures proper nonce count)
 	select {
 	case <-testBackend.cashDone:
 		log.Debug("cash transaction completed and committed")


### PR DESCRIPTION
This PR fixes various data races in the swap tests. With these fixes `go test -race -v ./swap/` should pass without errors.

This covers 4 different issues:
* As it turns out the `abigen` generated functions actually modify the `big.Int`s passed as an argument (by using the `.Mod` function on them internally). This meant that the big int underlying `cheque.CumulativePayout` actually was modified by the cashing which happens in a separate goroutine which caused a race if the value was read elsewhere. As a simple fix a copy is passed to the generated `CashChequeBeneficiary` function.
* In `TestTriggerPaymentThreshold` there is a loop waiting for the `lastSentCheque` to become non-nil. The peer lock is now also acquired in the test.
* In `TestMultiChequeSimulation` the wrong lock was used for accessing the `TestService.peers` map.
* `TestDebtCheque` now waits for cheque cashing to be completed. This is necessary to ensure the cashing goroutine has terminated before the next test starts which could have unintended consequences (e.g. here it lead to a data race regarding the global `swapLog` which was reset by the next test).

Furthermore it
* adds proper locking of peers where it was missing
* initialises `cashDone` during backend creation
* fixes various spelling errors