### PR TITLE
localstore: remove putToGCCheck calls in localstore

### DIFF
--- a/storage/localstore/mode_put.go
+++ b/storage/localstore/mode_put.go
@@ -203,13 +203,6 @@ func (db *DB) putUpload(batch *leveldb.Batch, binIDs map[uint8]uint64, item shed
 		return false, 0, err
 	}
 	if exists {
-		if db.putToGCCheck(item.Address) {
-			gcSizeChange, err = db.setGC(batch, item)
-			if err != nil {
-				return false, 0, err
-			}
-		}
-
 		return true, 0, nil
 	}
 	anonymous := false
@@ -232,18 +225,6 @@ func (db *DB) putUpload(batch *leveldb.Batch, binIDs map[uint8]uint64, item shed
 		db.pushIndex.PutInBatch(batch, item)
 	}
 
-	if db.putToGCCheck(item.Address) {
-
-		// TODO: this might result in an edge case where a node
-		// that has very little storage and uploads using an anonymous
-		// upload will have some of the content GCd before being able
-		// to sync it
-		gcSizeChange, err = db.setGC(batch, item)
-		if err != nil {
-			return false, 0, err
-		}
-	}
-
 	return false, gcSizeChange, nil
 }
 
@@ -257,13 +238,6 @@ func (db *DB) putSync(batch *leveldb.Batch, binIDs map[uint8]uint64, item shed.I
 		return false, 0, err
 	}
 	if exists {
-		if db.putToGCCheck(item.Address) {
-			gcSizeChange, err = db.setGC(batch, item)
-			if err != nil {
-				return false, 0, err
-			}
-		}
-
 		return true, gcSizeChange, nil
 	}
 
@@ -274,17 +248,6 @@ func (db *DB) putSync(batch *leveldb.Batch, binIDs map[uint8]uint64, item shed.I
 	}
 	db.retrievalDataIndex.PutInBatch(batch, item)
 	db.pullIndex.PutInBatch(batch, item)
-
-	if db.putToGCCheck(item.Address) {
-		// TODO: this might result in an edge case where a node
-		// that has very little storage and uploads using an anonymous
-		// upload will have some of the content GCd before being able
-		// to sync it
-		gcSizeChange, err = db.setGC(batch, item)
-		if err != nil {
-			return false, 0, err
-		}
-	}
 
 	return false, gcSizeChange, nil
 }

--- a/storage/localstore/mode_put_test.go
+++ b/storage/localstore/mode_put_test.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/ethersphere/swarm/chunk"
-	"github.com/syndtr/goleveldb/leveldb"
 )
 
 // TestModePutRequest validates ModePutRequest index values on the provided DB.
@@ -316,126 +315,6 @@ func TestModePut_sameChunk(t *testing.T) {
 				})
 			}
 		})
-	}
-}
-
-// TestModePutSync_addToGc validates ModePut* with PutSetCheckFunc stub results
-// in the added chunk to show up in GC index
-func TestModePut_addToGc(t *testing.T) {
-	retVal := true
-	// PutSetCheckFunc's output is toggled from the test case
-	opts := &Options{PutToGCCheck: func(_ []byte) bool { return retVal }}
-
-	for _, m := range []struct {
-		mode    chunk.ModePut
-		putToGc bool
-	}{
-		{mode: chunk.ModePutSync, putToGc: true},
-		{mode: chunk.ModePutSync, putToGc: false},
-		{mode: chunk.ModePutUpload, putToGc: true},
-		{mode: chunk.ModePutUpload, putToGc: false},
-		{mode: chunk.ModePutRequest, putToGc: true}, // in ModePutRequest we always insert to GC, so putToGc=false not needed
-	} {
-		for _, tc := range multiChunkTestCases {
-			t.Run(tc.name, func(t *testing.T) {
-				retVal = m.putToGc
-
-				db, cleanupFunc := newTestDB(t, opts)
-				defer cleanupFunc()
-
-				wantTimestamp := time.Now().UTC().UnixNano()
-				defer setNow(func() (t int64) {
-					return wantTimestamp
-				})()
-
-				chunks := generateTestRandomChunks(tc.count)
-
-				_, err := db.Put(context.Background(), m.mode, chunks...)
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				binIDs := make(map[uint8]uint64)
-
-				for _, ch := range chunks {
-					po := db.po(ch.Address())
-					binIDs[po]++
-					var wantErr error
-					if !m.putToGc {
-						wantErr = leveldb.ErrNotFound
-					}
-					newRetrieveIndexesTestWithAccess(db, ch, wantTimestamp, wantTimestamp)
-					newGCIndexTest(db, ch, wantTimestamp, wantTimestamp, binIDs[po], wantErr)(t)
-				}
-			})
-		}
-	}
-}
-
-// TestModePutSync_addToGcExisting validates ModePut* with PutSetCheckFunc stub results
-// in the added chunk to show up in GC index
-func TestModePut_addToGcExisting(t *testing.T) {
-	retVal := true
-	// PutSetCheckFunc's output is toggled from the test case
-	opts := &Options{PutToGCCheck: func(_ []byte) bool { return retVal }}
-
-	for _, m := range []struct {
-		mode    chunk.ModePut
-		putToGc bool
-	}{
-		{mode: chunk.ModePutSync, putToGc: true},
-		{mode: chunk.ModePutSync, putToGc: false},
-		{mode: chunk.ModePutUpload, putToGc: true},
-		{mode: chunk.ModePutUpload, putToGc: false},
-		{mode: chunk.ModePutRequest, putToGc: true}, // in ModePutRequest we always insert to GC, so putToGc=false not needed
-	} {
-		for _, tc := range multiChunkTestCases {
-			t.Run(tc.name, func(t *testing.T) {
-				retVal = m.putToGc
-
-				db, cleanupFunc := newTestDB(t, opts)
-				defer cleanupFunc()
-
-				wantStoreTimestamp := time.Now().UTC().UnixNano()
-				defer setNow(func() (t int64) {
-					return wantStoreTimestamp
-				})()
-
-				chunks := generateTestRandomChunks(tc.count)
-
-				_, err := db.Put(context.Background(), m.mode, chunks...)
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				time.Sleep(1 * time.Millisecond)
-				// change the timestamp, put the chunks again and
-				// expect the access timestamp to change
-				wantAccessTimestamp := time.Now().UTC().UnixNano()
-				defer setNow(func() (t int64) {
-					return wantAccessTimestamp
-				})()
-
-				_, err = db.Put(context.Background(), m.mode, chunks...)
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				binIDs := make(map[uint8]uint64)
-
-				for _, ch := range chunks {
-					po := db.po(ch.Address())
-					binIDs[po]++
-					var wantErr error
-					if !m.putToGc {
-						wantErr = leveldb.ErrNotFound
-					}
-
-					newRetrieveIndexesTestWithAccess(db, ch, wantStoreTimestamp, wantAccessTimestamp)
-					newGCIndexTest(db, ch, wantStoreTimestamp, wantAccessTimestamp, binIDs[po], wantErr)(t)
-				}
-			})
-		}
 	}
 }
 


### PR DESCRIPTION
This PR attempts to fix the push sync issue as described in issue #2204.

Based on a discussion and some manual tests (with @zelig @acud and @santicomp2014) it appears some calls to the GC in `mode_put` are creating race conditions which cause chunks to be garbage collected before an attempt is made to push them.

As a result, in this PR:
- the `putToGCCheck` calls are removed from the `putUpload` func
- the `putToGCCheck` calls are removed from the `putSync` func
- the `TestModePut_addToGc` test is removed
- the `TestModePut_addToGcExisting` test is removed

As of now—with the application of this change—the aforementioned push sync issue has not _yet_ been observed while bombarding the node with content surpassing its capacity (although it might reappear at some point, with the issue seemingly being an obscure race condition) and trojan deliveries seem to work OK.

It should be noted, however, that these `putToGCCheck` calls were there [for a reason](https://github.com/ethersphere/swarm/pull/1940), so we are very likely replacing one bug with another. 

In the context of this implementation for global pinning, this seems like a trade-off worth trying out.