### PR TITLE
chunk, prod, pss, storage, swarm: trigger trojan chunk sending

### DIFF
--- a/chunk/chunk.go
+++ b/chunk/chunk.go
@@ -283,7 +283,7 @@ type Validator interface {
 // with validators check.
 type ValidatorStore struct {
 	Store
-	deliverCallback func(Chunk)
+	deliverCallback func(Chunk) // callback hook used to validate chunk
 	validators      []Validator
 }
 

--- a/prod/prod.go
+++ b/prod/prod.go
@@ -24,7 +24,7 @@ import (
 	"github.com/ethersphere/swarm/pss/trojan"
 )
 
-// RecoveryHook defines code to be executed upon trigger of lost chunks
+// RecoveryHook defines code to be executed upon trigger of failed to be retrieved chunks
 type RecoveryHook func(ctx context.Context, chunkAddress chunk.Address) error
 
 // sender is the function call for sending trojan chunks
@@ -40,6 +40,7 @@ func NewRecoveryHook(send sender) RecoveryHook {
 		payload := chunkAddress
 		topic := trojan.NewTopic("RECOVERY")
 
+		// TODO: monitor return should
 		if _, err := send(ctx, targets, topic, payload); err != nil {
 			return err
 		}
@@ -47,6 +48,7 @@ func NewRecoveryHook(send sender) RecoveryHook {
 	}
 }
 
+// TODO: refactor this method to implement feed of target pinners
 // getPinners returns the specific target pinners for a corresponding chunk address
 func getPinners(chunkAddress chunk.Address) ([][]byte, error) {
 	//this should get the feed and return correct target of pinners

--- a/prod/prod.go
+++ b/prod/prod.go
@@ -1,0 +1,17 @@
+// Copyright 2020 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package prod

--- a/prod/prod.go
+++ b/prod/prod.go
@@ -15,3 +15,22 @@
 // along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
 
 package prod
+
+import (
+	"context"
+
+	"github.com/ethersphere/swarm/pss"
+	"github.com/ethersphere/swarm/pss/trojan"
+)
+
+// Sender defines code to be executed upon trigger of lost TODO: chunk????
+type Sender func(ctx context.Context, targets [][]byte, topic trojan.Topic, payload []byte) (*pss.Monitor, error)
+
+// Recover invokes underlying pss.Send as the first step of global pinning
+func Recover(send Sender) {
+
+}
+
+// func Register?
+// based of topic?
+// maybe the sender

--- a/prod/prod.go
+++ b/prod/prod.go
@@ -18,7 +18,9 @@ package prod
 
 import (
 	"context"
+	"sync"
 
+	"github.com/ethersphere/swarm/chunk"
 	"github.com/ethersphere/swarm/pss"
 	"github.com/ethersphere/swarm/pss/trojan"
 )
@@ -26,11 +28,69 @@ import (
 // Sender defines code to be executed upon trigger of lost TODO: chunk????
 type Sender func(ctx context.Context, targets [][]byte, topic trojan.Topic, payload []byte) (*pss.Monitor, error)
 
-// Recover invokes underlying pss.Send as the first step of global pinning
-func Recover(send Sender) {
-
+// Prod todo: define comment
+type Prod struct {
+	senders   map[*chunk.Address]Sender
+	sendersMu sync.RWMutex
 }
 
-// func Register?
-// based of topic?
-// maybe the sender
+// NewProd inits the Prod struct
+func NewProd() *Prod {
+	return &Prod{
+		senders: make(map[*chunk.Address]Sender),
+	}
+}
+
+// Recover invokes underlying pss.Send as the first step of global pinning
+// Does it return the chunk or the monitor?
+func (p *Prod) Recover(ctx context.Context, chunkAddress chunk.Address) (chunk.Chunk, error) {
+	var err error
+	h := p.getSender(chunkAddress)
+
+	// pss := NewPss(localStore, tags)
+
+	//are the targets injected in the send or is it when it's called
+	targets, err := p.getTargets(chunkAddress)
+	if err != nil {
+		return nil, err
+	}
+	payload := chunkAddress
+	topic := trojan.NewTopic("RECOVERY")
+
+	if h != nil {
+		if _, err = h(ctx, targets, topic, payload); err != nil {
+			return nil, err
+		}
+	}
+
+	// should it wait for the chunk and timeout if not
+	// using the monitor of pss until this is received
+	return nil, nil
+}
+
+func (p *Prod) getTargets(chunkAddress chunk.Address) ([][]byte, error) {
+	//this should get the feed and return correct target of pinners
+	return [][]byte{
+		{57, 120},
+		{209, 156},
+		{156, 38},
+		{89, 19},
+		{22, 129}}, nil
+}
+
+// Register should be called internally
+// for every chunk that is globally pinned thru the feed
+
+// register
+func (p *Prod) register(chunkAddress chunk.Address, sender Sender) {
+	p.sendersMu.Lock()
+	defer p.sendersMu.Unlock()
+	p.senders[&chunkAddress] = sender
+}
+
+// getSender returns the Sender func registered in prod for the given chunk address
+func (p *Prod) getSender(chunkAddress chunk.Address) Sender {
+	p.sendersMu.RLock()
+	defer p.sendersMu.RUnlock()
+	return p.senders[&chunkAddress]
+}

--- a/prod/prod.go
+++ b/prod/prod.go
@@ -40,8 +40,6 @@ func NewProd(sender Sender) *Prod {
 	}
 }
 
-//Prod is defined in swarm.go
-
 // Recover invokes underlying pss.Send as the first step of global pinning
 func (p *Prod) Recover(ctx context.Context, chunkAddress chunk.Address) error {
 	var err error

--- a/prod/prod.go
+++ b/prod/prod.go
@@ -27,9 +27,10 @@ import (
 // RecoveryHook defines code to be executed upon trigger of lost chunks
 type RecoveryHook func(ctx context.Context, chunkAddress chunk.Address) error
 
+// sender is the function call for sending trojan chunks
 type sender func(ctx context.Context, targets [][]byte, topic trojan.Topic, payload []byte) (*pss.Monitor, error)
 
-// NewRecoveryHook TODO: better comment please
+// NewRecoveryHook returns a new RecoveryHook with the sender function defined
 func NewRecoveryHook(send sender) RecoveryHook {
 	return func(ctx context.Context, chunkAddress chunk.Address) error {
 		targets, err := getPinners(chunkAddress)
@@ -46,26 +47,7 @@ func NewRecoveryHook(send sender) RecoveryHook {
 	}
 }
 
-// // Recover invokes underlying pss.Send as the first step of global pinning
-// func Recover(ctx context.Context, chunkAddress chunk.Address) error {
-
-// 	// TODO: REMOVE FROM HERE DO IT OUTSIDE
-// 	// TODO: where to get chunk from??, localstore/netstore etc?
-// 	// TODO: does it obtain it from RequestFromPeer?
-// 	// for {
-// 	// 	select {
-// 	// 	case <-time.After(timeouts.FetcherGlobalTimeout):
-// 	// 		return nil, errors.New("unable to retreive globally pinned chunk")
-// 	// 	case <-time.After(timeouts.SearchTimeout):
-// 	// 		break
-// 	// 	}
-// 	// }
-
-// 	// should it wait for the chunk and timeout if not
-// 	// using the monitor of pss until this is received
-// 	return nil
-// }
-
+// getPinners returns the specific target pinners for a corresponding chunk address
 func getPinners(chunkAddress chunk.Address) ([][]byte, error) {
 	//this should get the feed and return correct target of pinners
 	return [][]byte{

--- a/prod/prod_test.go
+++ b/prod/prod_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/ethersphere/swarm/chunk"
 	"github.com/ethersphere/swarm/pss"
 	"github.com/ethersphere/swarm/pss/trojan"
 )
@@ -40,13 +41,14 @@ func TestRecoveryHook(t *testing.T) {
 		return nil, nil
 	}
 
-	//prod := NewProd(testHandler)
+	recoverFunc := NewRecoveryHook(testHandler)
+	// call recoverFunc
+	recoverFunc(ctx, chunk.ZeroAddr)
 
-	// call prod Recovery and verify it's been called
-	//prod.Recover(ctx, chunk.ZeroAddr)
-	//if handlerVerifier != 1 {
-	//	t.Fatalf("unexpected result for prod Recover func, expected test variable to have a value of %v but is %v instead", 1, handlerVerifier)
-	//}
+	// verify the hook has been called
+	if handlerVerifier != 1 {
+		t.Fatalf("unexpected result for prod Recover func, expected test variable to have a value of %v but is %v instead", 1, handlerVerifier)
+	}
 
 }
 

--- a/prod/prod_test.go
+++ b/prod/prod_test.go
@@ -1,0 +1,17 @@
+// Copyright 2020 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package prod

--- a/prod/prod_test.go
+++ b/prod/prod_test.go
@@ -18,11 +18,20 @@ package prod
 
 import (
 	"context"
+	"crypto/rand"
+	"io/ioutil"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/ethersphere/swarm/chunk"
+	"github.com/ethersphere/swarm/network"
+	"github.com/ethersphere/swarm/network/retrieval"
+	"github.com/ethersphere/swarm/network/timeouts"
 	"github.com/ethersphere/swarm/pss"
 	"github.com/ethersphere/swarm/pss/trojan"
+	"github.com/ethersphere/swarm/storage"
+	"github.com/ethersphere/swarm/storage/localstore"
 )
 
 // TestRecoveryHook tests that a timeout in netstore
@@ -32,12 +41,11 @@ func TestRecoveryHook(t *testing.T) {
 	// verify that hook is correctly invoked
 	ctx := context.TODO()
 
-	handlerVerifier := 0 // test variable to check handler funcs are correctly retrieved
+	handlerWasCalled := false // test variable to check handler funcs are correctly retrieved
 
 	// register first handler
 	testHandler := func(ctx context.Context, targets [][]byte, topic trojan.Topic, payload []byte) (*pss.Monitor, error) {
-		handlerVerifier = 1
-		// what should I return?
+		handlerWasCalled = true
 		return nil, nil
 	}
 
@@ -46,16 +54,93 @@ func TestRecoveryHook(t *testing.T) {
 	recoverFunc(ctx, chunk.ZeroAddr)
 
 	// verify the hook has been called
-	if handlerVerifier != 1 {
-		t.Fatalf("unexpected result for prod Recover func, expected test variable to have a value of %v but is %v instead", 1, handlerVerifier)
+	if handlerWasCalled != true {
+		t.Fatalf("unexpected result for prod Recover func, expected test variable to have a value of %v but is %v instead", true, handlerWasCalled)
 	}
 
 }
 
+func newMockLocalStore(t *testing.T, tags *chunk.Tags) *localstore.DB {
+	dir, err := ioutil.TempDir("", "swarm-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	baseKey := make([]byte, 32)
+	if _, err = rand.Read(baseKey); err != nil {
+		t.Fatal(err)
+	}
+
+	localStore, err := localstore.New(dir, baseKey, &localstore.Options{Tags: tags})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return localStore
+}
+
 // TestSenderCall verifies that pss send is being called correctly
 func TestSenderCall(t *testing.T) {
+	ctx := context.TODO()
+	tags := chunk.NewTags()
+	localStore := newMockLocalStore(t, tags)
+
+	lstore := chunk.NewValidatorStore(
+		localStore,
+		storage.NewContentAddressValidator(storage.MakeHashFunc(storage.DefaultHash)),
+	)
+
+	baseKey := make([]byte, 32)
+	_, err := rand.Read(baseKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	baseAddress := network.NewBzzAddr(baseKey, baseKey)
 	// setup netstore
-	// setup recovery hook with pss Sender
-	// wait for timeout
-	// verify that pss was actually called
+	netStore := storage.NewNetStore(lstore, baseAddress)
+
+	handlerWasCalled := false // test variable to check handler funcs are correctly retrieved
+
+	// setup recovery hook
+	testHandler := func(ctx context.Context, targets [][]byte, topic trojan.Topic, payload []byte) (*pss.Monitor, error) {
+		handlerWasCalled = true
+		return nil, nil
+	}
+
+	//func(ctx context.Context, chunkAddress chunk.Address)
+	recoverFunc := NewRecoveryHook(testHandler)
+	netStore.WithRecoveryCallback(recoverFunc)
+
+	c := GenerateTestRandomChunk()
+	ref := c.Address()
+
+	kad := network.NewKademlia(baseAddress.Over(), network.NewKadParams())
+	ret := retrieval.New(kad, netStore, baseAddress, nil)
+	netStore.RemoteGet = ret.RequestFromPeers
+
+	netStore.Get(ctx, chunk.ModeGetRequest, storage.NewRequest(ref))
+
+	for {
+		// waits until the callback is called or timeout
+		select {
+		default:
+			if handlerWasCalled {
+				return
+			}
+		// TODO: change the timeout
+		case <-time.After(timeouts.FetcherGlobalTimeout):
+			t.Fatalf("no handler was called")
+		}
+	}
+
+}
+
+func GenerateTestRandomChunk() chunk.Chunk {
+	data := make([]byte, chunk.DefaultSize)
+	rand.Read(data)
+	key := make([]byte, 32)
+	rand.Read(key)
+	return chunk.NewChunk(key, data)
 }

--- a/prod/prod_test.go
+++ b/prod/prod_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ethersphere/swarm/chunk"
 	"github.com/ethersphere/swarm/pss"
 	"github.com/ethersphere/swarm/pss/trojan"
 )
@@ -41,13 +40,13 @@ func TestRecoveryHook(t *testing.T) {
 		return nil, nil
 	}
 
-	prod := NewProd(testHandler)
+	//prod := NewProd(testHandler)
 
 	// call prod Recovery and verify it's been called
-	prod.Recover(ctx, chunk.ZeroAddr)
-	if handlerVerifier != 1 {
-		t.Fatalf("unexpected result for prod Recover func, expected test variable to have a value of %v but is %v instead", 1, handlerVerifier)
-	}
+	//prod.Recover(ctx, chunk.ZeroAddr)
+	//if handlerVerifier != 1 {
+	//	t.Fatalf("unexpected result for prod Recover func, expected test variable to have a value of %v but is %v instead", 1, handlerVerifier)
+	//}
 
 }
 

--- a/prod/prod_test.go
+++ b/prod/prod_test.go
@@ -45,7 +45,7 @@ func TestRecoveryHook(t *testing.T) {
 		return nil, nil
 	}
 
-	// setup recovery hook with testHandler
+	// setup recovery hook with testHook
 	recoverFunc := NewRecoveryHook(testHook)
 
 	recoverFunc(ctx, chunk.ZeroAddr)

--- a/prod/prod_test.go
+++ b/prod/prod_test.go
@@ -30,13 +30,7 @@ import (
 func TestRecoveryHook(t *testing.T) {
 	// setup recovery hook
 	// verify that hook is correctly invoked
-	prod := NewProd()
 	ctx := context.TODO()
-
-	// pss handlers should be empty
-	if len(prod.handlers) != 0 {
-		t.Fatalf("expected prod senders to contain 0 elements, but its length is %d", len(prod.handlers))
-	}
 
 	handlerVerifier := 0 // test variable to check handler funcs are correctly retrieved
 
@@ -47,11 +41,7 @@ func TestRecoveryHook(t *testing.T) {
 		return nil, nil
 	}
 
-	prod.register(chunk.ZeroAddr, testHandler)
-
-	if len(prod.handlers) != 1 {
-		t.Fatalf("expected prod handlers to contain 1 element, but its length is %d", len(prod.handlers))
-	}
+	prod := NewProd(testHandler)
 
 	// call prod Recovery and verify it's been called
 	prod.Recover(ctx, chunk.ZeroAddr)

--- a/prod/prod_test.go
+++ b/prod/prod_test.go
@@ -15,3 +15,22 @@
 // along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
 
 package prod
+
+import "testing"
+
+// TestRecoveryHook tests that a timeout in netstore
+// invokes correctly recovery hook
+func TestRecoveryHookCalled(t *testing.T) {
+	// setup netstore
+	// setup recovery hook
+	// wait for timeout
+	// verify that hook is correctly invoked
+}
+
+// TestSenderCall veryfies that pss send is being called correctly
+func TestSenderCall(t *testing.T) {
+	// setup netstore
+	// setup recovery hook with pss Sender
+	// wait for timeout
+	// verify that pss was actually called
+}

--- a/prod/prod_test.go
+++ b/prod/prod_test.go
@@ -16,18 +16,52 @@
 
 package prod
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	"github.com/ethersphere/swarm/chunk"
+	"github.com/ethersphere/swarm/pss"
+	"github.com/ethersphere/swarm/pss/trojan"
+)
 
 // TestRecoveryHook tests that a timeout in netstore
 // invokes correctly recovery hook
-func TestRecoveryHookCalled(t *testing.T) {
-	// setup netstore
+func TestRecoveryHook(t *testing.T) {
 	// setup recovery hook
-	// wait for timeout
 	// verify that hook is correctly invoked
+	prod := NewProd()
+	ctx := context.TODO()
+
+	// pss handlers should be empty
+	if len(prod.handlers) != 0 {
+		t.Fatalf("expected prod senders to contain 0 elements, but its length is %d", len(prod.handlers))
+	}
+
+	handlerVerifier := 0 // test variable to check handler funcs are correctly retrieved
+
+	// register first handler
+	testHandler := func(ctx context.Context, targets [][]byte, topic trojan.Topic, payload []byte) (*pss.Monitor, error) {
+		handlerVerifier = 1
+		// what should I return?
+		return nil, nil
+	}
+
+	prod.register(chunk.ZeroAddr, testHandler)
+
+	if len(prod.handlers) != 1 {
+		t.Fatalf("expected prod handlers to contain 1 element, but its length is %d", len(prod.handlers))
+	}
+
+	// call prod Recovery and verify it's been called
+	prod.Recover(ctx, chunk.ZeroAddr)
+	if handlerVerifier != 1 {
+		t.Fatalf("unexpected result for prod Recover func, expected test variable to have a value of %v but is %v instead", 1, handlerVerifier)
+	}
+
 }
 
-// TestSenderCall veryfies that pss send is being called correctly
+// TestSenderCall verifies that pss send is being called correctly
 func TestSenderCall(t *testing.T) {
 	// setup netstore
 	// setup recovery hook with pss Sender

--- a/pss/pss_test.go
+++ b/pss/pss_test.go
@@ -18,16 +18,13 @@ package pss
 
 import (
 	"context"
-	"crypto/rand"
-	"io/ioutil"
-	"os"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/ethersphere/swarm/chunk"
+	psstest "github.com/ethersphere/swarm/pss/testing"
 	trojan "github.com/ethersphere/swarm/pss/trojan"
-	"github.com/ethersphere/swarm/storage/localstore"
 )
 
 // TestTrojanChunkRetrieval creates a trojan chunk
@@ -38,7 +35,7 @@ func TestTrojanChunkRetrieval(t *testing.T) {
 	ctx := context.TODO()
 	tags := chunk.NewTags()
 
-	localStore := newMockLocalStore(t, tags)
+	localStore := psstest.NewMockLocalStore(t, tags)
 	pss := NewPss(localStore, tags)
 
 	targets := [][]byte{
@@ -113,7 +110,7 @@ func TestPssMonitor(t *testing.T) {
 	ctx := context.TODO()
 	tags := chunk.NewTags()
 
-	localStore := newMockLocalStore(t, tags)
+	localStore := psstest.NewMockLocalStore(t, tags)
 
 	targets := [][]byte{
 		{57, 120},
@@ -157,30 +154,10 @@ func TestPssMonitor(t *testing.T) {
 
 }
 
-func newMockLocalStore(t *testing.T, tags *chunk.Tags) *localstore.DB {
-	dir, err := ioutil.TempDir("", "swarm-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	baseKey := make([]byte, 32)
-	if _, err = rand.Read(baseKey); err != nil {
-		t.Fatal(err)
-	}
-
-	localStore, err := localstore.New(dir, baseKey, &localstore.Options{Tags: tags})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return localStore
-}
-
 // TestRegister verifies that handler funcs are able to be registered correctly in pss
 func TestRegister(t *testing.T) {
 	tags := chunk.NewTags()
-	localStore := newMockLocalStore(t, tags)
+	localStore := psstest.NewMockLocalStore(t, tags)
 	pss := NewPss(localStore, tags)
 
 	// pss handlers should be empty
@@ -230,7 +207,7 @@ func TestRegister(t *testing.T) {
 // results in the execution of the expected handler func
 func TestDeliver(t *testing.T) {
 	tags := chunk.NewTags()
-	localStore := newMockLocalStore(t, tags)
+	localStore := psstest.NewMockLocalStore(t, tags)
 	pss := NewPss(localStore, tags)
 
 	// test message

--- a/pss/testing/pss.go
+++ b/pss/testing/pss.go
@@ -1,0 +1,52 @@
+// Copyright 2020 The Swarm Authors
+// This file is part of the Swarm library.
+//
+// The Swarm library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The Swarm library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the Swarm library. If not, see <http://www.gnu.org/licenses/>.
+
+package testing
+
+import (
+	"crypto/rand"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/ethersphere/swarm/chunk"
+	"github.com/ethersphere/swarm/storage/localstore"
+)
+
+// NewMockLocalStore generates a mocked localstore
+// this is used by test that need access to the localstore
+// the tags are initialized on store init
+func NewMockLocalStore(t *testing.T, tags *chunk.Tags) *localstore.DB {
+	dir, err := ioutil.TempDir("", "swarm-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	baseKey := make([]byte, 32)
+	if _, err = rand.Read(baseKey); err != nil {
+		t.Fatal(err)
+	}
+
+	localStore, err := localstore.New(dir, baseKey, &localstore.Options{Tags: tags})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return localStore
+}
+
+// TODO: later test could be a simulation test for 2 nodes, localstore + netstore

--- a/storage/netstore.go
+++ b/storage/netstore.go
@@ -193,6 +193,10 @@ func (n *NetStore) Get(ctx context.Context, mode chunk.ModeGet, req *Request) (c
 			if ok {
 				ch, err = n.RemoteFetch(ctx, req, fi)
 				if err != nil {
+					// prod.Recover
+					// RemoteFetch again, see the timeouts
+					// delay
+					// global timeout after this
 					return nil, err
 				}
 			}

--- a/storage/netstore.go
+++ b/storage/netstore.go
@@ -193,7 +193,6 @@ func (n *NetStore) Get(ctx context.Context, mode chunk.ModeGet, req *Request) (c
 			if ok {
 				ch, err = n.RemoteFetch(ctx, req, fi)
 				if err != nil {
-					// prod.Recover
 					// RemoteFetch again, see the timeouts
 					// delay
 					// global timeout after this

--- a/storage/netstore.go
+++ b/storage/netstore.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethersphere/swarm/chunk"
 	"github.com/ethersphere/swarm/network/timeouts"
-	"github.com/ethersphere/swarm/prod"
 	"github.com/ethersphere/swarm/spancontext"
 	lru "github.com/hashicorp/golang-lru"
 	olog "github.com/opentracing/opentracing-go/log"
@@ -100,7 +99,7 @@ type NetStore struct {
 	requestGroup     singleflight.Group
 	RemoteGet        RemoteGetFunc
 	logger           log.Logger
-	recoveryCallback prod.RecoveryHook
+	recoveryCallback func(ctx context.Context, chunkAddress chunk.Address) error
 }
 
 // NewNetStore creates a new NetStore using the provided chunk.Store and localID of the node.
@@ -168,7 +167,7 @@ func (n *NetStore) Close() error {
 }
 
 // WithRecoveryCallback allows injecting a callback func on the ValidatorStore struct
-func (n *NetStore) WithRecoveryCallback(f prod.RecoveryHook) *NetStore {
+func (n *NetStore) WithRecoveryCallback(f func(ctx context.Context, chunkAddress chunk.Address) error) *NetStore {
 	n.recoveryCallback = f
 	return n
 }

--- a/swarm.go
+++ b/swarm.go
@@ -49,6 +49,7 @@ import (
 	"github.com/ethersphere/swarm/oldpss"
 	oldpssmessage "github.com/ethersphere/swarm/oldpss/message"
 	"github.com/ethersphere/swarm/p2p/protocols"
+	"github.com/ethersphere/swarm/prod"
 	"github.com/ethersphere/swarm/pss"
 	"github.com/ethersphere/swarm/pss/trojan"
 	"github.com/ethersphere/swarm/pushsync"
@@ -287,8 +288,8 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 			// TODO: add missing chunk re-upload
 		}
 		self.pss.Register(trojan.NewTopic("RECOVERY"), recoveryFunc)
-		//prod := prod.NewProd(self.pss.Send)
-		//self.netStore.SetProd(prod)
+		prod := prod.NewProd(self.pss.Send)
+		self.netStore.SetProd(prod)
 	}
 
 	self.api = api.NewAPI(self.fileStore, self.dns, self.rns, feedsHandler, self.privateKey, self.tags)

--- a/swarm.go
+++ b/swarm.go
@@ -288,8 +288,8 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 			// TODO: add missing chunk re-upload
 		}
 		self.pss.Register(trojan.NewTopic("RECOVERY"), recoveryFunc)
-		prod := prod.NewProd(self.pss.Send)
-		self.netStore.SetProd(prod)
+		recoverFunc := prod.NewRecoveryHook(self.pss.Send)
+		self.netStore.WithRecoveryCallback(recoverFunc)
 	}
 
 	self.api = api.NewAPI(self.fileStore, self.dns, self.rns, feedsHandler, self.privateKey, self.tags)

--- a/swarm.go
+++ b/swarm.go
@@ -287,6 +287,8 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 			// TODO: add missing chunk re-upload
 		}
 		self.pss.Register(trojan.NewTopic("RECOVERY"), recoveryFunc)
+		//prod := prod.NewProd(self.pss.Send)
+		//self.netStore.SetProd(prod)
 	}
 
 	self.api = api.NewAPI(self.fileStore, self.dns, self.rns, feedsHandler, self.privateKey, self.tags)


### PR DESCRIPTION
**EXPERIMENTAL** 
(will not merge to `master`)

---
WIP for triggering trojan chunk sending used by implementation for global pinning.

this is invoked after trying to download content and failing, this will be a trigger to start the global pinning lifecycle.

Related issue: #2161

This PR:
- creates a new prod (recovery package) package for global pinning
- implements a way to trigger the sending of the trojan chunk; this should happen after failing to download content which the node understands is globally pinned.
- implemented by a fallback recoveryHook in netstore (similar to deliveryHook)
- should use feed-base retrieval but this maybe branch off into a separate PR.
  - sending should be done first with the hooks with a const target list hardwired in recovery package first
 - then it could be replaced with feed-based implementation

Remove `TODO`s for deprecated code after iteration