### PR TITLE
prod, pss, trojan: add Target and Targets types

### DIFF
--- a/prod/prod.go
+++ b/prod/prod.go
@@ -28,7 +28,7 @@ import (
 type RecoveryHook func(ctx context.Context, chunkAddress chunk.Address) error
 
 // sender is the function call for sending trojan chunks
-type sender func(ctx context.Context, targets [][]byte, topic trojan.Topic, payload []byte) (*pss.Monitor, error)
+type sender func(ctx context.Context, targets trojan.Targets, topic trojan.Topic, payload []byte) (*pss.Monitor, error)
 
 // NewRecoveryHook returns a new RecoveryHook with the sender function defined
 func NewRecoveryHook(send sender) RecoveryHook {
@@ -50,12 +50,11 @@ func NewRecoveryHook(send sender) RecoveryHook {
 
 // TODO: refactor this method to implement feed of target pinners
 // getPinners returns the specific target pinners for a corresponding chunk address
-func getPinners(chunkAddress chunk.Address) ([][]byte, error) {
-	//this should get the feed and return correct target of pinners
-	return [][]byte{
-		{57, 120},
-		{209, 156},
-		{156, 38},
-		{89, 19},
-		{22, 129}}, nil
+func getPinners(chunkAddress chunk.Address) (trojan.Targets, error) {
+
+	// TODO: dummy targets for now
+	t1 := trojan.Target([]byte{57, 120})
+	t2 := trojan.Target([]byte{209, 156})
+	t3 := trojan.Target([]byte{156, 38})
+	return trojan.Targets([]trojan.Target{t1, t2, t3}), nil
 }

--- a/prod/prod_test.go
+++ b/prod/prod_test.go
@@ -40,7 +40,7 @@ func TestRecoveryHook(t *testing.T) {
 	hookWasCalled := false // test variable to check hook func are correctly retrieved
 
 	// setup the hook
-	testHook := func(ctx context.Context, targets [][]byte, topic trojan.Topic, payload []byte) (*pss.Monitor, error) {
+	testHook := func(ctx context.Context, targets trojan.Targets, topic trojan.Topic, payload []byte) (*pss.Monitor, error) {
 		hookWasCalled = true
 		return nil, nil
 	}
@@ -81,7 +81,7 @@ func TestSenderCall(t *testing.T) {
 	hookWasCalled := false // test variable to check hook func are correctly retrieved
 
 	// setup recovery hook
-	testHook := func(ctx context.Context, targets [][]byte, topic trojan.Topic, payload []byte) (*pss.Monitor, error) {
+	testHook := func(ctx context.Context, targets trojan.Targets, topic trojan.Topic, payload []byte) (*pss.Monitor, error) {
 		hookWasCalled = true
 		return nil, nil
 	}

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -55,7 +55,7 @@ type Handler func(trojan.Message)
 // Send constructs a padded message with topic and payload,
 // wraps it in a trojan chunk such that one of the targets is a prefix of the chunk address
 // stores this in localstore for push-sync to pick up and deliver
-func (p *Pss) Send(ctx context.Context, targets [][]byte, topic trojan.Topic, payload []byte) (*Monitor, error) {
+func (p *Pss) Send(ctx context.Context, targets trojan.Targets, topic trojan.Topic, payload []byte) (*Monitor, error) {
 	metrics.GetOrRegisterCounter("trojanchunk/send", nil).Inc(1)
 	//construct Trojan Chunk
 	m, err := trojan.NewMessage(topic, payload)

--- a/pss/pss_test.go
+++ b/pss/pss_test.go
@@ -38,12 +38,7 @@ func TestTrojanChunkRetrieval(t *testing.T) {
 	localStore := psstest.NewMockLocalStore(t, tags)
 	pss := NewPss(localStore, tags)
 
-	targets := [][]byte{
-		{57, 120},
-		{209, 156},
-		{156, 38},
-		{89, 19},
-		{22, 129}}
+	targets := trojan.Targets([]trojan.Target{[]byte{1}}) // arbitrary test targets
 	payload := []byte("RECOVERY CHUNK")
 	topic := trojan.NewTopic("RECOVERY")
 
@@ -77,7 +72,7 @@ func TestTrojanChunkRetrieval(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	//create a stored chunk artificially
+	// create a stored chunk artificially
 	m, err := trojan.NewMessage(topic, payload)
 	if err != nil {
 		t.Fatal(err)
@@ -97,7 +92,6 @@ func TestTrojanChunkRetrieval(t *testing.T) {
 	if !reflect.DeepEqual(tc, storedChunk) {
 		t.Fatalf("store chunk does not match sent chunk")
 	}
-
 }
 
 // TestPssMonitor creates a trojan chunk
@@ -112,12 +106,7 @@ func TestPssMonitor(t *testing.T) {
 
 	localStore := psstest.NewMockLocalStore(t, tags)
 
-	targets := [][]byte{
-		{57, 120},
-		{209, 156},
-		{156, 38},
-		{89, 19},
-		{22, 129}}
+	targets := trojan.Targets([]trojan.Target{[]byte{1}}) // arbitrary test targets
 	payload := []byte("RECOVERY CHUNK")
 	topic := trojan.NewTopic("RECOVERY")
 
@@ -151,7 +140,6 @@ func TestPssMonitor(t *testing.T) {
 			}
 		}
 	}
-
 }
 
 // TestRegister verifies that handler funcs are able to be registered correctly in pss
@@ -218,7 +206,7 @@ func TestDeliver(t *testing.T) {
 		t.Fatal(err)
 	}
 	// test chunk
-	targets := [][]byte{{255}}
+	targets := trojan.Targets([]trojan.Target{[]byte{1}}) // arbitrary test targets
 	chunk, err := msg.Wrap(targets)
 	if err != nil {
 		t.Fatal(err)
@@ -236,7 +224,4 @@ func TestDeliver(t *testing.T) {
 	if tt != msg.Topic {
 		t.Fatalf("unexpected result for pss Deliver func, expected test variable to have a value of %v but is %v instead", msg.Topic, tt)
 	}
-
 }
-
-// TODO: later test could be a simulation test for 2 nodes, localstore + netstore

--- a/pss/pss_test.go
+++ b/pss/pss_test.go
@@ -38,7 +38,8 @@ func TestTrojanChunkRetrieval(t *testing.T) {
 	localStore := psstest.NewMockLocalStore(t, tags)
 	pss := NewPss(localStore, tags)
 
-	targets := trojan.Targets([]trojan.Target{[]byte{1}}) // arbitrary test targets
+	target := trojan.Target([]byte{1}) // arbitrary test target
+	targets := trojan.Targets([]trojan.Target{target})
 	payload := []byte("RECOVERY CHUNK")
 	topic := trojan.NewTopic("RECOVERY")
 
@@ -106,7 +107,8 @@ func TestPssMonitor(t *testing.T) {
 
 	localStore := psstest.NewMockLocalStore(t, tags)
 
-	targets := trojan.Targets([]trojan.Target{[]byte{1}}) // arbitrary test targets
+	target := trojan.Target([]byte{1}) // arbitrary test target
+	targets := trojan.Targets([]trojan.Target{target})
 	payload := []byte("RECOVERY CHUNK")
 	topic := trojan.NewTopic("RECOVERY")
 
@@ -206,7 +208,8 @@ func TestDeliver(t *testing.T) {
 		t.Fatal(err)
 	}
 	// test chunk
-	targets := trojan.Targets([]trojan.Target{[]byte{1}}) // arbitrary test targets
+	target := trojan.Target([]byte{1}) // arbitrary test target
+	targets := trojan.Targets([]trojan.Target{target})
 	chunk, err := msg.Wrap(targets)
 	if err != nil {
 		t.Fatal(err)

--- a/pss/trojan/message_test.go
+++ b/pss/trojan/message_test.go
@@ -27,12 +27,12 @@ import (
 )
 
 // arbitrary targets for tests
-var testTargets = [][]byte{
-	{57, 120},
-	{209, 156},
-	{156, 38},
-	{89, 19},
-	{22, 129}}
+var t1 = Target([]byte{57, 120})
+var t2 = Target([]byte{209, 156})
+var t3 = Target([]byte{156, 38})
+var t4 = Target([]byte{89, 19})
+var t5 = Target([]byte{22, 129})
+var testTargets = Targets([]Target{t1, t2, t3, t4, t5})
 
 // arbitrary topic for tests
 var testTopic = NewTopic("foo")
@@ -121,16 +121,15 @@ func TestWrap(t *testing.T) {
 func TestWrapFail(t *testing.T) {
 	m := newTestMessage(t)
 
-	emptyTargets := [][]byte{}
+	emptyTargets := Targets([]Target{})
 	if _, err := m.Wrap(emptyTargets); err != ErrEmptyTargets {
 		t.Fatalf("expected error when creating chunk for empty targets to be %q, but got %v", ErrEmptyTargets, err)
 	}
 
-	varLenTargets := [][]byte{
-		{34},
-		{25, 120},
-		{180, 18, 255},
-	}
+	t1 := Target([]byte{34})
+	t2 := Target([]byte{25, 120})
+	t3 := Target([]byte{180, 18, 255})
+	varLenTargets := Targets([]Target{t1, t2, t3})
 	if _, err := m.Wrap(varLenTargets); err != ErrVarLenTargets {
 		t.Fatalf("expected error when creating chunk for variable-length targets to be %q, but got %v", ErrVarLenTargets, err)
 	}


### PR DESCRIPTION
This PR adds the `Target` and `Targets` types to the `trojan` package as aliases for the `[]byte` and `[][]byte` types.

Marshalling and unmarshalling of these types should be done through `json`.

The `prod` package uses these types as pinner targets for content repair procedures.

Related issue: #2161