### PR TITLE
main, swarm, http, prod, api, client: repair globally pinned content through CLI publisher

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -424,9 +424,6 @@ func (a *API) Get(ctx context.Context, decrypt DecryptFunc, manifestAddr storage
 		}
 		mimeType = entry.ContentType
 		log.Debug("content lookup key", "key", contentAddr, "mimetype", mimeType)
-		if len(entry.Publisher) > 0 {
-			ctx = context.WithValue(ctx, "publisher", entry.Publisher)
-		}
 		reader, _ = a.fileStore.Retrieve(ctx, contentAddr)
 	} else {
 		// no entry found
@@ -632,12 +629,10 @@ func (a *API) Modify(ctx context.Context, addr storage.Address, path, contentHas
 		apiModifyFail.Inc(1)
 		return nil, err
 	}
-	publisher, _ := ctx.Value("publisher").(string)
 	if contentHash != "" {
 		entry := newManifestTrieEntry(&ManifestEntry{
 			Path:        path,
 			ContentType: contentType,
-			Publisher:   publisher,
 		}, nil)
 		entry.Hash = contentHash
 		trie.addEntry(entry, quitC)
@@ -672,14 +667,12 @@ func (a *API) AddFile(ctx context.Context, mhash, path, fname string, content []
 		path = path[1:]
 	}
 
-	publisher, _ := ctx.Value("publisher").(string)
 	entry := &ManifestEntry{
 		Path:        filepath.Join(path, fname),
 		ContentType: mime.TypeByExtension(filepath.Ext(fname)),
 		Mode:        0700,
 		Size:        int64(len(content)),
 		ModTime:     time.Now(),
-		Publisher:   publisher,
 	}
 
 	mw, err := a.NewManifestWriter(ctx, mkey, nil)
@@ -704,7 +697,7 @@ func (a *API) AddFile(ctx context.Context, mhash, path, fname string, content []
 	return fkey, newMkey.String(), nil
 }
 
-func (a *API) UploadTar(ctx context.Context, bodyReader io.ReadCloser, manifestPath, defaultPath string, mw *ManifestWriter, publisher string) (storage.Address, error) {
+func (a *API) UploadTar(ctx context.Context, bodyReader io.ReadCloser, manifestPath, defaultPath string, mw *ManifestWriter) (storage.Address, error) {
 	apiUploadTarCount.Inc(1)
 	var contentKey storage.Address
 	tr := tar.NewReader(bodyReader)
@@ -737,7 +730,6 @@ func (a *API) UploadTar(ctx context.Context, bodyReader io.ReadCloser, manifestP
 			Mode:        hdr.Mode,
 			Size:        hdr.Size,
 			ModTime:     hdr.ModTime,
-			Publisher:   publisher,
 		}
 		contentKey, err = mw.AddEntry(ctx, tr, entry)
 		if err != nil {
@@ -756,7 +748,6 @@ func (a *API) UploadTar(ctx context.Context, bodyReader io.ReadCloser, manifestP
 				Mode:        hdr.Mode,
 				Size:        hdr.Size,
 				ModTime:     hdr.ModTime,
-				Publisher:   publisher,
 			}
 			contentKey, err = mw.AddEntry(ctx, nil, entry)
 			if err != nil {
@@ -871,14 +862,12 @@ func (a *API) AppendFile(ctx context.Context, mhash, path, fname string, existin
 		return nil, "", err
 	}
 
-	publisher, _ := ctx.Value("publisher").(string)
 	entry := &ManifestEntry{
 		Path:        filepath.Join(path, fname),
 		ContentType: mime.TypeByExtension(filepath.Ext(fname)),
 		Mode:        0700,
 		Size:        totalSize,
 		ModTime:     time.Now(),
-		Publisher:   publisher,
 	}
 
 	fkey, err := mw.AddEntry(ctx, io.Reader(combinedReader), entry)

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -163,11 +163,11 @@ func Open(path string) (*File, error) {
 // (if the manifest argument is non-empty) or creates a new manifest containing
 // the file, returning the resulting manifest hash (the file will then be
 // available at bzz:/<hash>/<path>)
-func (c *Client) Upload(file *File, manifest string, toEncrypt, toPin, anonymous bool, publisher string) (string, error) {
+func (c *Client) Upload(file *File, manifest string, toEncrypt, toPin, anonymous bool) (string, error) {
 	if file.Size <= 0 {
 		return "", errors.New("file size must be greater than zero")
 	}
-	return c.TarUpload(manifest, &FileUploader{file}, "", toEncrypt, toPin, anonymous, publisher)
+	return c.TarUpload(manifest, &FileUploader{file}, "", toEncrypt, toPin, anonymous)
 }
 
 // Download downloads a file with the given path from the swarm manifest with
@@ -197,7 +197,7 @@ func (c *Client) Download(hash, path string) (*File, error) {
 // directory will then be available at bzz:/<hash>/path/to/file), with
 // the file specified in defaultPath being uploaded to the root of the manifest
 // (i.e. bzz:/<hash>/)
-func (c *Client) UploadDirectory(dir, defaultPath, manifest string, toEncrypt, toPin, anonymous bool, publisher string) (string, error) {
+func (c *Client) UploadDirectory(dir, defaultPath, manifest string, toEncrypt, toPin, anonymous bool) (string, error) {
 	stat, err := os.Stat(dir)
 	if err != nil {
 		return "", err
@@ -212,7 +212,7 @@ func (c *Client) UploadDirectory(dir, defaultPath, manifest string, toEncrypt, t
 			return "", fmt.Errorf("default path: %v", err)
 		}
 	}
-	return c.TarUpload(manifest, &DirectoryUploader{dir}, defaultPath, toEncrypt, toPin, anonymous, publisher)
+	return c.TarUpload(manifest, &DirectoryUploader{dir}, defaultPath, toEncrypt, toPin, anonymous)
 }
 
 // DownloadDirectory downloads the files contained in a swarm manifest under
@@ -511,7 +511,7 @@ type UploadFn func(file *File) error
 
 // TarUpload uses the given Uploader to upload files to swarm as a tar stream,
 // returning the resulting manifest hash
-func (c *Client) TarUpload(hash string, uploader Uploader, defaultPath string, toEncrypt, toPin, anonymous bool, publisher string) (string, error) {
+func (c *Client) TarUpload(hash string, uploader Uploader, defaultPath string, toEncrypt, toPin, anonymous bool) (string, error) {
 	ctx, sp := spancontext.StartSpan(context.Background(), "api.client.tarupload")
 	defer sp.Finish()
 
@@ -539,7 +539,6 @@ func (c *Client) TarUpload(hash string, uploader Uploader, defaultPath string, t
 	transport := http.DefaultTransport
 
 	req.Header.Set("Content-Type", "application/x-tar")
-	req.Header.Set("publisher", publisher)
 	if defaultPath != "" {
 		q := req.URL.Query()
 		q.Set("defaultpath", defaultPath)

--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -125,7 +125,7 @@ func testClientUploadDownloadFiles(toEncrypt bool, t *testing.T) string {
 				Size:        int64(len(data)),
 			},
 		}
-		hash, err := client.Upload(file, manifest, toEncrypt, toPin, true, "")
+		hash, err := client.Upload(file, manifest, toEncrypt, toPin, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -221,7 +221,7 @@ func TestClientUploadDownloadDirectory(t *testing.T) {
 	// upload the directory
 	client := NewClient(srv.URL)
 	defaultPath := testDirFiles[0]
-	hash, err := client.UploadDirectory(dir, defaultPath, "", false, false, true, "")
+	hash, err := client.UploadDirectory(dir, defaultPath, "", false, false, true)
 	if err != nil {
 		t.Fatalf("error uploading directory: %s", err)
 	}
@@ -289,7 +289,7 @@ func testClientFileList(toEncrypt bool, t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	client := NewClient(srv.URL)
-	hash, err := client.UploadDirectory(dir, "", "", toEncrypt, false, true, "")
+	hash, err := client.UploadDirectory(dir, "", "", toEncrypt, false, true)
 	if err != nil {
 		t.Fatalf("error uploading directory: %s", err)
 	}
@@ -475,7 +475,7 @@ func TestClientBzzWithFeed(t *testing.T) {
 	}
 
 	// upload data to bzz:// and retrieve the content-addressed manifest hash, hex-encoded.
-	manifestAddressHex, err := swarmClient.Upload(f, "", false, false, true, "")
+	manifestAddressHex, err := swarmClient.Upload(f, "", false, false, true)
 	if err != nil {
 		t.Fatalf("Error creating manifest: %s", err)
 	}

--- a/api/config.go
+++ b/api/config.go
@@ -83,6 +83,7 @@ type Config struct {
 	DisableAutoConnect bool
 	EnablePinning      bool
 	GlobalPinner       bool
+	RecoveryPublisher  string
 	Cors               string
 	BzzAccount         string
 	GlobalStoreAPI     string

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -468,12 +468,8 @@ func (s *Server) handleTarUpload(r *http.Request, mw *api.ManifestWriter) (stora
 	log.Debug("handle.tar.upload", "ruid", GetRUID(r.Context()), "tag", sctx.GetTag(r.Context()))
 
 	defaultPath := r.URL.Query().Get("defaultpath")
-	var publisher string
-	if len(r.Header["Publisher"]) > 0 {
-		publisher = r.Header["Publisher"][0]
-	}
 
-	key, err := s.api.UploadTar(r.Context(), r.Body, GetURI(r.Context()).Path, defaultPath, mw, publisher)
+	key, err := s.api.UploadTar(r.Context(), r.Body, GetURI(r.Context()).Path, defaultPath, mw)
 	if err != nil {
 		return nil, err
 	}

--- a/api/manifest.go
+++ b/api/manifest.go
@@ -57,7 +57,6 @@ type ManifestEntry struct {
 	Status      int          `json:"status,omitempty"`
 	Access      *AccessEntry `json:"access,omitempty"`
 	Feed        *feed.Feed   `json:"feed,omitempty"`
-	Publisher   string       `json:"publisher,omitempty"`
 }
 
 // ManifestList represents the result of listing files in a manifest

--- a/cmd/swarm-smoke/util.go
+++ b/cmd/swarm-smoke/util.go
@@ -212,7 +212,7 @@ func uploadWithTag(data []byte, endpoint string, tag string) (string, error) {
 		Tag: tag,
 	}
 
-	return swarm.TarUpload("", &client.FileUploader{File: f}, "", false, false, true, "")
+	return swarm.TarUpload("", &client.FileUploader{File: f}, "", false, false, true)
 }
 
 func digest(r io.Reader) ([]byte, error) {

--- a/cmd/swarm/config.go
+++ b/cmd/swarm/config.go
@@ -276,6 +276,9 @@ func flagsOverride(currentConfig *bzzapi.Config, ctx *cli.Context) *bzzapi.Confi
 	if ctx.GlobalBool(SwarmGlobalPinnerFlag.Name) {
 		currentConfig.GlobalPinner = true
 	}
+	if recoveryPublisher := ctx.GlobalString(SwarmRecoveryPublisherFlag.Name); recoveryPublisher != "" {
+		currentConfig.RecoveryPublisher = recoveryPublisher
+	}
 	return currentConfig
 }
 

--- a/cmd/swarm/flags.go
+++ b/cmd/swarm/flags.go
@@ -155,7 +155,7 @@ var (
 	}
 	SwarmUploadPublisher = cli.StringFlag{
 		Name:  "publisher",
-		Usage: "Manually specify Publisher",
+		Usage: "Content recovery feed publisher",
 	}
 	SwarmUploadMimeType = cli.StringFlag{
 		Name:  "mime",

--- a/cmd/swarm/flags.go
+++ b/cmd/swarm/flags.go
@@ -153,10 +153,6 @@ var (
 		Name:  "stdin",
 		Usage: "reads data to be uploaded from stdin",
 	}
-	SwarmUploadPublisher = cli.StringFlag{
-		Name:  "publisher",
-		Usage: "Content recovery feed publisher",
-	}
 	SwarmUploadMimeType = cli.StringFlag{
 		Name:  "mime",
 		Usage: "Manually specify MIME type",
@@ -243,6 +239,10 @@ var (
 	SwarmGlobalPinnerFlag = cli.BoolFlag{
 		Name:  "global-pinner",
 		Usage: "Use this flag to mark the running node as a global pinner",
+	}
+	SwarmRecoveryPublisherFlag = cli.StringFlag{
+		Name:  "publisher",
+		Usage: "Content recovery feed publisher",
 	}
 	SwarmProgressFlag = cli.BoolFlag{
 		Name:  "progress",

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -200,6 +200,7 @@ func init() {
 		SwarmNetworkIdFlag,
 		SwarmEnablePinningFlag,
 		SwarmGlobalPinnerFlag,
+		SwarmRecoveryPublisherFlag,
 		// upload flags
 		SwarmApiFlag,
 		SwarmRecursiveFlag,

--- a/cmd/swarm/upload.go
+++ b/cmd/swarm/upload.go
@@ -48,7 +48,7 @@ var (
 		Name:               "up",
 		Usage:              "uploads a file or directory to swarm using the HTTP API",
 		ArgsUsage:          "<file>",
-		Flags:              []cli.Flag{SwarmEncryptedFlag, SwarmPinFlag, SwarmProgressFlag, SwarmVerboseFlag, SwarmUploadPublisher},
+		Flags:              []cli.Flag{SwarmEncryptedFlag, SwarmPinFlag, SwarmProgressFlag, SwarmVerboseFlag},
 		Description:        "uploads a file or directory to swarm using the HTTP API and prints the root hash",
 	}
 
@@ -73,7 +73,6 @@ func upload(ctx *cli.Context) {
 		defaultPath     = ctx.GlobalString(SwarmUploadDefaultPath.Name)
 		fromStdin       = ctx.GlobalBool(SwarmUpFromStdinFlag.Name)
 		mimeType        = ctx.GlobalString(SwarmUploadMimeType.Name)
-		publisher       = ctx.String(SwarmUploadPublisher.Name)
 		verbose         = ctx.Bool(SwarmVerboseFlag.Name)
 		client          = swarm.NewClient(bzzapi)
 		toEncrypt       = ctx.Bool(SwarmEncryptedFlag.Name)
@@ -161,7 +160,7 @@ func upload(ctx *cli.Context) {
 					defaultPath = strings.TrimPrefix(absDefaultPath, absFile)
 				}
 			}
-			return client.UploadDirectory(file, defaultPath, "", toEncrypt, toPin, anon, publisher)
+			return client.UploadDirectory(file, defaultPath, "", toEncrypt, toPin, anon)
 		}
 	} else {
 		doUpload = func() (string, error) {
@@ -173,7 +172,7 @@ func upload(ctx *cli.Context) {
 			if mimeType != "" {
 				f.ContentType = mimeType
 			}
-			return client.Upload(f, "", toEncrypt, toPin, anon, publisher)
+			return client.Upload(f, "", toEncrypt, toPin, anon)
 		}
 	}
 	start := time.Now()

--- a/prod/prod.go
+++ b/prod/prod.go
@@ -76,6 +76,14 @@ func NewRecoveryHook(send sender, handler feed.GenericHandler, publisher string)
 	}
 }
 
+// NewRepairHandler creates a repair function to re-upload globally pinned chunks to the network with the given store
+func NewRepairHandler(s *chunk.ValidatorStore) pss.Handler {
+	return func(m trojan.Message) {
+		chAddr := m.Payload
+		s.Set(context.Background(), chunk.ModeSetReUpload, chAddr)
+	}
+}
+
 // getPinners returns the specific target pinners for a corresponding chunk
 func getPinners(ctx context.Context, handler feed.GenericHandler, publisher string) (trojan.Targets, error) {
 	// query feed using recovery topic and publisher
@@ -91,14 +99,6 @@ func getPinners(ctx context.Context, handler feed.GenericHandler, publisher stri
 	}
 
 	return *targets, nil
-}
-
-// NewRepairHandler creates a repair function to re-upload globally pinned chunks to the network with the given store
-func NewRepairHandler(s *chunk.ValidatorStore) pss.Handler {
-	return func(m trojan.Message) {
-		chAddr := m.Payload
-		s.Set(context.Background(), chunk.ModeSetReUpload, chAddr)
-	}
 }
 
 // queryRecoveryFeed attempts to create a feed topic and user, and query a feed based on these to fetch its content

--- a/prod/prod.go
+++ b/prod/prod.go
@@ -103,15 +103,11 @@ func getPinners(ctx context.Context, handler feed.GenericHandler, publisher stri
 
 // queryRecoveryFeed attempts to create a feed topic and user, and query a feed based on these to fetch its content
 func queryRecoveryFeed(ctx context.Context, topicText string, publisher string, handler feed.GenericHandler) ([]byte, error) {
-	var content []byte
 	topic, user, err := getFeedTopicAndUser(topicText, publisher)
-	if err == nil {
-		content, err = getFeedContent(ctx, handler, topic, user)
-	}
 	if err != nil {
 		return nil, err
 	}
-	return content, err
+	return getFeedContent(ctx, handler, topic, user)
 }
 
 // getFeedTopicAndUser creates a feed topic and user from the given topic text and publisher strings

--- a/prod/prod.go
+++ b/prod/prod.go
@@ -78,10 +78,8 @@ func NewRecoveryHook(send sender, handler feed.GenericHandler, publisher string)
 
 // getPinners returns the specific target pinners for a corresponding chunk
 func getPinners(ctx context.Context, handler feed.GenericHandler, publisher string) (trojan.Targets, error) {
-	// query feed using recovery topic and publisher if present
+	// query feed using recovery topic and publisher
 	feedContent, err := queryRecoveryFeed(ctx, RecoveryTopicText, publisher, handler)
-
-	// if there is an error and no fallback publisher is available, fail at this point
 	if err != nil {
 		return nil, err
 	}

--- a/prod/prod.go
+++ b/prod/prod.go
@@ -59,9 +59,9 @@ type RecoveryHook func(ctx context.Context, chunkAddress chunk.Address) error
 type sender func(ctx context.Context, targets trojan.Targets, topic trojan.Topic, payload []byte) (*pss.Monitor, error)
 
 // NewRecoveryHook returns a new RecoveryHook with the sender function defined
-func NewRecoveryHook(send sender, handler feed.GenericHandler) RecoveryHook {
+func NewRecoveryHook(send sender, handler feed.GenericHandler, publisher string) RecoveryHook {
 	return func(ctx context.Context, chunkAddress chunk.Address) error {
-		targets, err := getPinners(ctx, handler)
+		targets, err := getPinners(ctx, handler, publisher)
 		if err != nil {
 			return err
 		}
@@ -76,10 +76,9 @@ func NewRecoveryHook(send sender, handler feed.GenericHandler) RecoveryHook {
 }
 
 // getPinners returns the specific target pinners for a corresponding chunk
-func getPinners(ctx context.Context, handler feed.GenericHandler) (trojan.Targets, error) {
-	// TODO: obtain fallback Publisher from cli flag if no Publisher found in Manifest
+func getPinners(ctx context.Context, handler feed.GenericHandler, publisher string) (trojan.Targets, error) {
+	// TODO: obtain fallback Publisher from cli flag
 	// get feed user from publisher
-	publisher, _ := ctx.Value("publisher").(string)
 	publisherBytes, err := hex.DecodeString(publisher)
 	if err != nil {
 		return nil, ErrPublisher

--- a/prod/prod_test.go
+++ b/prod/prod_test.go
@@ -77,7 +77,7 @@ func TestRecoveryHookCalls(t *testing.T) {
 
 	// test cases variables
 	dummyPublisher := ""
-	publisher := "0226f213613e843a413ad35b40f193910d26eb35f00154afcde9ded57479a6224a"
+	recoveryPublisher := "0226f213613e843a413ad35b40f193910d26eb35f00154afcde9ded57479a6224a"
 	dummyHandler := feed.NewDummyHandler() // returns empty content for feed
 	feedsHandler := newTestRecoveryFeedsHandler(t)
 
@@ -90,7 +90,7 @@ func TestRecoveryHookCalls(t *testing.T) {
 		},
 		{
 			name:           "publisher set, no feed content",
-			publisher:      publisher,
+			publisher:      recoveryPublisher,
 			feedsHandler:   dummyHandler,
 			expectsFailure: true,
 		},
@@ -102,7 +102,7 @@ func TestRecoveryHookCalls(t *testing.T) {
 		},
 		{
 			name:           "publisher and feed content set",
-			publisher:      publisher,
+			publisher:      recoveryPublisher,
 			feedsHandler:   feedsHandler,
 			expectsFailure: false,
 		},

--- a/swarm.go
+++ b/swarm.go
@@ -290,7 +290,7 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 	}
 
 	// add recovery callback for content repair
-	recoverFunc := prod.NewRecoveryHook(self.pss.Send, feedsHandler)
+	recoverFunc := prod.NewRecoveryHook(self.pss.Send, feedsHandler, "") // TODO: inject from CLI flag
 	self.netStore.WithRecoveryCallback(recoverFunc)
 
 	self.api = api.NewAPI(self.fileStore, self.dns, self.rns, feedsHandler, self.privateKey, self.tags)

--- a/swarm.go
+++ b/swarm.go
@@ -289,10 +289,11 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 		self.pss.Register(prod.RecoveryTopic, repairHandler)
 	}
 
-	// add recovery callback for content repair
-	recoverFunc := prod.NewRecoveryHook(self.pss.Send, feedsHandler, "") // TODO: inject from CLI flag
-	self.netStore.WithRecoveryCallback(recoverFunc)
-
+	if self.config.RecoveryPublisher != "" {
+		// add recovery callback for content repair
+		recoverFunc := prod.NewRecoveryHook(self.pss.Send, feedsHandler, self.config.RecoveryPublisher)
+		self.netStore.WithRecoveryCallback(recoverFunc)
+	}
 	self.api = api.NewAPI(self.fileStore, self.dns, self.rns, feedsHandler, self.privateKey, self.tags)
 
 	if config.EnablePinning {


### PR DESCRIPTION
This PR attempts to solve issue #2193, which is about manifests being garbage collected, causing publishers data to be inaccessible and (as a result) the content repair process to fail.

The alternative instead, is to always attempt content repair through a fixed publisher provided through a CLI flag, instead of the derived from the manifest.

This solution:
- rolls back most changes from #2175 (this code is put into the `global-pinning-manifest-publisher` branch should we need it later)
- adapts code from #2183 due to implementation similarities
  - said PR is now on hold since this solution excludes the publisher fallback implementation

### Implementation details
- adds a Recovery Publisher flag on boot-up
  - without this flag set, no content repair will be attempted
  - the flag will be passed to the `NewRecoveryHook` func and used thereafter
- only this sole publisher will be use for _all_ content repair processes (this can later be expanded to 1 feed per root hash as specified in #2193)
- functions `queryRecoveryFeed`, `getFeedTopicAndUser`, `getFeedContent` and `publisherToAddress` were added from #2183 to make the code in the `prod` package more readable
- all the code related to the `publisher` field in manifests is rolled back
  - `prod` tests are adapted as a consequence

closes #2193