### PR TITLE
stream: eliminate overlapping requests on the same stream

### DIFF
--- a/network/stream/peer.go
+++ b/network/stream/peer.go
@@ -194,7 +194,7 @@ func (p *Peer) sealWant(w *want) error {
 	}
 	p.mtx.Lock()
 	delete(p.openWants, w.ruid)
-	s := fmt.Sprintf("%s_%t", w.stream.String(), w.head)
+	s := p.getRangeKey(w.stream, w.head)
 	delete(p.openGetRange, s)
 	p.mtx.Unlock()
 	return nil
@@ -225,4 +225,8 @@ func (p *Peer) getOrCreateInterval(key string) (*intervals.Intervals, error) {
 func (p *Peer) peerStreamIntervalKey(stream ID) string {
 	k := fmt.Sprintf("%s|%s", hex.EncodeToString(p.BzzAddr.OAddr), stream.String())
 	return k
+}
+
+func (p *Peer) getRangeKey(id ID, head bool) string {
+	return fmt.Sprintf("%s_%t", id.String(), head)
 }

--- a/network/stream/peer.go
+++ b/network/stream/peer.go
@@ -47,11 +47,6 @@ type Peer struct {
 	quit chan struct{} // closed when peer is going offline
 }
 
-type reqData struct {
-	timestamp time.Time
-	ruid      uint
-}
-
 // newPeer is the constructor for Peer
 func newPeer(peer *network.BzzPeer, baseAddress *network.BzzAddr, i state.Store, providers map[string]StreamProvider) *Peer {
 	p := &Peer{

--- a/network/stream/peer.go
+++ b/network/stream/peer.go
@@ -42,8 +42,14 @@ type Peer struct {
 	streamCursors   map[string]uint64 // key: Stream ID string representation, value: session cursor. Keeps cursors for all streams. when unset - we are not interested in that bin
 	openWants       map[uint]*want    // maintain open wants on the client side
 	openOffers      map[uint]offer    // maintain open offers on the server side
+	openGetRange    map[string]reqData
 
 	quit chan struct{} // closed when peer is going offline
+}
+
+type reqData struct {
+	timestamp time.Time
+	ruid      uint
 }
 
 // newPeer is the constructor for Peer
@@ -55,6 +61,7 @@ func newPeer(peer *network.BzzPeer, baseAddress *network.BzzAddr, i state.Store,
 		streamCursors:  make(map[string]uint64),
 		openWants:      make(map[uint]*want),
 		openOffers:     make(map[uint]offer),
+		openGetRange:   make(map[string]reqData),
 		quit:           make(chan struct{}),
 		logger:         log.NewBaseAddressLogger(baseAddress.ShortString(), "peer", peer.BzzAddr.ShortString()),
 	}

--- a/network/stream/peer.go
+++ b/network/stream/peer.go
@@ -42,7 +42,7 @@ type Peer struct {
 	streamCursors   map[string]uint64 // key: Stream ID string representation, value: session cursor. Keeps cursors for all streams. when unset - we are not interested in that bin
 	openWants       map[uint]*want    // maintain open wants on the client side
 	openOffers      map[uint]offer    // maintain open offers on the server side
-	openGetRange    map[string]reqData
+	openGetRange    map[string]uint   // maintain open GetRange requests to eliminate overlapping requests
 
 	quit chan struct{} // closed when peer is going offline
 }
@@ -61,7 +61,7 @@ func newPeer(peer *network.BzzPeer, baseAddress *network.BzzAddr, i state.Store,
 		streamCursors:  make(map[string]uint64),
 		openWants:      make(map[uint]*want),
 		openOffers:     make(map[uint]offer),
-		openGetRange:   make(map[string]reqData),
+		openGetRange:   make(map[string]uint),
 		quit:           make(chan struct{}),
 		logger:         log.NewBaseAddressLogger(baseAddress.ShortString(), "peer", peer.BzzAddr.ShortString()),
 	}
@@ -199,6 +199,8 @@ func (p *Peer) sealWant(w *want) error {
 	}
 	p.mtx.Lock()
 	delete(p.openWants, w.ruid)
+	s := fmt.Sprintf("%s_%t", w.stream.String(), w.head)
+	delete(p.openGetRange, s)
 	p.mtx.Unlock()
 	return nil
 }

--- a/network/stream/stream.go
+++ b/network/stream/stream.go
@@ -318,14 +318,14 @@ func (r *Registry) clientCreateSendWant(ctx context.Context, p *Peer, stream ID,
 	}
 
 	p.mtx.Lock()
-	s := fmt.Sprintf("%s_%t", stream.String(), head)
+	s := p.getRangeKey(stream, head)
 	if v, ok := p.openGetRange[s]; ok {
 		p.logger.Warn("batch already requested, skipping", "stream", stream, "head", head, "from", from, "to", to, "existing ruid", v)
+		p.mtx.Unlock()
 		return nil
 	}
 	p.openGetRange[s] = g.Ruid
 
-	p.logger.Trace("clientCreateSendWant", "ruid", g.Ruid, "stream", g.Stream, "from", g.From, "to", to)
 	p.openWants[g.Ruid] = &want{
 		ruid:   g.Ruid,
 		stream: g.Stream,
@@ -339,6 +339,8 @@ func (r *Registry) clientCreateSendWant(ctx context.Context, p *Peer, stream ID,
 		requested: time.Now(),
 	}
 	p.mtx.Unlock()
+
+	p.logger.Trace("clientCreateSendWant", "ruid", g.Ruid, "stream", g.Stream, "from", g.From, "to", to)
 
 	return p.Send(ctx, g)
 }


### PR DESCRIPTION
This PR solves a bug where multiple `GetRange` requests were issued without checking if there are any in-flight. This would happen when a depth change would happen on a node, resulting in changes to existing subscriptions on peers.

For example, in the case a stream was no longer wanted, the cursor would be deleted (resulting in a `WantStream()==false` when the range would be delivered), stopping the next batch on that specific stream).
However, a point was missed that the cursors could be deleted, but a request would still be in flight, and _another_ depth change happening in between. So the first request would be handled when the chunks would at some point appear, the cursors would be deleted, but then when the second depth change happens, and the stream is now _again_ wanted - the range would be subsequently requested again, without taking into account the fact that there's already an existing request in flight.

TODO: a check for whether a stream is wanted or not should also be put in `handleOfferedHashes`, due to the fact that a significant amount of time can pass between a `GetRange` to an `OfferedHashes` message while the upstream peer is waiting for new chunks on a specified bin, it could be that the stream is no longer wanted by the downstream peer in the meanwhile.