### PR TITLE
trojan, pss, swarm, api, main, localstore: add store hook for trojan messages

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -82,6 +82,7 @@ type Config struct {
 	BootnodeMode       bool
 	DisableAutoConnect bool
 	EnablePinning      bool
+	GlobalPinner       bool
 	Cors               string
 	BzzAccount         string
 	GlobalStoreAPI     string

--- a/chunk/chunk.go
+++ b/chunk/chunk.go
@@ -278,7 +278,7 @@ type Validator interface {
 // with validators check.
 type ValidatorStore struct {
 	Store
-	pssCallback func(Chunk) error
+	deliverHook func(Chunk)
 	validators  []Validator
 }
 
@@ -291,9 +291,9 @@ func NewValidatorStore(store Store, validators ...Validator) (s *ValidatorStore)
 	}
 }
 
-// SetPssCallback allows injecting a callback func on the ValidatorStore struct
-func (s *ValidatorStore) SetPssCallback(f func(Chunk) error) {
-	s.pssCallback = f
+// SetDeliverHook allows injecting a callback func on the ValidatorStore struct
+func (s *ValidatorStore) SetDeliverHook(f func(Chunk)) {
+	s.deliverHook = f
 }
 
 // Put overrides Store put method with validators check. For Put to succeed,
@@ -313,8 +313,8 @@ func (s *ValidatorStore) Put(ctx context.Context, mode ModePut, chs ...Chunk) (e
 func (s *ValidatorStore) validate(ch Chunk) bool {
 	for _, v := range s.validators {
 		if v.Validate(ch) {
-			if s.pssCallback != nil {
-				go s.pssCallback(ch) // TODO: needs error handling
+			if s.deliverHook != nil {
+				go s.deliverHook(ch)
 			}
 			return true
 		}

--- a/chunk/chunk.go
+++ b/chunk/chunk.go
@@ -278,8 +278,8 @@ type Validator interface {
 // with validators check.
 type ValidatorStore struct {
 	Store
-	deliverHook func(Chunk)
-	validators  []Validator
+	deliverCallback func(Chunk)
+	validators      []Validator
 }
 
 // NewValidatorStore returns a new ValidatorStore which uses
@@ -291,9 +291,10 @@ func NewValidatorStore(store Store, validators ...Validator) (s *ValidatorStore)
 	}
 }
 
-// SetDeliverHook allows injecting a callback func on the ValidatorStore struct
-func (s *ValidatorStore) SetDeliverHook(f func(Chunk)) {
-	s.deliverHook = f
+// WithDeliverCallback allows injecting a callback func on the ValidatorStore struct
+func (s *ValidatorStore) WithDeliverCallback(f func(Chunk)) *ValidatorStore {
+	s.deliverCallback = f
+	return s
 }
 
 // Put overrides Store put method with validators check. For Put to succeed,
@@ -313,8 +314,8 @@ func (s *ValidatorStore) Put(ctx context.Context, mode ModePut, chs ...Chunk) (e
 func (s *ValidatorStore) validate(ch Chunk) bool {
 	for _, v := range s.validators {
 		if v.Validate(ch) {
-			if s.deliverHook != nil {
-				go s.deliverHook(ch)
+			if s.deliverCallback != nil {
+				go s.deliverCallback(ch)
 			}
 			return true
 		}

--- a/cmd/swarm/config.go
+++ b/cmd/swarm/config.go
@@ -273,6 +273,9 @@ func flagsOverride(currentConfig *bzzapi.Config, ctx *cli.Context) *bzzapi.Confi
 	if ctx.GlobalBool(SwarmEnablePinningFlag.Name) {
 		currentConfig.EnablePinning = true
 	}
+	if ctx.GlobalBool(SwarmGlobalPinnerFlag.Name) {
+		currentConfig.GlobalPinner = true
+	}
 	return currentConfig
 }
 

--- a/cmd/swarm/flags.go
+++ b/cmd/swarm/flags.go
@@ -236,6 +236,10 @@ var (
 		Name:  "enable-pinning",
 		Usage: "Use this flag to enable the pinning feature",
 	}
+	SwarmGlobalPinnerFlag = cli.BoolFlag{
+		Name:  "global-pinner",
+		Usage: "Use this flag to mark the running node as a global pinner",
+	}
 	SwarmProgressFlag = cli.BoolFlag{
 		Name:  "progress",
 		Usage: "Use this flag to enable tracking of the upload progress through the CLI",

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -199,6 +199,7 @@ func init() {
 		SwarmBzzKeyHexFlag,
 		SwarmNetworkIdFlag,
 		SwarmEnablePinningFlag,
+		SwarmGlobalPinnerFlag,
 		// upload flags
 		SwarmApiFlag,
 		SwarmRecursiveFlag,

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -40,6 +40,7 @@ func NewPss(localStore chunk.Store) *Pss {
 	}
 }
 
+// Handler defines code to be executed upon reception of a trojan message
 type Handler func(trojan.Message) error
 
 // Send constructs a padded message with topic and payload,
@@ -67,13 +68,14 @@ func (p *Pss) Send(ctx context.Context, targets [][]byte, topic trojan.Topic, pa
 	return tc, nil
 }
 
+// Register allows the definition of a Handler func for a specific topic on the pss struct
 func (p *Pss) Register(topic trojan.Topic, hndlr Handler) {
 	p.handlersMu.Lock()
 	defer p.handlersMu.Unlock()
 	p.handlers[topic] = hndlr
 }
 
-func (p *Pss) GetHandler(topic trojan.Topic) Handler {
+func (p *Pss) getHandler(topic trojan.Topic) Handler {
 	p.handlersMu.RLock()
 	defer p.handlersMu.RUnlock()
 	return p.handlers[topic]

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -75,6 +75,15 @@ func (p *Pss) Register(topic trojan.Topic, hndlr Handler) {
 	p.handlers[topic] = hndlr
 }
 
+// Deliver allows unwrapping a chunk as a trojan message and calling its handler func based on its topic
+func (p *Pss) Deliver(c chunk.Chunk) error {
+	m, _ := trojan.Unwrap(c) // TODO: handle error
+	h := p.getHandler(m.GetTopic())
+	h(*m)
+	return nil
+}
+
+// getHandler returns the Handler func registered in pss for the given topic
 func (p *Pss) getHandler(topic trojan.Topic) Handler {
 	p.handlersMu.RLock()
 	defer p.handlersMu.RUnlock()

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -40,7 +40,7 @@ func NewPss(localStore chunk.Store) *Pss {
 }
 
 type handler struct {
-	f func()
+	f func() error
 }
 
 // Send constructs a padded message with topic and payload,
@@ -78,4 +78,9 @@ func (p *Pss) getHandler(topic trojan.Topic) *handler {
 	p.handlersMu.RLock()
 	defer p.handlersMu.RUnlock()
 	return &(p.handlers[topic])
+}
+
+func (p *Pss) executeHandler(topic trojan.Topic) error {
+	handler := p.getHandler(topic)
+	return handler.f()
 }

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -36,6 +36,7 @@ type Pss struct {
 func NewPss(localStore chunk.Store) *Pss {
 	return &Pss{
 		localStore: localStore,
+		handlers:   make(map[trojan.Topic]Handler),
 	}
 }
 

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -41,7 +41,7 @@ func NewPss(localStore chunk.Store) *Pss {
 }
 
 // Handler defines code to be executed upon reception of a trojan message
-type Handler func(trojan.Message) error
+type Handler func(trojan.Message)
 
 // Send constructs a padded message with topic and payload,
 // wraps it in a trojan chunk such that one of the targets is a prefix of the chunk address
@@ -77,10 +77,10 @@ func (p *Pss) Register(topic trojan.Topic, hndlr Handler) {
 
 // Deliver allows unwrapping a chunk as a trojan message and calling its handler func based on its topic
 func (p *Pss) Deliver(c chunk.Chunk) {
-	m, _ := trojan.Unwrap(c) // TODO: handle error
+	m, _ := trojan.Unwrap(c)
 	h := p.getHandler(m.Topic)
 	if h != nil {
-		h(*m) // TODO: handle error
+		h(*m)
 	}
 }
 

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -28,7 +28,7 @@ import (
 // Pss is the top-level struct, which takes care of message sending
 type Pss struct {
 	localStore chunk.Store
-	handlers   map[trojan.Topic]handler
+	handlers   map[trojan.Topic]Handler
 	handlersMu sync.RWMutex
 }
 
@@ -39,8 +39,14 @@ func NewPss(localStore chunk.Store) *Pss {
 	}
 }
 
-type handler struct {
+type Handler struct {
 	f func() error
+}
+
+func NewHandler(f func() error) *Handler {
+	return &Handler{
+		f: f,
+	}
 }
 
 // Send constructs a padded message with topic and payload,
@@ -68,13 +74,13 @@ func (p *Pss) Send(ctx context.Context, targets [][]byte, topic trojan.Topic, pa
 	return tc, nil
 }
 
-func (p *Pss) Register(topic trojan.Topic, hndlr *handler) {
+func (p *Pss) Register(topic trojan.Topic, hndlr *Handler) {
 	p.handlersMu.Lock()
 	defer p.handlersMu.Unlock()
 	p.handlers[topic] = *hndlr
 }
 
-func (p *Pss) getHandler(topic trojan.Topic) *handler {
+func (p *Pss) getHandler(topic trojan.Topic) *Handler {
 	p.handlersMu.RLock()
 	defer p.handlersMu.RUnlock()
 	h := p.handlers[topic]

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -76,13 +76,12 @@ func (p *Pss) Register(topic trojan.Topic, hndlr Handler) {
 }
 
 // Deliver allows unwrapping a chunk as a trojan message and calling its handler func based on its topic
-func (p *Pss) Deliver(c chunk.Chunk) error {
+func (p *Pss) Deliver(c chunk.Chunk) {
 	m, _ := trojan.Unwrap(c) // TODO: handle error
 	h := p.getHandler(m.GetTopic())
 	if h != nil {
 		h(*m)
 	}
-	return nil
 }
 
 // getHandler returns the Handler func registered in pss for the given topic

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -77,7 +77,8 @@ func (p *Pss) Register(topic trojan.Topic, hndlr *handler) {
 func (p *Pss) getHandler(topic trojan.Topic) *handler {
 	p.handlersMu.RLock()
 	defer p.handlersMu.RUnlock()
-	return &(p.handlers[topic])
+	h := p.handlers[topic]
+	return &h
 }
 
 func (p *Pss) executeHandler(topic trojan.Topic) error {

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -80,7 +80,7 @@ func (p *Pss) Deliver(c chunk.Chunk) {
 	m, _ := trojan.Unwrap(c) // TODO: handle error
 	h := p.getHandler(m.Topic)
 	if h != nil {
-		h(*m)
+		h(*m) // TODO: handle error
 	}
 }
 

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -73,3 +73,9 @@ func (p *Pss) Register(topic trojan.Topic, hndlr *handler) {
 	defer p.handlersMu.Unlock()
 	p.handlers[topic] = *hndlr
 }
+
+func (p *Pss) getHandler(topic trojan.Topic) *handler {
+	p.handlersMu.RLock()
+	defer p.handlersMu.RUnlock()
+	return &(p.handlers[topic])
+}

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -28,7 +28,7 @@ import (
 // Pss is the top-level struct, which takes care of message sending
 type Pss struct {
 	localStore chunk.Store
-	handlers   map[trojan.Topic]map[*handler]bool
+	handlers   map[trojan.Topic]handler
 	handlersMu sync.RWMutex
 }
 
@@ -71,11 +71,5 @@ func (p *Pss) Send(ctx context.Context, targets [][]byte, topic trojan.Topic, pa
 func (p *Pss) Register(topic trojan.Topic, hndlr *handler) {
 	p.handlersMu.Lock()
 	defer p.handlersMu.Unlock()
-	handlers := p.handlers[topic]
-	if handlers == nil {
-		handlers = make(map[*handler]bool)
-		p.handlers[topic] = handlers
-	}
-	handlers[hndlr] = true
-
+	p.handlers[topic] = *hndlr
 }

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -78,7 +78,7 @@ func (p *Pss) Register(topic trojan.Topic, hndlr Handler) {
 // Deliver allows unwrapping a chunk as a trojan message and calling its handler func based on its topic
 func (p *Pss) Deliver(c chunk.Chunk) {
 	m, _ := trojan.Unwrap(c) // TODO: handle error
-	h := p.getHandler(m.GetTopic())
+	h := p.getHandler(m.Topic)
 	if h != nil {
 		h(*m)
 	}

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -78,7 +78,3 @@ func (p *Pss) getHandler(topic trojan.Topic) Handler {
 	defer p.handlersMu.RUnlock()
 	return p.handlers[topic]
 }
-
-func (p *Pss) executeHandler(topic trojan.Topic, m trojan.Message) error {
-	return p.getHandler(topic)(m)
-}

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -73,7 +73,7 @@ func (p *Pss) Register(topic trojan.Topic, hndlr Handler) {
 	p.handlers[topic] = hndlr
 }
 
-func (p *Pss) getHandler(topic trojan.Topic) Handler {
+func (p *Pss) GetHandler(topic trojan.Topic) Handler {
 	p.handlersMu.RLock()
 	defer p.handlersMu.RUnlock()
 	return p.handlers[topic]

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -79,7 +79,9 @@ func (p *Pss) Register(topic trojan.Topic, hndlr Handler) {
 func (p *Pss) Deliver(c chunk.Chunk) error {
 	m, _ := trojan.Unwrap(c) // TODO: handle error
 	h := p.getHandler(m.GetTopic())
-	h(*m)
+	if h != nil {
+		h(*m)
+	}
 	return nil
 }
 

--- a/pss/pss_test.go
+++ b/pss/pss_test.go
@@ -89,6 +89,7 @@ func newMockLocalStore(t *testing.T) *localstore.DB {
 	return localStore
 }
 
+// TestRegister verifies that handler funcs are able to be registered correctly in pss
 func TestRegister(t *testing.T) {
 	localStore := newMockLocalStore(t)
 	pss := NewPss(localStore)
@@ -98,7 +99,7 @@ func TestRegister(t *testing.T) {
 		t.Fatalf("expected pss handlers to contain 0 elements, but its length is %d", len(pss.handlers))
 	}
 
-	handlerVerifier := 0 // test variable to check retrieved hanlder funcs are correct
+	handlerVerifier := 0 // test variable to check handler funcs are correctly retrieved
 
 	// register first handler
 	testHandler := func(m trojan.Message) error {
@@ -131,10 +132,10 @@ func TestRegister(t *testing.T) {
 	}
 
 	registeredHandler = pss.getHandler(testTopic)
-	registeredHandler(trojan.Message{}) // call handder to verify the retrieved func is correct
+	registeredHandler(trojan.Message{}) // call handler to verify the retrieved func is correct
 
 	if handlerVerifier != 2 {
-		t.Fatal("unexpected handler retrieved")
+		t.Fatalf("unexpected handler retrieved, verifier variable should be %d but is %d instead", 2, handlerVerifier)
 	}
 }
 
@@ -157,7 +158,7 @@ func TestDeliver(t *testing.T) {
 	}
 
 	// create and register handler
-	var tt trojan.Topic // test variable to check handler func was called
+	var tt trojan.Topic // test variable to check handler func was correctly called
 	hndlr := func(m trojan.Message) error {
 		tt = m.Topic // copy the message topic to the test variable
 		return nil
@@ -167,7 +168,7 @@ func TestDeliver(t *testing.T) {
 	// deliver on chunk and verify test topic variable value change
 	pss.Deliver(chunk)
 	if tt != msg.Topic {
-		t.Fatalf("expected test topic to have a value of %v but is %v instead", msg.Topic, tt)
+		t.Fatalf("unexpected result for pss Deliver func, expected test variable to have a value of %v but is %v instead", msg.Topic, tt)
 	}
 
 }

--- a/pss/pss_test.go
+++ b/pss/pss_test.go
@@ -102,9 +102,8 @@ func TestRegister(t *testing.T) {
 	handlerVerifier := 0 // test variable to check handler funcs are correctly retrieved
 
 	// register first handler
-	testHandler := func(m trojan.Message) error {
+	testHandler := func(m trojan.Message) {
 		handlerVerifier = 1
-		return nil
 	}
 	testTopic := trojan.NewTopic("FIRST_HANDLER")
 	pss.Register(testTopic, testHandler)
@@ -121,9 +120,8 @@ func TestRegister(t *testing.T) {
 	}
 
 	// register second handler
-	testHandler = func(m trojan.Message) error {
+	testHandler = func(m trojan.Message) {
 		handlerVerifier = 2
-		return nil
 	}
 	testTopic = trojan.NewTopic("SECOND_HANDLER")
 	pss.Register(testTopic, testHandler)
@@ -161,9 +159,8 @@ func TestDeliver(t *testing.T) {
 
 	// create and register handler
 	var tt trojan.Topic // test variable to check handler func was correctly called
-	hndlr := func(m trojan.Message) error {
+	hndlr := func(m trojan.Message) {
 		tt = m.Topic // copy the message topic to the test variable
-		return nil
 	}
 	pss.Register(topic, hndlr)
 

--- a/pss/pss_test.go
+++ b/pss/pss_test.go
@@ -93,15 +93,47 @@ func TestRegister(t *testing.T) {
 	localStore := newMockLocalStore(t)
 	pss := NewPss(localStore)
 
+	// pss handlers should be empty
 	if len(pss.handlers) != 0 {
 		t.Fatalf("expected pss handlers to contain 0 elements, but its length is %d", len(pss.handlers))
 	}
 
-	testHandler := func(m trojan.Message) error { return nil }
-	pss.Register(trojan.NewTopic("TEST"), testHandler)
+	handlerVerifier := 0
+	// register first handler
+	testHandler := func(m trojan.Message) error {
+		handlerVerifier = 1
+		return nil
+	}
+	testTopic := trojan.NewTopic("FIRST_HANDLER")
+	pss.Register(testTopic, testHandler)
 
 	if len(pss.handlers) != 1 {
 		t.Fatalf("expected pss handlers to contain 1 element, but its length is %d", len(pss.handlers))
+	}
+
+	registeredHandler := pss.getHandler(testTopic)
+	registeredHandler(trojan.Message{}) // call hanlder to verify the retrieved func is correct
+
+	if handlerVerifier != 1 {
+		t.Fatal("unexpected handler retrieved")
+	}
+
+	// register second handler
+	testHandler = func(m trojan.Message) error {
+		handlerVerifier = 2
+		return nil
+	}
+	testTopic = trojan.NewTopic("SECPMD_HANDLER")
+	pss.Register(testTopic, testHandler)
+	if len(pss.handlers) != 2 {
+		t.Fatalf("expected pss handlers to contain 2 elements, but its length is %d", len(pss.handlers))
+	}
+
+	registeredHandler = pss.getHandler(testTopic)
+	registeredHandler(trojan.Message{}) // call hanlder to verify the retrieved func is correct
+
+	if handlerVerifier != 2 {
+		t.Fatal("unexpected handler retrieved")
 	}
 }
 

--- a/pss/pss_test.go
+++ b/pss/pss_test.go
@@ -96,6 +96,13 @@ func TestRegister(t *testing.T) {
 	if len(pss.handlers) != 0 {
 		t.Fatalf("expected pss handlers to contain 0 elements, but its length is %d", len(pss.handlers))
 	}
+
+	testHandler := func(m trojan.Message) error { return nil }
+	pss.Register(trojan.NewTopic("TEST"), testHandler)
+
+	if len(pss.handlers) != 1 {
+		t.Fatalf("expected pss handlers to contain 1 element, but its length is %d", len(pss.handlers))
+	}
 }
 
 // TODO: later test could be a simulation test for 2 nodes, localstore + netstore

--- a/pss/pss_test.go
+++ b/pss/pss_test.go
@@ -117,7 +117,7 @@ func TestRegister(t *testing.T) {
 	registeredHandler(trojan.Message{}) // call handler to verify the retrieved func is correct
 
 	if handlerVerifier != 1 {
-		t.Fatalf("unexpected handler retrieved, verifier variable should be %d but is %d instead", 1, handlerVerifier)
+		t.Fatalf("unexpected handler retrieved, verifier variable should be 1 but is %d instead", handlerVerifier)
 	}
 
 	// register second handler
@@ -135,7 +135,7 @@ func TestRegister(t *testing.T) {
 	registeredHandler(trojan.Message{}) // call handler to verify the retrieved func is correct
 
 	if handlerVerifier != 2 {
-		t.Fatalf("unexpected handler retrieved, verifier variable should be %d but is %d instead", 2, handlerVerifier)
+		t.Fatalf("unexpected handler retrieved, verifier variable should be 2 but is %d instead", handlerVerifier)
 	}
 }
 

--- a/pss/pss_test.go
+++ b/pss/pss_test.go
@@ -37,6 +37,7 @@ func TestTrojanChunkRetrieval(t *testing.T) {
 	ctx := context.TODO()
 
 	localStore := newMockLocalStore(t)
+	pss := NewPss(localStore)
 
 	testTargets := [][]byte{
 		{57, 120},
@@ -48,8 +49,6 @@ func TestTrojanChunkRetrieval(t *testing.T) {
 	topic := trojan.NewTopic("RECOVERY")
 
 	var ch chunk.Chunk
-
-	pss := NewPss(localStore)
 
 	// call Send to store trojan chunk in localstore
 	if ch, err = pss.Send(ctx, testTargets, topic, payload); err != nil {
@@ -88,6 +87,15 @@ func newMockLocalStore(t *testing.T) *localstore.DB {
 	}
 
 	return localStore
+}
+
+func TestRegister(t *testing.T) {
+	localStore := newMockLocalStore(t)
+	pss := NewPss(localStore)
+
+	if len(pss.handlers) != 0 {
+		t.Fatalf("expected pss handlers to contain 0 elements, but its length is %d", len(pss.handlers))
+	}
 }
 
 // TODO: later test could be a simulation test for 2 nodes, localstore + netstore

--- a/pss/pss_test.go
+++ b/pss/pss_test.go
@@ -117,7 +117,7 @@ func TestRegister(t *testing.T) {
 	registeredHandler(trojan.Message{}) // call handler to verify the retrieved func is correct
 
 	if handlerVerifier != 1 {
-		t.Fatal("unexpected handler retrieved")
+		t.Fatalf("unexpected handler retrieved, verifier variable should be %d but is %d instead", 1, handlerVerifier)
 	}
 
 	// register second handler
@@ -139,6 +139,8 @@ func TestRegister(t *testing.T) {
 	}
 }
 
+// TestDeliver verifies that registering a handler on pss for a given topic and then submitting a trojan chunk with said topic to it
+// results in the execution of the expected handler func
 func TestDeliver(t *testing.T) {
 	localStore := newMockLocalStore(t)
 	pss := NewPss(localStore)
@@ -165,7 +167,7 @@ func TestDeliver(t *testing.T) {
 	}
 	pss.Register(topic, hndlr)
 
-	// deliver on chunk and verify test topic variable value change
+	// call pss Deliver on chunk and verify test topic variable value changes
 	pss.Deliver(chunk)
 	if tt != msg.Topic {
 		t.Fatalf("unexpected result for pss Deliver func, expected test variable to have a value of %v but is %v instead", msg.Topic, tt)

--- a/pss/trojan/message.go
+++ b/pss/trojan/message.go
@@ -113,7 +113,6 @@ func (m *Message) Wrap(targets [][]byte) (chunk.Chunk, error) {
 
 // Unwrap attemps to determine whether the given chunk is a trojan chunk
 // it will return the resulting message if the unwrapping is successful, and an error otherwise
-// TODO: move this to PSS API?
 func Unwrap(c chunk.Chunk) (*Message, error) {
 	d := c.Data()
 

--- a/pss/trojan/message.go
+++ b/pss/trojan/message.go
@@ -59,9 +59,6 @@ var ErrEmptyTargets = errors.New("target list cannot be empty")
 // ErrVarLenTargets is returned when the given target list for a trojan chunk has addresses of different lengths
 var ErrVarLenTargets = errors.New("target list cannot have targets of different length")
 
-// ErrChunkNotTrojan is returned when attempting to unwrap a chunk into a trojan message when the chunk is not trojan
-var ErrChunkNotTrojan = errors.New("cannot unwrap chunk as it is not trojan")
-
 // NewTopic creates a new Topic variable with the given input string
 // the input string is taken as a byte slice and hashed
 func NewTopic(topic string) Topic {

--- a/pss/trojan/message.go
+++ b/pss/trojan/message.go
@@ -110,8 +110,14 @@ func (m *Message) Wrap(targets [][]byte) (chunk.Chunk, error) {
 
 // Unwrap attemps to determine whether the given chunk is a trojan chunk
 // it will return the resulting trojan message if the unwrapping is successful, and an error otherwise
+// TODO: move this to PSS API?
 func Unwrap(c chunk.Chunk) (Message, error) {
-	return Message{}, errors.New("unimplemented func")
+	d := c.Data()
+	m := new(Message)
+	// first 40 bytes are span + nonce
+	err := m.UnmarshalBinary(d[40:])
+
+	return *m, err
 }
 
 // checkTargets verifies that the list of given targets is non empty and with elements of matching size

--- a/pss/trojan/message.go
+++ b/pss/trojan/message.go
@@ -116,19 +116,19 @@ func (m *Message) Wrap(targets [][]byte) (chunk.Chunk, error) {
 // TODO: move this to PSS API?
 func Unwrap(c chunk.Chunk) (*Message, error) {
 	d := c.Data()
-	payload := d[40:] // first 40 bytes are span + nonce
 
-	m := new(Message)
 	// unmarshal chunk payload into message
-	if err := m.UnmarshalBinary(payload); err != nil {
+	m := new(Message)
+	// first 40 bytes are span + nonce
+	if err := m.UnmarshalBinary(d[40:]); err != nil {
 		return nil, err
 	}
 
+	// check for trojan message correctness
 	hash, err := hash(d)
 	if err != nil {
 		return nil, err
 	}
-
 	if !bytes.Equal(hash, c.Address()) {
 		return nil, ErrChunkNotTrojan
 	}

--- a/pss/trojan/message.go
+++ b/pss/trojan/message.go
@@ -111,7 +111,7 @@ func (m *Message) Wrap(targets [][]byte) (chunk.Chunk, error) {
 // Unwrap attemps to determine whether the given chunk is a trojan chunk
 // it will return the resulting trojan message if the unwrapping is successful, and an error otherwise
 func Unwrap(c chunk.Chunk) (Message, error) {
-	return Message{}, nil
+	return Message{}, errors.New("unimplemented func")
 }
 
 // checkTargets verifies that the list of given targets is non empty and with elements of matching size

--- a/pss/trojan/message.go
+++ b/pss/trojan/message.go
@@ -111,7 +111,8 @@ func (m *Message) Wrap(targets [][]byte) (chunk.Chunk, error) {
 	return chunk, nil
 }
 
-// Unwrap attemps to determine whether the given chunk is a trojan chunk
+// Unwrap creates a new trojan message from the given chunk payload
+// this function assumes the chunk has been validated as a content-addressed chunk
 // it will return the resulting message if the unwrapping is successful, and an error otherwise
 func Unwrap(c chunk.Chunk) (*Message, error) {
 	d := c.Data()
@@ -119,18 +120,7 @@ func Unwrap(c chunk.Chunk) (*Message, error) {
 	// unmarshal chunk payload into message
 	m := new(Message)
 	// first 40 bytes are span + nonce
-	if err := m.UnmarshalBinary(d[40:]); err != nil {
-		return nil, err
-	}
-
-	// check for message correctness
-	hash, err := hash(d)
-	if err != nil {
-		return nil, err
-	}
-	if !bytes.Equal(hash, c.Address()) {
-		return nil, ErrChunkNotTrojan
-	}
+	err := m.UnmarshalBinary(d[40:])
 
 	return m, err
 }

--- a/pss/trojan/message.go
+++ b/pss/trojan/message.go
@@ -82,6 +82,7 @@ func NewMessage(topic Topic, payload []byte) (Message, error) {
 	// create new Message var and set fields
 	m := new(Message)
 	copy(m.length[:], lengthBuf[:])
+	m.Topic = topic
 	m.payload = payload
 	m.padding = padding
 

--- a/pss/trojan/message.go
+++ b/pss/trojan/message.go
@@ -108,6 +108,12 @@ func (m *Message) Wrap(targets [][]byte) (chunk.Chunk, error) {
 	return chunk, nil
 }
 
+// Unwrap attemps to determine whether the given chunk is a trojan chunk
+// it will return the resulting trojan message if the unwrapping is successful, and an error otherwise
+func Unwrap(c chunk.Chunk) (Message, error) {
+	return Message{}, nil
+}
+
 // checkTargets verifies that the list of given targets is non empty and with elements of matching size
 func checkTargets(targets [][]byte) error {
 	if len(targets) == 0 {

--- a/pss/trojan/message.go
+++ b/pss/trojan/message.go
@@ -112,7 +112,7 @@ func (m *Message) Wrap(targets [][]byte) (chunk.Chunk, error) {
 }
 
 // Unwrap attemps to determine whether the given chunk is a trojan chunk
-// it will return the resulting trojan message if the unwrapping is successful, and an error otherwise
+// it will return the resulting message if the unwrapping is successful, and an error otherwise
 // TODO: move this to PSS API?
 func Unwrap(c chunk.Chunk) (*Message, error) {
 	d := c.Data()

--- a/pss/trojan/message.go
+++ b/pss/trojan/message.go
@@ -40,6 +40,11 @@ type Message struct {
 	padding []byte
 }
 
+// GetTopic exposes the underlying topic of a Message type
+func (m *Message) GetTopic() Topic {
+	return m.topic
+}
+
 // MaxPayloadSize is the maximum allowed payload size for the Message type, in bytes
 const MaxPayloadSize = 4030
 

--- a/pss/trojan/message.go
+++ b/pss/trojan/message.go
@@ -35,14 +35,9 @@ type Topic [32]byte
 // Message represents a trojan message, which is a message that will be hidden within a chunk payload as part of its data
 type Message struct {
 	length  [2]byte // big-endian encoding of Message payload length
-	topic   Topic
+	Topic   Topic
 	payload []byte
 	padding []byte
-}
-
-// GetTopic exposes the underlying topic of a Message type
-func (m *Message) GetTopic() Topic {
-	return m.topic
 }
 
 // MaxPayloadSize is the maximum allowed payload size for the Message type, in bytes
@@ -219,7 +214,7 @@ func padBytes(b []byte) []byte {
 
 // MarshalBinary serializes a message struct
 func (m *Message) MarshalBinary() (data []byte, err error) {
-	data = append(m.length[:], m.topic[:]...)
+	data = append(m.length[:], m.Topic[:]...)
 	data = append(data, m.payload...)
 	data = append(data, m.padding...)
 	return data, nil
@@ -228,7 +223,7 @@ func (m *Message) MarshalBinary() (data []byte, err error) {
 // UnmarshalBinary deserializes a message struct
 func (m *Message) UnmarshalBinary(data []byte) (err error) {
 	copy(m.length[:], data[:2])  // first 2 bytes are length
-	copy(m.topic[:], data[2:34]) // following 32 bytes are topic
+	copy(m.Topic[:], data[2:34]) // following 32 bytes are topic
 
 	// rest of the bytes are payload and padding
 	length := binary.BigEndian.Uint16(m.length[:])

--- a/pss/trojan/message.go
+++ b/pss/trojan/message.go
@@ -54,7 +54,7 @@ var ErrEmptyTargets = errors.New("target list cannot be empty")
 // ErrVarLenTargets is returned when the given target list for a trojan chunk has addresses of different lengths
 var ErrVarLenTargets = errors.New("target list cannot have targets of different length")
 
-// ErrChunkNotTrojan is returned when attempting to unwrap a chunk into a trojan message but the chunk is not trojan
+// ErrChunkNotTrojan is returned when attempting to unwrap a chunk into a trojan message when the chunk is not trojan
 var ErrChunkNotTrojan = errors.New("cannot unwrap chunk as it is not trojan")
 
 // NewTopic creates a new Topic variable with the given input string
@@ -124,7 +124,7 @@ func Unwrap(c chunk.Chunk) (*Message, error) {
 		return nil, err
 	}
 
-	// check for trojan message correctness
+	// check for message correctness
 	hash, err := hash(d)
 	if err != nil {
 		return nil, err

--- a/pss/trojan/message_test.go
+++ b/pss/trojan/message_test.go
@@ -162,6 +162,11 @@ func TestPadBytes(t *testing.T) {
 	}
 }
 
+// TestUnwwwrap tests the correct unwrapping of chunks as trojan messages
+func TestUnwrap(t *testing.T) {
+
+}
+
 // TestMessageSerialization tests that the Message type can be correctly serialized and deserialized
 func TestMessageSerialization(t *testing.T) {
 	m := newTestMessage(t)

--- a/pss/trojan/message_test.go
+++ b/pss/trojan/message_test.go
@@ -51,8 +51,14 @@ func newTestMessage(t *testing.T) Message {
 // TestNewMessage tests the correct and incorrect creation of a Message struct
 func TestNewMessage(t *testing.T) {
 	smallPayload := make([]byte, 32)
-	if _, err := NewMessage(testTopic, smallPayload); err != nil {
+	m, err := NewMessage(testTopic, smallPayload)
+	if err != nil {
 		t.Fatal(err)
+	}
+
+	// verify topic
+	if m.Topic != testTopic {
+		t.Fatalf("expected message topic to be %v but is %v instead", testTopic, m.Topic)
 	}
 
 	maxPayload := make([]byte, MaxPayloadSize)

--- a/pss/trojan/message_test.go
+++ b/pss/trojan/message_test.go
@@ -181,6 +181,26 @@ func TestUnwrap(t *testing.T) {
 	}
 }
 
+// TestUnwrapFail tests that the uwnrapping of a chunk into a message fails if the chunk is not trojan
+func TestUnwrapFail(t *testing.T) {
+	// start from correct trojan chunk
+	m := newTestMessage(t)
+	c, err := m.Wrap(testTargets)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// annul chunk nonce
+	copy(c.Data()[8:40], make([]byte, 32))
+
+	// attempt unwrapping
+	_, err = Unwrap(c)
+	if err != ErrChunkNotTrojan {
+		t.Fatalf("expected error when unwrapping non-trojan chunk be %q, but got %v", ErrChunkNotTrojan, err)
+	}
+
+}
+
 // TestMessageSerialization tests that the Message type can be correctly serialized and deserialized
 func TestMessageSerialization(t *testing.T) {
 	m := newTestMessage(t)

--- a/pss/trojan/message_test.go
+++ b/pss/trojan/message_test.go
@@ -182,7 +182,7 @@ func TestUnwrap(t *testing.T) {
 
 // TestUnwrapFail tests that the uwnrapping of a chunk into a message fails if the chunk is not trojan
 func TestUnwrapFail(t *testing.T) {
-	// start from correct trojan chunk
+	// start out from a valid trojan chunk
 	m := newTestMessage(t)
 	c, err := m.Wrap(testTargets)
 	if err != nil {

--- a/pss/trojan/message_test.go
+++ b/pss/trojan/message_test.go
@@ -171,7 +171,6 @@ func TestUnwrap(t *testing.T) {
 	}
 
 	um, err := Unwrap(c)
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pss/trojan/message_test.go
+++ b/pss/trojan/message_test.go
@@ -162,7 +162,7 @@ func TestPadBytes(t *testing.T) {
 	}
 }
 
-// TestUnwwwrap tests the correct unwrapping of chunks as trojan messages
+// TestUnwrap tests the correct unwrapping of chunks as trojan messages
 func TestUnwrap(t *testing.T) {
 	m := newTestMessage(t)
 	c, err := m.Wrap(testTargets)
@@ -170,8 +170,14 @@ func TestUnwrap(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := Unwrap(c); err != nil {
+	um, err := Unwrap(c)
+
+	if err != nil {
 		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(m, *um) {
+		t.Fatalf("original message does not match unwrapped one")
 	}
 }
 

--- a/pss/trojan/message_test.go
+++ b/pss/trojan/message_test.go
@@ -164,7 +164,15 @@ func TestPadBytes(t *testing.T) {
 
 // TestUnwwwrap tests the correct unwrapping of chunks as trojan messages
 func TestUnwrap(t *testing.T) {
+	m := newTestMessage(t)
+	c, err := m.Wrap(testTargets)
+	if err != nil {
+		t.Fatal(err)
+	}
 
+	if _, err := Unwrap(c); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // TestMessageSerialization tests that the Message type can be correctly serialized and deserialized

--- a/pss/trojan/message_test.go
+++ b/pss/trojan/message_test.go
@@ -180,26 +180,6 @@ func TestUnwrap(t *testing.T) {
 	}
 }
 
-// TestUnwrapFail tests that the uwnrapping of a chunk into a message fails if the chunk is not trojan
-func TestUnwrapFail(t *testing.T) {
-	// start out from a valid trojan chunk
-	m := newTestMessage(t)
-	c, err := m.Wrap(testTargets)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// annul chunk nonce
-	copy(c.Data()[8:40], make([]byte, 32))
-
-	// attempt unwrapping
-	_, err = Unwrap(c)
-	if err != ErrChunkNotTrojan {
-		t.Fatalf("expected error when unwrapping non-trojan chunk to be %q, but got %v", ErrChunkNotTrojan, err)
-	}
-
-}
-
 // TestMessageSerialization tests that the Message type can be correctly serialized and deserialized
 func TestMessageSerialization(t *testing.T) {
 	m := newTestMessage(t)

--- a/pss/trojan/message_test.go
+++ b/pss/trojan/message_test.go
@@ -195,7 +195,7 @@ func TestUnwrapFail(t *testing.T) {
 	// attempt unwrapping
 	_, err = Unwrap(c)
 	if err != ErrChunkNotTrojan {
-		t.Fatalf("expected error when unwrapping non-trojan chunk be %q, but got %v", ErrChunkNotTrojan, err)
+		t.Fatalf("expected error when unwrapping non-trojan chunk to be %q, but got %v", ErrChunkNotTrojan, err)
 	}
 
 }

--- a/pss/trojan/message_test.go
+++ b/pss/trojan/message_test.go
@@ -162,7 +162,7 @@ func TestPadBytes(t *testing.T) {
 	}
 }
 
-// TestUnwrap tests the correct unwrapping of chunks as trojan messages
+// TestUnwrap tests the correct unwrapping of a trojan chunk to obtain a message
 func TestUnwrap(t *testing.T) {
 	m := newTestMessage(t)
 	c, err := m.Wrap(testTargets)

--- a/storage/localstore/mode_put.go
+++ b/storage/localstore/mode_put.go
@@ -33,6 +33,7 @@ import (
 // Put is required to implement chunk.Store
 // interface.
 func (db *DB) Put(ctx context.Context, mode chunk.ModePut, chs ...chunk.Chunk) (exist []bool, err error) {
+	// TODO: add hook here?
 	metricName := fmt.Sprintf("localstore/Put/%s", mode)
 
 	metrics.GetOrRegisterCounter(metricName, nil).Inc(1)

--- a/storage/localstore/mode_put.go
+++ b/storage/localstore/mode_put.go
@@ -33,7 +33,6 @@ import (
 // Put is required to implement chunk.Store
 // interface.
 func (db *DB) Put(ctx context.Context, mode chunk.ModePut, chs ...chunk.Chunk) (exist []bool, err error) {
-	// TODO: add hook here?
 	metricName := fmt.Sprintf("localstore/Put/%s", mode)
 
 	metrics.GetOrRegisterCounter(metricName, nil).Inc(1)

--- a/swarm.go
+++ b/swarm.go
@@ -50,6 +50,7 @@ import (
 	oldpssmessage "github.com/ethersphere/swarm/oldpss/message"
 	"github.com/ethersphere/swarm/p2p/protocols"
 	"github.com/ethersphere/swarm/pss"
+	"github.com/ethersphere/swarm/pss/trojan"
 	"github.com/ethersphere/swarm/pushsync"
 	"github.com/ethersphere/swarm/state"
 	"github.com/ethersphere/swarm/storage"
@@ -279,6 +280,15 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 	}
 
 	self.pss = pss.NewPss(localStore)
+	global_pinner := true // TODO: temporary, should be taken from CLI
+	if global_pinner {
+		recoveryFunc := func() error {
+			// TODO: add missing chunk re-upload
+			return nil
+		}
+		recoveryHandler := pss.NewHandler(recoveryFunc)
+		self.pss.Register(trojan.NewTopic("RECOVERY"), recoveryHandler)
+	}
 
 	self.api = api.NewAPI(self.fileStore, self.dns, self.rns, feedsHandler, self.privateKey, self.tags)
 

--- a/swarm.go
+++ b/swarm.go
@@ -282,6 +282,7 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 	self.pss = pss.NewPss(localStore)
 
 	if self.config.GlobalPinner {
+		lstore.SetPssCallback(self.pss.Deliver)
 		recoveryFunc := func(trojan.Message) error {
 			// TODO: add missing chunk re-upload
 			return nil

--- a/swarm.go
+++ b/swarm.go
@@ -282,12 +282,11 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 	self.pss = pss.NewPss(localStore)
 
 	if self.config.GlobalPinner {
-		recoveryFunc := func() error {
+		recoveryFunc := func(trojan.Message) error {
 			// TODO: add missing chunk re-upload
 			return nil
 		}
-		recoveryHandler := pss.NewHandler(recoveryFunc)
-		self.pss.Register(trojan.NewTopic("RECOVERY"), recoveryHandler)
+		self.pss.Register(trojan.NewTopic("RECOVERY"), recoveryFunc)
 	}
 
 	self.api = api.NewAPI(self.fileStore, self.dns, self.rns, feedsHandler, self.privateKey, self.tags)

--- a/swarm.go
+++ b/swarm.go
@@ -49,6 +49,7 @@ import (
 	"github.com/ethersphere/swarm/oldpss"
 	oldpssmessage "github.com/ethersphere/swarm/oldpss/message"
 	"github.com/ethersphere/swarm/p2p/protocols"
+	"github.com/ethersphere/swarm/pss"
 	"github.com/ethersphere/swarm/pushsync"
 	"github.com/ethersphere/swarm/state"
 	"github.com/ethersphere/swarm/storage"
@@ -83,6 +84,7 @@ type Swarm struct {
 	privateKey        *ecdsa.PrivateKey
 	netStore          *storage.NetStore
 	sfs               *fuse.SwarmFS // need this to cleanup all the active mounts on node exit
+	pss               *pss.Pss
 	oldpss            *oldpss.Pss
 	pushSync          *pushsync.Pusher
 	storer            *pushsync.Storer
@@ -275,6 +277,8 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 		self.pushSync = pushsync.NewPusher(localStore, pubsub, self.tags)
 		self.storer = pushsync.NewStorer(self.netStore, pubsub)
 	}
+
+	self.pss = pss.NewPss(localStore)
 
 	self.api = api.NewAPI(self.fileStore, self.dns, self.rns, feedsHandler, self.privateKey, self.tags)
 

--- a/swarm.go
+++ b/swarm.go
@@ -282,7 +282,7 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 	self.pss = pss.NewPss(localStore)
 
 	if self.config.GlobalPinner {
-		lstore.SetPssCallback(self.pss.Deliver)
+		lstore.SetDeliverHook(self.pss.Deliver)
 		recoveryFunc := func(trojan.Message) error {
 			// TODO: add missing chunk re-upload
 			return nil

--- a/swarm.go
+++ b/swarm.go
@@ -280,8 +280,8 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 	}
 
 	self.pss = pss.NewPss(localStore)
-	global_pinner := true // TODO: temporary, should be taken from CLI
-	if global_pinner {
+
+	if self.config.GlobalPinner {
 		recoveryFunc := func() error {
 			// TODO: add missing chunk re-upload
 			return nil

--- a/swarm.go
+++ b/swarm.go
@@ -283,9 +283,8 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 
 	if self.config.GlobalPinner {
 		lstore.WithDeliverCallback(self.pss.Deliver)
-		recoveryFunc := func(trojan.Message) error {
+		recoveryFunc := func(trojan.Message) {
 			// TODO: add missing chunk re-upload
-			return nil
 		}
 		self.pss.Register(trojan.NewTopic("RECOVERY"), recoveryFunc)
 	}

--- a/swarm.go
+++ b/swarm.go
@@ -282,7 +282,7 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 	self.pss = pss.NewPss(localStore)
 
 	if self.config.GlobalPinner {
-		lstore.SetDeliverHook(self.pss.Deliver)
+		lstore.WithDeliverCallback(self.pss.Deliver)
 		recoveryFunc := func(trojan.Message) error {
 			// TODO: add missing chunk re-upload
 			return nil

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -100,6 +100,9 @@ func TestNewSwarm(t *testing.T) {
 				if s.oldpss == nil {
 					t.Error("old pss not initialized")
 				}
+				if s.pss == nil {
+					t.Error("pss not initialized")
+				}
 				if s.api == nil {
 					t.Error("api not initialized")
 				}

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -97,8 +97,8 @@ func TestNewSwarm(t *testing.T) {
 				if s.bzz == nil {
 					t.Error("bzz not initialized")
 				}
-				if s.ps == nil {
-					t.Error("pss not initialized")
+				if s.oldpss == nil {
+					t.Error("old pss not initialized")
 				}
 				if s.api == nil {
 					t.Error("api not initialized")


### PR DESCRIPTION
This PR implements the following task:
>  implement a hook/subscription dispatcher mechanism, so that when a chunk is saved to disk, the hook checks whether the chunk is trojan, in order to later re-uploads the missing content in that case.

from issue #2154.

### Implementation overview
This PR:
- adds the `Unwrap` func, which takes a validated trojan chunk and unmarshals its payload to return the resulting trojan `Message`.
- adds a `pssCallback` func field in the `ValidatorStore` struct, which is not set through the constructor, but rather—being an optional field—set through a separate function.
  - this callback function is invoked through a `go` statement in the store's `validate` func, in case it exists (note there is no error handling as of now).
- adds the `handlers` and `handlersMu` fields to `Pss` struct.
  - `handlers` maps `trojan.Topic` values to `Handler` variables.
    - `Handlers` are defined as funcs which take a `trojan.Message` value and output an `error`. They are to be executed concurrently upon receiving a trojan message.
- adds the `Register` func to `Pss`, which allows setting a `Handler` for a `trojan.Topic`; the `getHandler` func is used to get said handlers after being set.
- adds the `Deliver` function, which will call `Unwrap` on a chunk and execute its handler function, should it exist for the embedded trojan message topic.
- adds the `GlobalPinner` `Config` `bool` field to mark the running node as a global pinner.
  - this was also added as a CLI boolean flag.
  - if the flag is set, `Swarm`'s local store will have the `pss.Deliver` function injected as a dependency into the local store, which will then be called for every chunk received which is correctly validated.
  - if the flag is set, an—as of now empty—recovery function will also be registered as a handler for the `RECOVERY` topic on the `Pss` struct.

### To-do
- [x] add more tests