### PR TITLE
protocols, swap: drop unincentivized peers when sending/receiving messages

### DIFF
--- a/swap/swap.go
+++ b/swap/swap.go
@@ -286,7 +286,7 @@ func (s *Swap) modifyBalanceOk(amount int64, swapPeer *Peer) (err error) {
 func (s *Swap) Check(amount int64, peer *protocols.Peer) (err error) {
 	swapPeer := s.getPeer(peer.ID())
 	if swapPeer == nil {
-		return fmt.Errorf("peer %s not a swap enabled peer", peer.ID().String())
+		return fmt.Errorf(protocols.ErrNotAccPeer.Error(), peer.ID().String())
 	}
 
 	swapPeer.lock.Lock()
@@ -300,7 +300,7 @@ func (s *Swap) Check(amount int64, peer *protocols.Peer) (err error) {
 func (s *Swap) Add(amount int64, peer *protocols.Peer) (err error) {
 	swapPeer := s.getPeer(peer.ID())
 	if swapPeer == nil {
-		return fmt.Errorf("peer %s not a swap enabled peer", peer.ID().String())
+		return fmt.Errorf(protocols.ErrNotAccPeer.Error(), peer.ID().String())
 	}
 
 	swapPeer.lock.Lock()


### PR DESCRIPTION
This PR changes the code in the sending and receiving messages functions so that peers are dropped when they are unincentivized (when the node running is not).

This can happen if the peer in question is registered in other protocols but not in SWAP. 

The benefit of this change is to avoid useless message exchanges that are going to be dropped every time they accounting hook is called.

closes #1917