### PR TITLE
update feed owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -21,5 +21,5 @@ swarm
 ├── storage ─────────────── ethersphere
 │   ├── encryption ──────── @gbalint, @zelig, @nagydani
 │   ├── mock ────────────── @janos
-│   └── feed ────────────── @nolash, @jpeletier
+│   └── feed ────────────── @jpeletier
 └── testutil ────────────── @lmars


### PR DESCRIPTION
This PR removes @nolash from `feed` as a code owner, per his request.