### PR TITLE
p2p, retrieval, storage: reduce logging

### DIFF
--- a/network/retrieval/retrieve.go
+++ b/network/retrieval/retrieve.go
@@ -401,11 +401,11 @@ FINDPEER:
 
 	protoPeer := r.getPeer(sp.ID())
 	if protoPeer == nil {
-		r.logger.Warn("findPeer returned a peer to skip", "peer", sp.String(), "retry", retries, "ref", req.Addr)
+		r.logger.Trace("findPeer returned a peer to skip", "peer", sp.String(), "retry", retries, "ref", req.Addr)
 		req.PeersToSkip.Store(sp.ID().String(), time.Now())
 		retries++
 		if retries == maxFindPeerRetries {
-			r.logger.Error("max find peer retries reached", "max retries", maxFindPeerRetries, "ref", req.Addr)
+			r.logger.Trace("max find peer retries reached", "max retries", maxFindPeerRetries, "ref", req.Addr)
 			return nil, func() {}, ErrNoPeerFound
 		}
 
@@ -423,7 +423,7 @@ FINDPEER:
 	}
 	err = protoPeer.Send(ctx, ret)
 	if err != nil {
-		protoPeer.logger.Error("error sending retrieve request to peer", "ruid", ret.Ruid, "err", err)
+		protoPeer.logger.Trace("error sending retrieve request to peer", "ruid", ret.Ruid, "err", err)
 		cleanup()
 		return nil, func() {}, err
 	}

--- a/p2p/protocols/protocol.go
+++ b/p2p/protocols/protocol.go
@@ -222,7 +222,7 @@ func (p *Peer) run(handler func(ctx context.Context, msg interface{}) error) err
 				if errors.As(err, &e) {
 					p.Drop(err.Error())
 				} else {
-					log.Warn(err.Error())
+					log.Trace(err.Error())
 				}
 			}
 		}()

--- a/storage/netstore.go
+++ b/storage/netstore.go
@@ -274,7 +274,7 @@ func (n *NetStore) RemoteFetch(ctx context.Context, req *Request, fi *Fetcher) (
 			osp.Finish()
 			break
 		case <-ctx.Done(): // global fetcher timeout
-			n.logger.Warn("remote.fetch, global timeout fail", "ref", ref, "err", ctx.Err())
+			n.logger.Trace("remote.fetch, global timeout fail", "ref", ref, "err", ctx.Err())
 			metrics.GetOrRegisterCounter("remote.fetch.timeout.global", nil).Inc(1)
 
 			osp.LogFields(olog.Bool("fail", true))


### PR DESCRIPTION
we log too much stuff to standard output and users are complaining on "errors" while we know these are not errors but just erroneous log level.

from now on - if we want to see dev messages we should just increase loglevel to debug/trace.
