### PR TITLE
prod, api, main, swarm: add fallback content recovery publisher

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -427,6 +427,8 @@ func (a *API) Get(ctx context.Context, decrypt DecryptFunc, manifestAddr storage
 		if len(entry.Publisher) > 0 {
 			ctx = context.WithValue(ctx, "publisher", entry.Publisher)
 		}
+		// add hash to context for fallback recovery
+		ctx = context.WithValue(ctx, "hash", entry.Hash)
 		reader, _ = a.fileStore.Retrieve(ctx, contentAddr)
 	} else {
 		// no entry found

--- a/api/config.go
+++ b/api/config.go
@@ -83,6 +83,7 @@ type Config struct {
 	DisableAutoConnect bool
 	EnablePinning      bool
 	GlobalPinner       bool
+	RecoveryPublisher  string
 	Cors               string
 	BzzAccount         string
 	GlobalStoreAPI     string

--- a/cmd/swarm/config.go
+++ b/cmd/swarm/config.go
@@ -276,8 +276,8 @@ func flagsOverride(currentConfig *bzzapi.Config, ctx *cli.Context) *bzzapi.Confi
 	if ctx.GlobalBool(SwarmGlobalPinnerFlag.Name) {
 		currentConfig.GlobalPinner = true
 	}
-	if ctx.GlobalIsSet(SwarmRecoveryPublisherFlag.Name) {
-		currentConfig.RecoveryPublisher = ctx.GlobalString(SwarmRecoveryPublisherFlag.Name)
+	if recoveryPublisher := ctx.GlobalString(SwarmRecoveryPublisherFlag.Name); recoveryPublisher != "" {
+		currentConfig.RecoveryPublisher = recoveryPublisher
 	}
 	return currentConfig
 }

--- a/cmd/swarm/config.go
+++ b/cmd/swarm/config.go
@@ -276,6 +276,10 @@ func flagsOverride(currentConfig *bzzapi.Config, ctx *cli.Context) *bzzapi.Confi
 	if ctx.GlobalBool(SwarmGlobalPinnerFlag.Name) {
 		currentConfig.GlobalPinner = true
 	}
+	if ctx.GlobalIsSet(SwarmRecoveryPublisherFlag.Name) {
+		currentConfig.RecoveryPublisher = ctx.GlobalString(SwarmRecoveryPublisherFlag.Name)
+	}
+
 	return currentConfig
 }
 

--- a/cmd/swarm/config.go
+++ b/cmd/swarm/config.go
@@ -279,7 +279,6 @@ func flagsOverride(currentConfig *bzzapi.Config, ctx *cli.Context) *bzzapi.Confi
 	if ctx.GlobalIsSet(SwarmRecoveryPublisherFlag.Name) {
 		currentConfig.RecoveryPublisher = ctx.GlobalString(SwarmRecoveryPublisherFlag.Name)
 	}
-
 	return currentConfig
 }
 

--- a/cmd/swarm/flags.go
+++ b/cmd/swarm/flags.go
@@ -223,6 +223,10 @@ var (
 		Name:  "user",
 		Usage: "Indicates the user who updates the feed",
 	}
+	SwarmRecoveryPublisherFlag = cli.StringFlag{
+		Name:  "recovery-publisher",
+		Usage: "Indicates the publisher for a fallback feed to be used for globally-pinned content repair",
+	}
 	SwarmGlobalStoreAPIFlag = cli.StringFlag{
 		Name:   "globalstore-api",
 		Usage:  "URL of the Global Store API provider (only for testing)",

--- a/cmd/swarm/flags.go
+++ b/cmd/swarm/flags.go
@@ -246,7 +246,7 @@ var (
 	}
 	SwarmRecoveryPublisherFlag = cli.StringFlag{
 		Name:  "recovery-publisher",
-		Usage: "Indicates the publisher for a fallback feed to be used for globally-pinned content repair",
+		Usage: "Use this flag to indicate the publisher for a fallback feed to be used for globally-pinned content repair",
 	}
 	SwarmProgressFlag = cli.BoolFlag{
 		Name:  "progress",

--- a/cmd/swarm/flags.go
+++ b/cmd/swarm/flags.go
@@ -223,10 +223,6 @@ var (
 		Name:  "user",
 		Usage: "Indicates the user who updates the feed",
 	}
-	SwarmRecoveryPublisherFlag = cli.StringFlag{
-		Name:  "recovery-publisher",
-		Usage: "Indicates the publisher for a fallback feed to be used for globally-pinned content repair",
-	}
 	SwarmGlobalStoreAPIFlag = cli.StringFlag{
 		Name:   "globalstore-api",
 		Usage:  "URL of the Global Store API provider (only for testing)",
@@ -247,6 +243,10 @@ var (
 	SwarmGlobalPinnerFlag = cli.BoolFlag{
 		Name:  "global-pinner",
 		Usage: "Use this flag to mark the running node as a global pinner",
+	}
+	SwarmRecoveryPublisherFlag = cli.StringFlag{
+		Name:  "recovery-publisher",
+		Usage: "Indicates the publisher for a fallback feed to be used for globally-pinned content repair",
 	}
 	SwarmProgressFlag = cli.BoolFlag{
 		Name:  "progress",

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -200,6 +200,7 @@ func init() {
 		SwarmNetworkIdFlag,
 		SwarmEnablePinningFlag,
 		SwarmGlobalPinnerFlag,
+		SwarmRecoveryPublisherFlag,
 		// upload flags
 		SwarmApiFlag,
 		SwarmRecursiveFlag,

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/googleapis/gnostic v0.0.0-20190624222214-25d8b0b66985 // indirect
 	github.com/gorilla/mux v1.7.3 // indirect
 	github.com/hashicorp/golang-lru v0.5.3
-	github.com/influxdata/influxdb v0.0.0-20180221223340-01288bdb0883
 	github.com/json-iterator/go v1.1.7 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/googleapis/gnostic v0.0.0-20190624222214-25d8b0b66985 // indirect
 	github.com/gorilla/mux v1.7.3 // indirect
 	github.com/hashicorp/golang-lru v0.5.3
+	github.com/influxdata/influxdb v0.0.0-20180221223340-01288bdb0883
 	github.com/json-iterator/go v1.1.7 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect

--- a/prod/prod.go
+++ b/prod/prod.go
@@ -103,7 +103,7 @@ func getPinners(ctx context.Context, handler feed.GenericHandler, fallbackPublis
 		if fallbackPublisher == "" {
 			return nil, err
 		}
-		// query feed using prod recovery topic, hash and fallback publisher
+		// query feed using recovery topic + hash and fallback publisher
 		hash, ok := ctx.Value("hash").(string) // TODO: is this the correct hash?
 		if !ok {
 			return nil, ErrContextHash

--- a/prod/prod.go
+++ b/prod/prod.go
@@ -118,6 +118,7 @@ func getPinners(ctx context.Context, handler feed.GenericHandler, fallbackPublis
 	return *targets, nil
 }
 
+// queryRecoveryFeeds attempts to create a feed topic and user, and query a feed based on these to fetch its content
 func queryRecoveryFeed(ctx context.Context, topicText string, publisher string, handler feed.GenericHandler) ([]byte, error) {
 	var content []byte
 	topic, user, err := getFeedTopicAndUser(topicText, publisher)
@@ -130,6 +131,7 @@ func queryRecoveryFeed(ctx context.Context, topicText string, publisher string, 
 	return content, err
 }
 
+// getFeedTopicAndUser creates a feed topic and user from the given topic text and publisher strings
 func getFeedTopicAndUser(topicText string, publisher string) (feed.Topic, common.Address, error) {
 	// get feed topic from topic text
 	topic, err := feed.NewTopic(topicText, nil)
@@ -144,6 +146,7 @@ func getFeedTopicAndUser(topicText string, publisher string) (feed.Topic, common
 	return topic, user, nil
 }
 
+// getFeedContent creates a feed with the given topic and user, and attempts to fetch its content using the given handler
 func getFeedContent(ctx context.Context, handler feed.GenericHandler, topic feed.Topic, user common.Address) ([]byte, error) {
 	fd := feed.Feed{
 		Topic: topic,
@@ -167,6 +170,7 @@ func getFeedContent(ctx context.Context, handler feed.GenericHandler, topic feed
 	return content, nil
 }
 
+// publisherToAddress derives an address based on the given publisher string
 func publisherToAddress(publisher string) (common.Address, error) {
 	publisherBytes, err := hex.DecodeString(publisher)
 	if err != nil {

--- a/prod/prod.go
+++ b/prod/prod.go
@@ -59,9 +59,9 @@ type RecoveryHook func(ctx context.Context, chunkAddress chunk.Address) error
 type sender func(ctx context.Context, targets trojan.Targets, topic trojan.Topic, payload []byte) (*pss.Monitor, error)
 
 // NewRecoveryHook returns a new RecoveryHook with the sender function defined
-func NewRecoveryHook(send sender, handler feed.GenericHandler) RecoveryHook {
+func NewRecoveryHook(send sender, handler feed.GenericHandler, fallbackPublisher string) RecoveryHook {
 	return func(ctx context.Context, chunkAddress chunk.Address) error {
-		targets, err := getPinners(ctx, handler)
+		targets, err := getPinners(ctx, handler, fallbackPublisher)
 		if err != nil {
 			return err
 		}
@@ -76,7 +76,7 @@ func NewRecoveryHook(send sender, handler feed.GenericHandler) RecoveryHook {
 }
 
 // getPinners returns the specific target pinners for a corresponding chunk
-func getPinners(ctx context.Context, handler feed.GenericHandler) (trojan.Targets, error) {
+func getPinners(ctx context.Context, handler feed.GenericHandler, fallbackPublisher string) (trojan.Targets, error) {
 	// TODO: obtain fallback Publisher from cli flag if no Publisher found in Manifest
 	// get feed user from publisher
 	publisher, _ := ctx.Value("publisher").(string)

--- a/prod/prod.go
+++ b/prod/prod.go
@@ -99,7 +99,7 @@ func getPinners(ctx context.Context, handler feed.GenericHandler, fallbackPublis
 			return nil, err
 		}
 		// query feed using recovery topic + hash and fallback publisher
-		hash, ok := ctx.Value("hash").(string) // TODO: is this the correct hash?
+		hash, ok := ctx.Value("hash").(string)
 		if !ok {
 			return nil, ErrContextHash
 		}

--- a/prod/prod.go
+++ b/prod/prod.go
@@ -89,14 +89,9 @@ func NewRepairHandler(s *chunk.ValidatorStore) pss.Handler {
 
 // getPinners returns the specific target pinners for a corresponding chunk by consulting recovery feeds
 func getPinners(ctx context.Context, handler feed.GenericHandler, fallbackPublisher string) (trojan.Targets, error) {
-	var feedContent []byte
-	var err error
-
 	// query feed using recovery topic and publisher if present
-	publisher, ok := ctx.Value("publisher").(string)
-	if ok {
-		feedContent, err = queryRecoveryFeed(ctx, RecoveryTopicText, publisher, handler)
-	}
+	publisher, _ := ctx.Value("publisher").(string)
+	feedContent, err := queryRecoveryFeed(ctx, RecoveryTopicText, publisher, handler)
 
 	// if there is an error and no fallback publisher is available, fail at this point
 	if err != nil {

--- a/prod/prod_test.go
+++ b/prod/prod_test.go
@@ -126,7 +126,7 @@ func TestRecoveryHookCalls(t *testing.T) {
 				if !tc.expectsFailure {
 					return
 				} else {
-					t.Fatal("recovery hook was unexpectedly call")
+					t.Fatal("recovery hook was unexpectedly called")
 				}
 			case <-time.After(100 * time.Millisecond):
 				if tc.expectsFailure {

--- a/prod/prod_test.go
+++ b/prod/prod_test.go
@@ -47,9 +47,10 @@ func TestRecoveryHook(t *testing.T) {
 		return nil, nil
 	}
 	testHandler := newTestRecoveryFeedHandler(t)
+	testFallbackPublisher := ""
 
 	// setup recovery hook with testHook
-	recoverFunc := NewRecoveryHook(testHook, testHandler)
+	recoverFunc := NewRecoveryHook(testHook, testHandler, testFallbackPublisher)
 
 	testChunk := "aacca8d446af47ebcab582ca2188fa73dfa871eb0a35eda798f47d4f91a575e9"
 	if err := recoverFunc(ctx, chunk.Address([]byte(testChunk))); err != nil {
@@ -92,8 +93,9 @@ func TestSenderCall(t *testing.T) {
 		return nil, nil
 	}
 	testHandler := newTestRecoveryFeedHandler(t)
+	testFallbackPublisher := ""
 
-	recoverFunc := NewRecoveryHook(testHook, testHandler)
+	recoverFunc := NewRecoveryHook(testHook, testHandler, testFallbackPublisher)
 	netStore.WithRecoveryCallback(recoverFunc)
 
 	c := ctest.GenerateTestRandomChunk()

--- a/prod/prod_test.go
+++ b/prod/prod_test.go
@@ -39,7 +39,7 @@ func TestRecoveryHook(t *testing.T) {
 	// test variables needed to be correctly set for any recovery hook to reach the sender func
 	chunkAddr := ctest.GenerateTestRandomChunk().Address()
 	ctx := context.WithValue(context.Background(), "publisher", "0226f213613e843a413ad35b40f193910d26eb35f00154afcde9ded57479a6224a")
-	handler := newTestRecoveryFeedHandler(t)
+	handler := newTestRecoveryFeedsHandler(t)
 
 	// setup the sender
 	hookWasCalled := false // test variable to check if hook is called
@@ -76,7 +76,7 @@ func TestRecoveryHookCalls(t *testing.T) {
 	dummyContext := context.Background()
 	publisherContext := context.WithValue(context.Background(), "publisher", "0226f213613e843a413ad35b40f193910d26eb35f00154afcde9ded57479a6224a")
 	dummyHandler := feed.NewDummyHandler()
-	feedsHandler := newTestRecoveryFeedHandler(t)
+	feedsHandler := newTestRecoveryFeedsHandler(t)
 
 	for _, tc := range []RecoveryHookTestCase{
 		{
@@ -167,8 +167,8 @@ func newTestNetStore(t *testing.T) *storage.NetStore {
 	return netStore
 }
 
-// newTestRecoveryFeedHandler returns a DummyHandler with binary content which can be correctly unmarshalled
-func newTestRecoveryFeedHandler(t *testing.T) *feed.DummyHandler {
+// newTestRecoveryFeedsHandler returns a DummyHandler with binary content which can be correctly unmarshalled
+func newTestRecoveryFeedsHandler(t *testing.T) *feed.DummyHandler {
 	h := feed.NewDummyHandler()
 
 	// test targets

--- a/prod/prod_test.go
+++ b/prod/prod_test.go
@@ -67,38 +67,40 @@ type RecoveryHookTestCase struct {
 	expectsFailure bool
 }
 
-// TestRecoveryHookCalls verifies that a hook calls are being called as expected when net store is called
+// TestRecoveryHookCalls verifies that recovery hook are being called as expected when net store attempts to get a chunk
 func TestRecoveryHookCalls(t *testing.T) {
-	// generate test chunk, store, ctx and feed handlers
+	// generate test chunk and store
 	netStore := newTestNetStore(t)
 	c := ctest.GenerateTestRandomChunk()
 	ref := c.Address()
-	dummyContext := context.Background()
+
+	// test cases variables
+	dummyContext := context.Background() // has no publisher
 	publisherContext := context.WithValue(context.Background(), "publisher", "0226f213613e843a413ad35b40f193910d26eb35f00154afcde9ded57479a6224a")
-	dummyHandler := feed.NewDummyHandler()
+	dummyHandler := feed.NewDummyHandler() // returns empty content for feed
 	feedsHandler := newTestRecoveryFeedsHandler(t)
 
 	for _, tc := range []RecoveryHookTestCase{
 		{
-			name:           "no publisher, no feeds handler",
+			name:           "no publisher, no feed content",
 			ctx:            dummyContext,
 			feedsHandler:   dummyHandler,
 			expectsFailure: true,
 		},
 		{
-			name:           "publisher set, no feeds handler",
+			name:           "publisher set, no feed content",
 			ctx:            publisherContext,
 			feedsHandler:   dummyHandler,
 			expectsFailure: true,
 		},
 		{
-			name:           "feeds handler set, no publisher",
+			name:           "feed content set, no publisher",
 			ctx:            dummyContext,
 			feedsHandler:   feedsHandler,
 			expectsFailure: true,
 		},
 		{
-			name:           "publisher and feeds handler set",
+			name:           "publisher and feed content set",
 			ctx:            publisherContext,
 			feedsHandler:   feedsHandler,
 			expectsFailure: false,
@@ -139,7 +141,7 @@ func TestRecoveryHookCalls(t *testing.T) {
 	}
 }
 
-// newTestNetStore creates a testing store with a set RemoteGet func
+// newTestNetStore creates a test store with a set RemoteGet func
 func newTestNetStore(t *testing.T) *storage.NetStore {
 	// generate address
 	baseKey := make([]byte, 32)

--- a/prod/prod_test.go
+++ b/prod/prod_test.go
@@ -67,7 +67,7 @@ type RecoveryHookTestCase struct {
 	expectsFailure bool
 }
 
-// TestRecoveryHookCalls verifies that recovery hook are being called as expected when net store attempts to get a chunk
+// TestRecoveryHookCalls verifies that recovery hooks are being called as expected when net store attempts to get a chunk
 func TestRecoveryHookCalls(t *testing.T) {
 	// generate test chunk and store
 	netStore := newTestNetStore(t)

--- a/prod/prod_test.go
+++ b/prod/prod_test.go
@@ -79,8 +79,8 @@ func TestRecoveryHookCalls(t *testing.T) {
 	// test contexts
 	dummyContext := context.Background()
 	publisherContext := context.WithValue(context.Background(), "publisher", "0226f213613e843a413ad35b40f193910d26eb35f00154afcde9ded57479a6224a")
-	hashContext := context.WithValue(context.Background(), "hash", "0xfea11223344") // used for fallback publisher feed topic construction
-	publisherAndHashContext := context.WithValue(publisherContext, "hash", "0xfea11223344")
+	hashContext := context.WithValue(context.Background(), "hash", "0xfea11223344")         // used for fallback publisher feed topic construction
+	publisherAndHashContext := context.WithValue(publisherContext, "hash", "0xfea11223344") // case of context with both publisher and fallback publisher
 
 	dummyFallbackPublisher := "" // emulates the a non-set fallback publisher
 	fallbackPublisher := "02e6f8d5e28faaa899744972bb847b6eb805a160494690c9ee7197ae9f619181db"

--- a/prod/prod_test.go
+++ b/prod/prod_test.go
@@ -80,6 +80,7 @@ func TestRecoveryHookCalls(t *testing.T) {
 	dummyContext := context.Background()
 	publisherContext := context.WithValue(context.Background(), "publisher", "0226f213613e843a413ad35b40f193910d26eb35f00154afcde9ded57479a6224a")
 	hashContext := context.WithValue(context.Background(), "hash", "0xfea11223344") // used for fallback publisher feed topic construction
+	publisherAndHashContext := context.WithValue(publisherContext, "hash", "0xfea11223344")
 
 	dummyFallbackPublisher := "" // emulates the a non-set fallback publisher
 	fallbackPublisher := "02e6f8d5e28faaa899744972bb847b6eb805a160494690c9ee7197ae9f619181db"
@@ -96,6 +97,27 @@ func TestRecoveryHookCalls(t *testing.T) {
 			expectsFailure:    true,
 		},
 		{
+			name:              "no publisher, no fallback publisher, feed content set",
+			ctx:               dummyContext,
+			fallbackPublisher: dummyFallbackPublisher,
+			feedsHandler:      feedsHandler,
+			expectsFailure:    true,
+		},
+		{
+			name:              "no publisher, fallback publisher set, no feed content",
+			ctx:               hashContext,
+			fallbackPublisher: fallbackPublisher,
+			feedsHandler:      dummyHandler,
+			expectsFailure:    true,
+		},
+		{
+			name:              "no publisher, fallback publisher set, feed content set",
+			ctx:               hashContext,
+			fallbackPublisher: fallbackPublisher,
+			feedsHandler:      feedsHandler,
+			expectsFailure:    false,
+		},
+		{
 			name:              "publisher set, no fallback publisher, no feed content",
 			ctx:               publisherContext,
 			fallbackPublisher: dummyFallbackPublisher,
@@ -103,22 +125,22 @@ func TestRecoveryHookCalls(t *testing.T) {
 			expectsFailure:    true,
 		},
 		{
-			name:              "feed content set, no publisher, no fallback publisher",
-			ctx:               dummyContext,
-			fallbackPublisher: dummyFallbackPublisher,
-			feedsHandler:      feedsHandler,
-			expectsFailure:    true,
-		},
-		{
-			name:              "publisher and feed content set, no fallback publisher",
+			name:              "publisher set, no fallback publisher, feed content set",
 			ctx:               publisherContext,
 			fallbackPublisher: dummyFallbackPublisher,
 			feedsHandler:      feedsHandler,
 			expectsFailure:    false,
 		},
 		{
-			name:              "fallback publisher and feed content set, no publisher",
-			ctx:               hashContext,
+			name:              "publisher set, fallback publisher set, no feed content",
+			ctx:               publisherAndHashContext,
+			fallbackPublisher: fallbackPublisher,
+			feedsHandler:      dummyHandler,
+			expectsFailure:    true,
+		},
+		{
+			name:              "publisher set, fallback publisher set, feed content set",
+			ctx:               publisherAndHashContext,
 			fallbackPublisher: fallbackPublisher,
 			feedsHandler:      feedsHandler,
 			expectsFailure:    false,

--- a/swarm.go
+++ b/swarm.go
@@ -290,7 +290,7 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 	}
 
 	// add recovery callback for content repair
-	recoverFunc := prod.NewRecoveryHook(self.pss.Send, feedsHandler, "")
+	recoverFunc := prod.NewRecoveryHook(self.pss.Send, feedsHandler, self.config.RecoveryPublisher)
 	self.netStore.WithRecoveryCallback(recoverFunc)
 
 	self.api = api.NewAPI(self.fileStore, self.dns, self.rns, feedsHandler, self.privateKey, self.tags)

--- a/swarm.go
+++ b/swarm.go
@@ -292,7 +292,7 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 			lstore.Set(context.Background(), chunk.ModeSetReUpload, chAddr)
 		}
 		self.pss.Register(prod.RecoveryTopic, repairFunc)
-		recoverFunc := prod.NewRecoveryHook(self.pss.Send, feedsHandler)
+		recoverFunc := prod.NewRecoveryHook(self.pss.Send, feedsHandler, "")
 		self.netStore.WithRecoveryCallback(recoverFunc)
 	}
 


### PR DESCRIPTION
WIP for #2182

This PR:
- adds the `RecoveryPublisher` config value and `SwarmRecoveryPublisherFlag` CLI flag to set a fallback content recovery publisher
- modifies the recovery hook constructor to use the `RecoveryPublisher` value
- injects the manifest `hash` value into the context for fallback content recovery when attempting to get a chunk (the hash will be used to create a fallback recovery feed topic)
- updates the `getPinners` func to query the fallback recovery feed if there is _some_ failure with the regular recovery feed
- extracts the `queryRecoveryFeed`, `getFeedTopicAndUser`, `getFeedContent` and `publisherToAddress` funcs
- updates `prod` tests to use fallback recovery publishers