### PR TITLE
chunk, feed, storage: condition trojan chunk inspection

### DIFF
--- a/chunk/chunk.go
+++ b/chunk/chunk.go
@@ -324,7 +324,7 @@ func (s *ValidatorStore) Put(ctx context.Context, mode ModePut, chs ...Chunk) (e
 		chunkTypes[i] = chunkType
 	}
 	exist, err = s.Store.Put(ctx, mode, chs...)
-	// if callback is defined, call it for every valid, content-addressed chunk
+	// if callback is defined, call it for every new, valid, content-addressed chunk
 	if err != nil && s.deliverCallback != nil {
 		for i, exists := range exist {
 			if !exists && chunkTypes[i] == ContentAddressed {

--- a/chunk/chunk.go
+++ b/chunk/chunk.go
@@ -325,7 +325,7 @@ func (s *ValidatorStore) Put(ctx context.Context, mode ModePut, chs ...Chunk) (e
 	}
 	exist, err = s.Store.Put(ctx, mode, chs...)
 	// if callback is defined, call it for every new, valid, content-addressed chunk
-	if err != nil && s.deliverCallback != nil {
+	if err == nil && s.deliverCallback != nil {
 		for i, exists := range exist {
 			if !exists && chunkTypes[i] == ContentAddressed {
 				go s.deliverCallback(chs[i])

--- a/chunk/chunk.go
+++ b/chunk/chunk.go
@@ -324,10 +324,10 @@ func (s *ValidatorStore) Put(ctx context.Context, mode ModePut, chs ...Chunk) (e
 		chunkTypes[i] = chunkType
 	}
 	exist, err = s.Store.Put(ctx, mode, chs...)
-	// if callback is defined, call it for every new, valid, content-addressed chunk
 	if err != nil {
 		return nil, err
 	}
+	// if callback is defined, call it for every new, valid, content-addressed chunk
 	if s.deliverCallback != nil {
 		for i, exists := range exist {
 			if !exists && chunkTypes[i] == ContentAddressed {

--- a/chunk/chunk.go
+++ b/chunk/chunk.go
@@ -248,6 +248,15 @@ const (
 	ModeSetReUpload
 )
 
+// Type describes a kind of chunk, whether it is content-addressed or other
+type Type int
+
+const (
+	Unknown Type = iota
+	ContentAddressed
+	Other
+)
+
 // Descriptor holds information required for Pull syncing. This struct
 // is provided by subscribing to pull index.
 type Descriptor struct {
@@ -276,7 +285,7 @@ type Store interface {
 
 // Validator validates a chunk.
 type Validator interface {
-	Validate(ch Chunk) bool
+	Validate(ch Chunk) (bool, Type)
 }
 
 // ValidatorStore encapsulates Store by decorating the Put method
@@ -305,25 +314,36 @@ func (s *ValidatorStore) WithDeliverCallback(f func(Chunk)) *ValidatorStore {
 // Put overrides Store put method with validators check. For Put to succeed,
 // all provided chunks must be validated with true by one of the validators.
 func (s *ValidatorStore) Put(ctx context.Context, mode ModePut, chs ...Chunk) (exist []bool, err error) {
-	for _, ch := range chs {
-		if !s.validate(ch) {
+	chunkTypes := make([]Type, len(chs))
+	for i, ch := range chs {
+		// register all valid chunk types, fail otherwise
+		valid, chunkType := s.validate(ch)
+		if !valid {
 			return nil, ErrChunkInvalid
 		}
+		chunkTypes[i] = chunkType
 	}
-	return s.Store.Put(ctx, mode, chs...)
+	exist, err = s.Store.Put(ctx, mode, chs...)
+	// if callback is defined, call it for every valid, content-addressed chunk
+	if err != nil && s.deliverCallback != nil {
+		for i, exists := range exist {
+			if !exists && chunkTypes[i] == ContentAddressed {
+				go s.deliverCallback(chs[i])
+			}
+		}
+	}
+	return exist, err
 }
 
 // validate returns true if one of the validators
 // return true. If all validators return false,
 // the chunk is considered invalid.
-func (s *ValidatorStore) validate(ch Chunk) bool {
+func (s *ValidatorStore) validate(ch Chunk) (bool, Type) {
 	for _, v := range s.validators {
-		if v.Validate(ch) {
-			if s.deliverCallback != nil {
-				go s.deliverCallback(ch)
-			}
-			return true
+		valid, chunkType := v.Validate(ch)
+		if valid {
+			return true, chunkType
 		}
 	}
-	return false
+	return false, Unknown
 }

--- a/chunk/chunk.go
+++ b/chunk/chunk.go
@@ -325,14 +325,17 @@ func (s *ValidatorStore) Put(ctx context.Context, mode ModePut, chs ...Chunk) (e
 	}
 	exist, err = s.Store.Put(ctx, mode, chs...)
 	// if callback is defined, call it for every new, valid, content-addressed chunk
-	if err == nil && s.deliverCallback != nil {
+	if err != nil {
+		return nil, err
+	}
+	if s.deliverCallback != nil {
 		for i, exists := range exist {
 			if !exists && chunkTypes[i] == ContentAddressed {
 				go s.deliverCallback(chs[i])
 			}
 		}
 	}
-	return exist, err
+	return exist, nil
 }
 
 // validate returns true if one of the validators

--- a/storage/feed/handler_test.go
+++ b/storage/feed/handler_test.go
@@ -364,8 +364,7 @@ func TestValidator(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	valid, _ := rh.Validate(chunk)
-	if !valid {
+	if valid, _ := rh.Validate(chunk); !valid {
 		t.Fatal("Chunk validator fail on update chunk")
 	}
 
@@ -374,8 +373,7 @@ func TestValidator(t *testing.T) {
 	address[0] = 11
 	address[15] = 99
 
-	valid, _ = rh.Validate(storage.NewChunk(address, chunk.Data()))
-	if valid {
+	if valid, _ := rh.Validate(storage.NewChunk(address, chunk.Data())); valid {
 		t.Fatal("Expected Validate to fail with false chunk address")
 	}
 }

--- a/storage/feed/handler_test.go
+++ b/storage/feed/handler_test.go
@@ -364,7 +364,8 @@ func TestValidator(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !rh.Validate(chunk) {
+	valid, _ := rh.Validate(chunk)
+	if !valid {
 		t.Fatal("Chunk validator fail on update chunk")
 	}
 
@@ -373,7 +374,8 @@ func TestValidator(t *testing.T) {
 	address[0] = 11
 	address[15] = 99
 
-	if rh.Validate(storage.NewChunk(address, chunk.Data())) {
+	valid, _ = rh.Validate(storage.NewChunk(address, chunk.Data()))
+	if valid {
 		t.Fatal("Expected Validate to fail with false chunk address")
 	}
 }

--- a/storage/types.go
+++ b/storage/types.go
@@ -195,11 +195,11 @@ func NewContentAddressValidator(hasher SwarmHasher) *ContentAddressValidator {
 }
 
 // Validate that the given key is a valid content address for the given data
-func (v *ContentAddressValidator) Validate(ch Chunk) bool {
+func (v *ContentAddressValidator) Validate(ch Chunk) (bool, chunk.Type) {
 	data := ch.Data()
 	if l := len(data); l < 9 || l > chunk.DefaultSize+8 {
 		// log.Error("invalid chunk size", "chunk", addr.Hex(), "size", l)
-		return false
+		return false, chunk.Unknown
 	}
 
 	hasher := v.Hasher()
@@ -208,7 +208,7 @@ func (v *ContentAddressValidator) Validate(ch Chunk) bool {
 	hasher.Write(data[8:])
 	hash := hasher.Sum(nil)
 
-	return bytes.Equal(hash, ch.Address())
+	return bytes.Equal(hash, ch.Address()), chunk.ContentAddressed
 }
 
 type ChunkStore = chunk.Store


### PR DESCRIPTION
This PR attempts to solve issue #2163, which is about **calling trojan chunk inspection only for content-addressed chunks and ones that are not already present in the localstore**.

### The problem with the code as-is
- `ValidatorStore.validate` inspects every chunk. If it is valid, it will call its `deliveryCallback` should it be defined.
  - This will be called for every chunk even if it is already in the store, which is undesirable.
  - This also will be called for chunks which are not content-addressed, which is [causing crashes](https://github.com/ethersphere/swarm/pull/2169#issuecomment-632296140).
 
### Solution
- add a new `Type` to the `chunk` package to indicate whether a chunk is content-addressed, something else, or unknown due to an error.
- `Validate` interface now returns the chunk `Type` as well as the `bool` indicating whether the chunk is valid or not.
  - if the chunk is invalid, the returned `Type` will be `Unknown`.
- `ValidatorStore`'s `Put` method will sitll return an error if a chunk is invalid, but it will register all chunk types along the way if there are no errors.
  - if all chunks are valid + the `store.Put` method returns no error + a `deliverCallback` is defined in the store, it will call the deliver callback for every new, content-addressed chunk.
  - as a result, the callback will be invoked in the `ValidatorStore.Put` method rather than the `ValidatorStore.Validate` func—this has the advantage of knowing whether the chunk is new or not (instead of just knowing whether it is valid).
- this is an alternative implementation to #2169. The advantage in this case is that `pss` does not have to be modified nor obscured, and the callback redundancy is reduced in comparison. 

closes #2163

