### PR TITLE
chunk, localstore, trojan, swarm: repair globally pinned content

### DIFF
--- a/chunk/chunk.go
+++ b/chunk/chunk.go
@@ -190,6 +190,8 @@ func (m ModePut) String() string {
 		return "Sync"
 	case ModePutUpload:
 		return "Upload"
+	case ModePutReUpload:
+		return "ReUpload"
 	default:
 		return "Unknown"
 	}
@@ -203,6 +205,8 @@ const (
 	ModePutSync
 	// ModePutUpload: when a chunk is created by local upload
 	ModePutUpload
+	// ModePutReUpload: when a pinned chunk is repaired
+	ModePutReUpload
 )
 
 // ModeSet enumerates different Setter modes.

--- a/chunk/chunk.go
+++ b/chunk/chunk.go
@@ -226,6 +226,8 @@ func (m ModeSet) String() string {
 		return "ModeSetPin"
 	case ModeSetUnpin:
 		return "ModeSetUnpin"
+	case ModeSetReUpload:
+		return "ModeSetReUpload"
 	default:
 		return "Unknown"
 	}

--- a/chunk/chunk.go
+++ b/chunk/chunk.go
@@ -245,6 +245,8 @@ const (
 	ModeSetPin
 	// ModeSetUnpin: when a chunk is unpinned using a command locally
 	ModeSetUnpin
+	// ModeSetReUpload: when a globally pinned chunk is repaired
+	ModeSetReUpload
 )
 
 // Descriptor holds information required for Pull syncing. This struct

--- a/chunk/chunk.go
+++ b/chunk/chunk.go
@@ -243,7 +243,7 @@ const (
 	ModeSetPin
 	// ModeSetUnpin: when a chunk is unpinned using a command locally
 	ModeSetUnpin
-	// ModeSetReUpload: when a globally pinned chunk is repaired
+	// ModeSetReUpload: when a push sync is forced for a chunk
 	ModeSetReUpload
 )
 

--- a/chunk/chunk.go
+++ b/chunk/chunk.go
@@ -190,8 +190,6 @@ func (m ModePut) String() string {
 		return "Sync"
 	case ModePutUpload:
 		return "Upload"
-	case ModePutReUpload:
-		return "ReUpload"
 	default:
 		return "Unknown"
 	}
@@ -205,8 +203,6 @@ const (
 	ModePutSync
 	// ModePutUpload: when a chunk is created by local upload
 	ModePutUpload
-	// ModePutReUpload: when a pinned chunk is repaired
-	ModePutReUpload
 )
 
 // ModeSet enumerates different Setter modes.

--- a/chunk/chunk.go
+++ b/chunk/chunk.go
@@ -33,6 +33,7 @@ const (
 var (
 	ErrChunkNotFound = errors.New("chunk not found")
 	ErrChunkInvalid  = errors.New("invalid chunk")
+	ErrNotPinned     = errors.New("chunk not pinned")
 )
 
 type Chunk interface {

--- a/pss/trojan/message.go
+++ b/pss/trojan/message.go
@@ -36,7 +36,7 @@ type Topic [32]byte
 type Message struct {
 	length  [2]byte // big-endian encoding of Message payload length
 	Topic   Topic
-	Payload []byte
+	Payload []byte // contains the chunk address to be repaired
 	padding []byte
 }
 

--- a/pss/trojan/message.go
+++ b/pss/trojan/message.go
@@ -36,7 +36,7 @@ type Topic [32]byte
 type Message struct {
 	length  [2]byte // big-endian encoding of Message payload length
 	Topic   Topic
-	payload []byte
+	Payload []byte
 	padding []byte
 }
 
@@ -83,7 +83,7 @@ func NewMessage(topic Topic, payload []byte) (Message, error) {
 	m := new(Message)
 	copy(m.length[:], lengthBuf[:])
 	m.Topic = topic
-	m.payload = payload
+	m.Payload = payload
 	m.padding = padding
 
 	return *m, nil
@@ -216,7 +216,7 @@ func padBytes(b []byte) []byte {
 // MarshalBinary serializes a message struct
 func (m *Message) MarshalBinary() (data []byte, err error) {
 	data = append(m.length[:], m.Topic[:]...)
-	data = append(data, m.payload...)
+	data = append(data, m.Payload...)
 	data = append(data, m.padding...)
 	return data, nil
 }
@@ -229,7 +229,7 @@ func (m *Message) UnmarshalBinary(data []byte) (err error) {
 	// rest of the bytes are payload and padding
 	length := binary.BigEndian.Uint16(m.length[:])
 	payloadEnd := 34 + length
-	m.payload = data[34:payloadEnd]
+	m.Payload = data[34:payloadEnd]
 	m.padding = data[payloadEnd:]
 	return nil
 }

--- a/storage/localstore/mode_put.go
+++ b/storage/localstore/mode_put.go
@@ -113,6 +113,8 @@ func (db *DB) put(mode chunk.ModePut, chs ...chunk.Chunk) (exist []bool, err err
 		for _, ch := range chs {
 			item := chunkToItem(ch)
 			item.StoreTimestamp = now()
+			// ask: what happens when the proc that sweps through the pushindex
+			// what does it do with this bin index
 			item.BinID, err = db.incBinID(binIDs, db.po(item.Address))
 			db.pushIndex.PutInBatch(batch, item)
 		}

--- a/storage/localstore/mode_put.go
+++ b/storage/localstore/mode_put.go
@@ -108,16 +108,6 @@ func (db *DB) put(mode chunk.ModePut, chs ...chunk.Chunk) (exist []bool, err err
 			}
 			gcSizeChange += c
 		}
-	case chunk.ModePutReUpload:
-		// TODO: check this, entirely unsure if correct
-		for _, ch := range chs {
-			item := chunkToItem(ch)
-			item.StoreTimestamp = now()
-			// ask: what happens when the proc that sweps through the pushindex
-			// what does it do with this bin index
-			item.BinID, err = db.incBinID(binIDs, db.po(item.Address))
-			db.pushIndex.PutInBatch(batch, item)
-		}
 	case chunk.ModePutSync:
 		for i, ch := range chs {
 			if containsChunk(ch.Address(), chs[:i]...) {

--- a/storage/localstore/mode_put.go
+++ b/storage/localstore/mode_put.go
@@ -109,7 +109,7 @@ func (db *DB) put(mode chunk.ModePut, chs ...chunk.Chunk) (exist []bool, err err
 			gcSizeChange += c
 		}
 	case chunk.ModePutReUpload:
-		// TODO: this should do the same as `ModePutUpload`, but add the chunk hash to the pushindex
+		// TODO: this should do the same as `ModePutUpload`, but also add the chunk hash to the pushindex
 		for i, ch := range chs {
 			if containsChunk(ch.Address(), chs[:i]...) {
 				exist[i] = true

--- a/storage/localstore/mode_put.go
+++ b/storage/localstore/mode_put.go
@@ -108,6 +108,7 @@ func (db *DB) put(mode chunk.ModePut, chs ...chunk.Chunk) (exist []bool, err err
 			}
 			gcSizeChange += c
 		}
+
 	case chunk.ModePutSync:
 		for i, ch := range chs {
 			if containsChunk(ch.Address(), chs[:i]...) {

--- a/storage/localstore/mode_put.go
+++ b/storage/localstore/mode_put.go
@@ -108,7 +108,26 @@ func (db *DB) put(mode chunk.ModePut, chs ...chunk.Chunk) (exist []bool, err err
 			}
 			gcSizeChange += c
 		}
-
+	case chunk.ModePutReUpload:
+		// TODO: this should do the same as `ModePutUpload`, but add the chunk hash to the pushindex
+		for i, ch := range chs {
+			if containsChunk(ch.Address(), chs[:i]...) {
+				exist[i] = true
+				continue
+			}
+			exists, c, err := db.putUpload(batch, binIDs, chunkToItem(ch))
+			if err != nil {
+				return nil, err
+			}
+			exist[i] = exists
+			if !exists {
+				// chunk is new so, trigger subscription feeds
+				// after the batch is successfully written
+				triggerPullFeed[db.po(ch.Address())] = struct{}{}
+				triggerPushFeed = true
+			}
+			gcSizeChange += c
+		}
 	case chunk.ModePutSync:
 		for i, ch := range chs {
 			if containsChunk(ch.Address(), chs[:i]...) {

--- a/storage/localstore/mode_set.go
+++ b/storage/localstore/mode_set.go
@@ -113,7 +113,7 @@ func (db *DB) set(mode chunk.ModeSet, addrs ...chunk.Address) (err error) {
 		}
 	case chunk.ModeSetReUpload:
 		for _, addr := range addrs {
-			err := db.setReupload(batch, addr)
+			err := db.setReUpload(batch, addr)
 			if err != nil {
 				return err
 			}
@@ -400,6 +400,6 @@ func (db *DB) setUnpin(batch *leveldb.Batch, addr chunk.Address) (err error) {
 	return nil
 }
 
-func (db *DB) setReupload(batch *leveldb.Batch, addr chunk.Address) (err error) {
+func (db *DB) setReUpload(batch *leveldb.Batch, addr chunk.Address) (err error) {
 	return nil
 }

--- a/storage/localstore/mode_set.go
+++ b/storage/localstore/mode_set.go
@@ -400,7 +400,7 @@ func (db *DB) setUnpin(batch *leveldb.Batch, addr chunk.Address) (err error) {
 	return nil
 }
 
-// setReUpload adds a pinned chunk to the push index so that it can be re-upuloaded to the network
+// setReUpload adds a pinned chunk to the push index so that it can be re-uploaded to the network
 func (db *DB) setReUpload(batch *leveldb.Batch, addr chunk.Address) (err error) {
 	item := addressToItem(addr)
 

--- a/storage/localstore/mode_set.go
+++ b/storage/localstore/mode_set.go
@@ -111,7 +111,13 @@ func (db *DB) set(mode chunk.ModeSet, addrs ...chunk.Address) (err error) {
 				return err
 			}
 		}
-
+	case chunk.ModeSetReUpload:
+		for _, addr := range addrs {
+			err := db.setReupload(batch, addr)
+			if err != nil {
+				return err
+			}
+		}
 	default:
 		return ErrInvalidMode
 	}
@@ -391,5 +397,9 @@ func (db *DB) setUnpin(batch *leveldb.Batch, addr chunk.Address) (err error) {
 		db.pinIndex.DeleteInBatch(batch, item)
 	}
 
+	return nil
+}
+
+func (db *DB) setReupload(batch *leveldb.Batch, addr chunk.Address) (err error) {
 	return nil
 }

--- a/storage/localstore/mode_set.go
+++ b/storage/localstore/mode_set.go
@@ -412,7 +412,6 @@ func (db *DB) setReUpload(batch *leveldb.Batch, addr chunk.Address) (err error) 
 		return err
 	}
 
-	// get retrieval data
 	retrievalDataIndexItem, err := db.retrievalDataIndex.Get(item)
 	if err != nil {
 		return err

--- a/storage/localstore/mode_set.go
+++ b/storage/localstore/mode_set.go
@@ -417,6 +417,5 @@ func (db *DB) setReUpload(batch *leveldb.Batch, addr chunk.Address) (err error) 
 		return err
 	}
 
-	item.StoreTimestamp = retrievalDataIndexItem.StoreTimestamp
-	return db.pushIndex.PutInBatch(batch, item)
+	return db.pushIndex.PutInBatch(batch, retrievalDataIndexItem)
 }

--- a/storage/localstore/mode_set.go
+++ b/storage/localstore/mode_set.go
@@ -421,9 +421,9 @@ func (db *DB) setReUpload(batch *leveldb.Batch, addr chunk.Address) (err error) 
 	if err != nil {
 		return err
 	}
-	if !itemPresent {
-		return db.pushIndex.PutInBatch(batch, retrievalDataIndexItem)
+	if itemPresent {
+	    return nil
 	}
 
-	return nil
+	return db.pushIndex.PutInBatch(batch, retrievalDataIndexItem)
 }

--- a/storage/localstore/mode_set.go
+++ b/storage/localstore/mode_set.go
@@ -412,10 +412,18 @@ func (db *DB) setReUpload(batch *leveldb.Batch, addr chunk.Address) (err error) 
 		return err
 	}
 
+	// put chunk item with retrieval data into the push index if not already present
 	retrievalDataIndexItem, err := db.retrievalDataIndex.Get(item)
 	if err != nil {
 		return err
 	}
+	itemPresent, err := db.pushIndex.Has(retrievalDataIndexItem)
+	if err != nil {
+		return err
+	}
+	if !itemPresent {
+		return db.pushIndex.PutInBatch(batch, retrievalDataIndexItem)
+	}
 
-	return db.pushIndex.PutInBatch(batch, retrievalDataIndexItem)
+	return nil
 }

--- a/storage/localstore/mode_set.go
+++ b/storage/localstore/mode_set.go
@@ -419,5 +419,6 @@ func (db *DB) setReUpload(batch *leveldb.Batch, addr chunk.Address) (err error) 
 	}
 
 	item.StoreTimestamp = retrievalDataIndexItem.StoreTimestamp
+	// TODO: do we need to do anything about bin ids?
 	return db.pushIndex.PutInBatch(batch, item)
 }

--- a/storage/localstore/mode_set.go
+++ b/storage/localstore/mode_set.go
@@ -409,6 +409,9 @@ func (db *DB) setReUpload(batch *leveldb.Batch, addr chunk.Address) (err error) 
 	// but before it is actually re-uploaded to the network
 	_, err = db.pinIndex.Get(item)
 	if err != nil {
+                 if err == leveldb.ErrNotFound {
+                     return chunk.ErrNotPinned
+                 }
 		return err
 	}
 

--- a/storage/localstore/mode_set.go
+++ b/storage/localstore/mode_set.go
@@ -418,6 +418,5 @@ func (db *DB) setReUpload(batch *leveldb.Batch, addr chunk.Address) (err error) 
 	}
 
 	item.StoreTimestamp = retrievalDataIndexItem.StoreTimestamp
-	// TODO: do we need to do anything about bin ids?
 	return db.pushIndex.PutInBatch(batch, item)
 }

--- a/storage/localstore/mode_set.go
+++ b/storage/localstore/mode_set.go
@@ -400,6 +400,7 @@ func (db *DB) setUnpin(batch *leveldb.Batch, addr chunk.Address) (err error) {
 	return nil
 }
 
+// setReUpload adds a pinned chunk to the push index so that it can be re-upuloaded to the network
 func (db *DB) setReUpload(batch *leveldb.Batch, addr chunk.Address) (err error) {
 	item := addressToItem(addr)
 

--- a/storage/localstore/mode_set_test.go
+++ b/storage/localstore/mode_set_test.go
@@ -374,26 +374,22 @@ func TestModeSetReUpload(t *testing.T) {
 			chunks := generateTestRandomChunks(tc.count)
 
 			// re-upload should fail if the chunk is not in the store
-			err := db.Set(context.Background(), chunk.ModeSetReUpload, chunkAddresses(chunks)...)
-			if err != leveldb.ErrNotFound {
-				t.Fatal(err)
+			if err := db.Set(context.Background(), chunk.ModeSetReUpload, chunkAddresses(chunks)...); err != leveldb.ErrNotFound {
+				t.Fatalf("expected error when re-uploading chunks to be %q, but got %v", leveldb.ErrNotFound, err)
 			}
 
 			// put the chunks in the db
-			_, err = db.Put(context.Background(), chunk.ModePutUpload, chunks...)
-			if err != err {
+			if _, err := db.Put(context.Background(), chunk.ModePutUpload, chunks...); err != nil {
 				t.Fatal(err)
 			}
 
 			// re-upload should fail if the chunk is not pinned
-			err = db.Set(context.Background(), chunk.ModeSetReUpload, chunkAddresses(chunks)...)
-			if err != leveldb.ErrNotFound {
-				t.Fatal(err)
+			if err := db.Set(context.Background(), chunk.ModeSetReUpload, chunkAddresses(chunks)...); err != leveldb.ErrNotFound {
+				t.Fatalf("expected error when re-uploading chunks to be %q, but got %v", leveldb.ErrNotFound, err)
 			}
 
 			// pin the chunks
-			err = db.Set(context.Background(), chunk.ModeSetPin, chunkAddresses(chunks)...)
-			if err != nil {
+			if err := db.Set(context.Background(), chunk.ModeSetPin, chunkAddresses(chunks)...); err != nil {
 				t.Fatal(err)
 			}
 
@@ -410,8 +406,7 @@ func TestModeSetReUpload(t *testing.T) {
 			t.Run("push index count", newItemsCountTest(db.pushIndex, 0))
 
 			// re-upload should go through at this point
-			err = db.Set(context.Background(), chunk.ModeSetReUpload, chunkAddresses(chunks)...)
-			if err != nil {
+			if err := db.Set(context.Background(), chunk.ModeSetReUpload, chunkAddresses(chunks)...); err != nil {
 				t.Fatal(err)
 			}
 

--- a/storage/localstore/mode_set_test.go
+++ b/storage/localstore/mode_set_test.go
@@ -366,7 +366,7 @@ func TestModeSetRemove(t *testing.T) {
 
 // TestModeSetReUpload validates ModeSetReUpload index values on the provided DB
 func TestModeSetReUpload(t *testing.T) {
-	for _, tc := range multiChunkTestCases[:1] {
+	for _, tc := range multiChunkTestCases {
 		t.Run(tc.name, func(t *testing.T) {
 			db, cleanupFunc := newTestDB(t, nil)
 			defer cleanupFunc()
@@ -375,19 +375,19 @@ func TestModeSetReUpload(t *testing.T) {
 
 			// re-upload should fail if the chunk is not in the store
 			err := db.Set(context.Background(), chunk.ModeSetReUpload, chunkAddresses(chunks)...)
-			if err == nil {
+			if err != leveldb.ErrNotFound {
 				t.Fatal(err)
 			}
 
 			// put the chunks in the db
 			_, err = db.Put(context.Background(), chunk.ModePutUpload, chunks...)
-			if err != nil {
+			if err != err {
 				t.Fatal(err)
 			}
 
 			// re-upload should fail if the chunk is not pinned
 			err = db.Set(context.Background(), chunk.ModeSetReUpload, chunkAddresses(chunks)...)
-			if err == nil {
+			if err != leveldb.ErrNotFound {
 				t.Fatal(err)
 			}
 

--- a/storage/localstore/mode_set_test.go
+++ b/storage/localstore/mode_set_test.go
@@ -384,8 +384,8 @@ func TestModeSetReUpload(t *testing.T) {
 			}
 
 			// re-upload should fail if the chunk is not pinned
-			if err := db.Set(context.Background(), chunk.ModeSetReUpload, chunkAddresses(chunks)...); err != leveldb.ErrNotFound {
-				t.Fatalf("expected error when re-uploading chunks to be %q, but got %v", leveldb.ErrNotFound, err)
+			if err := db.Set(context.Background(), chunk.ModeSetReUpload, chunkAddresses(chunks)...); err != chunk.ErrNotPinned {
+				t.Fatalf("expected error when re-uploading chunks to be %q, but got %v", chunk.ErrNotPinned, err)
 			}
 
 			// pin the chunks

--- a/swarm.go
+++ b/swarm.go
@@ -285,7 +285,6 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 	if self.config.GlobalPinner {
 		lstore.WithDeliverCallback(self.pss.Deliver)
 		recoveryFunc := func(m trojan.Message) {
-			// retrieve chunk from local store
 			chAddr := m.Payload // TODO: for now we assume payload = chunk address
 			// re-upload chunk to network
 			lstore.Set(context.Background(), chunk.ModeSetReUpload, chAddr) // TODO: ignoring output for now

--- a/swarm.go
+++ b/swarm.go
@@ -285,6 +285,7 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 	if self.config.GlobalPinner {
 		lstore.WithDeliverCallback(self.pss.Deliver)
 		// repairFunc takes care of re-uploading a globally pinned chunk to the network
+		// TODO: move this anonymous function into the prod package
 		repairFunc := func(m trojan.Message) {
 			chAddr := m.Payload
 			lstore.Set(context.Background(), chunk.ModeSetReUpload, chAddr)

--- a/swarm.go
+++ b/swarm.go
@@ -287,9 +287,8 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 		recoveryFunc := func(m trojan.Message) {
 			// retrieve chunk from local store
 			chAddr := m.Payload // TODO: for now we assume payload = chunk address
-			ch, _ := lstore.Get(context.Background(), chunk.ModeGetLookup, chAddr)
 			// re-upload chunk to network
-			lstore.Put(context.Background(), chunk.ModePutReUpload, ch) // ignoring output for now
+			lstore.Set(context.Background(), chunk.ModeSetReUpload, chAddr) // TODO: ignoring output for now
 		}
 		self.pss.Register(trojan.NewTopic("RECOVERY"), recoveryFunc)
 	}

--- a/swarm.go
+++ b/swarm.go
@@ -284,12 +284,12 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 
 	if self.config.GlobalPinner {
 		lstore.WithDeliverCallback(self.pss.Deliver)
-		recoveryFunc := func(m trojan.Message) {
-			chAddr := m.Payload // TODO: for now we assume payload = chunk address
-			// re-upload chunk to network
-			lstore.Set(context.Background(), chunk.ModeSetReUpload, chAddr) // TODO: ignoring output for now
+		// repairFunc takes care of re-uploading a globally pinned chunk to the network
+		repairFunc := func(m trojan.Message) {
+			chAddr := m.Payload
+			lstore.Set(context.Background(), chunk.ModeSetReUpload, chAddr)
 		}
-		self.pss.Register(trojan.NewTopic("RECOVERY"), recoveryFunc)
+		self.pss.Register(trojan.NewTopic("RECOVERY"), repairFunc)
 	}
 
 	self.api = api.NewAPI(self.fileStore, self.dns, self.rns, feedsHandler, self.privateKey, self.tags)


### PR DESCRIPTION
This PR is a WIP for the following task:
>  implement a handler function to re-upload missing pinned content in the case of receiving such notification in the form of a trojan chunk.

from issue #2161.

### Implementation overview
- makes `trojan.Message.Payload` field public so that it can be used by the repair func.
- registers a content repair func as a handler on `pss` when a global pinner node boots up.
- adds `mode.ModeSetReUpload` to the `chunk` package to be used for content repair through a push index update.

### Notes
There's a `TODO` left in the code for moving the anonymous repair func to the `prod` package, once [the related PR](https://github.com/ethersphere/swarm/pull/2166) is completed.

### To-do
- [x] add tests if possible