### PR TITLE
prod: use bzzaccounts as global pinning publishers

### DIFF
--- a/prod/prod.go
+++ b/prod/prod.go
@@ -118,10 +118,7 @@ func getFeedTopicAndUser(topicText string, publisher string) (feed.Topic, common
 		return feed.Topic{}, common.Address{}, err
 	}
 	// get feed user from publisher
-	user, err := common.HexToAddress(publisher)
-	if err != nil {
-		return feed.Topic{}, common.Address{}, err
-	}
+	user := common.HexToAddress(publisher)
 	return topic, user, nil
 }
 

--- a/prod/prod.go
+++ b/prod/prod.go
@@ -18,13 +18,11 @@ package prod
 
 import (
 	"context"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethersphere/swarm/chunk"
 	"github.com/ethersphere/swarm/pss"
 	"github.com/ethersphere/swarm/pss/trojan"
@@ -120,7 +118,7 @@ func getFeedTopicAndUser(topicText string, publisher string) (feed.Topic, common
 		return feed.Topic{}, common.Address{}, err
 	}
 	// get feed user from publisher
-	user, err := publisherToAddress(publisher)
+	user, err := common.HexToAddress(publisher)
 	if err != nil {
 		return feed.Topic{}, common.Address{}, err
 	}
@@ -149,17 +147,4 @@ func getFeedContent(ctx context.Context, handler feed.GenericHandler, topic feed
 	}
 
 	return content, nil
-}
-
-// publisherToAddress derives an address based on the given publisher string
-func publisherToAddress(publisher string) (common.Address, error) {
-	publisherBytes, err := hex.DecodeString(publisher)
-	if err != nil {
-		return common.Address{}, ErrPublisher
-	}
-	pubKey, err := crypto.DecompressPubkey(publisherBytes)
-	if err != nil {
-		return common.Address{}, ErrPubKey
-	}
-	return crypto.PubkeyToAddress(*pubKey), nil
 }

--- a/prod/prod.go
+++ b/prod/prod.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethersphere/swarm/chunk"
 	"github.com/ethersphere/swarm/pss"
@@ -75,37 +76,68 @@ func NewRecoveryHook(send sender, handler feed.GenericHandler) RecoveryHook {
 	}
 }
 
+// NewRepairHandler creates a repair function to re-upload globally pinned chunks to the network with the given store
+func NewRepairHandler(s *chunk.ValidatorStore) pss.Handler {
+	return func(m trojan.Message) {
+		chAddr := m.Payload
+		s.Set(context.Background(), chunk.ModeSetReUpload, chAddr)
+	}
+}
+
 // getPinners returns the specific target pinners for a corresponding chunk
 func getPinners(ctx context.Context, handler feed.GenericHandler) (trojan.Targets, error) {
-	// TODO: obtain fallback Publisher from cli flag if no Publisher found in Manifest
-	// get feed user from publisher
 	publisher, _ := ctx.Value("publisher").(string)
-	publisherBytes, err := hex.DecodeString(publisher)
-	if err != nil {
-		return nil, ErrPublisher
-	}
-	pubKey, err := crypto.DecompressPubkey(publisherBytes)
-	if err != nil {
-		return nil, ErrPubKey
-	}
-	addr := crypto.PubkeyToAddress(*pubKey)
 
-	// get feed topic from trojan recovery topic
-	topic, err := feed.NewTopic(RecoveryTopicText, nil)
+	// query feed using recovery topic and publisher
+	feedContent, err := queryRecoveryFeed(ctx, RecoveryTopicText, publisher, handler)
 	if err != nil {
 		return nil, err
 	}
 
-	// read feed
+	// extract targets from feed content
+	targets := new(trojan.Targets)
+	if err := json.Unmarshal(feedContent, targets); err != nil {
+		return nil, ErrTargets
+	}
+
+	return *targets, nil
+}
+
+// queryRecoveryFeed attempts to create a feed topic and user, and query a feed based on these to fetch its content
+func queryRecoveryFeed(ctx context.Context, topicText string, publisher string, handler feed.GenericHandler) ([]byte, error) {
+	topic, user, err := getFeedTopicAndUser(topicText, publisher)
+	if err != nil {
+		return nil, err
+	}
+	return getFeedContent(ctx, handler, topic, user)
+}
+
+// getFeedTopicAndUser creates a feed topic and user from the given topic text and publisher strings
+func getFeedTopicAndUser(topicText string, publisher string) (feed.Topic, common.Address, error) {
+	// get feed topic from topic text
+	topic, err := feed.NewTopic(topicText, nil)
+	if err != nil {
+		return feed.Topic{}, common.Address{}, err
+	}
+	// get feed user from publisher
+	user, err := publisherToAddress(publisher)
+	if err != nil {
+		return feed.Topic{}, common.Address{}, err
+	}
+	return topic, user, nil
+}
+
+// getFeedContent creates a feed with the given topic and user, and attempts to fetch its content using the given handler
+func getFeedContent(ctx context.Context, handler feed.GenericHandler, topic feed.Topic, user common.Address) ([]byte, error) {
 	fd := feed.Feed{
 		Topic: topic,
-		User:  addr,
+		User:  user,
 	}
 	query := feed.NewQueryLatest(&fd, lookup.NoClue)
 	ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 	defer cancel()
 
-	_, err = handler.Lookup(ctx, query)
+	_, err := handler.Lookup(ctx, query)
 	// feed should still be queried even if there are no updates
 	if err != nil && err.Error() != "no feed updates found" {
 		return nil, ErrFeedLookup
@@ -116,19 +148,18 @@ func getPinners(ctx context.Context, handler feed.GenericHandler) (trojan.Target
 		return nil, ErrFeedContent
 	}
 
-	// extract targets from feed content
-	targets := new(trojan.Targets)
-	if err := json.Unmarshal(content, targets); err != nil {
-		return nil, ErrTargets
-	}
-
-	return *targets, nil
+	return content, nil
 }
 
-// NewRepairHandler creates a repair function to re-upload globally pinned chunks to the network with the given store
-func NewRepairHandler(s *chunk.ValidatorStore) pss.Handler {
-	return func(m trojan.Message) {
-		chAddr := m.Payload
-		s.Set(context.Background(), chunk.ModeSetReUpload, chAddr)
+// publisherToAddress derives an address based on the given publisher string
+func publisherToAddress(publisher string) (common.Address, error) {
+	publisherBytes, err := hex.DecodeString(publisher)
+	if err != nil {
+		return common.Address{}, ErrPublisher
 	}
+	pubKey, err := crypto.DecompressPubkey(publisherBytes)
+	if err != nil {
+		return common.Address{}, ErrPubKey
+	}
+	return crypto.PubkeyToAddress(*pubKey), nil
 }

--- a/prod/prod.go
+++ b/prod/prod.go
@@ -36,8 +36,8 @@ const RecoveryTopicText = "RECOVERY"
 // RecoveryTopic is the topic used for repairing globally pinned chunks
 var RecoveryTopic = trojan.NewTopic(RecoveryTopicText)
 
-// ErrPublisher is returned when the publisher string cannot be decoded into bytes
-var ErrPublisher = errors.New("failed to decode publisher")
+// ErrPublisher is returned when the publisher address turns out to be empty
+var ErrPublisher = errors.New("content publisher is empty")
 
 // ErrPubKey is returned when the publisher bytes cannot be decompressed as a public key
 var ErrPubKey = errors.New("failed to decompress public key")
@@ -119,6 +119,9 @@ func getFeedTopicAndUser(topicText string, publisher string) (feed.Topic, common
 	}
 	// get feed user from publisher
 	user := common.HexToAddress(publisher)
+	if (user == common.Address{}) {
+		return feed.Topic{}, common.Address{}, ErrPublisher
+	}
 	return topic, user, nil
 }
 

--- a/prod/prod_test.go
+++ b/prod/prod_test.go
@@ -127,15 +127,13 @@ func TestRecoveryHookCalls(t *testing.T) {
 			case <-hookWasCalled:
 				if !tc.expectsFailure {
 					return
-				} else {
-					t.Fatal("recovery hook was unexpectedly called")
 				}
+				t.Fatal("recovery hook was unexpectedly called")
 			case <-time.After(100 * time.Millisecond):
 				if tc.expectsFailure {
 					return
-				} else {
-					t.Fatal("recovery hook was not called when expected")
 				}
+				t.Fatal("recovery hook was not called when expected")
 			}
 		})
 	}

--- a/prod/prod_test.go
+++ b/prod/prod_test.go
@@ -38,7 +38,8 @@ import (
 func TestRecoveryHook(t *testing.T) {
 	// test variables needed to be correctly set for any recovery hook to reach the sender func
 	chunkAddr := ctest.GenerateTestRandomChunk().Address()
-	ctx := context.WithValue(context.Background(), "publisher", "0226f213613e843a413ad35b40f193910d26eb35f00154afcde9ded57479a6224a")
+	publisher := "0xedC69a0F0E81394bb08F90F89e35F93287E99dc1"
+	ctx := context.WithValue(context.Background(), "publisher", publisher)
 	handler := newTestRecoveryFeedsHandler(t)
 
 	// setup the sender
@@ -69,14 +70,15 @@ type RecoveryHookTestCase struct {
 
 // TestRecoveryHookCalls verifies that recovery hooks are being called as expected when net store attempts to get a chunk
 func TestRecoveryHookCalls(t *testing.T) {
-	// generate test chunk and store
+	// generate test chunk, store and publisher
 	netStore := newTestNetStore(t)
 	c := ctest.GenerateTestRandomChunk()
 	ref := c.Address()
+	p := "0xbE165fe06c03e4387F79615b7A0b79d535e8D325"
 
 	// test cases variables
 	dummyContext := context.Background() // has no publisher
-	publisherContext := context.WithValue(context.Background(), "publisher", "0226f213613e843a413ad35b40f193910d26eb35f00154afcde9ded57479a6224a")
+	publisherContext := context.WithValue(context.Background(), "publisher", p)
 	dummyHandler := feed.NewDummyHandler() // returns empty content for feed
 	feedsHandler := newTestRecoveryFeedsHandler(t)
 


### PR DESCRIPTION
This PR:
- simplifies the logic of going from `publisher` to recovery feed `User` in global pinning
  - instead of interpreting the publisher field as a public key which has to be decoded, decompressed and then converted into an address, it is directly interpreted as a `bzzaccount` and transformed into an address
  - `ErrPublisher` is now used when the provided `publisher` field results in an empty `common.Address`-typed value
- adds functions `queryRecoveryFeed`, `getFeedTopicAndUser` and `getFeedContent` from #2183 to make the code in the `prod` package more readable

closes #2198 