### PR TITLE
api,client,http,main,prod,storage: Add query param for publisher and solve flooding in recovery

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -424,9 +424,6 @@ func (a *API) Get(ctx context.Context, decrypt DecryptFunc, manifestAddr storage
 		}
 		mimeType = entry.ContentType
 		log.Debug("content lookup key", "key", contentAddr, "mimetype", mimeType)
-		if len(entry.Publisher) > 0 {
-			ctx = context.WithValue(ctx, "publisher", entry.Publisher)
-		}
 		reader, _ = a.fileStore.Retrieve(ctx, contentAddr)
 	} else {
 		// no entry found
@@ -632,12 +629,10 @@ func (a *API) Modify(ctx context.Context, addr storage.Address, path, contentHas
 		apiModifyFail.Inc(1)
 		return nil, err
 	}
-	publisher, _ := ctx.Value("publisher").(string)
 	if contentHash != "" {
 		entry := newManifestTrieEntry(&ManifestEntry{
 			Path:        path,
 			ContentType: contentType,
-			Publisher:   publisher,
 		}, nil)
 		entry.Hash = contentHash
 		trie.addEntry(entry, quitC)
@@ -672,14 +667,12 @@ func (a *API) AddFile(ctx context.Context, mhash, path, fname string, content []
 		path = path[1:]
 	}
 
-	publisher, _ := ctx.Value("publisher").(string)
 	entry := &ManifestEntry{
 		Path:        filepath.Join(path, fname),
 		ContentType: mime.TypeByExtension(filepath.Ext(fname)),
 		Mode:        0700,
 		Size:        int64(len(content)),
 		ModTime:     time.Now(),
-		Publisher:   publisher,
 	}
 
 	mw, err := a.NewManifestWriter(ctx, mkey, nil)
@@ -704,7 +697,7 @@ func (a *API) AddFile(ctx context.Context, mhash, path, fname string, content []
 	return fkey, newMkey.String(), nil
 }
 
-func (a *API) UploadTar(ctx context.Context, bodyReader io.ReadCloser, manifestPath, defaultPath string, mw *ManifestWriter, publisher string) (storage.Address, error) {
+func (a *API) UploadTar(ctx context.Context, bodyReader io.ReadCloser, manifestPath, defaultPath string, mw *ManifestWriter) (storage.Address, error) {
 	apiUploadTarCount.Inc(1)
 	var contentKey storage.Address
 	tr := tar.NewReader(bodyReader)
@@ -737,7 +730,6 @@ func (a *API) UploadTar(ctx context.Context, bodyReader io.ReadCloser, manifestP
 			Mode:        hdr.Mode,
 			Size:        hdr.Size,
 			ModTime:     hdr.ModTime,
-			Publisher:   publisher,
 		}
 		contentKey, err = mw.AddEntry(ctx, tr, entry)
 		if err != nil {
@@ -756,7 +748,6 @@ func (a *API) UploadTar(ctx context.Context, bodyReader io.ReadCloser, manifestP
 				Mode:        hdr.Mode,
 				Size:        hdr.Size,
 				ModTime:     hdr.ModTime,
-				Publisher:   publisher,
 			}
 			contentKey, err = mw.AddEntry(ctx, nil, entry)
 			if err != nil {
@@ -871,14 +862,12 @@ func (a *API) AppendFile(ctx context.Context, mhash, path, fname string, existin
 		return nil, "", err
 	}
 
-	publisher, _ := ctx.Value("publisher").(string)
 	entry := &ManifestEntry{
 		Path:        filepath.Join(path, fname),
 		ContentType: mime.TypeByExtension(filepath.Ext(fname)),
 		Mode:        0700,
 		Size:        totalSize,
 		ModTime:     time.Now(),
-		Publisher:   publisher,
 	}
 
 	fkey, err := mw.AddEntry(ctx, io.Reader(combinedReader), entry)

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -217,7 +217,7 @@ func (c *Client) UploadDirectory(dir, defaultPath, manifest string, toEncrypt, t
 
 // DownloadDirectory downloads the files contained in a swarm manifest under
 // the given path into a local directory (existing files will be overwritten)
-func (c *Client) DownloadDirectory(hash, path, destDir, credentials string) error {
+func (c *Client) DownloadDirectory(hash, path, destDir, credentials, publisher string) error {
 	stat, err := os.Stat(destDir)
 	if err != nil {
 		return err
@@ -226,6 +226,9 @@ func (c *Client) DownloadDirectory(hash, path, destDir, credentials string) erro
 	}
 
 	uri := c.Gateway + "/bzz:/" + hash + "/" + path
+	if publisher != "" {
+		uri = uri + "?publisher=" + publisher
+	}
 	req, err := http.NewRequest("GET", uri, nil)
 	if err != nil {
 		return err
@@ -284,7 +287,7 @@ func (c *Client) DownloadDirectory(hash, path, destDir, credentials string) erro
 // DownloadFile downloads a single file into the destination directory
 // if the manifest entry does not specify a file name - it will fallback
 // to the hash of the file as a filename
-func (c *Client) DownloadFile(hash, path, dest, credentials string) error {
+func (c *Client) DownloadFile(hash, path, dest, credentials, publisher string) error {
 	hasDestinationFilename := false
 	if stat, err := os.Stat(dest); err == nil {
 		hasDestinationFilename = !stat.IsDir()
@@ -312,6 +315,9 @@ func (c *Client) DownloadFile(hash, path, dest, credentials string) error {
 	}
 
 	uri := c.Gateway + "/bzz:/" + hash + "/" + path
+	if publisher != "" {
+		uri = uri + "?publisher=" + publisher
+	}
 	req, err := http.NewRequest("GET", uri, nil)
 	if err != nil {
 		return err

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -226,10 +226,8 @@ func (c *Client) DownloadDirectory(hash, path, destDir, credentials, publisher s
 	}
 
 	uri := c.Gateway + "/bzz:/" + hash + "/" + path
-	if publisher != "" {
-		uri += "?publisher=" + publisher
-	}
 	req, err := http.NewRequest("GET", uri, nil)
+	req.URL.Query().Add("publisher", publisher)
 	if err != nil {
 		return err
 	}
@@ -315,10 +313,8 @@ func (c *Client) DownloadFile(hash, path, dest, credentials, publisher string) e
 	}
 
 	uri := c.Gateway + "/bzz:/" + hash + "/" + path
-	if publisher != "" {
-		uri += "?publisher=" + publisher
-	}
 	req, err := http.NewRequest("GET", uri, nil)
+	req.URL.Query().Add("publisher", publisher)
 	if err != nil {
 		return err
 	}
@@ -418,10 +414,8 @@ func (c *Client) DownloadManifest(hash string) (*api.Manifest, bool, error) {
 // where entries ending with "/" are common prefixes.
 func (c *Client) List(hash, prefix, credentials, publisher string) (*api.ManifestList, error) {
 	uri := c.Gateway + "/bzz-list:/" + hash + "/" + prefix
-	if publisher != "" {
-		uri = uri + "?publisher=" + publisher
-	}
 	req, err := http.NewRequest(http.MethodGet, uri, nil)
+	req.URL.Query().Add("publisher", publisher)
 	if err != nil {
 		return nil, err
 	}

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -302,7 +302,7 @@ func (c *Client) DownloadFile(hash, path, dest, credentials, publisher string) e
 		}
 	}
 
-	manifestList, err := c.List(hash, path, credentials)
+	manifestList, err := c.List(hash, path, credentials, publisher)
 	if err != nil {
 		return err
 	}
@@ -418,8 +418,12 @@ func (c *Client) DownloadManifest(hash string) (*api.Manifest, bool, error) {
 // - a prefix of "dir1/" would return [dir1/dir2/, dir1/file3.txt]
 //
 // where entries ending with "/" are common prefixes.
-func (c *Client) List(hash, prefix, credentials string) (*api.ManifestList, error) {
-	req, err := http.NewRequest(http.MethodGet, c.Gateway+"/bzz-list:/"+hash+"/"+prefix, nil)
+func (c *Client) List(hash, prefix, credentials, publisher string) (*api.ManifestList, error) {
+	uri := c.Gateway + "/bzz-list:/" + hash + "/" + prefix
+	if publisher != "" {
+		uri = uri + "?publisher=" + publisher
+	}
+	req, err := http.NewRequest(http.MethodGet, uri, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -218,7 +218,6 @@ func (c *Client) UploadDirectory(dir, defaultPath, manifest string, toEncrypt, t
 // DownloadDirectory downloads the files contained in a swarm manifest under
 // the given path into a local directory (existing files will be overwritten)
 func (c *Client) DownloadDirectory(hash, path, destDir, credentials, publisher string) error {
-	log.Debug("DownloadDirectory", "publisher", publisher)
 	stat, err := os.Stat(destDir)
 	if err != nil {
 		return err
@@ -228,7 +227,7 @@ func (c *Client) DownloadDirectory(hash, path, destDir, credentials, publisher s
 
 	uri := c.Gateway + "/bzz:/" + hash + "/" + path
 	if publisher != "" {
-		uri = uri + "?publisher=" + publisher
+		uri += "?publisher=" + publisher
 	}
 	req, err := http.NewRequest("GET", uri, nil)
 	if err != nil {
@@ -289,7 +288,6 @@ func (c *Client) DownloadDirectory(hash, path, destDir, credentials, publisher s
 // if the manifest entry does not specify a file name - it will fallback
 // to the hash of the file as a filename
 func (c *Client) DownloadFile(hash, path, dest, credentials, publisher string) error {
-	log.Debug("DownloadFile", "publisher", publisher)
 	hasDestinationFilename := false
 	if stat, err := os.Stat(dest); err == nil {
 		hasDestinationFilename = !stat.IsDir()
@@ -318,7 +316,7 @@ func (c *Client) DownloadFile(hash, path, dest, credentials, publisher string) e
 
 	uri := c.Gateway + "/bzz:/" + hash + "/" + path
 	if publisher != "" {
-		uri = uri + "?publisher=" + publisher
+		uri += "?publisher=" + publisher
 	}
 	req, err := http.NewRequest("GET", uri, nil)
 	if err != nil {

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -227,7 +227,9 @@ func (c *Client) DownloadDirectory(hash, path, destDir, credentials, publisher s
 
 	uri := c.Gateway + "/bzz:/" + hash + "/" + path
 	req, err := http.NewRequest("GET", uri, nil)
-	req.URL.Query().Add("publisher", publisher)
+	values := req.URL.Query()
+	values.Add("publisher", publisher)
+	req.URL.RawQuery = values.Encode()
 	if err != nil {
 		return err
 	}
@@ -314,7 +316,9 @@ func (c *Client) DownloadFile(hash, path, dest, credentials, publisher string) e
 
 	uri := c.Gateway + "/bzz:/" + hash + "/" + path
 	req, err := http.NewRequest("GET", uri, nil)
-	req.URL.Query().Add("publisher", publisher)
+	values := req.URL.Query()
+	values.Add("publisher", publisher)
+	req.URL.RawQuery = values.Encode()
 	if err != nil {
 		return err
 	}
@@ -415,7 +419,9 @@ func (c *Client) DownloadManifest(hash string) (*api.Manifest, bool, error) {
 func (c *Client) List(hash, prefix, credentials, publisher string) (*api.ManifestList, error) {
 	uri := c.Gateway + "/bzz-list:/" + hash + "/" + prefix
 	req, err := http.NewRequest(http.MethodGet, uri, nil)
-	req.URL.Query().Add("publisher", publisher)
+	values := req.URL.Query()
+	values.Add("publisher", publisher)
+	req.URL.RawQuery = values.Encode()
 	if err != nil {
 		return nil, err
 	}

--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -295,7 +295,7 @@ func testClientFileList(toEncrypt bool, t *testing.T) {
 	}
 
 	ls := func(prefix string) []string {
-		list, err := client.List(hash, prefix, "")
+		list, err := client.List(hash, prefix, "", "")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -125,7 +125,7 @@ func testClientUploadDownloadFiles(toEncrypt bool, t *testing.T) string {
 				Size:        int64(len(data)),
 			},
 		}
-		hash, err := client.Upload(file, manifest, toEncrypt, toPin, true, "")
+		hash, err := client.Upload(file, manifest, toEncrypt, toPin, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -221,7 +221,7 @@ func TestClientUploadDownloadDirectory(t *testing.T) {
 	// upload the directory
 	client := NewClient(srv.URL)
 	defaultPath := testDirFiles[0]
-	hash, err := client.UploadDirectory(dir, defaultPath, "", false, false, true, "")
+	hash, err := client.UploadDirectory(dir, defaultPath, "", false, false, true)
 	if err != nil {
 		t.Fatalf("error uploading directory: %s", err)
 	}
@@ -289,7 +289,7 @@ func testClientFileList(toEncrypt bool, t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	client := NewClient(srv.URL)
-	hash, err := client.UploadDirectory(dir, "", "", toEncrypt, false, true, "")
+	hash, err := client.UploadDirectory(dir, "", "", toEncrypt, false, true)
 	if err != nil {
 		t.Fatalf("error uploading directory: %s", err)
 	}
@@ -475,7 +475,7 @@ func TestClientBzzWithFeed(t *testing.T) {
 	}
 
 	// upload data to bzz:// and retrieve the content-addressed manifest hash, hex-encoded.
-	manifestAddressHex, err := swarmClient.Upload(f, "", false, false, true, "")
+	manifestAddressHex, err := swarmClient.Upload(f, "", false, false, true)
 	if err != nil {
 		t.Fatalf("Error creating manifest: %s", err)
 	}

--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -258,7 +258,7 @@ func TestClientUploadDownloadDirectory(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmp)
-	if err := client.DownloadDirectory(hash, "", tmp, ""); err != nil {
+	if err := client.DownloadDirectory(hash, "", tmp, "", ""); err != nil {
 		t.Fatal(err)
 	}
 	for _, file := range testDirFiles {

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -241,7 +241,6 @@ type Server struct {
 func (s *Server) HandleBzzGet(w http.ResponseWriter, r *http.Request) {
 	log.Debug("handleBzzGet", "ruid", GetRUID(r.Context()), "uri", r.RequestURI)
 	publisher := r.URL.Query().Get("publisher")
-	log.Debug("handleBzzGet", "publisher", publisher)
 	r = r.WithContext(context.WithValue(r.Context(), "publisher", publisher))
 	if r.Header.Get("Accept") == tarContentType {
 		uri := GetURI(r.Context())
@@ -840,7 +839,6 @@ func (s *Server) HandleGet(w http.ResponseWriter, r *http.Request) {
 // common prefixes using "/" as a delimiter
 func (s *Server) HandleGetList(w http.ResponseWriter, r *http.Request) {
 	publisher := r.URL.Query().Get("publisher")
-	log.Debug("handleBzzGet", "publisher", publisher)
 	r = r.WithContext(context.WithValue(r.Context(), "publisher", publisher))
 	ruid := GetRUID(r.Context())
 	uri := GetURI(r.Context())

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -839,6 +839,9 @@ func (s *Server) HandleGet(w http.ResponseWriter, r *http.Request) {
 // a list of all files contained in <manifest> under <path> grouped into
 // common prefixes using "/" as a delimiter
 func (s *Server) HandleGetList(w http.ResponseWriter, r *http.Request) {
+	publisher := r.URL.Query().Get("publisher")
+	log.Debug("handleBzzGet", "publisher", publisher)
+	r = r.WithContext(context.WithValue(r.Context(), "publisher", publisher))
 	ruid := GetRUID(r.Context())
 	uri := GetURI(r.Context())
 	_, credentials, _ := r.BasicAuth()

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -21,6 +21,7 @@ package http
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -239,6 +240,9 @@ type Server struct {
 
 func (s *Server) HandleBzzGet(w http.ResponseWriter, r *http.Request) {
 	log.Debug("handleBzzGet", "ruid", GetRUID(r.Context()), "uri", r.RequestURI)
+	publisher := r.URL.Query().Get("publisher")
+	log.Debug("handleBzzGet", "publisher", publisher)
+	r = r.WithContext(context.WithValue(r.Context(), "publisher", publisher))
 	if r.Header.Get("Accept") == tarContentType {
 		uri := GetURI(r.Context())
 		_, credentials, _ := r.BasicAuth()

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -83,7 +83,7 @@ const (
 
 	encryptAddr           = "encrypt"
 	tarContentType        = "application/x-tar"
-	StatusRecoveryAttempt = 420
+	StatusEnhanceYourCalm = 420
 )
 
 type methodHandler map[string]http.Handler
@@ -255,7 +255,7 @@ func (s *Server) HandleBzzGet(w http.ResponseWriter, r *http.Request) {
 			}
 			if isRecoveryAttemptError(err) {
 				w.Header().Set("WWW-Authenticate", fmt.Sprintf("Basic realm=%q", uri.Address().String()))
-				respondError(w, r, err.Error(), StatusRecoveryAttempt)
+				respondError(w, r, err.Error(), StatusEnhanceYourCalm)
 				return
 			}
 			respondError(w, r, fmt.Sprintf("Had an error building the tarball: %v", err), http.StatusInternalServerError)
@@ -876,7 +876,7 @@ func (s *Server) HandleGetList(w http.ResponseWriter, r *http.Request) {
 		}
 		if isRecoveryAttemptError(err) {
 			w.Header().Set("WWW-Authenticate", fmt.Sprintf("Basic realm=%q", addr.String()))
-			respondError(w, r, err.Error(), StatusRecoveryAttempt)
+			respondError(w, r, err.Error(), StatusEnhanceYourCalm)
 			return
 		}
 		respondError(w, r, err.Error(), http.StatusInternalServerError)
@@ -956,7 +956,7 @@ func (s *Server) HandleGetFile(w http.ResponseWriter, r *http.Request) {
 		}
 		if isRecoveryAttemptError(err) {
 			w.Header().Set("WWW-Authenticate", fmt.Sprintf("Basic realm=%q", manifestAddr))
-			respondError(w, r, err.Error(), StatusRecoveryAttempt)
+			respondError(w, r, err.Error(), StatusEnhanceYourCalm)
 			return
 		}
 

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -875,6 +875,11 @@ func (s *Server) HandleGetList(w http.ResponseWriter, r *http.Request) {
 			respondError(w, r, err.Error(), http.StatusUnauthorized)
 			return
 		}
+		if isRecoveryAttemptError(err) {
+			w.Header().Set("WWW-Authenticate", fmt.Sprintf("Basic realm=%q", uri.Address().String()))
+			respondError(w, r, err.Error(), http.StatusPaymentRequired)
+			return
+		}
 		respondError(w, r, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -954,6 +954,11 @@ func (s *Server) HandleGetFile(w http.ResponseWriter, r *http.Request) {
 			respondError(w, r, err.Error(), http.StatusUnauthorized)
 			return
 		}
+		if isRecoveryAttemptError(err) {
+			w.Header().Set("WWW-Authenticate", fmt.Sprintf("Basic realm=%q", manifestAddr))
+			respondError(w, r, err.Error(), StatusRecoveryAttempt)
+			return
+		}
 
 		switch status {
 		case http.StatusNotFound:

--- a/api/http/server.go
+++ b/api/http/server.go
@@ -472,12 +472,8 @@ func (s *Server) handleTarUpload(r *http.Request, mw *api.ManifestWriter) (stora
 	log.Debug("handle.tar.upload", "ruid", GetRUID(r.Context()), "tag", sctx.GetTag(r.Context()))
 
 	defaultPath := r.URL.Query().Get("defaultpath")
-	var publisher string
-	if len(r.Header["Publisher"]) > 0 {
-		publisher = r.Header["Publisher"][0]
-	}
 
-	key, err := s.api.UploadTar(r.Context(), r.Body, GetURI(r.Context()).Path, defaultPath, mw, publisher)
+	key, err := s.api.UploadTar(r.Context(), r.Body, GetURI(r.Context()).Path, defaultPath, mw)
 	if err != nil {
 		return nil, err
 	}

--- a/api/manifest.go
+++ b/api/manifest.go
@@ -242,7 +242,6 @@ func readManifest(mr storage.LazySectionReader, addr storage.Address, fileStore 
 	if err != nil { // size == 0
 		// can't determine size means we don't have the root chunk
 		log.Trace("manifest not found", "addr", addr)
-		err = fmt.Errorf("Manifest not Found")
 		return
 	}
 	if size > manifestSizeLimit {

--- a/api/manifest.go
+++ b/api/manifest.go
@@ -57,7 +57,6 @@ type ManifestEntry struct {
 	Status      int          `json:"status,omitempty"`
 	Access      *AccessEntry `json:"access,omitempty"`
 	Feed        *feed.Feed   `json:"feed,omitempty"`
-	Publisher   string       `json:"publisher,omitempty"`
 }
 
 // ManifestList represents the result of listing files in a manifest

--- a/cmd/swarm-smoke/util.go
+++ b/cmd/swarm-smoke/util.go
@@ -212,7 +212,7 @@ func uploadWithTag(data []byte, endpoint string, tag string) (string, error) {
 		Tag: tag,
 	}
 
-	return swarm.TarUpload("", &client.FileUploader{File: f}, "", false, false, true, "")
+	return swarm.TarUpload("", &client.FileUploader{File: f}, "", false, false, true)
 }
 
 func digest(r io.Reader) ([]byte, error) {

--- a/cmd/swarm/download.go
+++ b/cmd/swarm/download.go
@@ -31,7 +31,7 @@ import (
 var downloadCommand = cli.Command{
 	Action:      download,
 	Name:        "down",
-	Flags:       []cli.Flag{SwarmRecursiveFlag, SwarmAccessPasswordFlag},
+	Flags:       []cli.Flag{SwarmRecursiveFlag, SwarmAccessPasswordFlag, SwarmPublisher},
 	Usage:       "downloads a swarm manifest or a file inside a manifest",
 	ArgsUsage:   " <uri> [<dir>]",
 	Description: `Downloads a swarm bzz uri to the given dir. When no dir is provided, working directory is assumed. --recursive flag is expected when downloading a manifest with multiple entries.`,
@@ -60,6 +60,7 @@ func download(ctx *cli.Context) {
 		bzzapi      = strings.TrimRight(ctx.GlobalString(SwarmApiFlag.Name), "/")
 		isRecursive = ctx.Bool(SwarmRecursiveFlag.Name)
 		client      = swarm.NewClient(bzzapi)
+		publisher   = ctx.String(SwarmPublisher.Name)
 	)
 
 	if fi, err := os.Stat(dest); err == nil {
@@ -80,7 +81,7 @@ func download(ctx *cli.Context) {
 	dl := func(credentials string) error {
 		// assume behaviour according to --recursive switch
 		if isRecursive {
-			if err := client.DownloadDirectory(uri.Addr, uri.Path, dest, credentials); err != nil {
+			if err := client.DownloadDirectory(uri.Addr, uri.Path, dest, credentials, publisher); err != nil {
 				if err == swarm.ErrUnauthorized {
 					return err
 				}
@@ -90,7 +91,7 @@ func download(ctx *cli.Context) {
 			// we are downloading a file
 			log.Debug("downloading file/path from a manifest", "uri.Addr", uri.Addr, "uri.Path", uri.Path)
 
-			err := client.DownloadFile(uri.Addr, uri.Path, dest, credentials)
+			err := client.DownloadFile(uri.Addr, uri.Path, dest, credentials, publisher)
 			if err != nil {
 				if err == swarm.ErrUnauthorized {
 					return err

--- a/cmd/swarm/download.go
+++ b/cmd/swarm/download.go
@@ -77,6 +77,8 @@ func download(ctx *cli.Context) {
 	if err != nil {
 		utils.Fatalf("could not parse uri argument: %v", err)
 	}
+	log.Error("uri address", "address", uri.Addr)
+	log.Error("uri publisher", "publisher", publisher)
 
 	dl := func(credentials string) error {
 		// assume behaviour according to --recursive switch

--- a/cmd/swarm/download.go
+++ b/cmd/swarm/download.go
@@ -77,8 +77,6 @@ func download(ctx *cli.Context) {
 	if err != nil {
 		utils.Fatalf("could not parse uri argument: %v", err)
 	}
-	log.Debug("uri address", "address", uri.Addr)
-	log.Debug("uri publisher", "publisher", publisher)
 
 	dl := func(credentials string) error {
 		// assume behaviour according to --recursive switch

--- a/cmd/swarm/download.go
+++ b/cmd/swarm/download.go
@@ -77,8 +77,8 @@ func download(ctx *cli.Context) {
 	if err != nil {
 		utils.Fatalf("could not parse uri argument: %v", err)
 	}
-	log.Error("uri address", "address", uri.Addr)
-	log.Error("uri publisher", "publisher", publisher)
+	log.Debug("uri address", "address", uri.Addr)
+	log.Debug("uri publisher", "publisher", publisher)
 
 	dl := func(credentials string) error {
 		// assume behaviour according to --recursive switch

--- a/cmd/swarm/flags.go
+++ b/cmd/swarm/flags.go
@@ -158,10 +158,6 @@ var (
 		Name:  "stdin",
 		Usage: "reads data to be uploaded from stdin",
 	}
-	SwarmUploadPublisher = cli.StringFlag{
-		Name:  "publisher",
-		Usage: "Manually specify Publisher",
-	}
 	SwarmUploadMimeType = cli.StringFlag{
 		Name:  "mime",
 		Usage: "Manually specify MIME type",

--- a/cmd/swarm/flags.go
+++ b/cmd/swarm/flags.go
@@ -269,4 +269,8 @@ var (
 		Name:  "block-profile",
 		Usage: "Enable pprof block profile",
 	}
+	SwarmPublisher = cli.StringFlag{
+		Name:  "publisher",
+		Usage: "Manually specify Publisher",
+	}
 )

--- a/cmd/swarm/flags.go
+++ b/cmd/swarm/flags.go
@@ -267,6 +267,6 @@ var (
 	}
 	SwarmPublisher = cli.StringFlag{
 		Name:  "publisher",
-		Usage: "Manually specify Publisher",
+		Usage: "Manually specify content recovery publisher for a hash",
 	}
 )

--- a/cmd/swarm/flags.go
+++ b/cmd/swarm/flags.go
@@ -267,6 +267,6 @@ var (
 	}
 	SwarmPublisher = cli.StringFlag{
 		Name:  "publisher",
-		Usage: "Manually specify content recovery publisher for a hash",
+		Usage: "Manually specify content recovery publisher",
 	}
 )

--- a/cmd/swarm/list.go
+++ b/cmd/swarm/list.go
@@ -53,7 +53,7 @@ func list(ctx *cli.Context) {
 
 	bzzapi := strings.TrimRight(ctx.GlobalString(SwarmApiFlag.Name), "/")
 	client := swarm.NewClient(bzzapi)
-	list, err := client.List(manifest, prefix, "")
+	list, err := client.List(manifest, prefix, "", "")
 	if err != nil {
 		utils.Fatalf("Failed to generate file and directory list: %s", err)
 	}

--- a/cmd/swarm/upload.go
+++ b/cmd/swarm/upload.go
@@ -48,7 +48,7 @@ var (
 		Name:               "up",
 		Usage:              "uploads a file or directory to swarm using the HTTP API",
 		ArgsUsage:          "<file>",
-		Flags:              []cli.Flag{SwarmEncryptedFlag, SwarmPinFlag, SwarmProgressFlag, SwarmVerboseFlag, SwarmUploadPublisher},
+		Flags:              []cli.Flag{SwarmEncryptedFlag, SwarmPinFlag, SwarmProgressFlag, SwarmVerboseFlag},
 		Description:        "uploads a file or directory to swarm using the HTTP API and prints the root hash",
 	}
 
@@ -73,7 +73,6 @@ func upload(ctx *cli.Context) {
 		defaultPath     = ctx.GlobalString(SwarmUploadDefaultPath.Name)
 		fromStdin       = ctx.GlobalBool(SwarmUpFromStdinFlag.Name)
 		mimeType        = ctx.GlobalString(SwarmUploadMimeType.Name)
-		publisher       = ctx.String(SwarmUploadPublisher.Name)
 		verbose         = ctx.Bool(SwarmVerboseFlag.Name)
 		client          = swarm.NewClient(bzzapi)
 		toEncrypt       = ctx.Bool(SwarmEncryptedFlag.Name)
@@ -161,7 +160,7 @@ func upload(ctx *cli.Context) {
 					defaultPath = strings.TrimPrefix(absDefaultPath, absFile)
 				}
 			}
-			return client.UploadDirectory(file, defaultPath, "", toEncrypt, toPin, anon, publisher)
+			return client.UploadDirectory(file, defaultPath, "", toEncrypt, toPin, anon)
 		}
 	} else {
 		doUpload = func() (string, error) {
@@ -173,7 +172,7 @@ func upload(ctx *cli.Context) {
 			if mimeType != "" {
 				f.ContentType = mimeType
 			}
-			return client.Upload(f, "", toEncrypt, toPin, anon, publisher)
+			return client.Upload(f, "", toEncrypt, toPin, anon)
 		}
 	}
 	start := time.Now()

--- a/prod/prod.go
+++ b/prod/prod.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethersphere/swarm/chunk"
-	"github.com/ethersphere/swarm/log"
 	"github.com/ethersphere/swarm/pss"
 	"github.com/ethersphere/swarm/pss/trojan"
 	"github.com/ethersphere/swarm/storage/feed"
@@ -85,7 +84,6 @@ func NewRepairHandler(s *chunk.ValidatorStore) pss.Handler {
 // getPinners returns the specific target pinners for a corresponding chunk
 func getPinners(ctx context.Context, handler feed.GenericHandler) (trojan.Targets, error) {
 	publisher, _ := ctx.Value("publisher").(string)
-	log.Debug("gp getPinners", "publisher", publisher)
 
 	// query feed using recovery topic and publisher
 	feedContent, err := queryRecoveryFeed(ctx, RecoveryTopicText, publisher, handler)

--- a/prod/prod.go
+++ b/prod/prod.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethersphere/swarm/chunk"
+	"github.com/ethersphere/swarm/log"
 	"github.com/ethersphere/swarm/pss"
 	"github.com/ethersphere/swarm/pss/trojan"
 	"github.com/ethersphere/swarm/storage/feed"
@@ -84,6 +85,8 @@ func NewRepairHandler(s *chunk.ValidatorStore) pss.Handler {
 // getPinners returns the specific target pinners for a corresponding chunk
 func getPinners(ctx context.Context, handler feed.GenericHandler) (trojan.Targets, error) {
 	publisher, _ := ctx.Value("publisher").(string)
+	// REMOVE THIS
+	log.Debug("gp getPinners", "publisher", publisher)
 
 	// query feed using recovery topic and publisher
 	feedContent, err := queryRecoveryFeed(ctx, RecoveryTopicText, publisher, handler)

--- a/prod/prod.go
+++ b/prod/prod.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethersphere/swarm/chunk"
@@ -132,8 +131,6 @@ func getFeedContent(ctx context.Context, handler feed.GenericHandler, topic feed
 		User:  user,
 	}
 	query := feed.NewQueryLatest(&fd, lookup.NoClue)
-	ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
-	defer cancel()
 
 	_, err := handler.Lookup(ctx, query)
 	// feed should still be queried even if there are no updates

--- a/prod/prod.go
+++ b/prod/prod.go
@@ -85,7 +85,6 @@ func NewRepairHandler(s *chunk.ValidatorStore) pss.Handler {
 // getPinners returns the specific target pinners for a corresponding chunk
 func getPinners(ctx context.Context, handler feed.GenericHandler) (trojan.Targets, error) {
 	publisher, _ := ctx.Value("publisher").(string)
-	// REMOVE THIS
 	log.Debug("gp getPinners", "publisher", publisher)
 
 	// query feed using recovery topic and publisher

--- a/storage/netstore.go
+++ b/storage/netstore.go
@@ -178,7 +178,7 @@ func (n *NetStore) Get(ctx context.Context, mode chunk.ModeGet, req *Request) (c
 	metrics.GetOrRegisterCounter("netstore/get", nil).Inc(1)
 	publisher, ok := ctx.Value("publisher").(string)
 	if ok {
-		log.Debug("api.get", "netstore publisher", publisher)
+		log.Debug("gp netstore.get", "netstore publisher", publisher)
 	}
 
 	start := time.Now()

--- a/storage/netstore.go
+++ b/storage/netstore.go
@@ -207,7 +207,7 @@ func (n *NetStore) Get(ctx context.Context, mode chunk.ModeGet, req *Request) (c
 				if err != nil {
 					if n.recoveryCallback != nil && publisher != "" {
 						log.Debug("content recovery callback triggered", "ref", ref.String())
-						n.recoveryCallback(ctx, ref)
+						go n.recoveryCallback(ctx, ref)
 						return nil, errors.New("recovery was initiated")
 					}
 					return nil, err

--- a/storage/netstore.go
+++ b/storage/netstore.go
@@ -178,7 +178,7 @@ func (n *NetStore) Get(ctx context.Context, mode chunk.ModeGet, req *Request) (c
 	metrics.GetOrRegisterCounter("netstore/get", nil).Inc(1)
 	publisher, ok := ctx.Value("publisher").(string)
 	if ok {
-		log.Debug("gp netstore.get", "netstore publisher", publisher)
+		log.Debug("netstore get publisher received", "publisher", publisher)
 	}
 
 	start := time.Now()
@@ -206,7 +206,7 @@ func (n *NetStore) Get(ctx context.Context, mode chunk.ModeGet, req *Request) (c
 				ch, err = n.RemoteFetch(ctx, req, fi)
 				if err != nil {
 					if n.recoveryCallback != nil && publisher != "" {
-						log.Debug("gp netstore recovery triggered")
+						log.Debug("content recovery callback triggered", "ref", ref.String())
 						n.recoveryCallback(ctx, ref)
 						time.Sleep(500 * time.Millisecond) // TODO: view what the ideal timeout is
 						return n.RemoteFetch(ctx, req, fi)

--- a/storage/netstore.go
+++ b/storage/netstore.go
@@ -208,6 +208,7 @@ func (n *NetStore) Get(ctx context.Context, mode chunk.ModeGet, req *Request) (c
 					if n.recoveryCallback != nil && publisher != "" {
 						log.Debug("gp netstore recovery triggered")
 						n.recoveryCallback(ctx, ref)
+						ctx = context.WithValue(ctx, "publisher", "")
 						time.Sleep(500 * time.Millisecond) // TODO: view what the ideal timeout is
 						return n.RemoteFetch(ctx, req, fi)
 					}

--- a/storage/netstore.go
+++ b/storage/netstore.go
@@ -208,7 +208,6 @@ func (n *NetStore) Get(ctx context.Context, mode chunk.ModeGet, req *Request) (c
 					if n.recoveryCallback != nil && publisher != "" {
 						log.Debug("gp netstore recovery triggered")
 						n.recoveryCallback(ctx, ref)
-						ctx = context.WithValue(ctx, "publisher", "")
 						time.Sleep(500 * time.Millisecond) // TODO: view what the ideal timeout is
 						return n.RemoteFetch(ctx, req, fi)
 					}

--- a/storage/netstore.go
+++ b/storage/netstore.go
@@ -178,7 +178,7 @@ func (n *NetStore) Get(ctx context.Context, mode chunk.ModeGet, req *Request) (c
 	metrics.GetOrRegisterCounter("netstore/get", nil).Inc(1)
 	publisher, ok := ctx.Value("publisher").(string)
 	if ok {
-		log.Debug("api.get", "netstore test", publisher)
+		log.Debug("api.get", "netstore publisher", publisher)
 	}
 
 	start := time.Now()
@@ -205,7 +205,7 @@ func (n *NetStore) Get(ctx context.Context, mode chunk.ModeGet, req *Request) (c
 			if ok {
 				ch, err = n.RemoteFetch(ctx, req, fi)
 				if err != nil {
-					if n.recoveryCallback != nil && hex.EncodeToString(ref) == publisher {
+					if n.recoveryCallback != nil && publisher != "" {
 						n.recoveryCallback(ctx, ref)
 						time.Sleep(500 * time.Millisecond) // TODO: view what the ideal timeout is
 						return n.RemoteFetch(ctx, req, fi)

--- a/storage/netstore.go
+++ b/storage/netstore.go
@@ -208,8 +208,7 @@ func (n *NetStore) Get(ctx context.Context, mode chunk.ModeGet, req *Request) (c
 					if n.recoveryCallback != nil && publisher != "" {
 						log.Debug("content recovery callback triggered", "ref", ref.String())
 						n.recoveryCallback(ctx, ref)
-						time.Sleep(500 * time.Millisecond) // TODO: view what the ideal timeout is
-						return n.RemoteFetch(ctx, req, fi)
+						return nil, errors.New("recovery was initiated")
 					}
 					return nil, err
 				}

--- a/storage/netstore.go
+++ b/storage/netstore.go
@@ -206,6 +206,7 @@ func (n *NetStore) Get(ctx context.Context, mode chunk.ModeGet, req *Request) (c
 				ch, err = n.RemoteFetch(ctx, req, fi)
 				if err != nil {
 					if n.recoveryCallback != nil && publisher != "" {
+						log.Debug("gp netstore recovery triggered")
 						n.recoveryCallback(ctx, ref)
 						time.Sleep(500 * time.Millisecond) // TODO: view what the ideal timeout is
 						return n.RemoteFetch(ctx, req, fi)

--- a/storage/netstore.go
+++ b/storage/netstore.go
@@ -44,7 +44,8 @@ const (
 )
 
 var (
-	ErrNoSuitablePeer = errors.New("no suitable peer")
+	ErrNoSuitablePeer  = errors.New("no suitable peer")
+	ErrRecoveryAttempt = errors.New("recovery was initiated")
 )
 
 // Fetcher is a struct which maintains state of remote requests.
@@ -208,7 +209,7 @@ func (n *NetStore) Get(ctx context.Context, mode chunk.ModeGet, req *Request) (c
 					if n.recoveryCallback != nil && publisher != "" {
 						log.Debug("content recovery callback triggered", "ref", ref.String())
 						go n.recoveryCallback(ctx, ref)
-						return nil, errors.New("recovery was initiated")
+						return nil, ErrRecoveryAttempt
 					}
 					return nil, err
 				}


### PR DESCRIPTION
This PR resolves request flooding by only triggering content repair for the chunks related to the requested hash, as described in #2205.

The publisher is passed from query params or by `SwarmPublisher` on download by CLI.

It also removes Publisher from the manifest as it's not needed now.

The `bzz-list` is modified to receive the publisher in the query so it can also get the manifest before the actual download takes place. If this is not done the Download in CLI will fail as its first step is to issue a `List` command.

closes #2193
closes #2205