### PR TITLE
prod, swarm: enable content recovery requests all nodes

### DIFF
--- a/prod/prod.go
+++ b/prod/prod.go
@@ -124,3 +124,11 @@ func getPinners(ctx context.Context, handler feed.GenericHandler) (trojan.Target
 
 	return *targets, nil
 }
+
+// NewRepairHandler creates a repair function to re-upload globally pinned chunks to the network with the given store
+func NewRepairHandler(s *chunk.ValidatorStore) pss.Handler {
+	return func(m trojan.Message) {
+		chAddr := m.Payload
+		s.Set(context.Background(), chunk.ModeSetReUpload, chAddr)
+	}
+}

--- a/swarm.go
+++ b/swarm.go
@@ -284,6 +284,7 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 	self.pss = pss.NewPss(localStore, self.tags)
 
 	if self.config.GlobalPinner {
+		// add callback to inspect valid chunks for trojan messages
 		lstore.WithDeliverCallback(self.pss.Deliver)
 		// repairFunc takes care of re-uploading a globally pinned chunk to the network
 		// TODO: move this anonymous function into the prod package
@@ -292,9 +293,11 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 			lstore.Set(context.Background(), chunk.ModeSetReUpload, chAddr)
 		}
 		self.pss.Register(prod.RecoveryTopic, repairFunc)
-		recoverFunc := prod.NewRecoveryHook(self.pss.Send, feedsHandler)
-		self.netStore.WithRecoveryCallback(recoverFunc)
 	}
+
+	// add recovery callback for content repair
+	recoverFunc := prod.NewRecoveryHook(self.pss.Send, feedsHandler)
+	self.netStore.WithRecoveryCallback(recoverFunc)
 
 	self.api = api.NewAPI(self.fileStore, self.dns, self.rns, feedsHandler, self.privateKey, self.tags)
 

--- a/swarm.go
+++ b/swarm.go
@@ -18,7 +18,6 @@ package swarm
 
 import (
 	"bytes"
-	"context"
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
@@ -52,7 +51,6 @@ import (
 	"github.com/ethersphere/swarm/p2p/protocols"
 	"github.com/ethersphere/swarm/prod"
 	"github.com/ethersphere/swarm/pss"
-	"github.com/ethersphere/swarm/pss/trojan"
 	"github.com/ethersphere/swarm/pushsync"
 	"github.com/ethersphere/swarm/state"
 	"github.com/ethersphere/swarm/storage"
@@ -286,13 +284,9 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 	if self.config.GlobalPinner {
 		// add callback to inspect valid chunks for trojan messages
 		lstore.WithDeliverCallback(self.pss.Deliver)
-		// repairFunc takes care of re-uploading a globally pinned chunk to the network
-		// TODO: move this anonymous function into the prod package
-		repairFunc := func(m trojan.Message) {
-			chAddr := m.Payload
-			lstore.Set(context.Background(), chunk.ModeSetReUpload, chAddr)
-		}
-		self.pss.Register(prod.RecoveryTopic, repairFunc)
+		// register function for chunk repair upon receiving a trojan message
+		repairHandler := prod.NewRepairHandler(lstore)
+		self.pss.Register(prod.RecoveryTopic, repairHandler)
 	}
 
 	// add recovery callback for content repair


### PR DESCRIPTION
This PR:

- enables content recovery hooks to be created (and set as store callbacks) for all nodes, not just global pinners.
- moves the previously anonymous `repairFunc` from `NewSwarm` into the `prod` package, by adding a constructor for it which takes a store as parameter.

closes #2184