### PR TITLE
storage/localstore: Local Pinning fix for pinned chunks

### DIFF
--- a/storage/localstore/localstore_test.go
+++ b/storage/localstore/localstore_test.go
@@ -613,6 +613,6 @@ func TestDBDebugIndexes(t *testing.T) {
 	}
 
 	// assert that there's a pin and gc exclude entry now
-	testIndexCounts(t, 1, 1, 1, 1, 1, 1, 1, indexCounts)
+	testIndexCounts(t, 1, 1, 0, 1, 1, 1, 1, indexCounts)
 
 }

--- a/storage/localstore/mode_get.go
+++ b/storage/localstore/mode_get.go
@@ -154,7 +154,16 @@ func (db *DB) updateGC(item shed.Item) (err error) {
 	// update retrieve access index
 	db.retrievalAccessIndex.PutInBatch(batch, item)
 	// add new entry to gc index
-	db.gcIndex.PutInBatch(batch, item)
+	ok, err := db.pinIndex.Has(item)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		err = db.gcIndex.PutInBatch(batch, item)
+		if err != nil {
+			return err
+		}
+	}
 
 	return db.shed.WriteBatch(batch)
 }


### PR DESCRIPTION
This PR closes issue #2195, to summarize GC was removing pinned chunks when it was not supposed to.

This is related to PR #2190 which was the incorrect fix for this bug, thanks to @jmozah for providing the correct fix for this situation.

The solution is to check if the chunk is in the pinIndex before inserting it into gcIndex, this avoids the GC removing the chunk in the first place.

Replaced in these files
- `mode_set.go`
- `mode_get.go`
- `mode_put.go`

```
ok, err := db.pinIndex.Has(item)
	if err != nil {
		return 0, err
	}
	if !ok {
		err = db.gcIndex.PutInBatch(batch, item)
		if err != nil {
			return 0, err
		}
		gcSizeChange++
	}
```

Also, the test `TestDBDebugIndexes` was corrected due to the pinned chunks now being avoided correctly.

Test criteria were:
- 500 chunk store capacity
- no chunks in swarm storage (swarm folder empty)
- pinning is enabled in the swarm node
- Upload a chunk with `--pin`
- Upload another chunk without pinning
- Try to download it (should download correctly)
- upload random chunks multiple times (20 rounds of 40000 chunks and 20 rounds of 2000 chunks)
```shell
dd if=/dev/urandom of=output.txt bs=4096 count=40000 && /home/git/go/src/github.com/ethersphere/swarm/build/bin/swarm --bzzapi http://localhost:8503 up output.txt
```
- try to download upload/pinned chunk (should download correctly)
- the other chunk uploaded without pinned flag should not be retrievable due to GC removing this from the store.

The bug is also in Bee and it is [fixed](https://github.com/ethersphere/bee/pull/255) in a similar fashion 