### PR TITLE
storage/localstore: fix for pinned chunks that are GC under certain conditions

### DIFF
--- a/storage/localstore/gc.go
+++ b/storage/localstore/gc.go
@@ -183,7 +183,6 @@ func (db *DB) removeChunksInExcludeIndexFromGC() (err error) {
 				gcSizeChange--
 			}
 			excludedCount++
-			db.gcExcludeIndex.DeleteInBatch(batch, item)
 		}
 
 		return false, nil

--- a/storage/localstore/mode_set.go
+++ b/storage/localstore/mode_set.go
@@ -374,6 +374,7 @@ func (db *DB) setPin(batch *leveldb.Batch, addr chunk.Address) (err error) {
 // setUnpin decrements pin counter for the chunk by updating pin index.
 // Provided batch is updated.
 func (db *DB) setUnpin(batch *leveldb.Batch, addr chunk.Address) (err error) {
+	metricName := "localstore/gc/exclude"
 	item := addressToItem(addr)
 
 	// Get the existing pin counter of the chunk
@@ -389,6 +390,8 @@ func (db *DB) setUnpin(batch *leveldb.Batch, addr chunk.Address) (err error) {
 		db.pinIndex.PutInBatch(batch, item)
 	} else {
 		db.pinIndex.DeleteInBatch(batch, item)
+		db.gcExcludeIndex.DeleteInBatch(batch, item)
+		metrics.GetOrRegisterCounter(metricName+"/excluded-count", nil).Dec(int64(1))
 	}
 
 	return nil


### PR DESCRIPTION
This PR is a fix, for pinned chunks that are being garbage collected when multiple GC is run.

This can be verified by
- uploading a chunk/pinning it
- downloading it (works ok)
- upload random chunks multiple times the store capacity to flush all chunks with GC
- try to download the chunk it can fail if the GC is run multiple times

This should be tested by pinning once the content, and also by pinning multiple times the same chunk and repeating the test.

After the first run of the Garbage collection, the pinned chunk is removed from `gcExcludeIndex`
So the next time the GC is run it will be deleted from the chunks.

I moved this delete from gcExcludeIndex from `removeChunksInExcludeIndexFromGC (gc.go) `
to `setUnpin (mode_set.go)`

Another issue was the metric `localstore/gc/exclude/excluded-count` this was only increasing, also decreased it in the` setUnpin`

closes #2195