### PR TITLE
swarm, main, api: split sync flag into push and pull flags

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -76,7 +76,7 @@ type Config struct {
 	BzzKey             string
 	Enode              *enode.Node `toml:"-"`
 	NetworkID          uint64
-	SyncEnabled        bool
+	PullSyncEnabled    bool
 	PushSyncEnabled    bool
 	LightNodeEnabled   bool
 	BootnodeMode       bool
@@ -109,7 +109,7 @@ func NewConfig() *Config {
 		ListenAddr:              DefaultHTTPListenAddr,
 		Port:                    DefaultHTTPPort,
 		NetworkID:               network.DefaultNetworkID,
-		SyncEnabled:             true,
+		PullSyncEnabled:         true,
 		PushSyncEnabled:         true,
 		EnablePinning:           false,
 	}

--- a/cmd/swarm/config.go
+++ b/cmd/swarm/config.go
@@ -231,7 +231,7 @@ func flagsOverride(currentConfig *bzzapi.Config, ctx *cli.Context) *bzzapi.Confi
 	}
 	if ctx.GlobalIsSet(SwarmNoPullSyncFlag.Name) {
 		val := !ctx.GlobalBool(SwarmNoPullSyncFlag.Name)
-		currentConfig.SyncEnabled, currentConfig.PushSyncEnabled = val, val // if the flag is set (true) - push and pull sync should be disabled
+		currentConfig.PullSyncEnabled, currentConfig.PushSyncEnabled = val, val // if the flag is set (true) - push and pull sync should be disabled
 	}
 	if ctx.GlobalIsSet(SwarmLightNodeEnabled.Name) {
 		currentConfig.LightNodeEnabled = true

--- a/cmd/swarm/config.go
+++ b/cmd/swarm/config.go
@@ -230,8 +230,10 @@ func flagsOverride(currentConfig *bzzapi.Config, ctx *cli.Context) *bzzapi.Confi
 		currentConfig.SwapDisconnectThreshold = disconnectThreshold
 	}
 	if ctx.GlobalIsSet(SwarmNoPullSyncFlag.Name) {
-		val := !ctx.GlobalBool(SwarmNoPullSyncFlag.Name)
-		currentConfig.PullSyncEnabled, currentConfig.PushSyncEnabled = val, val // if the flag is set (true) - push and pull sync should be disabled
+		currentConfig.PullSyncEnabled = !ctx.GlobalBool(SwarmNoPullSyncFlag.Name) // if the flag is set (true) - pull sync should be disabled
+	}
+	if ctx.GlobalIsSet(SwarmNoPushSyncFlag.Name) {
+		currentConfig.PushSyncEnabled = !ctx.GlobalBool(SwarmNoPushSyncFlag.Name) // if the flag is set (true) - push sync should be disabled
 	}
 	if ctx.GlobalIsSet(SwarmLightNodeEnabled.Name) {
 		currentConfig.LightNodeEnabled = true

--- a/cmd/swarm/config.go
+++ b/cmd/swarm/config.go
@@ -72,7 +72,7 @@ const (
 	SwarmEnvSwapBackendURL          = "SWARM_SWAP_BACKEND_URL"
 	SwarmEnvSwapPaymentThreshold    = "SWARM_SWAP_PAYMENT_THRESHOLD"
 	SwarmEnvSwapDisconnectThreshold = "SWARM_SWAP_DISCONNECT_THRESHOLD"
-	SwarmNoSync                     = "SWARM_NO_SYNC"
+	SwarmNoPullSync                 = "SWARM_NO_PULL_SYNC"
 	SwarmNoPushSync                 = "SWARM_NO_PUSH_SYNC"
 	SwarmEnvSwapLogPath             = "SWARM_SWAP_LOG_PATH"
 	SwarmEnvSwapLogLevel            = "SWARM_SWAP_LOG_LEVEL"

--- a/cmd/swarm/config.go
+++ b/cmd/swarm/config.go
@@ -229,8 +229,8 @@ func flagsOverride(currentConfig *bzzapi.Config, ctx *cli.Context) *bzzapi.Confi
 	if disconnectThreshold := ctx.GlobalUint64(SwarmSwapDisconnectThresholdFlag.Name); disconnectThreshold != 0 {
 		currentConfig.SwapDisconnectThreshold = disconnectThreshold
 	}
-	if ctx.GlobalIsSet(SwarmNoSyncFlag.Name) {
-		val := !ctx.GlobalBool(SwarmNoSyncFlag.Name)
+	if ctx.GlobalIsSet(SwarmNoPullSyncFlag.Name) {
+		val := !ctx.GlobalBool(SwarmNoPullSyncFlag.Name)
 		currentConfig.SyncEnabled, currentConfig.PushSyncEnabled = val, val // if the flag is set (true) - push and pull sync should be disabled
 	}
 	if ctx.GlobalIsSet(SwarmLightNodeEnabled.Name) {

--- a/cmd/swarm/config.go
+++ b/cmd/swarm/config.go
@@ -73,6 +73,7 @@ const (
 	SwarmEnvSwapPaymentThreshold    = "SWARM_SWAP_PAYMENT_THRESHOLD"
 	SwarmEnvSwapDisconnectThreshold = "SWARM_SWAP_DISCONNECT_THRESHOLD"
 	SwarmNoSync                     = "SWARM_NO_SYNC"
+	SwarmNoPushSync                 = "SWARM_NO_PUSH_SYNC"
 	SwarmEnvSwapLogPath             = "SWARM_SWAP_LOG_PATH"
 	SwarmEnvSwapLogLevel            = "SWARM_SWAP_LOG_LEVEL"
 	SwarmEnvLightNodeEnable         = "SWARM_LIGHT_NODE_ENABLE"

--- a/cmd/swarm/config_test.go
+++ b/cmd/swarm/config_test.go
@@ -276,8 +276,8 @@ func TestConfigCmdLineOverrides(t *testing.T) {
 		t.Fatalf("Expected network ID to be %d, got %d", 42, info.NetworkID)
 	}
 
-	if info.SyncEnabled {
-		t.Fatal("Expected Sync to be disabled, but is true")
+	if info.PullSyncEnabled {
+		t.Fatal("Expected Pull Sync to be disabled, but is true")
 	}
 
 	if info.PushSyncEnabled {
@@ -315,7 +315,8 @@ func TestConfigFileOverrides(t *testing.T) {
 	//first, create a default conf
 	defaultConf := api.NewConfig()
 	//change some values in order to test if they have been loaded
-	defaultConf.SyncEnabled = false
+	defaultConf.PullSyncEnabled = false
+	defaultConf.PushSyncEnabled = false
 	defaultConf.NetworkID = 54
 	defaultConf.Port = httpPort
 	defaultConf.DbCapacity = 9000000
@@ -386,8 +387,8 @@ func TestConfigFileOverrides(t *testing.T) {
 		t.Fatalf("Expected network ID to be %d, got %d", 54, info.NetworkID)
 	}
 
-	if info.SyncEnabled {
-		t.Fatal("Expected Sync to be disabled, but is true")
+	if info.PullSyncEnabled {
+		t.Fatal("Expected Pull Sync to be disabled, but is true")
 	}
 
 	if info.DbCapacity != 9000000 {
@@ -491,8 +492,8 @@ func TestConfigEnvVars(t *testing.T) {
 		t.Fatalf("Expected Cors flag to be set to %s, got %s", "*", info.Cors)
 	}
 
-	if info.SyncEnabled {
-		t.Fatal("Expected Sync to be disabled, but is true")
+	if info.PullSyncEnabled {
+		t.Fatal("Expected Pull Sync to be disabled, but is true")
 	}
 
 	if info.PushSyncEnabled {
@@ -515,7 +516,7 @@ func TestConfigCmdLineOverridesFile(t *testing.T) {
 	//first, create a default conf
 	defaultConf := api.NewConfig()
 	//change some values in order to test if they have been loaded
-	defaultConf.SyncEnabled = true
+	defaultConf.PullSyncEnabled = true
 	defaultConf.PushSyncEnabled = true
 	defaultConf.NetworkID = 54
 	defaultConf.Port = "8588"
@@ -595,8 +596,8 @@ func TestConfigCmdLineOverridesFile(t *testing.T) {
 		t.Fatalf("Expected network ID to be %d, got %d", expectNetworkId, info.NetworkID)
 	}
 
-	if info.SyncEnabled {
-		t.Fatal("Expected Sync to be disabled, but is true")
+	if info.PullSyncEnabled {
+		t.Fatal("Expected Pull Sync to be disabled, but is true")
 	}
 
 	if info.PushSyncEnabled {

--- a/cmd/swarm/config_test.go
+++ b/cmd/swarm/config_test.go
@@ -391,6 +391,10 @@ func TestConfigFileOverrides(t *testing.T) {
 		t.Fatal("Expected Pull Sync to be disabled, but is true")
 	}
 
+	if info.PushSyncEnabled {
+		t.Fatal("Expected Push Sync to be disabled, but is true")
+	}
+
 	if info.DbCapacity != 9000000 {
 		t.Fatalf("Expected DbCapacity to be %d, got %d", 9000000, info.DbCapacity)
 	}

--- a/cmd/swarm/config_test.go
+++ b/cmd/swarm/config_test.go
@@ -231,7 +231,7 @@ func TestConfigCmdLineOverrides(t *testing.T) {
 		fmt.Sprintf("--%s", SwarmNetworkIdFlag.Name), "42",
 		fmt.Sprintf("--%s", SwarmPortFlag.Name), httpPort,
 		fmt.Sprintf("--%s", utils.ListenPortFlag.Name), "0",
-		fmt.Sprintf("--%s", SwarmNoSyncFlag.Name),
+		fmt.Sprintf("--%s", SwarmNoPullSyncFlag.Name),
 		fmt.Sprintf("--%s", CorsStringFlag.Name), "*",
 		fmt.Sprintf("--%s", SwarmAccountFlag.Name), account.Address.String(),
 		fmt.Sprintf("--%s", EnsAPIFlag.Name), "",
@@ -411,7 +411,7 @@ func TestConfigEnvVars(t *testing.T) {
 	envVars = append(envVars, fmt.Sprintf("%s=%s", SwarmPortFlag.EnvVar, httpPort))
 	envVars = append(envVars, fmt.Sprintf("%s=%s", SwarmNetworkIdFlag.EnvVar, "999"))
 	envVars = append(envVars, fmt.Sprintf("%s=%s", CorsStringFlag.EnvVar, "*"))
-	envVars = append(envVars, fmt.Sprintf("%s=%s", SwarmNoSyncFlag.EnvVar, "true"))
+	envVars = append(envVars, fmt.Sprintf("%s=%s", SwarmNoPullSyncFlag.EnvVar, "true"))
 
 	dir, err := ioutil.TempDir("", "bzztest")
 	if err != nil {
@@ -552,7 +552,7 @@ func TestConfigCmdLineOverridesFile(t *testing.T) {
 	flags := []string{
 		fmt.Sprintf("--%s", SwarmNetworkIdFlag.Name), "77",
 		fmt.Sprintf("--%s", SwarmPortFlag.Name), httpPort,
-		fmt.Sprintf("--%s", SwarmNoSyncFlag.Name),
+		fmt.Sprintf("--%s", SwarmNoPullSyncFlag.Name),
 		fmt.Sprintf("--%s", SwarmTomlConfigPathFlag.Name), f.Name(),
 		fmt.Sprintf("--%s", SwarmAccountFlag.Name), account.Address.String(),
 		fmt.Sprintf("--%s", EnsAPIFlag.Name), "",

--- a/cmd/swarm/config_test.go
+++ b/cmd/swarm/config_test.go
@@ -232,6 +232,7 @@ func TestConfigCmdLineOverrides(t *testing.T) {
 		fmt.Sprintf("--%s", SwarmPortFlag.Name), httpPort,
 		fmt.Sprintf("--%s", utils.ListenPortFlag.Name), "0",
 		fmt.Sprintf("--%s", SwarmNoPullSyncFlag.Name),
+		fmt.Sprintf("--%s", SwarmNoPushSyncFlag.Name),
 		fmt.Sprintf("--%s", CorsStringFlag.Name), "*",
 		fmt.Sprintf("--%s", SwarmAccountFlag.Name), account.Address.String(),
 		fmt.Sprintf("--%s", EnsAPIFlag.Name), "",
@@ -412,6 +413,7 @@ func TestConfigEnvVars(t *testing.T) {
 	envVars = append(envVars, fmt.Sprintf("%s=%s", SwarmNetworkIdFlag.EnvVar, "999"))
 	envVars = append(envVars, fmt.Sprintf("%s=%s", CorsStringFlag.EnvVar, "*"))
 	envVars = append(envVars, fmt.Sprintf("%s=%s", SwarmNoPullSyncFlag.EnvVar, "true"))
+	envVars = append(envVars, fmt.Sprintf("%s=%s", SwarmNoPushSyncFlag.EnvVar, "true"))
 
 	dir, err := ioutil.TempDir("", "bzztest")
 	if err != nil {
@@ -553,6 +555,7 @@ func TestConfigCmdLineOverridesFile(t *testing.T) {
 		fmt.Sprintf("--%s", SwarmNetworkIdFlag.Name), "77",
 		fmt.Sprintf("--%s", SwarmPortFlag.Name), httpPort,
 		fmt.Sprintf("--%s", SwarmNoPullSyncFlag.Name),
+		fmt.Sprintf("--%s", SwarmNoPushSyncFlag.Name),
 		fmt.Sprintf("--%s", SwarmTomlConfigPathFlag.Name), f.Name(),
 		fmt.Sprintf("--%s", SwarmAccountFlag.Name), account.Address.String(),
 		fmt.Sprintf("--%s", EnsAPIFlag.Name), "",

--- a/cmd/swarm/flags.go
+++ b/cmd/swarm/flags.go
@@ -95,9 +95,9 @@ var (
 		EnvVar: SwarmEnvSwapDisconnectThreshold,
 	}
 	SwarmNoPullSyncFlag = cli.BoolFlag{
-		Name:   "no-sync",
-		Usage:  "disable syncing",
-		EnvVar: SwarmNoSync,
+		Name:   "no-pull-sync",
+		Usage:  "disable pull syncing",
+		EnvVar: SwarmNoPullSync,
 	}
 	SwarmNoPushSyncFlag = cli.BoolFlag{
 		Name:   "no-push-sync",

--- a/cmd/swarm/flags.go
+++ b/cmd/swarm/flags.go
@@ -94,7 +94,7 @@ var (
 		Usage:  "honey amount at which a peer disconnects",
 		EnvVar: SwarmEnvSwapDisconnectThreshold,
 	}
-	SwarmNoSyncFlag = cli.BoolFlag{
+	SwarmNoPullSyncFlag = cli.BoolFlag{
 		Name:   "no-sync",
 		Usage:  "disable syncing",
 		EnvVar: SwarmNoSync,

--- a/cmd/swarm/flags.go
+++ b/cmd/swarm/flags.go
@@ -99,6 +99,11 @@ var (
 		Usage:  "disable syncing",
 		EnvVar: SwarmNoSync,
 	}
+	SwarmNoPushSyncFlag = cli.BoolFlag{
+		Name:   "no-push-sync",
+		Usage:  "disable push syncing",
+		EnvVar: SwarmNoPushSync,
+	}
 	SwarmSwapLogPathFlag = cli.StringFlag{
 		Name:   "swap-audit-logpath",
 		Usage:  "Write execution logs of swap audit to the given directory",

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -191,7 +191,7 @@ func init() {
 		SwarmSwapSkipDepositFlag,
 		SwarmSwapDepositAmountFlag,
 		// end of swap flags
-		SwarmNoSyncFlag,
+		SwarmNoPullSyncFlag,
 		SwarmLightNodeEnabled,
 		SwarmListenAddrFlag,
 		SwarmPortFlag,

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -192,6 +192,7 @@ func init() {
 		SwarmSwapDepositAmountFlag,
 		// end of swap flags
 		SwarmNoPullSyncFlag,
+		SwarmNoPushSyncFlag,
 		SwarmLightNodeEnabled,
 		SwarmListenAddrFlag,
 		SwarmPortFlag,

--- a/network/protocol.go
+++ b/network/protocol.go
@@ -114,7 +114,7 @@ type BzzConfig struct {
 	NetworkID    uint64
 	LightNode    bool // temporarily kept as we still only define light/full on operational level
 	BootnodeMode bool
-	SyncEnabled  bool // not sure if this one should also be renamed
+	SyncEnabled  bool
 }
 
 // Bzz is the swarm protocol bundle

--- a/network/protocol.go
+++ b/network/protocol.go
@@ -114,7 +114,7 @@ type BzzConfig struct {
 	NetworkID    uint64
 	LightNode    bool // temporarily kept as we still only define light/full on operational level
 	BootnodeMode bool
-	SyncEnabled  bool
+	SyncEnabled  bool // not sure if this one should also be renamed
 }
 
 // Bzz is the swarm protocol bundle

--- a/swarm.go
+++ b/swarm.go
@@ -245,7 +245,6 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 	feedsHandler.SetStore(self.netStore)
 
 	syncing := true
-	// should config.PushSyncEnabled have an effect here too?
 	if !config.PullSyncEnabled || config.LightNodeEnabled || config.BootnodeMode {
 		syncing = false
 	}
@@ -563,7 +562,7 @@ func (s *Swarm) APIs() []rpc.API {
 
 	// this is a workaround disabling syncing altogether from a node but
 	// must be changed when multiple stream implementations are at hand
-	if s.config.PullSyncEnabled { // should config.PushSyncEnabled have an effect here too?
+	if s.config.PullSyncEnabled {
 		apis = append(apis, s.streamer.APIs()...)
 	}
 	apis = append(apis, s.bzzEth.APIs()...)

--- a/swarm.go
+++ b/swarm.go
@@ -122,7 +122,7 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 		HiveParams:   config.HiveParams,
 		LightNode:    config.LightNodeEnabled,
 		BootnodeMode: config.BootnodeMode,
-		SyncEnabled:  config.SyncEnabled,
+		SyncEnabled:  config.PullSyncEnabled, // should config.PushSyncEnabled have an effect here as well?
 	}
 
 	// Swap initialization
@@ -245,7 +245,8 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 	feedsHandler.SetStore(self.netStore)
 
 	syncing := true
-	if !config.SyncEnabled || config.LightNodeEnabled || config.BootnodeMode {
+	// should config.PushSyncEnabled have an effect here too?
+	if !config.PullSyncEnabled || config.LightNodeEnabled || config.BootnodeMode {
 		syncing = false
 	}
 
@@ -562,7 +563,7 @@ func (s *Swarm) APIs() []rpc.API {
 
 	// this is a workaround disabling syncing altogether from a node but
 	// must be changed when multiple stream implementations are at hand
-	if s.config.SyncEnabled {
+	if s.config.PullSyncEnabled { // should config.PushSyncEnabled have an effect here too?
 		apis = append(apis, s.streamer.APIs()...)
 	}
 	apis = append(apis, s.bzzEth.APIs()...)

--- a/swarm.go
+++ b/swarm.go
@@ -122,7 +122,7 @@ func NewSwarm(config *api.Config, mockStore *mock.NodeStore) (self *Swarm, err e
 		HiveParams:   config.HiveParams,
 		LightNode:    config.LightNodeEnabled,
 		BootnodeMode: config.BootnodeMode,
-		SyncEnabled:  config.PullSyncEnabled, // should config.PushSyncEnabled have an effect here as well?
+		SyncEnabled:  config.PullSyncEnabled && config.PushSyncEnabled,
 	}
 
 	// Swap initialization


### PR DESCRIPTION
This PR separates the `SwarmNoSyncFlag` into 2 independent flags: `SwarmNoPullSyncFlag` and `SwarmNoPushSyncFlag`.

closes #2196