### PR TITLE
chunk, feed, storage, pss: further condition trojan chunk inspection

### DIFF
--- a/chunk/chunk.go
+++ b/chunk/chunk.go
@@ -353,6 +353,8 @@ func (s *ValidatorStore) Put(ctx context.Context, mode ModePut, chs ...Chunk) (e
 func (s *ValidatorStore) validate(ch Chunk) bool {
 	for _, v := range s.validators {
 		if v.Validate(ch) {
+			// set type for valid chunks and return
+			ch.WithType(v.Type())
 			return true
 		}
 	}

--- a/chunk/chunk.go
+++ b/chunk/chunk.go
@@ -357,8 +357,7 @@ func isPotentialTrojan(c Chunk, t Type) bool {
 	if t != ContentAddressed { // chunk must be of the content-addressed type
 		return false
 	}
-
-	// check for minimum chunk length
+	// check for minimum chunk data length
 	// span (8) + nonce (32) + length (2) + topic (32) = 74
 	return len(c.Data) >= 74
 }

--- a/chunk/chunk.go
+++ b/chunk/chunk.go
@@ -266,6 +266,7 @@ type Type int
 const (
 	Unknown Type = iota
 	ContentAddressed
+	Feed
 )
 
 // Descriptor holds information required for Pull syncing. This struct
@@ -294,9 +295,10 @@ type Store interface {
 	Close() (err error)
 }
 
-// Validator validates a chunk.
+// Validator validates a chunk and returns a chunk type
 type Validator interface {
 	Validate(ch Chunk) bool
+	Type() Type
 }
 
 // ValidatorStore encapsulates Store by decorating the Put method

--- a/chunk/chunk.go
+++ b/chunk/chunk.go
@@ -354,5 +354,11 @@ func (s *ValidatorStore) validate(ch Chunk) (bool, Type) {
 
 // isPotentialTrojan returns true if the given chunk could be trojan
 func isPotentialTrojan(c Chunk, t Type) bool {
-	return t == ContentAddressed
+	if t != ContentAddressed { // chunk must be of the content-addressed type
+		return false
+	}
+
+	// check for minimum chunk length
+	// span (8) + nonce (32) + length (2) + topic (32) = 74
+	return len(c.Data) >= 74
 }

--- a/chunk/chunk.go
+++ b/chunk/chunk.go
@@ -330,8 +330,9 @@ func (s *ValidatorStore) Put(ctx context.Context, mode ModePut, chs ...Chunk) (e
 	// if callback is defined, call it for every new, valid, content-addressed chunk
 	if s.deliverCallback != nil {
 		for i, exists := range exist {
-			if !exists && chunkTypes[i] == ContentAddressed {
-				go s.deliverCallback(chs[i])
+			c := chs[i]
+			if !exists && IsPotentialTrojan(c, chunkTypes[i]) {
+				go s.deliverCallback(c)
 			}
 		}
 	}
@@ -349,4 +350,9 @@ func (s *ValidatorStore) validate(ch Chunk) (bool, Type) {
 		}
 	}
 	return false, Unknown
+}
+
+// isPotentialTrojan returns true if the given chunk could be trojan
+func isPotentialTrojan(c Chunk, t Type) bool {
+	return t == ContentAddressed
 }

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -112,23 +112,13 @@ func (p *Pss) Register(topic trojan.Topic, hndlr Handler) {
 
 // Deliver allows unwrapping a chunk as a trojan message and calling its handler func based on its topic
 func (p *Pss) Deliver(c chunk.Chunk) {
-	if isPotentialTrojan(c) {
+	if trojan.Valid(c) {
 		m, _ := trojan.Unwrap(c) // if err occurs unwrapping, there will be no handler
 		h := p.getHandler(m.Topic)
 		if h != nil {
 			h(*m)
 		}
 	}
-}
-
-// isPotentialTrojan returns true if the given chunk could be trojan
-func isPotentialTrojan(c chunk.Chunk) bool {
-	if c.Type() != chunk.ContentAddressed { // chunk must be of the content-addressed type
-		return false
-	}
-	// check for minimum chunk data length
-	// span (8) + nonce (32) + length (2) + topic (32) = 74
-	return len(c.Data()) >= 74
 }
 
 // getHandler returns the Handler func registered in pss for the given topic

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -111,8 +111,8 @@ func (p *Pss) Register(topic trojan.Topic, hndlr Handler) {
 }
 
 // Deliver allows unwrapping a chunk as a trojan message and calling its handler func based on its topic
-func (p *Pss) Deliver(c chunk.Chunk, t chunk.Type) {
-	if isPotentialTrojan(c, t) {
+func (p *Pss) Deliver(c chunk.Chunk) {
+	if isPotentialTrojan(c) {
 		m, _ := trojan.Unwrap(c) // if err occurs unwrapping, there will be no handler
 		h := p.getHandler(m.Topic)
 		if h != nil {
@@ -122,8 +122,8 @@ func (p *Pss) Deliver(c chunk.Chunk, t chunk.Type) {
 }
 
 // isPotentialTrojan returns true if the given chunk could be trojan
-func isPotentialTrojan(c chunk.Chunk, t chunk.Type) bool {
-	if t != chunk.ContentAddressed { // chunk must be of the content-addressed type
+func isPotentialTrojan(c chunk.Chunk) bool {
+	if c.Type() != chunk.ContentAddressed { // chunk must be of the content-addressed type
 		return false
 	}
 	// check for minimum chunk data length

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -111,12 +111,24 @@ func (p *Pss) Register(topic trojan.Topic, hndlr Handler) {
 }
 
 // Deliver allows unwrapping a chunk as a trojan message and calling its handler func based on its topic
-func (p *Pss) Deliver(c chunk.Chunk) {
-	m, _ := trojan.Unwrap(c)
-	h := p.getHandler(m.Topic)
-	if h != nil {
-		h(*m)
+func (p *Pss) Deliver(c chunk.Chunk, t chunk.Type) {
+	if isPotentialTrojan(c, t) {
+		m, _ := trojan.Unwrap(c) // if err occurs unwrapping, there will be no handler
+		h := p.getHandler(m.Topic)
+		if h != nil {
+			h(*m)
+		}
 	}
+}
+
+// isPotentialTrojan returns true if the given chunk could be trojan
+func isPotentialTrojan(c chunk.Chunk, t chunk.Type) bool {
+	if t != chunk.ContentAddressed { // chunk must be of the content-addressed type
+		return false
+	}
+	// check for minimum chunk data length
+	// span (8) + nonce (32) + length (2) + topic (32) = 74
+	return len(c.Data()) >= 74
 }
 
 // getHandler returns the Handler func registered in pss for the given topic

--- a/pss/pss.go
+++ b/pss/pss.go
@@ -112,7 +112,7 @@ func (p *Pss) Register(topic trojan.Topic, hndlr Handler) {
 
 // Deliver allows unwrapping a chunk as a trojan message and calling its handler func based on its topic
 func (p *Pss) Deliver(c chunk.Chunk) {
-	if trojan.Valid(c) {
+	if trojan.IsPotential(c) {
 		m, _ := trojan.Unwrap(c) // if err occurs unwrapping, there will be no handler
 		h := p.getHandler(m.Topic)
 		if h != nil {

--- a/pss/pss_test.go
+++ b/pss/pss_test.go
@@ -210,10 +210,12 @@ func TestDeliver(t *testing.T) {
 	// test chunk
 	target := trojan.Target([]byte{1}) // arbitrary test target
 	targets := trojan.Targets([]trojan.Target{target})
-	chunk, err := msg.Wrap(targets)
+	c, err := msg.Wrap(targets)
 	if err != nil {
 		t.Fatal(err)
 	}
+	// trojan chunk has its type set through the validator called by the store, so this needs to be simulated
+	c.WithType(chunk.ContentAddressed)
 
 	// create and register handler
 	var tt trojan.Topic // test variable to check handler func was correctly called
@@ -223,7 +225,7 @@ func TestDeliver(t *testing.T) {
 	pss.Register(topic, hndlr)
 
 	// call pss Deliver on chunk and verify test topic variable value changes
-	pss.Deliver(chunk)
+	pss.Deliver(c)
 	if tt != msg.Topic {
 		t.Fatalf("unexpected result for pss Deliver func, expected test variable to have a value of %v but is %v instead", msg.Topic, tt)
 	}

--- a/pss/trojan/message.go
+++ b/pss/trojan/message.go
@@ -107,12 +107,7 @@ func (m *Message) Wrap(targets Targets) (chunk.Chunk, error) {
 	// 4064 bytes for trojan message + 32 bytes for nonce = 4096 bytes as payload for resulting chunk
 	binary.LittleEndian.PutUint64(span, chunk.DefaultSize)
 
-	c, err := m.toChunk(targets, span)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.WithType(chunk.ContentAddressed), nil
+	return m.toChunk(targets, span)
 }
 
 // Unwrap creates a new trojan message from the given chunk payload
@@ -129,9 +124,9 @@ func Unwrap(c chunk.Chunk) (*Message, error) {
 	return m, err
 }
 
-// Valid returns true if the given chunk could be trojan
+// Valid returns true if the given chunk is a potential trojan
 func Valid(c chunk.Chunk) bool {
-	if c.Type() != chunk.ContentAddressed { // chunk must be of the content-addressed type
+	if c.Type() != chunk.ContentAddressed {
 		return false
 	}
 	// check for minimum chunk data length

--- a/pss/trojan/message.go
+++ b/pss/trojan/message.go
@@ -107,12 +107,12 @@ func (m *Message) Wrap(targets Targets) (chunk.Chunk, error) {
 	// 4064 bytes for trojan message + 32 bytes for nonce = 4096 bytes as payload for resulting chunk
 	binary.LittleEndian.PutUint64(span, chunk.DefaultSize)
 
-	chunk, err := m.toChunk(targets, span)
+	c, err := m.toChunk(targets, span)
 	if err != nil {
 		return nil, err
 	}
 
-	return chunk, nil
+	return c.WithType(chunk.ContentAddressed), nil
 }
 
 // Unwrap creates a new trojan message from the given chunk payload

--- a/pss/trojan/message.go
+++ b/pss/trojan/message.go
@@ -140,11 +140,7 @@ func IsPotential(c chunk.Chunk) bool {
 
 	// check for valid trojan message length in bytes #41 and #42
 	messageLen := int(binary.BigEndian.Uint16(data[40:42]))
-	if 74+messageLen > len(data) {
-		return false
-	}
-
-	return true
+	return 74+messageLen <= len(data)
 }
 
 // checkTargets verifies that the list of given targets is non empty and with elements of matching size

--- a/pss/trojan/message.go
+++ b/pss/trojan/message.go
@@ -129,6 +129,16 @@ func Unwrap(c chunk.Chunk) (*Message, error) {
 	return m, err
 }
 
+// Valid returns true if the given chunk could be trojan
+func Valid(c chunk.Chunk) bool {
+	if c.Type() != chunk.ContentAddressed { // chunk must be of the content-addressed type
+		return false
+	}
+	// check for minimum chunk data length
+	// span (8) + nonce (32) + length (2) + topic (32) = 74
+	return len(c.Data()) >= 74
+}
+
 // checkTargets verifies that the list of given targets is non empty and with elements of matching size
 func checkTargets(targets Targets) error {
 	if len(targets) == 0 {

--- a/pss/trojan/message_test.go
+++ b/pss/trojan/message_test.go
@@ -201,7 +201,7 @@ func TestIsPotential(t *testing.T) {
 	length := len(c.Data()) - 73 // go 1 byte over the maximum allowed
 	lengthBuf := make([]byte, 2)
 	binary.BigEndian.PutUint16(lengthBuf, uint16(length))
-	// put into bytes #41 and #42
+	// put invalid length into bytes #41 and #42
 	copy(c.Data()[40:42], lengthBuf[:])
 	if IsPotential(c) {
 		t.Fatal("chunk with invalid trojan message length marked as potential trojan")

--- a/pss/trojan/message_test.go
+++ b/pss/trojan/message_test.go
@@ -186,25 +186,44 @@ func TestUnwrap(t *testing.T) {
 	}
 }
 
-// TestIsPotential tests if chunk are correctly interpreted as potentially trojan
+// TestIsPotential tests if chunks are correctly interpreted as potentially trojan
 func TestIsPotential(t *testing.T) {
 	c := chunktesting.GenerateTestRandomChunk()
 
 	// invalid type
 	c.WithType(chunk.Unknown)
 	if IsPotential(c) {
-		t.Fatal("non content-address chunk marked as potential trojan")
+		t.Fatal("non content-addressed chunk marked as potential trojan")
 	}
 
-	// correct type, but invalid length
+	// valid type, but invalid trojan message length
 	c.WithType(chunk.ContentAddressed)
-	length := len(c.Data()) + 1
+	length := len(c.Data()) - 73 // go 1 byte over the maximum allowed
 	lengthBuf := make([]byte, 2)
 	binary.BigEndian.PutUint16(lengthBuf, uint16(length))
 	// put into bytes #41 and #42
 	copy(c.Data()[40:42], lengthBuf[:])
 	if IsPotential(c) {
 		t.Fatal("chunk with invalid trojan message length marked as potential trojan")
+	}
+
+	// valid type, but invalid chunk data length
+	data := make([]byte, 10)
+	c = chunk.NewChunk(nil, data)
+	c.WithType(chunk.ContentAddressed)
+	if IsPotential(c) {
+		t.Fatal("chunk with invalid data length marked as potential trojan")
+	}
+
+	// valid potential trojan
+	m := newTestMessage(t)
+	c, err := m.Wrap(testTargets)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.WithType(chunk.ContentAddressed)
+	if !IsPotential(c) {
+		t.Fatal("valid test trojan chunk not marked as potential trojan")
 	}
 }
 

--- a/storage/feed/handler.go
+++ b/storage/feed/handler.go
@@ -26,7 +26,6 @@ import (
 	"sync/atomic"
 
 	"github.com/ethersphere/swarm/chunk"
-	c "github.com/ethersphere/swarm/chunk"
 	"github.com/ethersphere/swarm/log"
 	"github.com/ethersphere/swarm/storage"
 	"github.com/ethersphere/swarm/storage/feed/lookup"
@@ -88,9 +87,9 @@ func (h *Handler) SetStore(store *storage.NetStore) {
 // Validate is a chunk validation method
 // If it looks like a feed update, the chunk address is checked against the userAddr of the update's signature
 // It implements the storage.ChunkValidator interface
-func (h *Handler) Validate(chunk storage.Chunk) (bool, chunk.Type) {
+func (h *Handler) Validate(chunk storage.Chunk) bool {
 	if len(chunk.Data()) < minimumSignedUpdateLength {
-		return false, c.Unknown
+		return false
 	}
 
 	// check if it is a properly formatted update chunk with
@@ -101,7 +100,7 @@ func (h *Handler) Validate(chunk storage.Chunk) (bool, chunk.Type) {
 	var r Request
 	if err := r.fromChunk(chunk); err != nil {
 		log.Debug("Invalid feed update chunk", "addr", chunk.Address(), "err", err)
-		return false, c.Unknown
+		return false
 	}
 
 	// Verify signatures and that the signer actually owns the feed
@@ -109,10 +108,10 @@ func (h *Handler) Validate(chunk storage.Chunk) (bool, chunk.Type) {
 	// or someone is trying to update someone else's feed.
 	if err := r.Verify(); err != nil {
 		log.Debug("Invalid feed update signature", "err", err)
-		return false, c.Unknown
+		return false
 	}
 
-	return true, c.Other
+	return true
 }
 
 // GetContent retrieves the data payload of the last synced update of the feed

--- a/storage/feed/handler.go
+++ b/storage/feed/handler.go
@@ -114,6 +114,11 @@ func (h *Handler) Validate(chunk storage.Chunk) bool {
 	return true
 }
 
+// Type returns the feed chunk type
+func (h *Handler) Type() chunk.Type {
+	return chunk.Feed
+}
+
 // GetContent retrieves the data payload of the last synced update of the feed
 func (h *Handler) GetContent(feed *Feed) (storage.Address, []byte, error) {
 	if feed == nil {

--- a/storage/feed/handler_test.go
+++ b/storage/feed/handler_test.go
@@ -364,7 +364,7 @@ func TestValidator(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if valid, _ := rh.Validate(chunk); !valid {
+	if !rh.Validate(chunk) {
 		t.Fatal("Chunk validator fail on update chunk")
 	}
 
@@ -373,7 +373,7 @@ func TestValidator(t *testing.T) {
 	address[0] = 11
 	address[15] = 99
 
-	if valid, _ := rh.Validate(storage.NewChunk(address, chunk.Data())); valid {
+	if rh.Validate(storage.NewChunk(address, chunk.Data())) {
 		t.Fatal("Expected Validate to fail with false chunk address")
 	}
 }

--- a/storage/types.go
+++ b/storage/types.go
@@ -195,11 +195,11 @@ func NewContentAddressValidator(hasher SwarmHasher) *ContentAddressValidator {
 }
 
 // Validate that the given key is a valid content address for the given data
-func (v *ContentAddressValidator) Validate(ch Chunk) (bool, chunk.Type) {
+func (v *ContentAddressValidator) Validate(ch Chunk) bool {
 	data := ch.Data()
 	if l := len(data); l < 9 || l > chunk.DefaultSize+8 {
 		// log.Error("invalid chunk size", "chunk", addr.Hex(), "size", l)
-		return false, chunk.Unknown
+		return false
 	}
 
 	hasher := v.Hasher()
@@ -208,7 +208,11 @@ func (v *ContentAddressValidator) Validate(ch Chunk) (bool, chunk.Type) {
 	hasher.Write(data[8:])
 	hash := hasher.Sum(nil)
 
-	return bytes.Equal(hash, ch.Address()), chunk.ContentAddressed
+	valid := bytes.Equal(hash, ch.Address())
+	if valid {
+		ch.WithType(chunk.ContentAddressed)
+	}
+	return valid
 }
 
 type ChunkStore = chunk.Store

--- a/storage/types.go
+++ b/storage/types.go
@@ -215,6 +215,11 @@ func (v *ContentAddressValidator) Validate(ch Chunk) bool {
 	return valid
 }
 
+// Type returns the content addressed chunk type
+func (v *ContentAddressValidator) Type() chunk.Type {
+	return chunk.ContentAddressed
+}
+
 type ChunkStore = chunk.Store
 
 // FakeChunkStore doesn't store anything, just implements the ChunkStore interface

--- a/storage/types.go
+++ b/storage/types.go
@@ -208,11 +208,7 @@ func (v *ContentAddressValidator) Validate(ch Chunk) bool {
 	hasher.Write(data[8:])
 	hash := hasher.Sum(nil)
 
-	valid := bytes.Equal(hash, ch.Address())
-	if valid {
-		ch.WithType(chunk.ContentAddressed)
-	}
-	return valid
+	return bytes.Equal(hash, ch.Address())
 }
 
 // Type returns the content addressed chunk type


### PR DESCRIPTION
This PR attempts to solve issue #2163, which is about **restricting trojan chunk inspection**.

The issue was re-opened since the original solution (#2191) was not enough to stop nodes from `panic`ing once we enabled push-sync in the global pinning tests and executed trojan inspection on received chunks.

### Implementation
This PR rolls back part of the solution implemented in #2191, which changed the `Validate` interface to not only return a `bool` indicating validity, but also a `chunk.Type`-typed var.

The chunk type now needs to reach the `pss` package to properly restrict trojan inspection, and it's just not a clean design to pass it around as a parameter across 3 packages. Instead, the chunks should know their own type.

With this in mind, this PR:
- adds the `chunkType` field to the `chunk` struct (with its getter/setter-type funcs)—the word `chunk` is redundant in this field, but `type` is a reserved word, and I think `cType` might be too vague.
- adds the `Type` func to the `Validator` interface, which should return a fixed `chunk.Type`.
- adds logic to set the `chunkType` field for each valid chunk during `ValidatorStore.validate`.  The type set is the one returned by the `Type` func of the validator which declared the chunk as valid.
- adds the `IsPotential` func to the `trojan` package, which checks the conditions that are necessary (but not sufficient) for a chunk to be trojan.
  - `pss.Deliver` will call this func before attempting to unwrap a chunk.
  -  the`TestIsPotential`  func was added to the trojan package.
- cleans up `ValidatorStore.Put`—there is no longer a need to keep track of chunk types in separate variables.

### False positives
Having `chunk.IsPotential` return `true` on a given chunk **does not necessarily mean** it contains a valid trojan message. There _can_ be content-addressed chunks with the minimum `Data()` length, plus an apparently sensical trojan message length encoded in the data, but still not actually be trojan.

What will happen with these "false positives" is that they will be correctly unwrapped, but its trojan message `Topic` and `Payload` will most likely be garbage: "regular" data bytes which are not meant to be a trojan message.

closes #2163
