### PR TITLE
soc: Single Owner Chunks

### DIFF
--- a/storage/soc/doc.go
+++ b/storage/soc/doc.go
@@ -1,0 +1,29 @@
+/*
+Traditionally Swarm chuns are content addressable. i.e.
+
+Chunk Address = sha3(Chunk Payload)
+Lately there is a requirement of chunk structure that adhere to certain modifications. These modification enable
+certain features in Swarm such as Feeds. These features allow only the Owner of the feature to construct the chunk.
+The chunk structure of feeds follow the following structureTraditionally Swarm chunks are content addressable. i.e.
+
+	Chunk Address = sha3(Chunk Payload)
+
+Lately there is a requirement for a chunk structure that adheres to a certain format such that enable the owner of the
+chunks to create certain features in Swarm such as Feeds and Global pinning. These features allow only the Owner of the
+data to construct the chunk. Hence these chunks are called Single Owner Chunks (SOC). The format of SOC is as
+follows
+
+     Chunk Address = Sha3( pubkey(owner) +   ID   )
+                                 (32)    +  (32)       = 64 bytes
+
+
+    Chunk Data = ID   + Signature + padding + span  + payload
+                (32)  +   (65)    +  (23)   + (8)   +  (4096)
+
+          Where, Signature = sign(pubkey(owner) + sha3 (ID + BMTHash(payload)))
+                 span = 8 bytes of real chunk
+                 padding = 23 bytes
+
+*/
+
+package soc

--- a/storage/soc/soc.go
+++ b/storage/soc/soc.go
@@ -1,0 +1,140 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package soc
+
+import (
+	"crypto/ecdsa"
+	"encoding/binary"
+	"errors"
+	"math/rand"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethersphere/swarm/network"
+	"github.com/ethersphere/swarm/storage"
+)
+
+const (
+	DefaultHash       = "SHA3" // http://golang.org/pkg/hash/#Hash
+	PayloadHash       = "BMT"
+	PublicKeySize     = 32  //
+	ReferenceIdSize   = 32  //
+	SOCDataHeaderSize = 128 // // ID  + Signature + padding + span  = 128
+	SignatureSize     = 65
+	PaddingSize       = 23
+)
+
+type Soc struct {
+	pkey        *ecdsa.PrivateKey
+	overlayAddr *network.BzzAddr
+}
+
+type SocChunk struct {
+	address []byte
+	data    []byte
+}
+
+func NewSoc(key *ecdsa.PrivateKey, bzzAddr *network.BzzAddr) *Soc {
+	return &Soc{
+		pkey:        key,
+		overlayAddr: bzzAddr,
+	}
+}
+
+func (s *Soc) NewChunk(refId uint32, ownerPubKey string, span uint64, payload []byte) (*SocChunk, error) {
+	add, err := s.setChunkAddress(ownerPubKey, refId)
+	if err != nil {
+		return nil, err
+	}
+
+	payload, err = s.setChunkData(refId, span, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SocChunk{
+		address: add,
+		data:    payload,
+	}, nil
+}
+
+func (s *Soc) setChunkAddress(ownerKey string, refId uint32) ([]byte, error) {
+	hasher := storage.MakeHashFunc(DefaultHash)
+	hasher().Reset()
+	saddr := make([]byte, PublicKeySize+ReferenceIdSize)
+
+	copy(saddr[:PublicKeySize], []byte(ownerKey))
+	binary.BigEndian.PutUint32(saddr[:PublicKeySize], refId)
+	_, err := hasher().Write(saddr)
+	if err != nil {
+		return nil, err
+	}
+	return hasher().Sum(nil), nil
+}
+
+func (s *Soc) setChunkData(refId uint32, span uint64, data []byte) ([]byte, error) {
+	if data == nil {
+		return nil, errors.New("Invalid data length")
+	}
+
+	//(32)  +   (65)    +  (23)   + (8)   =  128
+	socData := make([]byte, SOCDataHeaderSize+len(data))
+
+	// 1 - Add refId
+	binary.BigEndian.PutUint32(socData[:ReferenceIdSize], refId)
+
+	//BMT (data)
+	payloadHasher := storage.MakeHashFunc(PayloadHash)
+	payloadHasher().Reset()
+	_, err := payloadHasher().Write(data)
+	if err != nil {
+		return nil, err
+	}
+	dataHash := payloadHasher().Sum(nil)
+
+	// Sha3 ( refId + BMT (data))
+	hasher := storage.MakeHashFunc(DefaultHash)
+	hasher().Reset()
+	saddr := make([]byte, ReferenceIdSize+len(dataHash))
+	binary.BigEndian.PutUint32(saddr[:ReferenceIdSize], refId)
+	copy(saddr[ReferenceIdSize:], dataHash)
+	_, err = hasher().Write(saddr)
+	if err != nil {
+		return nil, err
+	}
+	IdandDataHash := hasher().Sum(nil)
+
+	sig, err := crypto.Sign(IdandDataHash, s.pkey)
+	if err != nil {
+		return nil, err
+	}
+
+	// 2 - Add Signature
+	copy(socData[ReferenceIdSize:], sig)
+
+	// 3 - Add Padding
+	padding := make([]byte, PaddingSize)
+	rand.Read(padding)
+	copy(socData[ReferenceIdSize+SignatureSize:], padding)
+
+	// 4 - Span
+	binary.BigEndian.PutUint64(socData[ReferenceIdSize+SignatureSize+PaddingSize:], span)
+
+	// 5 - data
+	copy(socData[:SOCDataHeaderSize], data)
+
+	return saddr, nil
+}

--- a/storage/soc/soc.go
+++ b/storage/soc/soc.go
@@ -29,13 +29,13 @@ const (
 	PayloadHash       = "BMT"
 	PublicKeySize     = 32  //
 	ReferenceIdSize   = 32   //
-	SOCDataHeaderSize = 128 // // ID  + Signature + padding + span  = 128
+	DataHeaderSize    = 128 // // ID  + Signature + padding + span  = 128
 	SignatureSize     = 65
 	PaddingSize       = 23
 	SpanLength        = 8
 )
 
-
+// NewSOCAddress creates the address portion of the Single Owner Chunk
 func NewSOCAddress(ownerKey string, refId []byte) ([]byte, error) {
 	hasher := storage.MakeHashFunc(DefaultHash)
 	hasher().Reset()
@@ -50,18 +50,18 @@ func NewSOCAddress(ownerKey string, refId []byte) ([]byte, error) {
 	return hasher().Sum(nil), nil
 }
 
+//NewSOCData creates the chunk payload required for a Single Owner Chunk
 func NewSOCData(refId []byte, span uint64, data []byte, pkey *ecdsa.PrivateKey) ([]byte, error) {
 	if data == nil {
 		return nil, errors.New("Invalid data length")
 	}
 
 	//(32)  +   (65)    +  (23)   + (8)   =  128
-	socData := make([]byte, SOCDataHeaderSize+len(data))
+	socData := make([]byte, DataHeaderSize+len(data))
 
 	// 1 - Add refId
 	copy(socData[:ReferenceIdSize], refId)
-
-
+	
 	// 2 - Add Signature
 	idAndDataHash, err := getIdAndDataHash(span, data, refId)
 	if err != nil {
@@ -81,7 +81,7 @@ func NewSOCData(refId []byte, span uint64, data []byte, pkey *ecdsa.PrivateKey) 
 	binary.BigEndian.PutUint64(socData[ReferenceIdSize+SignatureSize+PaddingSize:], span)
 
 	// 5 - data
-	copy(socData[:SOCDataHeaderSize], data)
+	copy(socData[:DataHeaderSize], data)
 
 	return socData, nil
 }

--- a/storage/soc/soc_test.go
+++ b/storage/soc/soc_test.go
@@ -1,0 +1,60 @@
+// Copyright 2019 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package soc
+
+import (
+	"encoding/hex"
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethersphere/swarm/chunk"
+	"github.com/ethersphere/swarm/network"
+)
+
+func createRandomSOC(t *testing.T, refId uint32) {
+	privKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("could not generate a random key")
+	}
+
+	pubKey := hex.EncodeToString(crypto.FromECDSAPub(&privKey.PublicKey))
+	data := make([]byte, chunk.DefaultSize)
+	rand.Read(data)
+
+	soc := NewSoc(privKey, network.RandomBzzAddr())
+	span := rand.Uint64()
+	socChunk, err := soc.NewChunk(refId, pubKey, span, data)
+	if err != nil {
+		t.Fatalf("could not create Soc chunk")
+	}
+
+	if !verifySocChunk(refId, pubKey, data, socChunk) {
+		t.Fatalf("chunk verification failed")
+	}
+}
+
+func verifySocChunk(refId uint32, pubKey string, data []byte, socChunk *SocChunk) bool {
+	return true
+}
+
+func TestRandomDataForSoc(t *testing.T) {
+	s := make([]int, 10)
+	for _ = range s {
+		createRandomSOC(t, rand.Uint32())
+	}
+}

--- a/storage/soc/soc_test.go
+++ b/storage/soc/soc_test.go
@@ -60,7 +60,7 @@ func verifySocChunk(t *testing.T, refId []byte, pubKey string, span uint64, data
 		t.Fatalf("soc address length is not 32 bytes")
 	}
 
-	if len(data) !=  (SOCDataHeaderSize + len(data)) {
+	if len(socData) !=  (DataHeaderSize + len(data)) {
 		t.Fatalf("soc payload length is not 128 + actual data length")
 	}
 
@@ -70,21 +70,19 @@ func verifySocChunk(t *testing.T, refId []byte, pubKey string, span uint64, data
 	}
 
 
-	// verify signatures
-
-	//extractedSignature := make([]byte, SignatureSize)
-	//extractedSignature = data[ReferenceIdSize:ReferenceIdSize+SignatureSize]
-	//dataUsedForSignature, err := getIdAndDataHash(span, data, refId)
-	//if err != nil {
-	//	t.Fatalf("could not get the data used for signature")
-	//}
-	//extractedPublicKey, err := crypto.SigToPub(dataUsedForSignature, extractedSignature)
-	//extractedPublicKey.
-	//
-	//if pkey.Public() == extractedPublicKey {
-	//	t.Fatalf("error in signature")
-	//}
-
+	// verify signatures and public key
+	extractedSignature := make([]byte, SignatureSize)
+	extractedSignature = data[ReferenceIdSize:ReferenceIdSize+SignatureSize]
+	dataUsedForSignature, err := getIdAndDataHash(span, data, refId)
+	if err != nil {
+		t.Fatalf("could not get the data used for signature")
+	}
+	extractedPublicKey, err := crypto.SigToPub(dataUsedForSignature, extractedSignature)
+	extractedPublicKeyBytes := crypto.FromECDSAPub(extractedPublicKey)
+	pubkey := crypto.FromECDSAPub(&pkey.PublicKey)
+	if bytes.Equal(pubkey,extractedPublicKeyBytes) {
+		t.Fatalf("error in signature")
+	}
 }
 
 


### PR DESCRIPTION
Traditionally Swarm chuns are content addressable. i.e.

```
   Chunk Address = sha3(Chunk Payload)
```

Lately there is a requirement of chunk structure that adhere to certain modifications. These modification enable certain features in Swarm such as Feeds. These features allow only the Owner of the feature to construct the chunk. But this requirement is being felt in other places too.. like recovery chunks in GLobal pining.

This PR tries to implement a generic design for something called as Single Owner Chuks.  THe format of which is as follows

```
    Chunk Address = Sha3( pubkey(owner) +   referenceId  )
                                                               ( 32)    +  (32)       = 64 bytes
                                
                                
    Chunk Data = referenceID + Signature + padding + span  + payload  
                                   (32)               (65)              (23)          (8)        (4096) 
           
          Where, Signature = sign(pubkey(owner) + sha3 (ID + BMTHash(payload)))
                 span = 8 bytes of real chunk
                 padding = 23 bytes
```
