### PR TITLE
chunk/testing: fixed Sent conditional in CheckTag

### DIFF
--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -408,7 +408,7 @@ func TestClientQueryTagByHash(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tagg, err := client.TagByHash(hash)
+	tagAPI, err := client.TagByHash(hash)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -418,7 +418,7 @@ func TestClientQueryTagByHash(t *testing.T) {
 	chunktesting.CheckTag(t, tag, 1, 1, 0, 0, 0, 1)
 
 	// check that the tag we got back from the API is also correct
-	chunktesting.CheckTag(t, tagg, 1, 1, 0, 0, 0, 1)
+	chunktesting.CheckTag(t, tagAPI, 1, 1, 0, 0, 0, 1)
 }
 
 func newTestSigner() (*feed.GenericSigner, error) {

--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -415,10 +415,10 @@ func TestClientQueryTagByHash(t *testing.T) {
 
 	// check the tag was created successfully
 	tag := srv.Tags.All()[0]
-	chunktesting.CheckTag(t, tag, 1, 1, 0, 1, 0, 1)
+	chunktesting.CheckTag(t, tag, 1, 1, 0, 0, 0, 1)
 
 	// check that the tag we got back from the API is also correct
-	chunktesting.CheckTag(t, tagg, 1, 1, 0, 1, 0, 1)
+	chunktesting.CheckTag(t, tagg, 1, 1, 0, 0, 0, 1)
 }
 
 func newTestSigner() (*feed.GenericSigner, error) {

--- a/chunk/testing/tag.go
+++ b/chunk/testing/tag.go
@@ -44,7 +44,7 @@ func CheckTag(t *testing.T, tag *chunk.Tag, split, stored, seen, sent, synced, t
 	}
 
 	tSent := tag.Get(chunk.StateSent)
-	if tStored != stored {
+	if tSent != seen {
 		t.Fatalf("mismatch sent chunks, got %d want %d", tSent, sent)
 	}
 

--- a/chunk/testing/tag.go
+++ b/chunk/testing/tag.go
@@ -44,7 +44,7 @@ func CheckTag(t *testing.T, tag *chunk.Tag, split, stored, seen, sent, synced, t
 	}
 
 	tSent := tag.Get(chunk.StateSent)
-	if tSent != seen {
+	if tSent != sent {
 		t.Fatalf("mismatch sent chunks, got %d want %d", tSent, sent)
 	}
 

--- a/storage/localstore/mode_set_test.go
+++ b/storage/localstore/mode_set_test.go
@@ -116,8 +116,8 @@ func TestModeSetSyncPullNormalTag(t *testing.T) {
 		t.Fatalf("unexpected tag id value got %d want %d", item.Tag, tag.Uid)
 	}
 
-	// 1 stored (because incremented manually in test), 1 sent, 1 total
-	tagtesting.CheckTag(t, tag, 0, 1, 0, 1, 0, 1)
+	// 1 stored (because incremented manually in test), 1 total
+	tagtesting.CheckTag(t, tag, 0, 1, 0, 0, 0, 1)
 }
 
 // TestModeSetSyncPullAnonymousTag checks that pull sync correcly increments


### PR DESCRIPTION
This PR is a bugfix for CheckTag,
This method  is invoked to check the state of a tag,
It was using stored as the conditional for sent state.
```
tSent := tag.Get(chunk.StateSent)
	if tStored != stored {
		t.Fatalf("mismatch sent chunks, got %d want %d", tSent, sent)
	}
```
Changed it to

```
tSent := tag.Get(chunk.StateSent)
	if tSent != sent {
		t.Fatalf("mismatch sent chunks, got %d want %d", tSent, sent)
	}
```
This was detected due to strage behaviour when using tag monitoring for global-pinning