### PR TITLE
prod: improve global pinning recovery hook tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/googleapis/gnostic v0.0.0-20190624222214-25d8b0b66985 // indirect
 	github.com/gorilla/mux v1.7.3 // indirect
 	github.com/hashicorp/golang-lru v0.5.3
-	github.com/influxdata/influxdb v0.0.0-20180221223340-01288bdb0883
 	github.com/json-iterator/go v1.1.7 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/googleapis/gnostic v0.0.0-20190624222214-25d8b0b66985 // indirect
 	github.com/gorilla/mux v1.7.3 // indirect
 	github.com/hashicorp/golang-lru v0.5.3
+	github.com/influxdata/influxdb v0.0.0-20180221223340-01288bdb0883
 	github.com/json-iterator/go v1.1.7 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect

--- a/prod/prod_test.go
+++ b/prod/prod_test.go
@@ -126,7 +126,7 @@ func TestRecoveryHookCalls(t *testing.T) {
 				if !tc.expectsFailure {
 					return
 				} else {
-					t.Fatal("recovery hook was unexpectedly call")
+					t.Fatal("recovery hook was unexpectedly called")
 				}
 			case <-time.After(100 * time.Millisecond):
 				if tc.expectsFailure {

--- a/prod/prod_test.go
+++ b/prod/prod_test.go
@@ -39,7 +39,7 @@ func TestRecoveryHook(t *testing.T) {
 	// test variables needed to be correctly set for any recovery hook to reach the sender func
 	chunkAddr := ctest.GenerateTestRandomChunk().Address()
 	ctx := context.WithValue(context.Background(), "publisher", "0226f213613e843a413ad35b40f193910d26eb35f00154afcde9ded57479a6224a")
-	handler := newTestRecoveryFeedHandler(t)
+	handler := newTestRecoveryFeedsHandler(t)
 
 	// setup the sender
 	hookWasCalled := false // test variable to check if hook is called
@@ -76,7 +76,7 @@ func TestRecoveryHookCalls(t *testing.T) {
 	dummyContext := context.Background()
 	publisherContext := context.WithValue(context.Background(), "publisher", "0226f213613e843a413ad35b40f193910d26eb35f00154afcde9ded57479a6224a")
 	dummyHandler := feed.NewDummyHandler()
-	feedsHandler := newTestRecoveryFeedHandler(t)
+	feedsHandler := newTestRecoveryFeedsHandler(t)
 
 	for _, tc := range []RecoveryHookTestCase{
 		{
@@ -167,8 +167,8 @@ func newTestNetStore(t *testing.T) *storage.NetStore {
 	return netStore
 }
 
-// newTestRecoveryFeedHandler returns a DummyHandler with binary content which can be correctly unmarshalled
-func newTestRecoveryFeedHandler(t *testing.T) *feed.DummyHandler {
+// newTestRecoveryFeedsHandler returns a DummyHandler with binary content which can be correctly unmarshalled
+func newTestRecoveryFeedsHandler(t *testing.T) *feed.DummyHandler {
 	h := feed.NewDummyHandler()
 
 	// test targets

--- a/prod/prod_test.go
+++ b/prod/prod_test.go
@@ -67,38 +67,40 @@ type RecoveryHookTestCase struct {
 	expectsFailure bool
 }
 
-// TestRecoveryHookCalls verifies that a hook calls are being called as expected when net store is called
+// TestRecoveryHookCalls verifies that recovery hook are being called as expected when net store attempts to get a chunk
 func TestRecoveryHookCalls(t *testing.T) {
-	// generate test chunk, store, ctx and feed handlers
+	// generate test chunk and store
 	netStore := newTestNetStore(t)
 	c := ctest.GenerateTestRandomChunk()
 	ref := c.Address()
-	dummyContext := context.Background()
+
+	// test cases variables
+	dummyContext := context.Background() // has no publisher
 	publisherContext := context.WithValue(context.Background(), "publisher", "0226f213613e843a413ad35b40f193910d26eb35f00154afcde9ded57479a6224a")
-	dummyHandler := feed.NewDummyHandler()
+	dummyHandler := feed.NewDummyHandler() // returns empty content for feed
 	feedsHandler := newTestRecoveryFeedsHandler(t)
 
 	for _, tc := range []RecoveryHookTestCase{
 		{
-			name:           "no publisher, no feeds handler",
+			name:           "no publisher, no feed content",
 			ctx:            dummyContext,
 			feedsHandler:   dummyHandler,
 			expectsFailure: true,
 		},
 		{
-			name:           "publisher set, no feeds handler",
+			name:           "publisher set, no feed content",
 			ctx:            publisherContext,
 			feedsHandler:   dummyHandler,
 			expectsFailure: true,
 		},
 		{
-			name:           "feeds handler set, no publisher",
+			name:           "feed content set, no publisher",
 			ctx:            dummyContext,
 			feedsHandler:   feedsHandler,
 			expectsFailure: true,
 		},
 		{
-			name:           "publisher and feeds handler set",
+			name:           "publisher and feed content set",
 			ctx:            publisherContext,
 			feedsHandler:   feedsHandler,
 			expectsFailure: false,
@@ -139,7 +141,7 @@ func TestRecoveryHookCalls(t *testing.T) {
 	}
 }
 
-// newTestNetStore creates a testing store with a set RemoteGet func
+// newTestNetStore creates a test store with a set RemoteGet func
 func newTestNetStore(t *testing.T) *storage.NetStore {
 	// generate address
 	baseKey := make([]byte, 32)

--- a/prod/prod_test.go
+++ b/prod/prod_test.go
@@ -67,7 +67,7 @@ type RecoveryHookTestCase struct {
 	expectsFailure bool
 }
 
-// TestRecoveryHookCalls verifies that recovery hook are being called as expected when net store attempts to get a chunk
+// TestRecoveryHookCalls verifies that recovery hooks are being called as expected when net store attempts to get a chunk
 func TestRecoveryHookCalls(t *testing.T) {
 	// generate test chunk and store
 	netStore := newTestNetStore(t)


### PR DESCRIPTION
This PR:
- renames `TestSenderCall` func to `TestRecoveryHookCalls` and fixes its failure detection code
- adds the `RecoveryHookTestCase` type as a test case struct
- adds 3 failure test cases to `TestRecoveryHookCalls`
- extracts the `newTestNetStore` func
- tidies up the `TestRecoveryHook` func

closes #2187