### PR TITLE
update pss owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -15,7 +15,7 @@ swarm
 │       ├── intervals ───── @janos
 │       └── testing ─────── @zelig
 ├── pot ─────────────────── @zelig
-├── pss ─────────────────── @nolash, @zelig, @nonsense
+├── pss ─────────────────── @zelig, @nonsense
 ├── services ────────────── @zelig
 ├── state ───────────────── @justelad
 ├── storage ─────────────── ethersphere


### PR DESCRIPTION
This PR removes @nolash from `pss` as a code owner, per his request.