### PR TITLE
feed: add handler interface and testutils

### DIFF
--- a/storage/feed/handler.go
+++ b/storage/feed/handler.go
@@ -31,6 +31,13 @@ import (
 	"github.com/ethersphere/swarm/storage/feed/lookup"
 )
 
+// GenericHandler is an interface which specifies funcs any feeds handler should use
+type GenericHandler interface {
+	Lookup(ctx context.Context, query *Query) (*cacheEntry, error)
+	GetContent(feed *Feed) (storage.Address, []byte, error)
+}
+
+// Handler is the struct to be used as the API for feeds
 type Handler struct {
 	chunkStore *storage.NetStore
 	HashSize   int


### PR DESCRIPTION
This PR adds a `GenericHandler` interface and a `DummyHandler` type to the `feed` package.

- The `GenericHandler` type will be used by the `prod` package to query feeds.
- The `DummyHandler` type will be used by the `prod` package to test the querying of feeds.

Related issue: #2161